### PR TITLE
Don't crash when unhandled rejections have a null reason

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1283,14 +1283,17 @@
       window.addEventListener("unhandledrejection", function (event) {
         if (getSetting("notifyUnhandledRejections", false)) {
           var err = event.reason;
+          if (!err) {
+            err = {};
+          }
           var metaData = {};
           addScriptToMetaData(metaData);
-          if (err && !err.message) {
+          if (!err.message) {
             metaData.promiseRejectionValue = err;
           }
           sendToBugsnag({
-            name: (err && err.name) ? err.name : "UnhandledRejection",
-            message: (err && err.message) ? err.message : "",
+            name: err.name ? err.name : "UnhandledRejection",
+            message: err.message ? err.message : "",
             stacktrace: stacktraceFromException(err) || generateStacktrace(),
             file: err.fileName || err.sourceURL,
             lineNumber: err.lineNumber || err.line,


### PR DESCRIPTION
Up to line 1251, everything checks if err is null. Then
stacktraceFromException attempts to access err.stack and friends which,
of course, throws.  This creates a dummy object instead.