### PR TITLE
Add speculative inline script content plugin

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -16,7 +16,8 @@ const plugins = {
   'throttle': require('../base/plugins/throttle'),
   'console breadcrumbs': require('./plugins/console-breadcrumbs'),
   'navigation breadcrumbs': require('./plugins/navigation-breadcrumbs'),
-  'interaction breadcrumbs': require('./plugins/interaction-breadcrumbs')
+  'interaction breadcrumbs': require('./plugins/interaction-breadcrumbs'),
+  'inline script content': require('./plugins/inline-script-content')
 }
 
 const transports = {
@@ -62,6 +63,7 @@ module.exports = (opts) => {
     bugsnag.use(plugins['console breadcrumbs'])
   }
 
+  bugsnag.use(plugins['inline script content'])
   bugsnag.use(plugins['throttle'])
 
   return bugsnag

--- a/browser/plugins/inline-script-content.js
+++ b/browser/plugins/inline-script-content.js
@@ -1,0 +1,21 @@
+const { map } = require('../../base/lib/es-utils')
+
+module.exports = {
+  init: (client) => {
+    const addInlineContent = report => {
+      report.stacktrace = map(report.stacktrace, frame => {
+        if (frame.file.replace(/#.*$/) !== window.location.href.replace(/#.*$/)) return frame
+        if (!frame.file || !frame.lineNumber) return frame
+        const start = Math.max(0, frame.lineNumber - 5 - 1)
+        const end = frame.lineNumber + 5 - 1
+        const code = {}
+        map([ '<!-- DOCUMENT START -->' ].concat(document.all[0].outerHTML.split('\n')).slice(start, end), (line, i) => {
+          code[`${start + i + 1}`] = line
+        })
+        return { ...frame, code }
+      })
+    }
+
+    client.config.beforeSend.push(addInlineContent)
+  }
+}


### PR DESCRIPTION
Attempting to get the contents of an inline `<script>` as the `code` property of a `stackframe` when an error is caught/reported.

Results are mixed, the DOM doesn't provide access to the original page source meaning line numbers are inconsistent… for example

![image](https://user-images.githubusercontent.com/609579/32183403-20bdcd9e-bd91-11e7-874b-15fc662a78b7.png)
