### PR TITLE
Add support for almond.js [Fixes #81]

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -14,6 +14,7 @@ module.exports = (grunt) ->
           global: true
           module: true
           define: true
+          require: true
 
         # The Good Parts
         eqeqeq: true

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -12,10 +12,18 @@
 // The `Bugsnag` object is the only globally exported variable
 (function(definition) {
   if (typeof define === "function" && define.amd) {
-    // AMD/Require.js
-    define(function () {
-      return definition(window);
-    });
+    // AMD
+    if (typeof require === "object" && require.load) {
+      // Require.js
+      define(function () {
+        return definition(window);
+      });
+    } else {
+      // Almond.js
+      define("Bugsnag", function () {
+        return definition(window);
+      });
+    }
   } else if (typeof module === "object" && typeof module.exports === "object") {
     // CommonJS/Browserify
     module.exports = definition(global);


### PR DESCRIPTION
It would seem that because almond.js does not make any requests to external files (due to it being a library for concatenated AMD modules), we can check whether the AMD implementation has the `require.load` function - which is used to load external files into the DOM.

So, ideally, this should fix issue #81. I've set the module name to `Bugsnag` to match the name of the global variable Bugsnag uses when no module loading library is used.

Feedback?
