### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "bugsnag-js",
     "version": "3.0.7",
+    "license": "MIT",
     "main": "src/bugsnag.js",
     "scripts": {
         "test": "karma start --single-run",


### PR DESCRIPTION
So it displays without an * in tools like:
https://www.npmjs.com/package/license-checker