### PR TITLE
Document linter usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,14 @@ Install the dependencies for the project:
 npm install
 ```
 
+### Linting
+
+We have some basic lint rules set up to catch style issues. Run with:
+
+```
+npm run lint
+```
+
 ### Headless (Using PhantomJS)
 
 ```

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "main": "src/bugsnag.js",
     "scripts": {
+        "lint": "grunt eslint",
         "test": "karma start --single-run",
         "test:watch": "karma start --browsers PhantomJS",
         "test:quick": "karma start --single-run --browsers PhantomJS"

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -168,15 +168,15 @@ describe("Bugsnag", function () {
       div.innerHTML = "<input id='myInput' type='date'/>";
       document.body.appendChild(div);
 
-      // eslint-disable-next-line no-undef
+      /* eslint-disable no-undef */
       Bugsnag.notifyException(new Error("Oahi"), {input: myInput, working: "working"});
 
       var metaData = requestData().params.metaData;
 
       assert.equal(metaData.working, "working");
 
-      // eslint-disable-next-line no-undef
       document.body.removeChild(myInput.parentElement);
+      /* eslint-enable no-undef */
     });
 
     it("should contain a stacktrace", function () {


### PR DESCRIPTION
I noticed that we never explain how to run our linter in CONTRIBUTING.md, let's fix that. ✨  This PR:

- documents eslint usage
- adds an npm wrapper: you can now run with `npm run lint` because I forget `grunt eslint` literally every time I open this repo
- fixes up a lint error for an undefined test variable in some versions of eslint