### PR TITLE
Fix markdown syntax breaking README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Bugsnag.endpoint = "https://bugsnag.local:49000/js";
 ###projectRoot
 
 By default, Bugsnag sets the projectRoot to the current host address (protocol
-+ the domain). For example, `https://example.com` is the projectRoot for all
+& the domain). For example, `https://example.com` is the projectRoot for all
 errors that occur within the `example.com` domain.
 
 ```javascript


### PR DESCRIPTION
This is in relation to 407f59ae8c76c49fa527700e59f56e75d976beab breaking the pretty version of the readme.md - due to `+` being a syntax for a bullet point.

Cheers.
