### PR TITLE
Only collect input values for buttons

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -521,10 +521,12 @@
 
   // extract text content from a element
   function nodeText(el) {
-    if (el.getAttribute('type') === 'password') {
-      return 'Password value can not be shown or it is empty';
+    var text = el.textContent || el.innerText || "";
+
+    if (el.type === "submit" || el.type === "button") {
+      text = el.value;
     }
-    var text = el.textContent || el.innerText || el.value || "";
+
     text = text.replace(/^\s+|\s+$/g, ""); // trim whitespace
     return truncate(text, 140);
   }

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -565,6 +565,30 @@ describe("Bugsnag", function () {
         assert.equal(requestData().params.breadcrumbs[1].metaData.targetText, "Hello");
       });
 
+      it("reports the value, if the target is a submit button", function() {
+        var input = document.createElement("input");
+        input.type = "submit";
+        input.value = "Submit";
+        document.body.appendChild(input);
+
+        clickOn(input);
+        Bugsnag.notify("Something");
+        document.body.removeChild(input);
+        assert.equal(requestData().params.breadcrumbs[1].metaData.targetText, "Submit");
+      });
+
+      it("does not collect value from password elements", function() {
+        var input = document.createElement("input");
+        input.type = "password";
+        input.value = "s0s3cret";
+        document.body.appendChild(input);
+
+        clickOn(input);
+        Bugsnag.notify("Something");
+        document.body.removeChild(input);
+        assert.equal(requestData().params.breadcrumbs[1].metaData.targetText, "");
+      });
+
       it("handles invalid id attributes", function() {
         container.id = "12345";
         clickOn(container);


### PR DESCRIPTION
Follow-up to #184. Avoids privacy issues with collecting value from some text input types. 