### PR TITLE
Ensure empty stackframes are removed

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,10 @@
+version: "2"
+checks:
+  method-complexity:
+    config:
+      threshold: 7
+  return-statements:
+    enabled: false
 engines:
   duplication:
     enabled: true

--- a/base/report.js
+++ b/base/report.js
@@ -1,7 +1,7 @@
 const ErrorStackParser = require('error-stack-parser')
 const StackGenerator = require('stack-generator')
 const hasStack = require('./lib/has-stack')
-const { reduce, filter, map } = require('./lib/es-utils')
+const { reduce, filter } = require('./lib/es-utils')
 
 class BugsnagReport {
   constructor (errorClass, errorMessage, stacktrace = [], handledState = defaultHandledState()) {
@@ -19,18 +19,18 @@ class BugsnagReport {
     this.breadcrumbs = []
     this.context = undefined
     this.device = undefined
-    this.errorClass = typeof errorClass === 'string' && errorClass ? errorClass : '[no error class]'
-    this.errorMessage = typeof errorMessage === 'string' && errorMessage ? errorMessage : '[no error message]'
+    this.errorClass = stringOrFallback(errorClass, '[no error class]')
+    this.errorMessage = stringOrFallback(errorMessage, '[no error message]')
     this.groupingHash = undefined
     this.metaData = {}
     this.request = undefined
     this.severity = this._handledState.severity
-    this.stacktrace = map(stacktrace, frame => formatStackframe(frame))
-    // don't include a stackframe if none of its properties are defined
-    this.stacktrace = reduce(this.stacktrace, (accum, frame) => {
+    this.stacktrace = reduce(stacktrace, (accum, frame) => {
+      const f = formatStackframe(frame)
+      // don't include a stackframe if none of its properties are defined
       try {
-        if (JSON.stringify(frame) === '{}') return accum
-        return accum.concat(frame)
+        if (JSON.stringify(f) === '{}') return accum
+        return accum.concat(f)
       } catch (e) {
         return accum
       }
@@ -145,6 +145,8 @@ const defaultHandledState = () => ({
   severity: 'warning',
   severityReason: { type: 'handledException' }
 })
+
+const stringOrFallback = (str, fallback) => typeof str === 'string' && str ? str : fallback
 
 // Helpers
 

--- a/base/report.js
+++ b/base/report.js
@@ -1,7 +1,7 @@
 const ErrorStackParser = require('error-stack-parser')
 const StackGenerator = require('stack-generator')
 const hasStack = require('./lib/has-stack')
-const { reduce, filter, map, keys } = require('./lib/es-utils')
+const { reduce, filter, map } = require('./lib/es-utils')
 
 class BugsnagReport {
   constructor (errorClass, errorMessage, stacktrace = [], handledState = defaultHandledState()) {
@@ -27,9 +27,13 @@ class BugsnagReport {
     this.severity = this._handledState.severity
     this.stacktrace = map(stacktrace, frame => formatStackframe(frame))
     // don't include a stackframe if none of its properties are defined
-    reduce(stacktrace, (accum, frame) => {
-      if (filter(keys(frame), k => frame[k] !== undefined).length === 0) return accum
-      return accum.concat(frame)
+    this.stacktrace = reduce(this.stacktrace, (accum, frame) => {
+      try {
+        if (JSON.stringify(frame) === '{}') return accum
+        return accum.concat(frame)
+      } catch (e) {
+        return accum
+      }
     }, [])
     this.user = undefined
   }

--- a/base/test/report.test.js
+++ b/base/test/report.test.js
@@ -13,6 +13,16 @@ describe('base/report', () => {
       expect(r._handledState.unhandled).toBe(false)
       expect(r._handledState.severityReason).toEqual({ type: 'handledException' })
     })
+
+    it('doesn’t create empty stackframes', () => {
+      const Report = require('../report')
+      const err = new Error('noooooo')
+      const r = new Report(err.name, err.message, [
+        { foo: 10 },
+        { toJSON: () => { throw new Error('do not serialise me, srsly') } }
+      ])
+      expect(r.stacktrace.length).toBe(0)
+    })
   })
 
   describe('BugsnagReport.ensureReport()', () => {

--- a/browser/plugins/test/unhandled-rejection.test.js
+++ b/browser/plugins/test/unhandled-rejection.test.js
@@ -11,54 +11,38 @@ describe('plugin: unhandled rejection', () => {
     describe('window.onunhandledrejection function', () => {
       it('captures unhandled promise rejections', done => {
         const client = new Client(VALID_NOTIFIER)
-        const payloads = []
         client.configure({ apiKey: 'API_KEY_YEAH' })
         client.use(plugin)
-        client.transport({ sendReport: (logger, config, payload) => payloads.push(payload) })
-
-        setTimeout(() => {
-          Promise.reject(new Error('BAD_PROMISE'))
-        }, 0)
-
-        setTimeout(() => {
-          try {
-            expect(payloads.length).toBe(1)
-            const report = payloads[0].events[0].toJSON()
+        client.transport({
+          sendReport: (logger, config, payload) => {
+            const report = payload.events[0].toJSON()
             expect(report.severity).toBe('error')
             expect(report.unhandled).toBe(true)
             expect(report.severityReason).toEqual({ type: 'unhandledPromiseRejection' })
             done()
-          } catch (e) {
-            done(e)
           }
-        }, 50)
+        })
+
+        setTimeout(() => Promise.reject(new Error('BAD_PROMISE')), 0)
       })
 
       it('handles bad user input', done => {
         const client = new Client(VALID_NOTIFIER)
-        const payloads = []
         client.configure({ apiKey: 'API_KEY_YEAH' })
         client.use(plugin)
-        client.transport({ sendReport: (logger, config, payload) => payloads.push(payload) })
-
-        setTimeout(() => {
-          Promise.reject(null) // eslint-disable-line
-        }, 0)
-
-        setTimeout(() => {
-          try {
-            expect(payloads.length).toBe(1)
-            const report = payloads[0].events[0].toJSON()
+        client.transport({
+          sendReport: (logger, config, payload) => {
+            const report = payload.events[0].toJSON()
             expect(report.severity).toBe('error')
             expect(report.unhandled).toBe(true)
             expect(report.exceptions[0].errorClass).toBe('UnhandledRejection')
             expect(report.exceptions[0].message).toBe('Unhandled promise rejection')
             expect(report.severityReason).toEqual({ type: 'unhandledPromiseRejection' })
             done()
-          } catch (e) {
-            done(e)
           }
-        }, 50)
+        })
+
+        Promise.reject(null) // eslint-disable-line
       })
     })
   }


### PR DESCRIPTION
Reports are being sent with an empty object (sometimes as the only stackframe, sometimes as the last of many frames), for example…

![image](https://user-images.githubusercontent.com/609579/33773957-9869caf0-dc31-11e7-88cf-a67ba67a4c62.png)

I have been unable to reproduce this. And I don't really have a hunch at how it's happening – perhaps cross origin / cross iframe or calling in/out from a plugin (flash/java applet). Anyhow, this _should_ filter out such frames by serialising them and checking `=== '{}'`.