### PR TITLE
Fix `Node.nodeValue` deprecation notice

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -281,7 +281,7 @@
       var attr = attrs[i];
       if (dataRegex.test(attr.nodeName)) {
         var key = attr.nodeName.match(dataRegex)[1];
-        dataAttrs[key] = attr.nodeValue;
+        dataAttrs[key] = attr.value || attr.nodeValue;
       }
     }
 


### PR DESCRIPTION
I have left the reference to `Node.nodeValue` in, because I was not able to find a good source of information that refers to the overall implementation of `Node.value`.

This at least removes the deprecation notice from Google Chrome (https://github.com/bugsnag/bugsnag-js/issues/63), and should not break backwards compatibility.
