### PR TITLE
Remove deprecated userId setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ Changelog
 -----
 
 ### Enhancements
-  
+
 - Add support for sending "breadcrumbs" - notable events leading up to an error
   [Christian Schlensker](https://github.com/wordofchristian)
   [#149](https://github.com/bugsnag/bugsnag-js/pull/149)
 
-  
+### Deprecations/Breakages
+
+- Remove support for deprecated `userId` in favor of the `user` object.
+
+
 2.5.0 (2016-01-29)
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ Changelog
 3.0.0-rc.1 (2016-07-22)
 -----
 
+This release adds support for automatic and custom breadcrumb tracking.
+Breadcrumbs replace the private implementation of "last event" tracking.
+It also removes support for the deprecated `userId` setting, which has been
+replaced by the `user` object.
+
 ### Enhancements
 
 - Add support for sending "breadcrumbs" - notable events leading up to an error
   [Christian Schlensker](https://github.com/wordofchristian)
   [#149](https://github.com/bugsnag/bugsnag-js/pull/149)
-
-### Deprecations/Breakages
-
-- Remove support for deprecated `userId` in favor of the `user` object.
 
 
 2.5.0 (2016-01-29)

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -785,7 +785,6 @@
       apiKey: apiKey,
       projectRoot: getSetting("projectRoot") || window.location.protocol + "//" + window.location.host,
       context: getSetting("context") || window.location.pathname,
-      userId: getSetting("userId"), // Deprecated, remove in v3
       user: getSetting("user"),
       metaData: merge(merge({}, getSetting("metaData")), metaData),
       releaseStage: releaseStage,


### PR DESCRIPTION
We used to support sending a `userId` setting, but this has been deprecated in favor of the [user](https://github.com/bugsnag/bugsnag-js#user) object. This PR will remove userId support for v3.

Closes #153 (h/t @jacobmarshall)
👋 @kattrali @wordofchristian 
