### PR TITLE
Fix bugsnag not notifying when notifyReleaseStages is set but releaseSta...

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -362,7 +362,7 @@
     eventsRemaining -= 1;
 
     // Check if we should notify for this release stage.
-    var releaseStage = getSetting("releaseStage");
+    var releaseStage = getSetting("releaseStage", "production");
     var notifyReleaseStages = getSetting("notifyReleaseStages");
     if (notifyReleaseStages) {
       var shouldNotify = false;

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -184,12 +184,27 @@ describe("Bugsnag", function () {
       assert(!Bugsnag.testRequest.called, "Bugsnag.testRequest should not have been called");
     });
 
-    it("should notify if a custom releaseStage is in notifyReleaseStages", function () {
+    it("should not notify if releaseStage isn't in notifyReleaseStages", function () {
+      Bugsnag.notifyReleaseStages = ["production"];
+      Bugsnag.releaseStage = "development";
+      Bugsnag.notifyException(new Error("Example error"));
+
+      assert(!Bugsnag.testRequest.called, "Bugsnag.testRequest should not have been called");
+    });
+
+    it("should notify if the default releaseStage is in notifyReleaseStages", function () {
+      console.log(Bugsnag.releaseStage);
       Bugsnag.notifyReleaseStages = ["production", "custom"];
-      Bugsnag.releaseStage = "custom";
       Bugsnag.notifyException(new Error("Example error"));
 
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
+    });
+
+    it("should not notify if the default releaseStage is not in notifyReleaseStages", function () {
+      Bugsnag.notifyReleaseStages = ["custom"];
+      Bugsnag.notifyException(new Error("Example error"));
+
+      assert(!Bugsnag.testRequest.called, "Bugsnag.testRequest should not have been called");
     });
 
     it("should contain global metaData if set", function () {


### PR DESCRIPTION
Fix bugsnag not notifying when notifyReleaseStages is set but releaseStage isn't.

As is written here https://bugsnag.com/docs/notifiers/js under releaseStage, by default, the releaseStage is "production". It is true that when notifying, if releaseStage is not specified, the server will consider it as "production".

The problem I noticed is, when notifyReleaseStages is set but releaseStage isn't, then it won't notify at all. That is contrary to what you'd expect when reading the documentation.