### PR TITLE
Use a contemporary version of Chrome for saucelabs tests

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -64,10 +64,10 @@
     "version": "31",
     "platform": "Windows 7"
   },
-  "sl_chrome_36": {
+  "sl_chrome_54": {
     "base": "SauceLabs",
     "browserName": "chrome",
-    "version": "36.0",
+    "version": "54.0",
     "platform": "Windows 7"
   },
   "sl_android_4_3": {


### PR DESCRIPTION
Since chrome auto-updates, testing older versions is probably less important than testing a recent release. Bumping us up to the latest that Sauce has for now.