### PR TITLE
Add breadcrumb configuration methods

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -324,14 +324,12 @@
     }
 
     // keep track of functions that we will need to hijack
-    var originalLog, originalWarn, originalError;
+    var nativeLog = console.log,
+      nativeWarn = console.warn,
+      nativeError = console.error;
 
     self.enableAutoBreadcrumbsConsole = function() {
       self.autoBreadcrumbsConsole = true;
-
-      originalLog = console.log;
-      originalWarn = console.warn;
-      originalError = console.error;
 
       enhance(console, "log", function() {
         trackLog("log", arguments);
@@ -349,9 +347,9 @@
     self.disableAutoBreadcrumbsConsole = function() {
       self.autoBreadcrumbsConsole = false;
 
-      console.log = originalLog;
-      console.warn = originalWarn;
-      console.error = originalError;
+      console.log = nativeLog;
+      console.warn = nativeWarn;
+      console.error = nativeError;
     };
 
     if(getBreadcrumbSetting("autoBreadcrumbsConsole", true)) {
@@ -365,9 +363,6 @@
 
   // Setup breadcrumbs for history navigation events
   function setupNavigationBreadcrumbs() {
-    // setup variables of functions that we will need to hijack.
-    var nativePushState, nativeReplaceState;
-
 
     function parseHash(url) {
       return url.split("#")[1] || "";
@@ -471,12 +466,13 @@
       return;
     }
 
+    // keep track of native functions
+    var nativePushState = history.pushState,
+      nativeReplaceState = history.replaceState;
+
     // create enable function
     self.enableAutoBreadcrumbsNavigation = function() {
       self.autoBreadcrumbsNavigation = true;
-      // keep track of native functions
-      nativePushState = history.pushState;
-      nativeReplaceState = history.replaceState;
       // create hooks for pushstate and replaceState
       enhance(history, "pushState", wrapBuilder(buildPushState));
       enhance(history, "replaceState", wrapBuilder(buildReplaceState));

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -517,12 +517,14 @@
   self.enableAutoBreadcrumbs = function() {
     self.enableAutoBreadcrumbsClicks();
     self.enableAutoBreadcrumbsConsole();
+    self.enableAutoBreadcrumbsErrors();
     self.enableAutoBreadcrumbsNavigation();
   };
 
   self.disableAutoBreadcrumbs = function() {
     self.disableAutoBreadcrumbsClicks();
     self.disableAutoBreadcrumbsConsole();
+    self.disableAutoBreadcrumbsErrors();
     self.disableAutoBreadcrumbsNavigation();
   };
 

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -267,7 +267,7 @@
     }
 
     var callback = function(event) {
-      if(!getBreadcrumbSetting("autoBreadcrumbsClicks", true)) {
+      if(!getBreadcrumbSetting("autoBreadcrumbsClicks")) {
         return;
       }
 
@@ -352,7 +352,7 @@
       console.error = nativeError;
     };
 
-    if(getBreadcrumbSetting("autoBreadcrumbsConsole", true)) {
+    if(getBreadcrumbSetting("autoBreadcrumbsConsole")) {
       self.enableAutoBreadcrumbsConsole();
     }
   }
@@ -448,7 +448,7 @@
     // functional fu to make it easier to setup event listeners
     function wrapBuilder(builder) {
       return function() {
-        if(!getBreadcrumbSetting("autoBreadcrumbsNavigation", true)) {
+        if(!getBreadcrumbSetting("autoBreadcrumbsNavigation")) {
           return;
         }
 
@@ -493,7 +493,7 @@
     window.addEventListener("load", wrapBuilder(buildLoad), true);
     window.addEventListener("DOMContentLoaded", wrapBuilder(buildDOMContentLoaded), true);
 
-    if(getBreadcrumbSetting("autoBreadcrumbsNavigation", true)) {
+    if(getBreadcrumbSetting("autoBreadcrumbsNavigation")) {
       self.enableAutoBreadcrumbsNavigation();
     }
   }
@@ -873,12 +873,10 @@
   }
 
   // get breadcrumb specific setting. When autoBreadcrumbs is true, all individual events are defaulted
-  // to true. Otherwise they will all defaul to false. You can set any event specicically and it will override
+  // to true. Otherwise they will all default to false. You can set any event specifically and it will override
   // the default.
-  function getBreadcrumbSetting(name, fallback) {
-    if (typeof fallback === "undefined") {
-      fallback = getSetting("autoBreadcrumbs", true);
-    }
+  function getBreadcrumbSetting(name) {
+    var fallback = getSetting("autoBreadcrumbs", true);
     return getSetting(name, fallback);
   }
 

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -875,8 +875,10 @@
   // get breadcrumb specific setting. When autoBreadcrumbs is true, all individual events are defaulted
   // to true. Otherwise they will all defaul to false. You can set any event specicically and it will override
   // the default.
-  function getBreadcrumbSetting(name) {
-    var fallback = getSetting("autoBreadcrumbs", true);
+  function getBreadcrumbSetting(name, fallback) {
+    if (typeof fallback === "undefined") {
+      fallback = getSetting("autoBreadcrumbs", true);
+    }
     return getSetting(name, fallback);
   }
 

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -567,6 +567,13 @@ describe("Bugsnag", function () {
         assert.deepEqual(actual.metaData, expected.metaData);
       });
 
+      it("can be disabled", function() {
+        Bugsnag.disableAutoBreadcrumbsClicks();
+        clickOn(container);
+        Bugsnag.notify("Something");
+        assert.equal(requestData().params.breadcrumbs.length, 1);
+      });
+
       it("builds a css selector from the target", function() {
         container.id = "container";
         container.className = "blue steel";

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -528,6 +528,25 @@ describe("Bugsnag", function () {
       });
     });
 
+    if (typeof window["console"] !== "undefined") {
+      describe("console.log breadcrumbs", function() {
+        it("captures console output", function() {
+          Bugsnag.enableAutoBreadcrumbsConsole();
+          console.log("HELLO");
+          Bugsnag.notify("Something");
+          var crumb = requestData().params.breadcrumbs[1];
+          assert.equal(crumb.metaData.message, "HELLO");
+        });
+
+        it("can be disabled", function() {
+          Bugsnag.disableAutoBreadcrumbsConsole();
+          console.log("HELLO");
+          Bugsnag.notify("Something");
+          assert.equal(requestData().params.breadcrumbs[1], undefined);
+        });
+      });
+    }
+
     describe("click tracking", function () {
       // modern browsers only
       if (!window.addEventListener) {
@@ -571,7 +590,7 @@ describe("Bugsnag", function () {
         Bugsnag.disableAutoBreadcrumbsClicks();
         clickOn(container);
         Bugsnag.notify("Something");
-        assert.equal(requestData().params.breadcrumbs.length, 1);
+        assert.equal(requestData().params.breadcrumbs[1], undefined);
       });
 
       it("builds a css selector from the target", function() {


### PR DESCRIPTION
fixes #156 
fixes #189 

This PR creates new methods on the Bugsnag objects for enabling/disabling the different automatic breadcrumbs. 

```
Bugsnag.enableAutoBreadcrumbs();
Bugsnag.disableAutoBreadcrumbs();
Bugsnag.enableAutoBreadcrumbsClicks();
Bugsnag.disableAutoBreadcrumbsClicks();
Bugsnag.enableAutoBreadcrumbsErrors();
Bugsnag.disableAutoBreadcrumbsErrors();
Bugsnag.enableAutoBreadcrumbsConsole();
Bugsnag.disableAutoBreadcrumbsConsole();
Bugsnag.enableAutoBreadcrumbsNavigation();
Bugsnag.disableAutoBreadcrumbsNavigation();
```

These are necessary because the console and navigation breadcrumbs in particular need to wrap native browser functions in order to work. This has some drawbacks as seen in #156 which is why many people will want to disable them in the development environment. Unfortunately current API for configuring these options by assigning an attribute on the Bugsnag object (`Bugsnag.autoNotifyBreadcrumbsConsole = false`) does not give us the opportunity to do the necessary setup/teardown. 

Even though these new methods are only necessary for the console and navigation breadcrumbs, I went ahead and created functions for all the breadcrumb options to keep the API consistent.