### PR TITLE
Add a null check to node so we don't try access attributes on undefined

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -313,6 +313,11 @@
   function getData(node) {
     var dataAttrs = {};
     var dataRegex = /^data\-([\w\-]+)$/;
+
+    // If the node doesn't exist due to being loaded as a commonjs module,
+    // then return an empty object and fallback to self[].
+    if (!node) { return dataAttrs; }
+
     var attrs = node.attributes;
     for (var i = 0; i < attrs.length; i++) {
       var attr = attrs[i];


### PR DESCRIPTION
This addresses the use case of trying to load bugsnag when you don't load it through a script tag, typically through commmonjs.

Fixes: https://github.com/bugsnag/bugsnag-js/issues/100