### PR TITLE
Parse array-typed options from data-* attrs. Fixes 249.

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -887,6 +887,10 @@
     if (setting === "false") {
       setting = false;
     }
+    // some settings may need extracting from comma separated strings -> arrays
+    if (name === "notifyReleaseStages" && typeof setting === "string") {
+      setting = setting.split(/\s*,\s*/);
+    }
     return setting !== undefined ? setting : fallback;
   }
 
@@ -921,6 +925,8 @@
     // Check if we should notify for this release stage.
     var releaseStage = getSetting("releaseStage", "production");
     var notifyReleaseStages = getSetting("notifyReleaseStages");
+    // console.log(releaseStage)
+    // console.log(notifyReleaseStages)
     if (notifyReleaseStages) {
       var shouldNotify = false;
       for (var i = 0; i < notifyReleaseStages.length; i++) {

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -925,8 +925,6 @@
     // Check if we should notify for this release stage.
     var releaseStage = getSetting("releaseStage", "production");
     var notifyReleaseStages = getSetting("notifyReleaseStages");
-    // console.log(releaseStage)
-    // console.log(notifyReleaseStages)
     if (notifyReleaseStages) {
       var shouldNotify = false;
       for (var i = 0; i < notifyReleaseStages.length; i++) {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -1071,6 +1071,45 @@ describe("noConflict", function() {
   });
 });
 
+describe("data-* settings", function () {
+  it("should correctly coerce notifyReleaseStages setting to an array when set via data-* attributes (1 value)", function (done) {
+    buildUp(function () {
+      try {
+        Bugsnag.notifyException(new Error("Example error"));
+        assert(Bugsnag.testRequest.called, "Bugsnag.testRequest should have been called");
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, { "data-notifyreleasestages": "production" });
+  });
+
+  it("should correctly coerce notifyReleaseStages setting to an array when set via data-* attributes (2 values)", function (done) {
+    buildUp(function () {
+      try {
+        Bugsnag.notifyException(new Error("Example error"));
+        assert(Bugsnag.testRequest.called, "Bugsnag.testRequest should have been called");
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, { "data-notifyreleasestages": "development,production" });
+  });
+
+  it("should correctly coerce notifyReleaseStages setting to an array when set via data-* attributes (2 values, not containing releaseStage)", function (done) {
+    buildUp(function () {
+      try {
+        Bugsnag.notifyException(new Error("Example error"));
+        assert(!Bugsnag.testRequest.called, "Bugsnag.testRequest should not have been called");
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, { "data-notifyreleasestages": "development,production", "data-releasestage": "other" });
+  });
+})
+
+
 function loadJQuery(cb) {
   var jq = document.createElement("script");
   jq.id = "jquery";
@@ -1090,7 +1129,7 @@ function unloadJQuery () {
   jq.parentNode.removeChild(jq);
 }
 
-function buildUp(cb) {
+function buildUp(cb, attributes) {
   // dummy object to override
   window.Bugsnag = {putMeBack: 1};
 
@@ -1102,6 +1141,11 @@ function buildUp(cb) {
   bugsnag.id = "bugsnag";
   bugsnag.type = "text/javascript";
   bugsnag.src = "../src/bugsnag.js?" + Math.random();
+  if (typeof attributes === 'object') {
+    for (attribute in attributes) {
+      bugsnag.setAttribute(attribute, attributes[attribute]);
+    }
+  }
   bugsnag.onload = bugsnag.onreadystatechange = function () {
     if(!this.readyState || this.readyState === "loaded" || this.readyState === "complete") {
       // Set api key to use when testing


### PR DESCRIPTION
Array-typed settings are split on comma, with whitespace trimmed.

This fixes the inability to set "notifyReleaseStages", which can now be done as follows:

```html
  <script src="…" data-notifyreleasestages="production"></script>
  <script src="…" data-notifyreleasestages="production,staging"></script>
```