### PR TITLE
Release 2.4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ node_js:
 - '2'
 - '0.12'
 - '0.10'
-
+env:
+- CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 before_install:
 - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: node_js
+node_js:
+- '5'
+- '4'
+- '3'
+- '2'
+- '0.12'
+- '0.10'
+
+before_install:
+- npm install -g grunt-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+2.4.9
+-----
+
+### Bug Fixes
+
+- Fix an issue where null exceptions throw an error
+  | [Rick Harrison](https://github.com/rickharrison)
+  | [#110](https://github.com/bugsnag/bugsnag-js/pull/110)
+
+### Enhancements
+
+- Add configuration option for `maxDepth`
+  | [Jacob Marshall](https://github.com/jacobmarshall)
+  | [#114](https://github.com/bugsnag/bugsnag-js/pull/114)
+
 2.4.8
 -----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,31 +10,40 @@ Contributing
 Testing
 =======
 
-The tests need to be run from a browser running on localhost (not directly from the filesystem).
+Running the tests requires [Grunt CLI](https://github.com/gruntjs/grunt-cli). It
+is available via [npm](https://npmjs.org):
 
-- Install coffeescript globally
+```
+npm install grunt-cli
+```
 
-    npm install -g coffee-script
+Also install the dependencies for the project:
 
-- Install the [serve](https://github.com/jlong/serve) gem
+```
+npm install
+```
 
-    gem install serve
+### In browser
 
-- Boot a webserver in the current directory
+```
+grunt browsertest
+```
 
-    serve
-
-- Navigate to the tests
-
-    open http://localhost:4000/test/
-
-Any large changes should be tested in old IEs (we support IE 6!), and any other browsers you can get your hands on. The easiest way
+Any large changes should be tested in old IEs (we support IE 6!), and any other
+browsers you can get your hands on. The easiest way
 to get these is from [modern.ie](https://www.modern.ie/en-gb/virtualization-tools#downloads).
+
+### Headless (Using PhantomJS)
+
+```
+grunt test
+```
 
 Releasing
 =========
 
-- Ensure you have the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables set.
+- Ensure you have the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+  environment variables set.
 - Bump the version number
 
     grunt bump::{major,minor,patch}

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -211,7 +211,10 @@ module.exports = (grunt) ->
   # Run a webserver for testing
   grunt.registerTask "server", ["connect:server:keepalive"]
 
-  # Run tests
+  # Run tests in browser
+  grunt.registerTask "browsertest", ["jshint", "connect:test", "watch:test"]
+
+  # Run tests headless
   grunt.registerTask "test", ["jshint", "mocha_phantomjs"]
 
   # Default meta-task

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -123,6 +123,11 @@ module.exports = (grunt) ->
             'test'
             './'
           ]
+    # Headless tests
+    mocha_phantomjs:
+      options:
+        reporter: 'spec'
+      all: ['test/index.html'],
 
     # Documentation
     docco:
@@ -131,6 +136,7 @@ module.exports = (grunt) ->
         dest: "docs/"
 
   # Load tasks from plugins
+  grunt.loadNpmTasks "grunt-mocha-phantomjs"
   grunt.loadNpmTasks "grunt-contrib-jshint"
   grunt.loadNpmTasks "grunt-contrib-connect"
   grunt.loadNpmTasks "grunt-contrib-watch"
@@ -206,7 +212,7 @@ module.exports = (grunt) ->
   grunt.registerTask "server", ["connect:server:keepalive"]
 
   # Run tests
-  grunt.registerTask "test", ["jshint", "connect:test", "watch:test"]
+  grunt.registerTask "test", ["jshint", "mocha_phantomjs"]
 
   # Default meta-task
   grunt.registerTask "default", ["jshint", "uglify", "docco"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Bugsnag Notifier for JavaScript
+Bugsnag Notifier for JavaScript <img src="https://travis-ci.org/bugsnag/bugsnag-js.svg?branch=master" alt="build status" class="build-status">
 ===============================
 
 The Bugsnag Notifier for JavaScript gives you instant notification of errors and

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ that the javascript will never change, feel free to include the specific version
 directly.
 
 ```html
-<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.4.8.min.js"
+<script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.4.9.min.js"
         data-apikey="YOUR-API-KEY-HERE"></script>
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - nodejs_version: "5"
+    - nodejs_version: "4"
+    - nodejs_version: "3"
+    - nodejs_version: "2"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+install:
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - grunt
+  - npm test

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
     "name": "bugsnag",
-    "version": "2.4.8",
+    "version": "2.4.9",
     "main": "./src/bugsnag.js"
 }

--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
     "name": "bugsnag",
-    "version": "2.4.8",
+    "version": "2.4.9",
     "main": "./src/bugsnag.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bugsnag-js",
-    "version": "2.4.8",
+    "version": "2.4.9",
     "main": "src/bugsnag.js",
     "scripts": {
         "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "grunt-s3": "git://github.com/pifantastic/grunt-s3",
         "grunt-bumpx": "~0.1.0",
         "mocha": "~1.15.1",
-        "grunt-docco": "git://github.com/bdougherty/grunt-docco#grunt-0.4",
+        "grunt-docco": "~0.4.0",
         "grunt-regex-replace": "~0.2.5",
         "grunt-invalidate-cloudfront": "~0.1.4",
         "mocha-browserstack": "~0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,27 +1,28 @@
 {
-    "name": "bugsnag-js",
-    "version": "2.4.9",
-    "main": "src/bugsnag.js",
-    "scripts": {
-        "test": "grunt test"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/bugsnag/bugsnag-js"
-    },
-    "devDependencies": {
-        "grunt": "~0.4.2",
-        "grunt-contrib-jshint": "~0.6.3",
-        "uglifyjs": "latest",
-        "grunt-contrib-connect": "~0.5.0",
-        "grunt-contrib-watch": "~0.5.2",
-        "grunt-s3": "git://github.com/pifantastic/grunt-s3",
-        "grunt-bumpx": "~0.1.0",
-        "mocha": "~1.15.1",
-        "grunt-docco": "~0.4.0",
-        "grunt-regex-replace": "~0.2.5",
-        "grunt-invalidate-cloudfront": "~0.1.4",
-        "mocha-browserstack": "~0.2.2",
-        "browserstack-test": "~0.2.10"
-    }
+  "name": "bugsnag-js",
+  "version": "2.4.9",
+  "main": "src/bugsnag.js",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bugsnag/bugsnag-js"
+  },
+  "devDependencies": {
+    "browserstack-test": "~0.2.10",
+    "grunt": "~0.4.2",
+    "grunt-bumpx": "~0.1.0",
+    "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-jshint": "~0.6.3",
+    "grunt-contrib-watch": "~0.5.2",
+    "grunt-docco": "~0.4.0",
+    "grunt-invalidate-cloudfront": "~0.1.4",
+    "grunt-mocha-phantomjs": "^2.0.1",
+    "grunt-regex-replace": "~0.2.5",
+    "grunt-s3": "git://github.com/pifantastic/grunt-s3",
+    "mocha": "~1.15.1",
+    "mocha-browserstack": "~0.2.2",
+    "uglifyjs": "latest"
+  }
 }

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -247,7 +247,7 @@
   // nested object syntax, `nested[keys]=val`, to support heirachical
   // objects. Similar to jQuery's `$.param` method.
   function serialize(obj, prefix, depth) {
-    var maxDepth = getSetting('maxDepth', 5);
+    var maxDepth = getSetting("maxDepth", 5);
 
     if (depth >= maxDepth) {
       return encodeURIComponent(prefix) + "=[RECURSIVE]";

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -224,7 +224,7 @@
   // Set up default notifier settings.
   var DEFAULT_BASE_ENDPOINT = "https://notify.bugsnag.com/";
   var DEFAULT_NOTIFIER_ENDPOINT = DEFAULT_BASE_ENDPOINT + "js";
-  var NOTIFIER_VERSION = "2.4.8";
+  var NOTIFIER_VERSION = "2.4.9";
 
   // Keep a reference to the currently executing script in the DOM.
   // We'll use this later to extract settings from attributes.

--- a/test/index.html
+++ b/test/index.html
@@ -3,6 +3,7 @@
 <head>
   <title>Running</title>
   <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 </head>
 
 <body>


### PR DESCRIPTION
- Update version of `grunt-docco` dependency
- Add CI files to run the tests on major versions of node
- Updated the changelog
- Fixed a minor linting issue

### Notes

- There are two test failures (only?) in Safari 9, both regarding multi-line backtraces
- The generated API documentation looks good, we should host it alongside the general docs