### PR TITLE
Fix Sourcemap Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ your javascript file that points to the location of a source map, we will
 expand the lines in your stacktrace.
 
 For an example of how this should look, you can see the comment at the bottom
-of [bugsnag.js](http://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.1.0.min.js) itself.
+of [bugsnag.js](https://gist.githubusercontent.com/jessicard/10924962/raw/6826aa6d934d95d9e39cdef1bb6a1991c3d4fd7e/bugsnag-2.1.0.min.js) itself.
 Most modern minifiers support source maps, we use [UglifyJS2](https://github.com/mishoo/UglifyJS2).
 
 Advanced hosting


### PR DESCRIPTION
Update Sourcemap docs to point to older version of Bugsnag.min.js
