### PR TITLE
Limit total number of breadcrumbs

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -194,7 +194,7 @@
 
       // limit breadcrumb trail length, so the payload doesn't get too large
       if (breadcrumbs.length > breadcrumbLimit) {
-        breadcrumbs = breadcrumbs.slice(0, breadcrumbLimit);
+        breadcrumbs = breadcrumbs.slice(-breadcrumbLimit);
       }
     }
   };

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -18,6 +18,9 @@
     ignoreOnError = 0,
     breadcrumbs = [],
 
+    // Cap total breadcrumbs at 20, so we don't send a giant payload.
+    breadcrumbLimit = 20,
+
     // We've seen cases where individual clients can infinite loop sending us errors
     // (in some cases 10,000+ errors per page). This limit is at the point where
     // you've probably learned everything useful there is to debug the problem,
@@ -188,6 +191,11 @@
     } else {
       crumb.name = truncate(crumb.name, 32);
       breadcrumbs.push(truncateDeep(crumb, 140));
+
+      // limit breadcrumb trail length, so the payload doesn't get too large
+      if (breadcrumbs.length > breadcrumbLimit) {
+        breadcrumbs = breadcrumbs.slice(0, breadcrumbLimit);
+      }
     }
   };
 

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -521,7 +521,10 @@ describe("Bugsnag", function () {
         for (key in breadcrumbs) {
           if (breadcrumbs.hasOwnProperty(key)) breadcrumbCount++;
         }
+
         assert.equal(breadcrumbCount, 20);
+        // Confirm we kept the most recent 20 breadcrumbs instead of the first 20
+        assert.equal(requestData().params.breadcrumbs[19].metaData.message, "I am breadcrumb 20");
       });
     });
 

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -509,7 +509,7 @@ describe("Bugsnag", function () {
         assert.equal(crumb.metaData.message.length, 140);
       });
 
-      it("limits total breadcumbs to 20", function () {
+      it("limits total breadcrumbs to 20", function () {
         var i, key, breadcrumbs, breadcrumbCount = 0;
         for (i=0; i < 21; i++) {
           Bugsnag.leaveBreadcrumb("I am breadcrumb " + i);

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -508,6 +508,18 @@ describe("Bugsnag", function () {
 
         assert.equal(crumb.metaData.message.length, 140);
       });
+
+      it("limits total breadcumbs to 20", function () {
+        var i;
+        for (i=0; i < 21; i++) {
+          Bugsnag.leaveBreadcrumb("I am breadcrumb " + i);
+        }
+        Bugsnag.notify("Something");
+
+        var breadcrumbCount = Object.keys(requestData().params.breadcrumbs).length;
+
+        assert.equal(breadcrumbCount, 20);
+      });
     });
 
     describe("click tracking", function () {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -510,14 +510,17 @@ describe("Bugsnag", function () {
       });
 
       it("limits total breadcumbs to 20", function () {
-        var i;
+        var i, key, breadcrumbs, breadcrumbCount = 0;
         for (i=0; i < 21; i++) {
           Bugsnag.leaveBreadcrumb("I am breadcrumb " + i);
         }
         Bugsnag.notify("Something");
 
-        var breadcrumbCount = Object.keys(requestData().params.breadcrumbs).length;
-
+        // Do shenanigans to get around IE<9 not supporting Object.keys
+        breadcrumbs = requestData().params.breadcrumbs;
+        for (key in breadcrumbs) {
+          if (breadcrumbs.hasOwnProperty(key)) breadcrumbCount++;
+        }
         assert.equal(breadcrumbCount, 20);
       });
     });


### PR DESCRIPTION
This caps the total quantity of breadcrumbs we'll track and send at 20. This should keep things more in line with our other notifier libraries and help keep the payload size more manageable. 

Fixes #193. @wordofchristian would you mind giving this a review when you have time?