### PR TITLE
Add an option for serialization depth

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -244,7 +244,7 @@
   // nested object syntax, `nested[keys]=val`, to support heirachical
   // objects. Similar to jQuery's `$.param` method.
   function serialize(obj, prefix, depth) {
-    if (depth >= 5) {
+    if (depth >= getSetting("serializeMaxDepth", 5)) {
       return encodeURIComponent(prefix) + "=[RECURSIVE]";
     }
     depth = depth + 1 || 1;


### PR DESCRIPTION
At my current workplace we often log errors sent by our API which tend to have a structure that quickly gets cut off by this mechanism.