### PR TITLE
Fixes an issue where null exceptions throws an error.

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -69,6 +69,9 @@
   // backend, all other values cause the notification to be dropped; and you
   // will not see it in your dashboard.
   self.notifyException = function (exception, name, metaData, severity) {
+    if (!exception) {
+      return;
+    }
     if (name && typeof name !== "string") {
       metaData = name;
       name = undefined;


### PR DESCRIPTION
You may consider this a userland issue, but in an extreme edge case, I was accidentally calling `notifyException` with an `err` that I thought existed, but it actually did not. This caused my client's code execution to stop with nothing reported to bugsnag. Adding this sanity check would fix my issue.