### PR TITLE
Fix millisecondsAgo factory for stone-age browsers

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -717,7 +717,7 @@
   // This is necessary because depending on the browser the event.timeStamp could be a
   // DOMTimeStamp or a DOMHighResTimeStamp
   function makeMillisecondsAgo() {
-    function highPerf(timeStamp) {
+    function highRes(timeStamp) {
       return performance.now() - timeStamp;
     }
 
@@ -739,10 +739,10 @@
     }
 
     // if the testTimeStamp is close to performance.now() then it is a DOMHighResTimeStamp
-    var isHighPerf = window.hasOwnProperty("performance")
+    var isHighRes = window.hasOwnProperty("performance")
                      && timeNear(testEvent.timeStamp, window.performance.now());
 
-    return isHighPerf ? highPerf : legacy;
+    return isHighRes ? highRes : legacy;
   }
 
   window.Bugsnag = self;

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -733,7 +733,7 @@
     // Old browsers don't support document.createEvent
     var testEvent;
     try {
-      testEvent = document.createEvent('CustomEvent');
+      testEvent = document.createEvent("CustomEvent");
     } catch(e) {
       return legacy;
     }


### PR DESCRIPTION
IE versions 6-8 do not support `document.createEvent`.
They wouldn't be using high resolution time stamps either, so for them we can just use the old method for calculating millisecondsAgo.