### PR TITLE
Swap JSHint for ESLint analysis

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "node":    true,
+        "amd":     true
+    },
+    "extends": "eslint:recommended",
+    // Rule definitions
+    //
+    // key: [code, {value}]
+    // codes:
+    //   * 0 - turn the rule off
+    //   * 1 - turn the rule on as a warning (doesn't affect exit code)
+    //   * 2 - turn the rule on as an error (exit code will be 1)
+    "rules": {
+        "camelcase":          [2],
+        "curly":              [2],
+        "eqeqeq":             [2, "smart"],
+        "indent":             [2, 2],
+        "linebreak-style":    [2, "unix"],
+        "no-console":         [0],
+        "no-trailing-spaces": [2],
+        "quotes":             [2, "double"],
+        "semi":               [2, "always"]
+    }
+};

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -3,36 +3,8 @@ module.exports = (grunt) ->
   grunt.initConfig
     # Package information
     pkg: grunt.file.readJSON "package.json"
-
-    # JSHint (see http://www.jshint.com/docs/)
-    jshint:
-      options:
-        # Predefined globals
-        browser: true
-        globals:
-          BUGSNAG_TESTING: false
-          global: true
-          module: true
-          define: true
-
-        # The Good Parts
-        eqeqeq: true
-        eqnull: true
-        curly: true
-        latedef: true
-        undef: true
-        forin: true
-
-        # Style preferences
-        indent: 2
-        camelcase: true
-        trailing: true
-        quotmark: "double"
-        newcap: true
-
-      dist:
-        files:
-          src: ["src/bugsnag.js"]
+    eslint:
+      src: ["src/bugsnag.js"]
 
     "regex-replace":
       dist:
@@ -109,7 +81,7 @@ module.exports = (grunt) ->
         options:
           livereload: 35729
         files: ['test/*.js', 'src/*.js'],
-        tasks: ['jshint']
+        tasks: ['eslint']
 
     # Web server
     connect:
@@ -137,7 +109,6 @@ module.exports = (grunt) ->
 
   # Load tasks from plugins
   grunt.loadNpmTasks "grunt-mocha-phantomjs"
-  grunt.loadNpmTasks "grunt-contrib-jshint"
   grunt.loadNpmTasks "grunt-contrib-connect"
   grunt.loadNpmTasks "grunt-contrib-watch"
   grunt.loadNpmTasks "grunt-bumpx"
@@ -145,6 +116,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks "grunt-docco"
   grunt.loadNpmTasks "grunt-regex-replace"
   grunt.loadNpmTasks "grunt-invalidate-cloudfront"
+  grunt.loadNpmTasks "gruntify-eslint"
 
   # Task to tag a version in git
   grunt.registerTask "git-tag", "Tags a release in git", ->
@@ -183,7 +155,6 @@ module.exports = (grunt) ->
       console.log("Error running uglify.coffee: " + error) if error?
       done(!error?)
 
-
   grunt.registerTask "uglify-stats", "Outputs stats about uglification", ->
     exec = require("child_process").exec
     done = this.async()
@@ -206,16 +177,16 @@ module.exports = (grunt) ->
 
 
   # Release meta-task
-  grunt.registerTask "release", ["jshint", "uglify", "docco", "git-tag", "git-push", "s3", "npm_publish", "invalidate_cloudfront"]
+  grunt.registerTask "release", ["eslint", "uglify", "docco", "git-tag", "git-push", "s3", "npm_publish", "invalidate_cloudfront"]
 
   # Run a webserver for testing
   grunt.registerTask "server", ["connect:server:keepalive"]
 
   # Run tests in browser
-  grunt.registerTask "browsertest", ["jshint", "connect:test", "watch:test"]
+  grunt.registerTask "browsertest", ["eslint", "connect:test", "watch:test"]
 
   # Run tests headless
-  grunt.registerTask "test", ["jshint", "mocha_phantomjs"]
+  grunt.registerTask "test", ["eslint", "mocha_phantomjs"]
 
   # Default meta-task
-  grunt.registerTask "default", ["jshint", "uglify", "docco"]
+  grunt.registerTask "default", ["eslint", "uglify", "docco"]

--- a/package.json
+++ b/package.json
@@ -1,28 +1,28 @@
 {
-    "name": "bugsnag-js",
-    "version": "2.5.0",
-    "main": "src/bugsnag.js",
-    "scripts": {
-        "test": "grunt test"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/bugsnag/bugsnag-js"
-    },
-    "devDependencies": {
-        "browserstack-test": "~0.2.10",
-        "grunt": "~0.4.2",
-        "grunt-bumpx": "~0.1.0",
-        "grunt-contrib-connect": "~0.5.0",
-        "grunt-contrib-jshint": "~0.6.3",
-        "grunt-contrib-watch": "~0.5.2",
-        "grunt-docco": "~0.4.0",
-        "grunt-invalidate-cloudfront": "~0.1.4",
-        "grunt-mocha-phantomjs": "^2.0.1",
-        "grunt-regex-replace": "~0.2.5",
-        "grunt-s3": "git://github.com/pifantastic/grunt-s3",
-        "mocha": "~1.15.1",
-        "mocha-browserstack": "~0.2.2",
-        "uglifyjs": "latest"
-    }
+  "name": "bugsnag-js",
+  "version": "2.5.0",
+  "main": "src/bugsnag.js",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bugsnag/bugsnag-js"
+  },
+  "devDependencies": {
+    "browserstack-test": "~0.2.10",
+    "grunt": "~0.4.2",
+    "grunt-bumpx": "~0.1.0",
+    "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-watch": "~0.5.2",
+    "grunt-docco": "~0.4.0",
+    "grunt-invalidate-cloudfront": "~0.1.4",
+    "grunt-mocha-phantomjs": "^2.0.1",
+    "grunt-regex-replace": "~0.2.5",
+    "grunt-s3": "git://github.com/pifantastic/grunt-s3",
+    "gruntify-eslint": "^1.3.0",
+    "mocha": "~1.15.1",
+    "mocha-browserstack": "~0.2.2",
+    "uglifyjs": "latest"
+  }
 }

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -12,20 +12,20 @@
 // The `Bugsnag` object is the only globally exported variable
 (function (window, old) {
   var self = {},
-      lastEvent,
-      lastScript,
-      previousNotification,
-      shouldCatch = true,
-      ignoreOnError = 0,
+    lastEvent,
+    lastScript,
+    previousNotification,
+    shouldCatch = true,
+    ignoreOnError = 0,
 
-      // We've seen cases where individual clients can infinite loop sending us errors
-      // (in some cases 10,000+ errors per page). This limit is at the point where
-      // you've probably learned everything useful there is to debug the problem,
-      // and we're happy to under-estimate the count to save the client (and Bugsnag's) resources.
-      eventsRemaining = 10,
-      // The default depth of attached metadata which is parsed before truncation. It
-      // is configurable via the `maxDepth` setting.
-      maxPayloadDepth = 5;
+    // We've seen cases where individual clients can infinite loop sending us errors
+    // (in some cases 10,000+ errors per page). This limit is at the point where
+    // you've probably learned everything useful there is to debug the problem,
+    // and we're happy to under-estimate the count to save the client (and Bugsnag's) resources.
+    eventsRemaining = 10,
+    // The default depth of attached metadata which is parsed before truncation. It
+    // is configurable via the `maxDepth` setting.
+    maxPayloadDepth = 5;
 
   // #### Bugsnag.noConflict
   //
@@ -529,7 +529,7 @@
       if (attrs) {
         var ret = "<" + target.nodeName.toLowerCase();
         for (var i = 0; i < attrs.length; i++) {
-          if (attrs[i].value && attrs[i].value.toString() != "null") {
+          if (attrs[i].value && attrs[i].value.toString() !== "null") {
             ret += " " + attrs[i].name + "=\"" + attrs[i].value + "\"";
           }
         }
@@ -561,7 +561,7 @@
       if (new window.ErrorEvent("test").colno === 0) {
         shouldCatch = false;
       }
-    } catch(e){ }
+    } catch(e){ /* No action needed */ }
   }
 
 
@@ -665,7 +665,7 @@
 
     if (window.setImmediate) {
       polyFill(window, "setImmediate", function (_super) {
-        return function (f) {
+        return function () {
           var args = Array.prototype.slice.call(arguments);
           args[0] = wrap(args[0]);
           return _super.apply(this, args);


### PR DESCRIPTION
ESLint checking has clearer error reporting, perhaps because it is AST-based. Examples:

* A single starting line being out of alignment is reported correctly, as opposed to reporting all of the following lines as having errors.
* `eqeqeq`/avoiding type coercion is enforced more intelligently around `null`