### PR TITLE
Sidestep uglify's drop_console option

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -95,10 +95,12 @@ module.exports = (opts, userPlugins = []) => {
 
 const getPrefixedConsole = () => {
   const logger = {}
+  const consoleLog = console['log']
   map([ 'debug', 'info', 'warn', 'error' ], (method) => {
-    logger[method] = typeof console[method] === 'function'
-      ? console[method].bind(console, '[bugsnag]')
-      : console.log.bind(console, '[bugsnag]')
+    const consoleMethod = console[method]
+    logger[method] = typeof consoleMethod === 'function'
+      ? consoleMethod.bind(console, '[bugsnag]')
+      : consoleLog.bind(console, '[bugsnag]')
   })
   return logger
 }


### PR DESCRIPTION
#279 was caused by uglify's `drop_console` option being set in [Laravel Mix](https://github.com/JeffreyWay/laravel-mix)'s webpack setup. I think this is a bug with the `drop_console` functionality but the maintainer of uglify-js [seems to disagree](https://github.com/mishoo/UglifyJS2/issues/2557#issuecomment-349601340).

Assigning the console method to another identifier prevents the option from taking effect (which I think goes to show how incomplete/problematic the `drop_console` feature is in the first place).