### PR TITLE
Support for catching unhandled rejections

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1185,6 +1185,19 @@
       });
     }
 
+    if ("onunhandledrejection" in window) {
+      // browsers with promise support have `addEventListener`
+      window.addEventListener("unhandledrejection", function (event) {
+        var err = event.reason;
+        if (err && (err instanceof Error || err.message)) {
+          self.notifyException(err);
+        } else {
+          // Hopefully the reason is a serializable value (this may yield less than useful results if reject() is abused)
+          self.notify("UnhandledRejection", err);
+        }
+      });
+    }
+
     // EventTarget is all that's required in modern chrome/opera
     // EventTarget + Window + ModalWindow is all that's required in modern FF (there are a few Moz prefixed ones that we're ignoring)
     // The rest is a collection of stuff for Safari and IE 11. (Again ignoring a few MS and WebKit prefixed things)

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -542,6 +542,14 @@
     self.disableAutoBreadcrumbsNavigation();
   };
 
+  self.enableNotifyUnhandledRejections = function() {
+    self.notifyUnhandledRejections = true;
+  };
+
+  self.disableNotifyUnhandledRejections = function() {
+    self.notifyUnhandledRejections = false;
+  };
+
   //
   // ### Script tag tracking
   //
@@ -1188,12 +1196,14 @@
     if ("onunhandledrejection" in window) {
       // browsers with promise support have `addEventListener`
       window.addEventListener("unhandledrejection", function (event) {
-        var err = event.reason;
-        if (err && (err instanceof Error || err.message)) {
-          self.notifyException(err);
-        } else {
-          // Hopefully the reason is a serializable value (this may yield less than useful results if reject() is abused)
-          self.notify("UnhandledRejection", err);
+        if (getSetting("notifyUnhandledRejections", false)) {
+          var err = event.reason;
+          if (err && (err instanceof Error || err.message)) {
+            self.notifyException(err);
+          } else {
+            // Hopefully the reason is a serializable value (this may yield less than useful results if reject() is abused)
+            self.notify("UnhandledRejection", err);
+          }
         }
       });
     }


### PR DESCRIPTION
See #112 

This PR adds support for catching uncaught/unhandled Promise rejections.

Just to clarify, the handler checks the `event.reason` is "error-like" to prevent [this](https://github.com/bugsnag/bugsnag-js/blob/master/src/bugsnag.js#L93-L97) message from showing - which could be otherwise rather confusing.