### PR TITLE
Change typscript module name to match npm module

### DIFF
--- a/src/bugsnag.d.ts
+++ b/src/bugsnag.d.ts
@@ -149,6 +149,6 @@ interface BugsnagStatic {
 
 declare var Bugsnag: BugsnagStatic;
 
-declare module "Bugsnag" {
+declare module "bugsnag-js" {
     export = Bugsnag;
 }


### PR DESCRIPTION
Bugsnag types definition exports a module called `Bugsnag` here https://github.com/bugsnag/bugsnag-js/blob/e1f27d33684b3d6c7e3ba18b9c06dc4ed883f269/src/bugsnag.d.ts#L152

The npm module is called `bugsnag-js`. 

When using both `bugsnag-js` and `bugsnag-node`(which is very unfortunately published as `bugsnag` and not `bugsnag-node`) in a project this causes problems resolving the dependency. I am using Webpack and it assumes that I am trying to import `bugsnag-node` instead of `bugsnag-js`. 

Renaming the module to `bugsnag-js` solves this problem. No one else has mentioned this issue yet so curious if others have managed to use the typescript definitions successfully or if it hasn't been used much since it was just recently added and is not available in a public release yet.