### PR TITLE
Add support for "npm test".

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "bugsnag-js",
     "version": "2.4.7",
     "main": "src/bugsnag.js",
+    "scripts": {
+        "test": "grunt test"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/bugsnag/bugsnag-js"


### PR DESCRIPTION
Add support for "npm test".
    
Add a test script in package.json so that newcomers can easily launch tests using "npm test", without having to figure out how to run the tests. It is explained in the README, but having npm test available makes it easier.