### PR TITLE
Add a `Bugsnag.maxDepth` option (number) [Fixes #113]

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -247,7 +247,9 @@
   // nested object syntax, `nested[keys]=val`, to support heirachical
   // objects. Similar to jQuery's `$.param` method.
   function serialize(obj, prefix, depth) {
-    if (depth >= 5) {
+    var maxDepth = getSetting('maxDepth', 5);
+
+    if (depth >= maxDepth) {
       return encodeURIComponent(prefix) + "=[RECURSIVE]";
     }
     depth = depth + 1 || 1;


### PR DESCRIPTION
Originally requested by @Yappli in issue #113 (https://github.com/bugsnag/bugsnag-js/issues/113).

I also require this feature, so I thought I'd hurry this along by submitting my own PR (not that it's much of a rush, but yeah... #swag).

<img width="542" alt="screenshot 2015-07-21 19 38 59" src="https://cloud.githubusercontent.com/assets/4710291/8795327/303a7dc6-2fe0-11e5-93f2-4f46cc97328a.png">
