### PR TITLE
Truncation of non-Object.prototype objects, fixes #261

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -779,7 +779,7 @@
     } if (typeof object === "object" && object != null) {
       var newObject = {};
       for (var key in object) {
-        if (object.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(object, key)) {
           newObject[key] = truncateDeep(object[key], length, newDepth);
         }
       }

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -520,6 +520,15 @@ describe("Bugsnag", function () {
         assert.equal(crumb.metaData.message.length, 140);
       });
 
+      it("truncates values for objects that don't inherit from Object.prototype", function () {
+        var plainObject = Object.create(null);
+        plainObject.dummyProperty = true;
+        Bugsnag.leaveBreadcrumb({ metaData: plainObject })
+        Bugsnag.notify("Something");
+        assert.equal(requestData().params.breadcrumbs[1].type, "manual");
+        assert.ok(requestData().params.breadcrumbs[1].metaData.dummyProperty);
+      });
+
       it("limits total breadcrumbs to 20", function () {
         var i, key, breadcrumbs, breadcrumbCount = 0;
         for (i=0; i < 21; i++) {

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -520,14 +520,16 @@ describe("Bugsnag", function () {
         assert.equal(crumb.metaData.message.length, 140);
       });
 
-      it("truncates values for objects that don't inherit from Object.prototype", function () {
-        var plainObject = Object.create(null);
-        plainObject.dummyProperty = true;
-        Bugsnag.leaveBreadcrumb({ metaData: plainObject })
-        Bugsnag.notify("Something");
-        assert.equal(requestData().params.breadcrumbs[1].type, "manual");
-        assert.ok(requestData().params.breadcrumbs[1].metaData.dummyProperty);
-      });
+      if (Object.create) {
+        it("truncates values for objects that don't inherit from Object.prototype", function () {
+          var plainObject = Object.create(null);
+          plainObject.dummyProperty = true;
+          Bugsnag.leaveBreadcrumb({ metaData: plainObject })
+          Bugsnag.notify("Something");
+          assert.equal(requestData().params.breadcrumbs[1].type, "manual");
+          assert.ok(requestData().params.breadcrumbs[1].metaData.dummyProperty);
+        });
+      }
 
       it("limits total breadcrumbs to 20", function () {
         var i, key, breadcrumbs, breadcrumbCount = 0;


### PR DESCRIPTION
Grab the method from the `Object.prototype` and `call()` it instead.