### PR TITLE
Fixes infinite recursion in truncateDeep

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -709,7 +709,13 @@
   function truncateDeep(object, length) {
     var traversed = [], index;
     function _truncateDeep(object, length) {
-      index = traversed.indexOf(object);
+      index = traversed.length - 1;
+      while (index > 0) {
+        if (traversed[index] === object) {
+          break;
+        }
+        index -= 1;
+      }
       if (index !== -1) {
         return traversed[index];
       } else if (typeof object === "object") {

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -21,7 +21,6 @@
 
     // Cap total breadcrumbs at 20, so we don't send a giant payload.
     breadcrumbLimit = 20,
-    
 
     // We've seen cases where individual clients can infinite loop sending us errors
     // (in some cases 10,000+ errors per page). This limit is at the point where

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -707,22 +707,30 @@
 
   // truncate all string values in nested object
   function truncateDeep(object, length) {
-    if (typeof object === "object") {
-      var newObject = {};
-      each(object, function(value, key){
-        if (value != null && value !== undefined) {
-          newObject[key] = truncateDeep(value, length);
-        }
-      });
+    var traversed = [], index;
+    function _truncateDeep(object, length) {
+      index = traversed.indexOf(object);
+      if (index !== -1) {
+        return traversed[index];
+      } else if (typeof object === "object") {
+        var newObject = {};
+        traversed.push(newObject);
+        each(object, function(value, key){
+          if (value != null && value !== undefined) {
+            newObject[key] = _truncateDeep(value, length);
+          }
+        });
 
-      return newObject;
-    } else if (typeof object === "string") {
-      return truncate(object, length);
-    } else if (object && Array === object.constructor) {
-      return map(object, function(value) { return truncateDeep(value, length); });
-    } else {
-      return object;
+        return newObject;
+      } else if (typeof object === "string") {
+        return truncate(object, length);
+      } else if (object && Array === object.constructor) {
+        return map(object, function(value) { return _truncateDeep(value, length); });
+      } else {
+        return object;
+      }
     }
+    return _truncateDeep(object, length);
   }
 
   // Deeply serialize an object into a query string. We use the PHP-style

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -21,6 +21,7 @@
 
     // Cap total breadcrumbs at 20, so we don't send a giant payload.
     breadcrumbLimit = 20,
+    
 
     // We've seen cases where individual clients can infinite loop sending us errors
     // (in some cases 10,000+ errors per page). This limit is at the point where

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -712,13 +712,11 @@
       index = traversed.length - 1;
       while (index > 0) {
         if (traversed[index] === object) {
-          break;
+          return traversed[index];
         }
         index -= 1;
       }
-      if (index !== -1) {
-        return traversed[index];
-      } else if (typeof object === "object") {
+      if (typeof object === "object") {
         var newObject = {};
         traversed.push(newObject);
         each(object, function(value, key){

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -707,14 +707,12 @@
 
   // truncate all string values in nested object
   function truncateDeep(object, length) {
-    var traversed = [], index;
+    var traversed = [];
     function _truncateDeep(object, length) {
-      index = traversed.length - 1;
-      while (index > 0) {
+      for (var index = 0; index < traversed.length; index++) {
         if (traversed[index] === object) {
           return traversed[index];
         }
-        index -= 1;
       }
       if (typeof object === "object") {
         var newObject = {};

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -711,18 +711,17 @@
     function _truncateDeep(object, length) {
       for (var index = 0; index < traversed.length; index++) {
         if (traversed[index] === object) {
-          return traversed[index];
+          return "[RECURSIVE]";
         }
       }
       if (typeof object === "object") {
         var newObject = {};
-        traversed.push(newObject);
+        traversed.push(object);
         each(object, function(value, key){
           if (value != null && value !== undefined) {
             newObject[key] = _truncateDeep(value, length);
           }
         });
-
         return newObject;
       } else if (typeof object === "string") {
         return truncate(object, length);

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -540,6 +540,17 @@ describe("Bugsnag", function () {
         // Confirm we kept the most recent 20 breadcrumbs instead of the first 20
         assert.equal(requestData().params.breadcrumbs[19].metaData.message, "I am breadcrumb 20");
       });
+
+      it("lets me set metaData with self nesting", function() {
+        var metaData = {a: metaData, b: "text"};
+        Bugsnag.leaveBreadcrumb("deepCrumb", metaData);
+        Bugsnag.notify("Something");
+
+        var crumb = requestData().params.breadcrumbs[1];
+
+        assert.equal(crumb.name, "deepCrumb");
+        assert.equal(crumb.metaData.b, "text");
+      });
     });
 
     if (typeof window["console"] !== "undefined") {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -542,14 +542,27 @@ describe("Bugsnag", function () {
       });
 
       it("lets me set metaData with self nesting", function() {
-        var metaData = {a: metaData, b: "text"};
+        var metaData = {a: "text"};
+        metaData.b = metaData; // recursive
+
         Bugsnag.leaveBreadcrumb("deepCrumb", metaData);
         Bugsnag.notify("Something");
 
         var crumb = requestData().params.breadcrumbs[1];
 
         assert.equal(crumb.name, "deepCrumb");
-        assert.equal(crumb.metaData.b, "text");
+        assert.equal(crumb.metaData.a, "text");
+      });
+
+      it("marks recursive breadcrumb as [RECURSIVE]", function() {
+        var metaData = {};
+        metaData.a = metaData;
+
+        Bugsnag.leaveBreadcrumb("deepCrumb", metaData);
+        Bugsnag.notify("Something");
+
+        var crumb = requestData().params.breadcrumbs[1];
+        assert.equal(crumb.metaData.a, "[RECURSIVE]");
       });
     });
 


### PR DESCRIPTION
Takes over from #202 (fixes #200)

The main issue was the fact that the new object (`newObject`) was being added to the `traversed` array, and thus never actually being matched by the traversed checking loop.

This also marks any recursive objects with `[RECURSIVE]`, and I've also added to test to check that. But from memory the tests can't be run by non-bugsnag peeps right now, is that correct @eanakashima @wordofchristian?

Cheers @Omniroot for starting work on this branch :)