### PR TITLE
Check for CustomEvent.detail that Bluebird uses for unhandled rejections

### DIFF
--- a/browser/plugins/unhandled-rejection.js
+++ b/browser/plugins/unhandled-rejection.js
@@ -11,7 +11,7 @@ module.exports = {
     if (!('onunhandledrejection' in window)) return
 
     window.addEventListener('unhandledrejection', (event) => {
-      const error = event.reason
+      const error = event.detail ? event.detail.reason : event.reason
       const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledPromiseRejection' } }
 
       let report


### PR DESCRIPTION
I've noticed that unhandled Bluebird rejections do not have stack traces. This is because Bluebird fires a CustomEvent that contains the rejection reason inside `CustomEvent.detail.reason` instead of just having it stored in `Error.reason`.

See here: http://bluebirdjs.com/docs/api/error-management-configuration.html