### PR TITLE
Improve inline script handling

### DIFF
--- a/browser/plugins/inline-script-content.js
+++ b/browser/plugins/inline-script-content.js
@@ -1,22 +1,58 @@
-const { map } = require('../../base/lib/es-utils')
+const { reduce } = require('../../base/lib/es-utils')
 
 module.exports = {
   init: (client) => {
-    const html = document.documentElement.outerHTML
+    let html = ''
+    let DOMContentLoaded = false
+    const getHtml = () => document.documentElement.outerHTML
+
     const addInlineContent = report => {
-      report.stacktrace = map(report.stacktrace, frame => {
-        if (!frame.file || !frame.lineNumber) return frame
-        if (frame.file.replace(/#.*$/) !== window.location.href.replace(/#.*$/)) return frame
-        const start = Math.max(0, frame.lineNumber - 5 - 1)
-        const end = frame.lineNumber + 5 - 1
-        const code = {}
-        map([ '<!-- DOCUMENT START -->' ].concat(html.split('\n')).slice(start, end), (line, i) => {
-          code[`${start + i + 1}`] = line
-        })
-        return { ...frame, code }
-      })
+      const frame = report.stacktrace[0]
+      if (!frame || !frame.file || !frame.lineNumber) return frame
+      if (frame.file.replace(/#.*$/) !== window.location.href.replace(/#.*$/)) return frame
+      if (!DOMContentLoaded) html = getHtml()
+      const htmlLines = [ '<!-- DOCUMENT START -->' ].concat(html.split('\n'))
+      const { script, start } = extractScriptContent(htmlLines, frame.lineNumber - 1)
+      const code = reduce(script, (accum, line, i) => {
+        if (Math.abs((start + i + 1) - frame.lineNumber) > 10) return accum
+        accum[`${start + i + 1}`] = line
+        return accum
+      }, {})
+      frame.code = code
+      report.updateMetaData('script', { content: script.join('\n') })
+    }
+
+    // get whatever HTML exists at this point in time
+    html = getHtml()
+
+    // then update it when the DOM content has loaded
+    document.onreadystatechange = () => {
+      // IE8 compatible alternative to document#DOMContentLoaded
+      if (document.readyState === 'interactive') {
+        html = getHtml()
+        DOMContentLoaded = true
+      }
     }
 
     client.config.beforeSend.push(addInlineContent)
   }
+}
+
+const extractScriptContent = (lines, startLine) => {
+  // search down for </script>
+  let line = startLine
+  while (line < lines.length && !/<\/script>/.test(lines[line])) line++
+
+  // search up for <script>
+  const end = line
+  while (line > 0 && !/<script.*>/.test(lines[line])) line--
+  const start = line
+
+  // strip <script> tags so that lines just contain js content
+  const script = lines.slice(start, end + 1)
+  script[0] = script[0].replace(/^.*<script.*>/, '')
+  script[script.length - 1] = script[script.length - 1].replace(/<\/script>.*$/, '')
+
+  // return the array of lines, and the line number the script started at
+  return { script, start }
 }

--- a/browser/plugins/test/inline-script-content.test.js
+++ b/browser/plugins/test/inline-script-content.test.js
@@ -20,6 +20,8 @@ describe('plugin: inline script content', () => {
       { fileName: window.location.href.replace(/#.*$/), lineNumber: 10 }
     ]))
     expect(payloads.length).toEqual(1)
-    expect(Object.keys(payloads[0].events[0].stacktrace[0].code).length).toBe(10)
+    expect(payloads[0].events[0].stacktrace[0].code).toBeDefined()
+    expect(payloads[0].events[0].metaData.script).toBeDefined()
+    expect(payloads[0].events[0].metaData.script.content).toBeDefined()
   })
 })


### PR DESCRIPTION
If Bugsnag was loaded in the `<head>` (or anywhere before an inline script that produces an error, really) the cached representation of the page content will be incomplete, only containing up to the point at which Bugsnag was included.

This makes a couple of changes:

- update the cached page html when `DOMContentLoaded` happens (using IE8-safe method)
- if an inline error happens before `DOMContentLoaded` grab the current state of the DOM

Old bugsnag sent the inline script content in a "script" metadata tab, which in turn was used for grouping. This meant that new errors from inline scripts were not grouped in the same way.

This change replicates the old behaviour (in addition to showing the surrounding code in `stackframe.code`) to preserve grouping. 