### PR TITLE
src/bugsnag: do not polyfill requestAnimationFrame

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -624,9 +624,7 @@
 
     polyFill(window, "setTimeout", hijackTimeFunc);
     polyFill(window, "setInterval", hijackTimeFunc);
-    if (window.requestAnimationFrame) {
-      polyFill(window, "requestAnimationFrame", hijackTimeFunc);
-    }
+
     if (window.setImmediate) {
       polyFill(window, "setImmediate", function (_super) {
         return function (f) {


### PR DESCRIPTION
Fixes #72 (`requestAnimationFrame` wrapper doesn't honor the passed
timestamp)

What's the point, really? It doesn't have anything to do with
 hijackTimeFunc at all.
