### PR TITLE
Remove broken postMessage tests

### DIFF
--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -771,57 +771,6 @@ describe("window", function () {
   });
 
   if (window.addEventListener) {
-    describe("sendMessage", function () {
-      var callback, handle;
-      function makeHandle() {
-        return function handle(e) {
-          setTimeout(function () {
-            Bugsnag._onerror.restore();
-            callback();
-          });
-          function failA() {
-            throw new Error(e.data);
-          }
-          function failB() {
-            failA();
-          }
-          failB(e);
-        };
-      }
-
-      beforeEach(function () {
-        stub(Bugsnag, "_onerror"); // disable reporting error to mocha.
-        handle = makeHandle();
-        window.addEventListener("message", handle, false);
-      });
-
-      afterEach(function () {
-        window.removeEventListener("message", handle, false);
-      });
-
-      it("should automatically call the error handler once", function (done) {
-        callback = function () {
-          assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
-          done();
-        };
-        window.postMessage("hello", "*");
-      });
-
-      if (!/(MSIE 9|Safari)/.test(navigator.appVersion)) {
-        it("should include multi-line backtraces", function (done) {
-          callback = function () {
-            assert(Bugsnag.testRequest.calledOnce);
-            assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
-            assert(/failA(.|\n)*failB(.|\n)*handle/.test(requestData().params.stacktrace), "Bugsnag.testRequest should have been called with a multi-line stacktrace:: " + JSON.stringify(requestData().params.stacktrace));
-            done();
-          };
-          window.postMessage("hello", "*");
-        });
-      } else {
-        it("should pass once", function () { });
-      }
-    });
-
     describe("addEventListener with object", function () {
       var callback, handle;
       function makeHandle() {


### PR DESCRIPTION
These seem to cause the latest versions of Chrome, Safari, Firefox and PhantomJS to spin at 100% CPU forever. The use case here is also a little unclear, since we are sending the message to and from the same window/origin. I'd like to just remove them for now, and maybe we can add back a more realistic test case around postMessage in the future. 