### PR TITLE
src/bugsnag: fix Opera Mobile test failures

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -206,7 +206,7 @@
     var script = document.currentScript || lastScript;
 
     if (!script && synchronousScriptsRunning) {
-      var scripts = document.getElementsByTagName("script");
+      var scripts = document.scripts || document.getElementsByTagName("script");
       script = scripts[scripts.length - 1];
     }
 


### PR DESCRIPTION
Fixes #67 (Some tests fail on Opera Mobile)

The old approach was giving failures on Opera Mobile (and probably
some other minor browsers). The problem is that
`document.currentScript` is unsupported by Opera Mobile, so it was
always undefined (hence, `lastScript`, too).

We use `document.scripts` instead. It is supported by all browsers:
https://developer.mozilla.org/en-US/docs/Web/API/document.scripts
