### PR TITLE
Update handled unhandled for Unity

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -111,9 +111,10 @@
 
     var state;
 
-    if (handledState) {
+    if (handledState && handledState.originalSeverity && handledState.severityReason &&
+      handledState.severityReason.type && handledState.unhandled != undefined) {
       state = handledState;
-    } else {
+    } else { // revert to default
       state = {
         originalSeverity: "warning",
         unhandled: false,

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -81,7 +81,7 @@
   // The default value is "warning" and "error" and "info" are also supported by the
   // backend, all other values cause the notification to be dropped; and you
   // will not see it in your dashboard.
-  self.notifyException = function (exception, name, metaData, severity) {
+  self.notifyException = function (exception, name, metaData, severity, handledState) {
     if (!exception) {
       var message = "Bugsnag.notifyException() was called with no arguments";
       log(message);
@@ -109,6 +109,18 @@
     }
     addScriptToMetaData(metaData);
 
+    var state;
+
+    if (handledState) {
+      state = handledState;
+    } else {
+      state = {
+        originalSeverity: "warning",
+        unhandled: false,
+        severityReason: { type: "handledException" }
+      };
+    }
+
     sendToBugsnag({
       name: name || exception.name,
       message: exception.message || exception.description,
@@ -117,11 +129,7 @@
       lineNumber: exception.lineNumber || exception.line,
       columnNumber: exception.columnNumber ? exception.columnNumber + 1 : undefined,
       severity: severity
-    }, metaData, {
-      originalSeverity: "warning",
-      unhandled: false,
-      severityReason: { type: "handledException" }
-    });
+    }, metaData, state);
   };
 
   // #### Bugsnag.notify


### PR DESCRIPTION
Adds a handledState param to the notify method, which by default will be a handledException.