### PR TITLE
Send time error occurred in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ replaced by the `user` object.
 - Add support for sending "breadcrumbs" - notable events leading up to an error
   [Christian Schlensker](https://github.com/wordofchristian)
   [#149](https://github.com/bugsnag/bugsnag-js/pull/149)
+- Send device time in error payload
+  [#165](https://github.com/bugsnag/bugsnag-js/pull/165)
 
 
 2.5.0 (2016-01-29)

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -949,7 +949,7 @@
       return function bugsnag(message, url, lineNo, charNo, exception) {
         var shouldNotify = getSetting("autoNotify", true);
         var metaData = {
-          Device: {
+          device: {
             time: new Date().getTime()
           }
         };

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -948,7 +948,11 @@
 
       return function bugsnag(message, url, lineNo, charNo, exception) {
         var shouldNotify = getSetting("autoNotify", true);
-        var metaData = {};
+        var metaData = {
+          Device: {
+            time: new Date().getTime()
+          }
+        };
 
         // IE 6+ support.
         if (!charNo && window.event) {


### PR DESCRIPTION
We currently show the time the error was _received_ as the starting point in the breadcrumb list, but if the client clock is far off from our server time, it can look like there's a gap between all the breadcrumbs and the error. This adds a "Device.time" timestamp like we have for our mobile notifiers, so we can show the whole breadcrumb list in client time. The new version will look like this, changing the top field from "Error Received" to "Error Occurred" in the UI:

![screen shot 2016-08-02 at 6 09 53 pm](https://cloud.githubusercontent.com/assets/187987/17350562/9ccfaf76-58dc-11e6-98a3-9e41e3578e05.png)

👋  @kattrali @wordofchristian 