### PR TITLE
Data in configuration

### DIFF
--- a/base/client.js
+++ b/base/client.js
@@ -61,6 +61,8 @@ class BugsnagClient {
     }
     if (typeof this.config.beforeSend === 'function') this.config.beforeSend = [ this.config.beforeSend ]
     if (this.config.appVersion !== null) this.app.version = this.config.appVersion
+    if (this.config.metaData) this.app.metaData = this.config.metaData
+    if (this.config.user) this.app.user = this.config.user
     this._configured = true
     this._logger.debug(`Loaded!`)
     return this

--- a/base/config.js
+++ b/base/config.js
@@ -56,6 +56,16 @@ module.exports.schema = {
     defaultValue: () => true,
     message: '(boolean) autoBreadcrumbs should be true or false',
     validate: (value) => typeof value === 'boolean'
+  },
+  user: {
+    defaultValue: () => null,
+    message: '(object) user should be an object',
+    validate: (value) => typeof value === 'object'
+  },
+  metaData: {
+    defaultValue: () => null,
+    message: '(object) metaData should be an object',
+    validate: (value) => typeof value === 'object'
   }
 }
 

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -17,6 +17,8 @@ interface IConfig {
   consoleBreadcrumbsEnabled?: boolean;
   navigationBreadcrumbsEnabled?: boolean;
   interactionBreadcrumbsEnabled?: boolean;
+  user?: object;
+  metaData?: object;
 }
 
 interface IFinalConfig extends IConfig {
@@ -33,6 +35,8 @@ interface IFinalConfig extends IConfig {
   consoleBreadcrumbsEnabled: boolean;
   navigationBreadcrumbsEnabled: boolean;
   interactionBreadcrumbsEnabled: boolean;
+  user: object;
+  metaData: object;
 }
 
 type BeforeSend = (report: Report) => boolean | void;

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -17,8 +17,8 @@ interface IConfig {
   consoleBreadcrumbsEnabled?: boolean;
   navigationBreadcrumbsEnabled?: boolean;
   interactionBreadcrumbsEnabled?: boolean;
-  user?: object;
-  metaData?: object;
+  user?: object | null;
+  metaData?: object | null;
 }
 
 interface IFinalConfig extends IConfig {
@@ -35,8 +35,8 @@ interface IFinalConfig extends IConfig {
   consoleBreadcrumbsEnabled: boolean;
   navigationBreadcrumbsEnabled: boolean;
   interactionBreadcrumbsEnabled: boolean;
-  user: object;
-  metaData: object;
+  user: object | null;
+  metaData: object | null;
 }
 
 type BeforeSend = (report: Report) => boolean | void;


### PR DESCRIPTION
Allow `user` and `metaData` to be set in initial configuration object.