### PR TITLE
Fixing 'no implicit any' TypeScript error

### DIFF
--- a/src/bugsnag.d.ts
+++ b/src/bugsnag.d.ts
@@ -108,7 +108,7 @@ interface BugsnagStatic {
            severity?: string): void;
 
     /** Add a breadcrumb to be sent with next notify payload to Bugsnag **/
-    leaveBreadcrumb(value?: string|Object)
+    leaveBreadcrumb(value?: string|Object): void;
 }
 
 declare var Bugsnag: BugsnagStatic;


### PR DESCRIPTION
This fixes the 'no implicit any' error if you have noImplicitAny set in tsconfig.json. As far as I could see, leaveBreadcrumb() never returns any value.