### PR TITLE
Handle edge case with invalid ID attribute

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -517,7 +517,13 @@
       return label;
     }
 
-    if (document.querySelectorAll(label).length === 1) {
+    try {
+      if (document.querySelectorAll(label).length === 1) {
+        return label;
+      }
+    } catch (e) {
+      // sometime the query selector can be invalid, for example, if the id attribute is anumber.
+      // in these cases, just return the label as is.
       return label;
     }
 

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -507,6 +507,14 @@ describe("Bugsnag", function () {
         Bugsnag.notify("Something");
         assert.equal(requestData().params.breadcrumbs[0].metaData.targetText, "Hello");
       });
+
+      it("handles invalid id attributes", function() {
+        container.id = "12345";
+        clickOn(container);
+        Bugsnag.notify("Something");
+        var selector = requestData().params.breadcrumbs[0].metaData.targetSelector;
+        assert.equal(selector, "DIV#12345");
+      });
     });
   });
 });


### PR DESCRIPTION
When building click event target selector, be sure not to choke on invalid id attributes, (e.g. ones that start with a number).