### PR TITLE
Add handled/unhandled properties to payload

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1296,7 +1296,7 @@
             lineNumber: err.lineNumber || err.line,
             columnNumber: err.columnNumber ? err.columnNumber + 1 : undefined
           }, metaData, {
-            severity: "error",
+            originalSeverity: "error",
             unhandled: true,
             severityReason: { type: "unhandledPromiseRejection" }
           });

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1028,17 +1028,17 @@
     var callbackSetSeverity = callbackSeverity && !callbackSeverity.__userSpecifiedSeverity && callbackSeverity !== handledState.originalSeverity;
 
     if (callbackSetSeverity) {
-        // callbacks set a valid severity value
-        payload.severity = callbackSeverity;
-        payload.severityReason = { type: "userCallbackSetSeverity" };
+      // callbacks set a valid severity value
+      payload.severity = callbackSeverity;
+      payload.severityReason = { type: "userCallbackSetSeverity" };
     } else if (userSpecifiedSeverity) {
-        // user specified a valid severity value
-        payload.severity = userSeverity;
-        payload.severityReason = { type: "userSpecifiedSeverity" };
+      // user specified a valid severity value
+      payload.severity = userSeverity;
+      payload.severityReason = { type: "userSpecifiedSeverity" };
     } else {
-        // user did not specify severity, or specified and invalid value
-        payload.severity = handledState.originalSeverity;
-        payload.severityReason = handledState.severityReason;
+      // user did not specify severity, or specified and invalid value
+      payload.severity = handledState.originalSeverity;
+      payload.severityReason = handledState.severityReason;
     }
 
     // finally, add whether the error was unhandled so that callbacks can't fiddle with it

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -255,7 +255,20 @@
               return _super.apply(this, arguments);
             } catch (e) {
               if (getSetting("autoNotify", true)) {
-                self.notifyException(e, null, null, "error");
+                var metaData = {};
+                addScriptToMetaData(metaData);
+                sendToBugsnag({
+                  name: e.name,
+                  message: e.message,
+                  stacktrace: stacktraceFromException(e) || generateStacktrace(),
+                  file: e.fileName || e.sourceURL,
+                  lineNumber: e.lineNumber || e.line,
+                  columnNumber: e.columnNumber ? e.columnNumber + 1 : undefined
+                }, metaData, {
+                  severity: "error",
+                  unhandled: true,
+                  severityReason: { type: "exception_handler" }
+                });
                 ignoreNextOnError();
               }
               throw e;

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1255,7 +1255,8 @@
       window.addEventListener("unhandledrejection", function (event) {
         if (getSetting("notifyUnhandledRejections", false)) {
           var err = event.reason;
-          var metaData = {}
+          var metaData = {};
+          addScriptToMetaData(metaData);
           if (err && !err.message) {
             metaData.promiseRejectionValue = err;
           }

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -1127,6 +1127,30 @@ describe("data-* settings", function () {
   });
 })
 
+if ("onunhandledrejection" in window) {
+  describe("unhandled promise rejections", function () {
+    beforeEach(buildUp);
+    afterEach(tearDown);
+
+    it("should catch uncaught rejections after enableNotifyUnhandledRejections() is called", function (done) {
+      Bugsnag.enableNotifyUnhandledRejections()
+      Promise.reject(new Error("boom"))
+      setTimeout(function () {
+        try {
+          assert(Bugsnag.testRequest.called, "Bugsnag.testRequest should have been called");
+          var params = requestData().params;
+          assert.equal(params.defaultSeverity, "true");
+          assert.equal(params.severity, "error");
+          assert.equal(params.unhandled, "true");
+          assert.deepEqual(params.severityReason, { type: "promise_rejection" });
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, 0);
+    })
+  });
+}
 
 function loadJQuery(cb) {
   var jq = document.createElement("script");

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -339,9 +339,8 @@ describe("Bugsnag", function () {
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
       var params = requestData().params;
       assert.equal(params.severity, "warning");
-      assert.equal(params.defaultSeverity, decode(Bugsnag._serialize({ defaultSeverity: true })).defaultSeverity);
       assert.equal(params.unhandled, decode(Bugsnag._serialize({ unhandled: false })).unhandled);
-      assert.equal(params.severityReason, undefined);
+      assert.deepEqual(params.severityReason, decode(Bugsnag._serialize({ severityReason: { type: 'handledException' } })).severityReason);
     });
 
     it("should set correct handled-state properties when user changes severity", function () {
@@ -350,7 +349,7 @@ describe("Bugsnag", function () {
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
       var params = requestData().params;
       assert.equal(params.severity, "info");
-      assert.equal(params.defaultSeverity, decode(Bugsnag._serialize({ defaultSeverity: false })).defaultSeverity);
+      assert.deepEqual(params.severityReason, decode(Bugsnag._serialize({ severityReason: { type: 'userSpecifiedSeverity' } })).severityReason);
     });
 
     if (navigator.appVersion.indexOf("MSIE 9") > -1) {
@@ -777,9 +776,8 @@ describe("window", function () {
       assert.equal(params.lineNumber, 123);
       assert.equal(params.severity, "error");
       // the next assertions are all crazy because of the fudged deserialization (true => "true" etc.)
-      assert.equal(params.defaultSeverity, decode(Bugsnag._serialize({ defaultSeverity: true })).defaultSeverity);
       assert.equal(params.unhandled, decode(Bugsnag._serialize({ unhandled: true })).unhandled);
-      assert.deepEqual(params.severityReason, decode(Bugsnag._serialize({ type: "window_onerror" })));
+      assert.deepEqual(params.severityReason, decode(Bugsnag._serialize({ type: "unhandledException" })));
     });
 
     it("should be able to process column number and stacktrace in some browsers", function () {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -1137,10 +1137,9 @@ if ("onunhandledrejection" in window) {
         try {
           assert(Bugsnag.testRequest.called, "Bugsnag.testRequest should have been called");
           var params = requestData().params;
-          assert.equal(params.defaultSeverity, "true");
           assert.equal(params.severity, "error");
           assert.equal(params.unhandled, "true");
-          assert.deepEqual(params.severityReason, { type: "promise_rejection" });
+          assert.deepEqual(params.severityReason, { type: "unhandledPromiseRejection" });
           done();
         } catch (e) {
           done(e);

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -337,7 +337,20 @@ describe("Bugsnag", function () {
       Bugsnag.notifyException(new Error("Example error"));
 
       assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
-      assert.equal(requestData().params.severity, "warning");
+      var params = requestData().params;
+      assert.equal(params.severity, "warning");
+      assert.equal(params.defaultSeverity, decode(Bugsnag._serialize({ defaultSeverity: true })).defaultSeverity);
+      assert.equal(params.unhandled, decode(Bugsnag._serialize({ unhandled: false })).unhandled);
+      assert.equal(params.severityReason, undefined);
+    });
+
+    it("should set correct handled-state properties when user changes severity", function () {
+      Bugsnag.notifyException(new Error("Example error"), null, null, "info");
+
+      assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
+      var params = requestData().params;
+      assert.equal(params.severity, "info");
+      assert.equal(params.defaultSeverity, decode(Bugsnag._serialize({ defaultSeverity: false })).defaultSeverity);
     });
 
     if (navigator.appVersion.indexOf("MSIE 9") > -1) {
@@ -762,6 +775,11 @@ describe("window", function () {
       assert.equal(params.name, "window.onerror");
       assert.equal(params.message, "Something broke");
       assert.equal(params.lineNumber, 123);
+      assert.equal(params.severity, "error");
+      // the next assertions are all crazy because of the fudged deserialization (true => "true" etc.)
+      assert.equal(params.defaultSeverity, decode(Bugsnag._serialize({ defaultSeverity: true })).defaultSeverity);
+      assert.equal(params.unhandled, decode(Bugsnag._serialize({ unhandled: true })).unhandled);
+      assert.deepEqual(params.severityReason, decode(Bugsnag._serialize({ type: "window_onerror" })));
     });
 
     it("should be able to process column number and stacktrace in some browsers", function () {


### PR DESCRIPTION
Added `handledState` object argument to `sendToBugsnag()` detailing:

- `severity`
- `unhandled `
- `severityReason`

`payload.defaultSeverity` is set based on whether the user sets severity (or changes it via `beforeNotify` callback) such that `payload.severity === handledState.severity`.