### PR TITLE
Add support for `wrapCallbacks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,29 @@ any search parameters or the page's fragment identifier.
 Bugsnag.context = "/path/to/my/page.php";
 ```
 
+###wrapCallbacks
+
+Bugsnag wraps all callbacks passed to browser APIs (such as setTimeout or
+addEventListener) in order to catch exceptions and provide diagnostics. If you'd like to hook into this functionality, you can set a `wrapCallbacks` method.
+
+This will be called once at the time the callback is registered (e.g. when you call `setTimeout`) and the returned function will be called every time instead of the original.
+
+```
+Bugsnag.wrapCallbacks = function (callback) {
+    return function () {
+        var start = performance.now()
+
+        try {
+            return callback.call(this, arguments);
+        } finally {
+            if (performance.now() - start > 16.6) {
+                alert("missed 60fps goal!");
+            }
+        }
+    }
+});
+```
+
 noConflict Support
 ------------------
 

--- a/src/bugsnag.d.ts
+++ b/src/bugsnag.d.ts
@@ -22,6 +22,8 @@ interface BugsnagStatic {
      *  To cancel sending the report, return false from this function.
      */
     beforeNotify: (payload: any, metaData: any) => boolean;
+    /** Callback used to hook into Bugsnag's automatic wrapping. */
+    wrapCallbacks: (callback: Function) => Function;
     /** The pathname of the current page, not including the fragment identifier
      *  nor search parameters
      */

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -131,7 +131,7 @@
       }
       if (!_super.bugsnag) {
         var currentScript = getCurrentScript();
-        var callback = Bugsnag.wrapCallbacks ? Bugsnag.wrapCallbacks(_super) : _super;
+        var callback = self.wrapCallbacks ? self.wrapCallbacks(_super) : _super;
 
         _super.bugsnag = function (event) {
           if (options && options.eventHandler) {

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -131,18 +131,21 @@
       }
       if (!_super.bugsnag) {
         var currentScript = getCurrentScript();
+        var callback = Bugsnag.wrapCallbacks ? Bugsnag.wrapCallbacks(_super) : _super;
+
         _super.bugsnag = function (event) {
           if (options && options.eventHandler) {
             lastEvent = event;
           }
           lastScript = currentScript;
 
+
           // We set shouldCatch to false on IE < 10 because catching the error ruins the file/line as reported in window.onerror,
           // We set shouldCatch to false on Chrome/Safari because it interferes with "break on unhandled exception"
           // All other browsers need shouldCatch to be true, as they don't pass the exception object to window.onerror
           if (shouldCatch) {
             try {
-              return _super.apply(this, arguments);
+              return callback.apply(this, arguments);
             } catch (e) {
               // We do this rather than stashing treating the error like lastEvent
               // because in FF 26 onerror is not called for synthesized event handlers.
@@ -155,7 +158,7 @@
               lastScript = null;
             }
           } else {
-            var ret = _super.apply(this, arguments);
+            var ret = callback.apply(this, arguments);
             // in case of error, this is set to null in window.onerror
             lastScript = null;
             return ret;


### PR DESCRIPTION
Hey Bugsnag!

I'd love to be able to re-use the Bugsnag callback wrapping mechanism without re-implementing it in our code-base. This tiny change exposes a `wrapCallbacks` function that lets people like me intercept all callbacks in the same manner that Bugsnag does.

I want to use it to monitor typing lag in the Superhuman email client. Because there are asynchronous jumps in the code while handling key events, it's not sufficient to just see how long handling a keypress event takes, instead we need to take into account all the time in the background spent synching drafts to the database etc, and see whether any of these contribute to delayed keypresses or long ticks.

Would anyone else find this useful?