### PR TITLE
Update README with correct default behaviour for notifyReleaseStages

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ By default this is set to be "production".
 
 ###notifyReleaseStages
 
-By default, we will only notify Bugsnag of errors that happen when your
-`releaseStage` is set to be "production". If you would like to change which
-release stages notify Bugsnag of errors you can set `notifyReleaseStages`:
+By default, we will notify Bugsnag of exceptions that happen in any
+`releaseStage`. If you would like to change which release stages notify
+Bugsnag of errors you can set `notifyReleaseStages`:
 
 ```javascript
 Bugsnag.notifyReleaseStages = ["development", "production"];


### PR DESCRIPTION
Since 25ea7f01b01fdca93ae306c4cec471bd91be1766, there is no default for `notifyReleaseStages`
