### PR TITLE
Add a hard breadcrumb limit (pulls in #211)

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -19,9 +19,6 @@
     breadcrumbs = [],
     placeholderErrorName = "BugsnagNotify",
 
-    // Cap total breadcrumbs at 20, so we don't send a giant payload.
-    breadcrumbLimit = 20,
-
     // We've seen cases where individual clients can infinite loop sending us errors
     // (in some cases 10,000+ errors per page). This limit is at the point where
     // you've probably learned everything useful there is to debug the problem,
@@ -30,6 +27,10 @@
     // The default depth of attached metadata which is parsed before truncation. It
     // is configurable via the `maxDepth` setting.
     maxPayloadDepth = 5;
+
+    // Cap total breadcrumbs at 20, so we don't send a giant payload.
+    // Allow this to be overridden for special use cases.
+  self.breadcrumbLimit = 20;
 
   // #### Bugsnag.noConflict
   //
@@ -203,8 +204,8 @@
       breadcrumbs.push(truncateDeep(crumb, 140));
 
       // limit breadcrumb trail length, so the payload doesn't get too large
-      if (breadcrumbs.length > breadcrumbLimit) {
-        breadcrumbs = breadcrumbs.slice(-breadcrumbLimit);
+      if (breadcrumbs.length > self.breadcrumbLimit) {
+        breadcrumbs = breadcrumbs.slice(-self.breadcrumbLimit);
       }
     }
   };

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -17,6 +17,7 @@
     shouldCatch = true,
     ignoreOnError = 0,
     breadcrumbs = [],
+    breadcrumbHardLimit = 40,
     placeholderErrorName = "BugsnagNotify",
 
     // We've seen cases where individual clients can infinite loop sending us errors
@@ -28,8 +29,9 @@
     // is configurable via the `maxDepth` setting.
     maxPayloadDepth = 5;
 
-    // Cap total breadcrumbs at 20, so we don't send a giant payload.
-    // Allow this to be overridden for special use cases.
+
+  // Set default breadcrumbLimit to 20, so we don't send a giant payload.
+  // This can be overridden up to the breadcrumbHardLimit
   self.breadcrumbLimit = 20;
 
   // #### Bugsnag.noConflict
@@ -200,12 +202,13 @@
       lastCrumb.count = lastCrumb.count || 1;
       lastCrumb.count++;
     } else {
+      var breadcrumbLimit = Math.min(self.breadcrumbLimit, breadcrumbHardLimit);
       crumb.name = truncate(crumb.name, 32);
       breadcrumbs.push(truncateDeep(crumb, 140));
 
       // limit breadcrumb trail length, so the payload doesn't get too large
-      if (breadcrumbs.length > self.breadcrumbLimit) {
-        breadcrumbs = breadcrumbs.slice(-self.breadcrumbLimit);
+      if (breadcrumbs.length > breadcrumbLimit) {
+        breadcrumbs = breadcrumbs.slice(-breadcrumbLimit);
       }
     }
   };

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -540,6 +540,23 @@ describe("Bugsnag", function () {
         // Confirm we kept the most recent 20 breadcrumbs instead of the first 20
         assert.equal(requestData().params.breadcrumbs[19].metaData.message, "I am breadcrumb 20");
       });
+
+      it("allows configuring the breadcrumbLimit", function () {
+        var i, key, breadcrumbs, breadcrumbCount = 0;
+
+        Bugsnag.breadcrumbLimit = 3;
+
+        for (i=0; i < 4; i++) {
+          Bugsnag.leaveBreadcrumb("I am breadcrumb " + i);
+        }
+        Bugsnag.notify("Something");
+
+        breadcrumbs = requestData().params.breadcrumbs;
+        for (key in breadcrumbs) {
+          if (breadcrumbs.hasOwnProperty(key)) { breadcrumbCount++; }
+        }
+        assert.equal(breadcrumbCount, 3);
+      });
     });
 
     if (typeof window["console"] !== "undefined") {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -424,9 +424,6 @@ describe("Bugsnag", function () {
   });
 
   describe("Breadcrumbs", function() {
-    beforeEach(buildUp);
-    afterEach(tearDown);
-
     describe("leaveBreadcrumb", function () {
       it("adds a breadcrumb", function () {
         Bugsnag.leaveBreadcrumb("Test crumb");

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -540,7 +540,6 @@ describe("Bugsnag", function () {
 
       it("allows configuring the breadcrumbLimit", function () {
         var i, key, breadcrumbs, breadcrumbCount = 0;
-
         Bugsnag.breadcrumbLimit = 3;
 
         for (i=0; i < 4; i++) {
@@ -553,6 +552,22 @@ describe("Bugsnag", function () {
           if (breadcrumbs.hasOwnProperty(key)) { breadcrumbCount++; }
         }
         assert.equal(breadcrumbCount, 3);
+      });
+
+      it("enforces a hard limit on number of breadcrumbs", function () {
+        var i, key, breadcrumbs, breadcrumbCount = 0;
+        Bugsnag.breadcrumbLimit = 41;
+
+        for (i=0; i < 41; i++) {
+          Bugsnag.leaveBreadcrumb("I am breadcrumb " + i);
+        }
+        Bugsnag.notify("Something");
+
+        breadcrumbs = requestData().params.breadcrumbs;
+        for (key in breadcrumbs) {
+          if (breadcrumbs.hasOwnProperty(key)) { breadcrumbCount++; }
+        }
+        assert.equal(breadcrumbCount, 40);
       });
     });
 


### PR DESCRIPTION
This merges in #211 with a few updates:

- Add a hard limit of 2x the default limit (40 breadcrumbs)
- Add a test for the configurable limit behavior
- Fix some whitespace weirdness