### PR TITLE
Updated bugsnag README.md for Bugsnag.beforeNotify example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Include `bugsnag.js` from our CDN in the `<head>` tag of your website, before
 any other `<script>` tags.
 
 ```html
-<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-1.0.9.min.js" data-apikey="YOUR-API-KEY-HERE"></script>
+<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-1.0.10.min.js" data-apikey="YOUR-API-KEY-HERE"></script>
 ```
 
 Make sure to set your Bugsnag API key in the `data-apikey` attribute on the
@@ -147,7 +147,7 @@ parameter.
 Bugsnag.beforeNotify = function(error, metaData) {
   // Example: Only notify Bugsnag of errors in `app.js` or `vendor.js` files
   var match = error.file.match(/app\.js|vendor\.js/i);
-  return (match && match[0].length > 0);
+  return !!(match && match[0].length > 0);
 }
 ```
 


### PR DESCRIPTION
I couldn't find beforeNotify in bugsnag-1.0.9.min.js. Also, when I used the example for beforeNotify, I noticed that it would return null, at least in Chrome and Safari on mac, which would mean retVal === false would never equal true on line 246 on dist/bugsnag.js in this example.
