### PR TITLE
Separation of bugsnag core or just share sendToBugsnag

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,12 +29,12 @@ module.exports = (grunt) ->
 
       dist:
         files:
-          src: ["src/bugsnag.js"]
+          src: ["src/bugsnag.core.js", "src/bugsnag.notify.js"]
 
     "regex-replace":
       dist:
         src:
-          ["src/bugsnag.js", "README.md"]
+          ["src/bugsnag.notify.js", "README.md"]
         actions: [
           name: "version"
           search: /var NOTIFIER_VERSION =[^;]*;/
@@ -170,7 +170,8 @@ module.exports = (grunt) ->
     exec = require("child_process").exec
     done = this.async()
 
-    exec ['echo "Size: $(cat src/bugsnag.js | wc -c)"',
+    exec ['echo "Size: $(cat src/bugsnag.core.js | wc -c)"',
+          'echo "Size: $(cat src/bugsnag.notify.js | wc -c)"',
           'echo "Ugly: $(cat dist/bugsnag.min.js | wc -c)"',
           'echo "Gzip: $(cat dist/bugsnag.min.js | gzip | wc -c)"'].join(" && "), (error, stdout, stderr) ->
             grunt.log.write(stdout.toString())

--- a/bin/uglify.coffee
+++ b/bin/uglify.coffee
@@ -4,9 +4,9 @@ fs = require 'fs'
 UglifyJS = require 'uglifyjs'
 version = require('../package.json').version
 
-ast = UglifyJS.parse(fs.readFileSync('src/bugsnag.js').toString('utf8'),
-  filename: "bugsnag-#{version}.js"
-)
+filesToString = fs.readFileSync('src/bugsnag.core.js').toString('utf8') + fs.readFileSync('src/bugsnag.notify.js').toString('utf8')
+
+ast = UglifyJS.parse(filesToString, filename: "bugsnag-#{version}.js")
 
 compressor = UglifyJS.Compressor(
   warnings: false # A bucket-load of 'Boolean && always false'

--- a/src/bugsnag.core.js
+++ b/src/bugsnag.core.js
@@ -1,0 +1,210 @@
+//
+// **Bugsnag.js** is the official JavaScript notifier for
+// [Bugsnag](https://bugsnag.com).
+//
+// Bugsnag gives you instant notification of errors and
+// exceptions in your website's JavaScript code.
+//
+// Bugsnag.js is incredibly small, and has no external dependencies (not even
+// jQuery!) so you can safely use it on any website.
+//
+
+(function(definition) {
+  var old = window.Bugsnag;
+  window.Bugsnag = definition(window, old);
+})(function (window, old) {
+  var self = {},
+      shouldCatch = true;
+
+  var FUNCTION_REGEX = /function\s*([\w\-$]+)?\s*\(/i;
+
+      // Disable catching on IE < 10 as it destroys stack-traces from generateStackTrace()
+  if (!window.atob) {
+    shouldCatch = false;
+
+  // Disable catching on browsers that support HTML5 ErrorEvents properly.
+  // This lets debug on unhandled exceptions work.
+  } else if (window.ErrorEvent) {
+    try {
+      if (new window.ErrorEvent("test").colno === 0) {
+        shouldCatch = false;
+      }
+    } catch(e){ }
+  }
+
+  self.noConflict = function() {
+    window.Bugsnag = old;
+    return self;
+  };
+
+  // Get the stacktrace string from an exception
+  self.stacktraceFromException = function (exception) {
+    return exception.stack || exception.backtrace || exception.stacktrace;
+  };
+
+  self.checkFuncOnErrors = function (_super, args) {
+  //   // We set shouldCatch to false on IE < 10 because catching the error ruins the file/line as reported in window.onerror,
+  //   // We set shouldCatch to false on Chrome/Safari because it interferes with "break on unhandled exception"
+  //   // All other browsers need shouldCatch to be true, as they don't pass the exception object to window.onerror
+    if (shouldCatch) {
+      try {
+        return _super.apply(this, args);
+      } catch (e) {
+        return e;
+      }
+    } else {
+      return _super.apply(this, args);
+    }
+  };
+
+  // Generate a browser stacktrace (or approximation) from the current stack.
+  // This is used to add a stacktrace to `Bugsnag.notify` calls, and to add a
+  // stacktrace approximation where we can't get one from an exception.
+  self.generateStacktrace = function () {
+    var stacktrace;
+    var MAX_FAKE_STACK_SIZE = 10;
+    var ANONYMOUS_FUNCTION_PLACEHOLDER = "[anonymous]";
+
+    // Try to generate a real stacktrace (most browsers, except IE9 and below).
+    try {
+      throw new Error("");
+    } catch (exception) {
+      stacktrace = self.stacktraceFromException(exception);
+    }
+
+    // Otherwise, build a fake stacktrace from the list of method names by
+    // looping through the list of functions that called this one (and skip
+    // whoever called us).
+    if (!stacktrace) {
+      var functionStack = [];
+      try {
+        var curr = arguments.callee.caller.caller;
+        while (curr && functionStack.length < MAX_FAKE_STACK_SIZE) {
+          var fn = FUNCTION_REGEX.test(curr.toString()) ? RegExp.$1 || ANONYMOUS_FUNCTION_PLACEHOLDER : ANONYMOUS_FUNCTION_PLACEHOLDER;
+          functionStack.push(fn);
+          curr = curr.caller;
+        }
+      } catch (e) {}
+
+      stacktrace = functionStack.join("\n");
+    }
+
+    // Tell the backend to ignore the first two lines in the stack-trace.
+    // generateStacktrace() + window.onerror,
+    // generateStacktrace() + notify,
+    // generateStacktrace() + notifyException
+    return "<generated>\n" + stacktrace;
+  };
+
+  //
+  // ### Hijacking
+  //
+  // hijack an object method
+  var hijack = function (obj, name, makeReplacement) {
+    var original = obj[name];
+    var replacement = makeReplacement(original);
+    obj[name] = replacement;
+  };
+
+
+  var hijackTimeFunc = function (_super) {
+    // Note, we don't do `_super.call` because that doesn't work on IE 8,
+    // luckily this is implicitly window so it just works everywhere.
+    //
+    // setTimout in all browsers except IE <9 allows additional parameters
+    // to be passed, so in order to support these without resorting to call/apply
+    // we need an extra layer of wrapping.
+    return function (f, t) {
+      if (typeof f === "function") {
+        f = wrap(f);
+        var args = Array.prototype.slice.call(arguments, 2);
+        return _super(function () {
+          f.apply(this, args);
+        }, t);
+      } else {
+        return _super(f, t);
+      }
+    };
+  };
+
+  // This is not a public function because it can only be used if
+  // the exception is not caught after being thrown out of this function.
+  //
+  // If you call wrap twice on the same function, it'll give you back the
+  // same wrapped function. This lets removeEventListener to continue to
+  // work.
+
+  var wrap = function (_super, options) {
+    try {
+      if (typeof _super !== "function") {
+        return _super;
+      }
+      if (!_super.bugsnag) {
+        _super.bugsnag = self.hijackFunction(_super, options);
+        _super.bugsnag.bugsnag = _super.bugsnag;
+      }
+      return _super.bugsnag;
+
+    // This can happen if _super is not a normal javascript function.
+    // For example, see https://github.com/bugsnag/bugsnag-js/issues/28
+    } catch (e) {
+      return _super;
+    }
+  };
+
+  self.hijackAll = function (hijackOnerrorFunc, hijackFunction, maybeOverrideHijack) {
+    if (!hijackOnerrorFunc || !hijackFunction) {
+      throw new Error("hijackOnerrorFunc and hijackFunction must be defined");
+    }
+    hijack = maybeOverrideHijack || hijack;
+
+    self.hijackFunction = hijackFunction;
+
+    hijack(window, "onerror", hijackOnerrorFunc);
+    hijack(window, "setTimeout", hijackTimeFunc);
+    hijack(window, "setInterval", hijackTimeFunc);
+    if (window.requestAnimationFrame) {
+      hijack(window, "requestAnimationFrame", hijackTimeFunc);
+    }
+    if (window.setImmediate) {
+      hijack(window, "setImmediate", function (_super) {
+        return function (f) {
+          var args = Array.prototype.slice.call(arguments);
+          args[0] = wrap(args[0]);
+          return _super.apply(this, args);
+        };
+      });
+    }
+
+    // EventTarget is all that's required in modern chrome/opera
+    // EventTarget + Window + ModalWindow is all that's required in modern FF (there are a few Moz prefixed ones that we're ignoring)
+    // The rest is a collection of stuff for Safari and IE 11. (Again ignoring a few MS and WebKit prefixed things)
+    "EventTarget Window Node ApplicationCache AudioTrackList ChannelMergerNode CryptoOperation EventSource FileReader HTMLUnknownElement IDBDatabase IDBRequest IDBTransaction KeyOperation MediaController MessagePort ModalWindow Notification SVGElementInstance Screen TextTrack TextTrackCue TextTrackList WebSocket WebSocketWorker Worker XMLHttpRequest XMLHttpRequestEventTarget XMLHttpRequestUpload".replace(/\w+/g, function (global) {
+      var prototype = window[global] && window[global].prototype;
+      if (prototype && prototype.hasOwnProperty && prototype.hasOwnProperty("addEventListener")) {
+        hijack(prototype, "addEventListener", function (_super) {
+          return function (e, f, capture, secure) {
+            var options = {eventHandler: true};
+            // HTML lets event-handlers be objects with a handlEvent function,
+            // we need to change f.handleEvent here, as self.wrap will ignore f.
+            if (f && f.handleEvent) {
+              f.handleEvent = wrap(f.handleEvent, options);
+            }
+            return _super.call(this, e, wrap(f, options), capture, secure);
+          };
+        });
+
+        // We also need to hack removeEventListener so that you can remove any
+        // event listeners.
+        hijack(prototype, "removeEventListener", function (_super) {
+          return function (e, f, capture, secure) {
+            _super.call(this, e, f, capture, secure);
+            return _super.call(this, e, wrap(f), capture, secure);
+          };
+        });
+      }
+    });
+  };
+
+  return self;
+});

--- a/test/inlinescript.html
+++ b/test/inlinescript.html
@@ -1,7 +1,8 @@
 <html>
 <head>
   <script>var BUGSNAG_TESTING = true;</script>
-  <script src="../src/bugsnag.js" data-apikey="9e68f5104323042c09d8809674e8d05c"></script>
+  <script src="../src/bugsnag.core.js"></script>
+  <script src="../src/bugsnag.notify.js" data-apikey="9e68f5104323042c09d8809674e8d05c"></script>
   <script>
     Bugsnag.testRequest = function (url, params) {
       window.top.testResult(params);

--- a/test/inlinescript1.html
+++ b/test/inlinescript1.html
@@ -1,7 +1,8 @@
 <html>
 <head>
   <script>var BUGSNAG_TESTING = true;</script>
-  <script src="../src/bugsnag.js" data-apikey="9e68f5104323042c09d8809674e8d05c"></script>
+  <script src="../src/bugsnag.core.js"></script>
+  <script src="../src/bugsnag.notify.js" data-apikey="9e68f5104323042c09d8809674e8d05c"></script>
   <script>
     Bugsnag.testRequest = function (url, params) {
       window.top.testResult(params);

--- a/test/inlinescript2.html
+++ b/test/inlinescript2.html
@@ -1,7 +1,8 @@
 <html>
 <head>
   <script>var BUGSNAG_TESTING = true;</script>
-  <script src="../src/bugsnag.js" data-apikey="9e68f5104323042c09d8809674e8d05c" data-inlinescript="false"></script>
+  <script src="../src/bugsnag.core.js"></script>
+  <script src="../src/bugsnag.notify.js" data-apikey="9e68f5104323042c09d8809674e8d05c" data-inlinescript="false"></script>
   <script>
     Bugsnag.testRequest = function (url, params) {
       window.top.testResult(params);

--- a/test/smoke.html
+++ b/test/smoke.html
@@ -12,7 +12,8 @@
 <hr/>
 
 <script>BUGSNAG_TESTING = true;</script>
-<script src="../src/bugsnag.js" data-apikey="a60409cf3d6fa1f8ac9906fe88364aa2"></script>
+<script src="../src/bugsnag.core.js"></script>
+<script src="../src/bugsnag.notify.js" data-apikey="9e68f5104323042c09d8809674e8d05c"></script>
 <script src="http://code.jquery.com/jquery-1.10.2.js"></script>
 
 <script>

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -567,6 +567,18 @@ describe("noConflict", function() {
   });
 });
 
+function createScriptTag(id, src, onload) {
+  // Create bugsnag.js script tag
+  var bugsnag = document.createElement("script");
+  bugsnag.id = id;
+  bugsnag.type = "text/javascript";
+  bugsnag.src = src;
+  bugsnag.onload = bugsnag.onreadystatechange = onload;
+
+  // Add bugsnag.js script tag to dom
+  document.getElementsByTagName("body")[0].appendChild(bugsnag);
+}
+
 function buildUp(cb) {
   // dummy object to override
   window.Bugsnag = {put_me_back: 1};
@@ -574,26 +586,20 @@ function buildUp(cb) {
   window.BUGSNAG_TESTING = true;
   window.undo = [];
 
-  // Create bugsnag.js script tag
-  var bugsnag = document.createElement("script");
-  bugsnag.id = "bugsnag";
-  bugsnag.type = "text/javascript";
-  bugsnag.src = "../src/bugsnag.js";
-  bugsnag.onload = bugsnag.onreadystatechange = function () {
-    if(!this.readyState || this.readyState === "loaded" || this.readyState === "complete") {
-      // Set api key to use when testing
-      Bugsnag.apiKey = "9e68f5104323042c09d8809674e8d05c";
+  createScriptTag("bugsnag_core", "../src/bugsnag.core.js", function () {
+    createScriptTag("bugsnag", "../src/bugsnag.notify.js", function () {
+      if(!this.readyState || this.readyState === "loaded" || this.readyState === "complete") {
+        // Set api key to use when testing
+        Bugsnag.apiKey = "9e68f5104323042c09d8809674e8d05c";
 
-      // Stub out requests
-      stub(Bugsnag, "testRequest");
+        // Stub out requests
+        stub(Bugsnag, "testRequest");
 
-      // Setup is done
-      cb();
-    }
-  };
-
-  // Add bugsnag.js script tag to dom
-  document.getElementsByTagName("body")[0].appendChild(bugsnag);
+        // Setup is done
+        cb();
+      }
+    });
+  });
 }
 
 function tearDown() {


### PR DESCRIPTION
Thanks for the great job. I want to be able to use your code in our project but not to send error reports to notify.bugsnag.com.  From my point of view there can be  two options.

The first one is very brave -  to isolate the code that is could be used by other folks into a separate file. I know it will mean huge changes but anyway, could something similar be included to the bugsnag-js?

The second option is not so traumatic for your code and would make us happy. Here is the changes https://github.com/pavel-blagodov/bugsnag-js/commit/2b8607600a4357c03c8d078dfffc1f3424797017. It makes possible to override the sending method.

So can one of those options be approved by you?
