### PR TITLE
Configurable file/url regex for a white list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,22 @@ By default this is set to be "production".
 
 ###notifyReleaseStages
 
-By default, we will only notify Bugsnag of errors that happen when your 
+By default, we will only notify Bugsnag of errors that happen when your
 `releaseStage` is set to be "production". If you would like to change which
 release stages notify Bugsnag of errors you can set `notifyReleaseStages`:
 
 ```javascript
 Bugsnag.notifyReleaseStages = ["development", "production"];
+```
+
+###notifyFilesWhiteList
+
+By default, we notify Bugsnag of errors that happen in any file. But you can provide a
+white list regexp expression to the variable `notifyFilesWhiteList`.
+So it will notify only if filename matches this expression.
+
+```javascript
+Bugsnag.notifyFilesWhiteList = /app\.js|vendor\.js/i;
 ```
 
 ###autoNotify

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -102,8 +102,7 @@ window.Bugsnag = (function (window, document, navigator) {
   var NOTIFIER_VERSION = "<%= pkg.version %>";
   var DEFAULT_RELEASE_STAGE = "production";
   var DEFAULT_NOTIFY_RELEASE_STAGES = [DEFAULT_RELEASE_STAGE];
-
-  var DEFAULT_WHITELIST = "(.)*";
+  var DEFAULT_WHITE_LIST = "(.)*";
 
   // Keep a reference to the currently executing script in the DOM.
   // We'll use this later to extract settings from attributes.
@@ -222,9 +221,9 @@ window.Bugsnag = (function (window, document, navigator) {
     }
 
     // Check if we should notify for this release stage.
-    var releaseStage = getSetting("releaseStage") || DEFAULT_RELEASE_STAGE;
-    var notifyReleaseStages = getSetting("notifyReleaseStages") || DEFAULT_NOTIFY_RELEASE_STAGES;
-    var notifyFilesWhitelist = getSetting("notifyFilesWhitelist") || DEFAULT_WHITELIST;
+    var releaseStage = getSetting("releaseStage", DEFAULT_RELEASE_STAGE);
+    var notifyReleaseStages = getSetting("notifyReleaseStages", DEFAULT_NOTIFY_RELEASE_STAGES);
+    var notifyFilesWhiteList = getSetting("notifyFilesWhiteList", DEFAULT_WHITE_LIST);
     var shouldNotify = false;
     for (var i = 0; i < notifyReleaseStages.length; i++) {
       if (releaseStage === notifyReleaseStages[i]) {
@@ -235,7 +234,7 @@ window.Bugsnag = (function (window, document, navigator) {
 
     if (shouldNotify) {
       var filename = details.file || "undefined";
-      var match = filename.match(notifyFilesWhitelist);
+      var match = filename.match(notifyFilesWhiteList);
       shouldNotify = (match && match[0].length > 0);
     }
 

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -56,8 +56,8 @@ describe("Bugsnag", function () {
       assert(requestData().params.stacktrace != null, "stacktrace should be in request params");
     });
 
-    it("should not notify if notifyFilesWhitelist regex doesn't match", function () {
-      Bugsnag.notifyFilesWhitelist = "(w)*";
+    it("should not notify if notifyFilesWhiteList regex doesn't match", function () {
+      Bugsnag.notifyFilesWhiteList = "(w)*";
       var error = new Error("Example error");
       error.fileName = "production.js";
       Bugsnag.notifyException(error);
@@ -65,8 +65,8 @@ describe("Bugsnag", function () {
       assert(!Bugsnag.testRequest.called, "Bugsnag.testRequest should not have been called");
     });
 
-    it("should notify if notifyFilesWhitelist regex matches", function() {
-      Bugsnag.notifyFilesWhitelist = "production";
+    it("should notify if notifyFilesWhiteList regex matches", function() {
+      Bugsnag.notifyFilesWhiteList = "production";
       var error = new Error("Example error");
       error.fileName = "production.js";
       Bugsnag.notifyException(error);
@@ -74,7 +74,7 @@ describe("Bugsnag", function () {
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
     });
 
-    it("should notify if notifyFilesWhitelist is default '.*'", function() {
+    it("should notify if notifyFilesWhiteList is default '.*'", function() {
       var error = new Error("Example error");
       error.fileName = "production.js";
       Bugsnag.notifyException(error);
@@ -82,8 +82,8 @@ describe("Bugsnag", function () {
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
     });
 
-    it("should notify if notifyFilesWhitelist regex matches 'undefined' and no file name given", function() {
-      Bugsnag.notifyFilesWhitelist = "undefined";
+    it("should notify if notifyFilesWhiteList regex matches 'undefined' and no file name given", function() {
+      Bugsnag.notifyFilesWhiteList = "undefined";
       Bugsnag.notifyException(new Error("Example error"));
 
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");


### PR DESCRIPTION
Added regex matching in order to white list files and urls, so only exceptions from them are sent (and 3rd party stuff can be ignored). Should also resolve issue #5 
