### PR TITLE
Support IE 9 and lower better

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -436,7 +436,7 @@
   // This is used to add a stacktrace to `Bugsnag.notify` calls, and to add a
   // stacktrace approximation where we can't get one from an exception.
   function generateStacktrace() {
-    var stacktrace;
+    var generated, stacktrace;
     var MAX_FAKE_STACK_SIZE = 10;
     var ANONYMOUS_FUNCTION_PLACEHOLDER = "[anonymous]";
 
@@ -444,6 +444,7 @@
     try {
       throw new Error("");
     } catch (exception) {
+      generated = "<generated>\n";
       stacktrace = stacktraceFromException(exception);
     }
 
@@ -451,6 +452,7 @@
     // looping through the list of functions that called this one (and skip
     // whoever called us).
     if (!stacktrace) {
+      generated = "<generated-ie>\n";
       var functionStack = [];
       try {
         var curr = arguments.callee.caller.caller;
@@ -459,9 +461,6 @@
           functionStack.push(fn);
           curr = curr.caller;
         }
-        // Manually add two fake frames for consistency with browsers that
-        // generate real stack traces.
-        functionStack.unshift('<ie9lte-frame1>', '<ie9lte-frame2>');
       } catch (e) {
         log(e);
       }
@@ -472,7 +471,7 @@
     // generateStacktrace() + window.onerror,
     // generateStacktrace() + notify,
     // generateStacktrace() + notifyException
-    return "<generated>\n" + stacktrace;
+    return generated + stacktrace;
   }
 
   // Get the stacktrace string from an exception

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -221,6 +221,18 @@ describe("Bugsnag", function () {
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
       assert.equal(requestData().params.severity, "warning");
     });
+
+    if (navigator.appVersion.indexOf("MSIE 9") > -1) {
+      it("should tell that the stacktrace is from IE", function () {
+        Bugsnag.notifyException(new Error("Example error"));
+
+        assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
+        match = /^<generated-ie>\n/.test(requestData().params.stacktrace);
+        assert(match, "No metaframes included");
+      });
+    } else {
+      it("should pass once", function() {});
+    }
   });
 
   describe("notify", function () {
@@ -259,6 +271,18 @@ describe("Bugsnag", function () {
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
       assert(requestData().params.stacktrace != null, "stacktrace should be present");
     });
+
+    if (navigator.appVersion.indexOf("MSIE 9") > -1) {
+      it("should tell that the stacktrace is from IE", function () {
+        Bugsnag.notify("CustomError", "Something broke");
+
+        assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
+        match = /^<generated-ie>\n/.test(requestData().params.stacktrace);
+        assert(match, "No metaframes included");
+      });
+    } else {
+      it("should pass once", function() {});
+    }
   });
 });
 
@@ -346,13 +370,13 @@ describe("window", function () {
       assert(Bugsnag._onerror.calledOnce, "Bugsnag._onerror should have been called once");
     });
 
-    if (navigator.appVersion.indexOf("MSIE 9") > -1 || nagivator.appVersion.indexOf("Safari/5") > -1) {
-      it("should append two metaframes to the stacktrace", function () {
+    if (navigator.appVersion.indexOf("MSIE 9") > -1) {
+      it("should tell that the stacktrace is from IE", function () {
         Bugsnag._onerror = null; // Disable mocha's onerror for this test
         window.onerror("Something broke", "http://example.com/example.js", 123, 15, new Error("Example error"));
 
         assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
-        match = /^<generated>(.|\n)*<ie9lte-frame1>(.|\n)*<ie9lte-frame2>/.test(requestData().params.stacktrace);
+        match = /^<generated-ie>\n/.test(requestData().params.stacktrace);
         assert(match, "No metaframes included");
       });
     } else {


### PR DESCRIPTION
Although it is already supported, the problem is that the back-end
expects 2 extra metaframes, if a stack trace was generated by us.

The first approach in `generateStacktrace()` provides these frames,
but if it fails, we fall back to the second approach, which lacks
them. It means that on the back-end side the parser chops off two
important frames.

![screenshot 2014-08-20 21 22 50](https://cloud.githubusercontent.com/assets/1079123/3991809/07092a94-28eb-11e4-873f-524b5ff0efd1.png)
