### PR TITLE
Disable automatic breadcrumb logging except in production

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -291,7 +291,9 @@
 
   // Setup breadcrumbs for console.log, console.warn, console.error
   function trackConsoleLog(){
-    if(!getBreadcrumbSetting("autoBreadcrumbsConsole")) {
+    // by default, only enable automatic console logging in production.
+    var defaultEnabled = getSetting("releaseStage") === "production";
+    if(!getBreadcrumbSetting("autoBreadcrumbsConsole", defaultEnabled)) {
       return;
     }
 
@@ -787,8 +789,11 @@
   // get breadcrumb specific setting. When autoBreadcrumbs is true, all individual events are defaulted
   // to true. Otherwise they will all defaul to false. You can set any event specicically and it will override
   // the default.
-  function getBreadcrumbSetting(name) {
-    var fallback = getSetting("autoBreadcrumbs", true);
+  function getBreadcrumbSetting(name, fallback) {
+    if (typeof fallback === "undefined") {
+      fallback = getSetting("autoBreadcrumbs", true);
+    }
+
     return getSetting(name, fallback);
   }
 


### PR DESCRIPTION
Meant to address #156 

This change defaults the automatic breadcrumbs for console logging to be disabled unless the release stage is set to production. 

Unfortunately this means that the breadcrumb will be disabled if you don't end up setting the release stage at all. I think this is preferable though to the alternative of having the console log line numbers messed up and not knowing why. 