### PR TITLE
src/bugsnag: fix polyfilling if requestAnimationFrame

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -624,9 +624,15 @@
 
     polyFill(window, "setTimeout", hijackTimeFunc);
     polyFill(window, "setInterval", hijackTimeFunc);
+
     if (window.requestAnimationFrame) {
-      polyFill(window, "requestAnimationFrame", hijackTimeFunc);
+      polyFill(window, "requestAnimationFrame", function (_super) {
+        return function (callback) {
+          return _super(wrap(callback));
+        };
+      });
     }
+
     if (window.setImmediate) {
       polyFill(window, "setImmediate", function (_super) {
         return function (f) {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -321,6 +321,20 @@ describe("window", function () {
     it("should pass", function () {});
   }
 
+  if (window.requestAnimationFrame) {
+    describe("requestAnimationFrame", function () {
+      it("doesn't swallow timestamp", function (done) {
+        window.requestAnimationFrame(function (timestamp) {
+          assert.notEqual(undefined, timestamp);
+          assert.equal("number", typeof timestamp);
+          done();
+        });
+      });
+    });
+  } else {
+    it("should pass", function () {});
+  }
+
 
   describe("onerror", function() {
     it("should notify bugsnag", function () {


### PR DESCRIPTION
Fixes #72 (`requestAnimationFrame` wrapper doesn't honor the passed
timestamp)

The old approach rely on `hijackTimeFunc`, which expects a callback to
accept at least two arguments. If the function being wrapped accepts
only argument, it is being swallowed.

Thanks-to: Jacob Marshall
