### PR TITLE
Make targetSelector more specific for click breadcrumbs

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -516,11 +516,36 @@
 
     if (el.className && el.className.length) {
       var classString = "." + el.className.split(" ").join(".");
-      classString = truncate(classString, 40);
       parts.push(classString);
     }
 
-    return parts.join("");
+    var label = parts.join("");
+
+    if (!document.querySelectorAll || !Array.prototype.indexOf) {
+      // can't get much more advanced with the current browser
+      return label;
+    }
+
+    if (document.querySelectorAll(label).length === 1) {
+      return label;
+    }
+
+    // try to get a more specific selector if this one matches more than one element
+    if (el.parentNode.childNodes.length > 1) {
+      var index = Array.prototype.indexOf.call(el.parentNode.childNodes, el) + 1;
+      label = label + ":nth-child(" + index + ")";
+    }
+
+    if (document.querySelectorAll(label).length === 1) {
+      return label;
+    }
+
+    // try prepending the parent node selector
+    if (el.parentNode) {
+      return nodeLabel(el.parentNode) + " > " + label;
+    }
+
+    return label;
   }
 
   function truncate(value, length) {


### PR DESCRIPTION
Before, when we created a click event breadcrumb, we would generate a CSS selector for the clicked element based on the `id`, `tagName`, and css classes. The purpose is to help you identify the element that got clicked after the fact.

In cases when the clicked element didn't have an ID or a recognizable class, this would often produce an ambiguous selector that would match several elements. 

This change will test the generated selector, and if it matches several elements it will try to make it more specific.

The first thing it will do is check if the clicked element has any siblings and will append `:nth-child` to the end of the selector. This is useful for cases where you had a list of repeating elements all with the same class.  If that selector still matches more than 1 element it will travel up the DOM tree and repeat the process. This will continue recursively until it either has a unique selector or it reaches the root element.

The end result will be a CSS selector like this: 
`DIV.movie-list.favorites > DIV.movie:nth-child(5)`