### PR TITLE
Persist severity properly

### DIFF
--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1010,7 +1010,7 @@
     // annotate this property so that we can check if the "beforeNotify" callbacks changed it
     // can't annotate a string literal ""/'', so create a String() object, woo!
     if (userSpecifiedSeverity) {
-      payload.severity = new String(userSpecifiedSeverity);
+      payload.severity = new String(userSeverity);
       payload.severity.__userSpecifiedSeverity = true;
     }
 

--- a/test/test.bugsnag.js
+++ b/test/test.bugsnag.js
@@ -352,6 +352,18 @@ describe("Bugsnag", function () {
       assert.deepEqual(params.severityReason, decode(Bugsnag._serialize({ severityReason: { type: 'userSpecifiedSeverity' } })).severityReason);
     });
 
+    it("should persist severity in beforeNotify", function () {
+      var callFlag = false;
+      Bugsnag.beforeNotify = function beforeNotify(payload, metadata) {
+        assert.equal(payload.severity, "info")
+        callFlag = true;
+      }
+      Bugsnag.notifyException(new Error("Example error"), null, null, "info");
+
+      assert(Bugsnag.testRequest.calledOnce, "Bugsnag.testRequest should have been called once");
+      assert(callFlag);
+    });
+
     if (navigator.appVersion.indexOf("MSIE 9") > -1) {
       it("should tell that the stacktrace is from IE", function () {
         Bugsnag.notifyException(new Error("Example error"));


### PR DESCRIPTION
Resolves https://github.com/bugsnag/bugsnag-js/issues/275

The test I added failed before the fix, and passes after. No new tests are broken.