### PR TITLE
Tweak `Bugsnag.noConflict()` to delete `window.Bugsnag` when previous reference is `undefined`

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -33,6 +33,9 @@
   // Maybe it's worth removing all together, if we're loading via any UMD method.
   self.noConflict = function() {
     window.Bugsnag = old;
+    if (typeof old === 'undefined') {
+      delete window.Bugsnag;
+    }
     return self;
   };
 


### PR DESCRIPTION
Delete `undefined` property in `window` object when using `Bugsnag.noConflict()` [Fixes #115]

Using the `delete` operator makes sure that if the `old` object is `undefined` that the `window.Bugsnag` property is deleted entirely, and not just modified to be `undefined`.