### PR TITLE
Fix tests not reloading when using watch mode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,11 +22,11 @@ module.exports = function(config) {
       "mocha-ie-legacy"
     ],
     files: [
-      { pattern: "src/bugsnag.js", watched: true, included: false, served: true },
-      { pattern: "test/**/*", watched: true, included: false, served: true },
       "test/assert.js",
       "test/stub.js",
-      "test/test.bugsnag.js"
+      "test/test.bugsnag.js",
+      { pattern: "src/bugsnag.js", watched: true, included: false, served: true },
+      { pattern: "test/**/*", watched: true, included: false, served: true }
     ],
     proxies: {
       "/": "/base/test/",

--- a/package.json
+++ b/package.json
@@ -1,31 +1,31 @@
 {
-    "name": "bugsnag-js",
-    "version": "3.0.5",
-    "main": "src/bugsnag.js",
-    "scripts": {
-        "test": "karma start --single-run",
-        "test:watch": "karma start --browsers PhantomJS",
-        "test:quick": "karma start --single-run --browsers PhantomJS"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/bugsnag/bugsnag-js"
-    },
-    "devDependencies": {
-        "eslint": "^3.4.0",
-        "grunt": "~0.4.2",
-        "grunt-bumpx": "~0.1.0",
-        "grunt-contrib-watch": "~0.5.2",
-        "grunt-docco": "~0.4.0",
-        "grunt-invalidate-cloudfront": "~0.1.4",
-        "grunt-regex-replace": "~0.2.5",
-        "grunt-s3": "git://github.com/pifantastic/grunt-s3",
-        "gruntify-eslint": "^1.3.0",
-        "karma": "^1.1.2",
-        "karma-mocha-ie-legacy": "file:./test/karma-mocha",
-        "karma-phantomjs-launcher": "^1.0.1",
-        "karma-sauce-launcher": "^1.0.0",
-        "mocha": "~1.15.1",
-        "uglifyjs": "latest"
-    }
+  "name": "bugsnag-js",
+  "version": "3.0.5",
+  "main": "src/bugsnag.js",
+  "scripts": {
+    "test": "karma start --single-run",
+    "test:watch": "karma start --browsers PhantomJS",
+    "test:quick": "karma start --single-run --browsers PhantomJS"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bugsnag/bugsnag-js"
+  },
+  "devDependencies": {
+    "eslint": "^3.4.0",
+    "grunt": "~0.4.2",
+    "grunt-bumpx": "~0.1.0",
+    "grunt-contrib-watch": "~0.5.2",
+    "grunt-docco": "~0.4.0",
+    "grunt-invalidate-cloudfront": "~0.1.4",
+    "grunt-regex-replace": "~0.2.5",
+    "grunt-s3": "git://github.com/pifantastic/grunt-s3",
+    "gruntify-eslint": "^1.3.0",
+    "karma": "^1.3.0",
+    "karma-mocha-ie-legacy": "file:./test/karma-mocha",
+    "karma-phantomjs-launcher": "^1.0.1",
+    "karma-sauce-launcher": "^1.0.0",
+    "mocha": "~1.15.1",
+    "uglifyjs": "latest"
+  }
 }


### PR DESCRIPTION
Changes to the test file weren't getting reloaded when running `npm run test:watch`. Reordering the karma files so `"test/test.bugsnag.js"` comes before ` { pattern: "test/**/*", watched: true, included: false, served: true }` fixes the problem. 

Also upgraded karma to the latest version.