### PR TITLE
fixing where user & metadata are displayed.

### DIFF
--- a/base/client.js
+++ b/base/client.js
@@ -61,8 +61,8 @@ class BugsnagClient {
     }
     if (typeof this.config.beforeSend === 'function') this.config.beforeSend = [ this.config.beforeSend ]
     if (this.config.appVersion !== null) this.app.version = this.config.appVersion
-    if (this.config.metaData) this.app.metaData = this.config.metaData
-    if (this.config.user) this.app.user = this.config.user
+    if (this.config.metaData) this.metaData = this.config.metaData
+    if (this.config.user) this.user = this.config.user
     this._configured = true
     this._logger.debug(`Loaded!`)
     return this


### PR DESCRIPTION
currently, user & metadata set at initialization are being saved inside the APP tab, rather than in their own separate tabs.