### PR TITLE
adding session attribute to definitions for Typescript

### DIFF
--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -7,6 +7,7 @@ interface IConfig {
   autoBreadcrumbs?: boolean;
   autoNotify?: boolean;
   appVersion?: string;
+  autoCaptureSessions?: boolean;
   endpoint?: string;
   sessionEndpoint?: string;
   autoCaptureSessions?: boolean;


### PR DESCRIPTION
"Object literal may only specify known properties, and 'autoCaptureSessions' does not exist in type 'string | IConfig'."