### PR TITLE
Typescript example - updated user/metadata config, added session.  

### DIFF
--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -26,20 +26,20 @@ var bugsnagClient = bugsnag({
         // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending the error to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
         // the below downgrades handled exceptions sent with the generic "Error" class to info. In this example, it only affects the notification called at the very end of this app.ts.
         beforeSend: function (report) {
-          if (report.errorClass === "Error" && report.severity === "warning")  {
-            report.severity = "info"
+          if (report.errorClass === 'Error' && report.severity === 'warning')  {
+            report.severity = 'info'
           }
         },
 
         user: {
-          name: "Grace Hopper",
-          email: "ghopper@code.com",
-          id: "123456789"
+          name: 'Grace Hopper',
+          email: 'ghopper@code.com',
+          id: '123456789'
         },
 
         // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify or in a beforeSend.
         metaData: { company: {
-          name: "Xavier's School for Gifted Youngsters"
+          name: 'Xavier's School for Gifted Youngsters'
           }
         },
 
@@ -85,4 +85,4 @@ function sendUnhandled() {
 
 // below is the simplest notification syntax, akin to logging.
 console.log('a notification with 1 set of metadata has been reported to your Bugsnag dashboard')
-bugsnagClient.notify("End of file")
+bugsnagClient.notify('End of file')

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -9,7 +9,7 @@
 
 var bugsnagClient = bugsnag({
         // get your own api key at bugsnag.com
-        apiKey: '363658de4c5abbb27df673397aae3fdb',
+        apiKey: 'API_KEY',
 
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -7,7 +7,7 @@
 // this example app demonstrates some of the basic syntax to get Bugsnag error reporting configured in your Javascript code.
 // ***********************************************************
 
-var bugsnagClient = bugsnag({ 
+var bugsnagClient = bugsnag({
         // get your own api key at bugsnag.com
         apiKey: 'API_KEY',
 
@@ -21,7 +21,7 @@ var bugsnagClient = bugsnag({
         notifyReleaseStages: [ 'development', 'production'],
 
         // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
-        
+
         beforeSend: function (report) {
           report.user = {
             name: "Grace Hopper",
@@ -48,9 +48,9 @@ try {
   JSON.parse(rawjson)
 } catch (e) {
   console.log('a handled error with 2 sets of metadata has been reported to your Bugsnag dashboard')
-  bugsnagClient.notify(e, { 
+  bugsnagClient.notify(e, {
     metaData: {
-      content:  { rawjson: rawjson } 
+      content:  { rawjson: rawjson }
     }
   })
 }

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -14,8 +14,8 @@ var bugsnagClient = bugsnag({
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',
 
-        // Bugsnag can track the number of “sessions” that happen in your application, and calculate a crash rate for each release. This defaults to false.
-        autoCaptureSessions: true,
+        // // Bugsnag can track the number of “sessions” that happen in your application, and calculate a crash rate for each release. This defaults to false.
+        // autoCaptureSessions: true,
 
         // defines the release stage for all events that occur in this app.
         releaseStage: 'development',
@@ -79,7 +79,7 @@ function sendHandled() {
 // Below function will trigger an unhandled error which will report to bugsnag, without any explcit reference to the client here.
 function sendUnhandled() {
   console.log('an unhandled error has been reported to your Bugsnag dashboard')
-  // below is throwing and exception, but all data is missing. :(
+  // below is throwing an exception, but all data is missing. :(
   throw('Bad thing!')
 }
 

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -9,7 +9,7 @@
 
 var bugsnagClient = bugsnag({
         // get your own api key at bugsnag.com
-        apiKey: 'API_KEY',
+        apiKey: 'API_KEU',
 
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',
@@ -24,10 +24,10 @@ var bugsnagClient = bugsnag({
         notifyReleaseStages: [ 'development', 'production'],
 
         // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending the error to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
-        // the below downgrades handled exceptions sent with the generic "Error" class to info. In this example, it only affects the notification called at the very end of this app.ts.
         beforeSend: function (report) {
           if (report.errorClass === 'Error' && report.severity === 'warning')  {
-            report.severity = 'info'
+            //note that this overwrites the company metadata definted below.  beforeSend is the last code applied before an exception is sent.
+            report.metaData = {example: {thing: "one"}}
           }
         },
 
@@ -63,26 +63,26 @@ var rawjson: string = el.value || ''
 // Below function will catch an error, and shows how you can add/modify information to the report right before sending.
 // Note that the beforeSend defined in the earlier initialization of bugsnag above will be applied *after* the statements executed here in notify().
 function sendHandled() {
+
   try {
     // potentially buggy code goes here
-    JSON.parse(rawjson)
+    //for this example, we're just throwing an error explicitly, but you do not need this syntax in your try clause.
+    throw("Bad thing!");
   } catch (e) {
-    console.log('a handled error with 2 sets of metadata has been reported to your Bugsnag dashboard')
+    console.log('a handled error has been reported to your Bugsnag dashboard')
+    // below modifies the handled error, and then sends it to your dashboard.
     bugsnagClient.notify(e, {
-      metaData: {
-        content:  { rawjson: rawjson }
-      }
-    })
+      context: 'Don\'t worry - I handled it.'
+    });
   }
 }
 
 // Below function will trigger an unhandled error which will report to bugsnag, without any explcit reference to the client here.
 function sendUnhandled() {
   console.log('an unhandled error has been reported to your Bugsnag dashboard')
-  // below is throwing an exception, but all data is missing. :(
-  throw('Bad thing!')
+  JSON.parse(rawjson)
 }
 
 // below is the simplest notification syntax, akin to logging.
-console.log('a notification with 1 set of metadata has been reported to your Bugsnag dashboard')
+console.log('a notification has been reported to your Bugsnag dashboard')
 bugsnagClient.notify('End of file')

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -20,41 +20,59 @@ var bugsnagClient = bugsnag({
         //  defines which release stages bugsnag should report. e.g. ignore staging errors.
         notifyReleaseStages: [ 'development', 'production'],
 
-        // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
-
+        // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending the error to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
         beforeSend: function (report) {
-          report.user = {
-            name: "Grace Hopper",
-            email: "ghopper@code.com",
-            id: "123456789"
-          };
-          // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify (example bleow) or globally.
-          // using updateMetaData() to preserve any metadata already attached to the report object.
-          report.updateMetaData('company', {
-            name: "Xavier's School for Gifted Youngsters"
-          })
+          if (report.errorClass === "Error") {
+            report.severity = "info"
+          }
         },
+
+        // user: {
+        //   name: "Grace Hopper",
+        //   email: "ghopper@code.com",
+        //   id: "123456789"
+        // },
+
+        // // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify or in a beforeSend.
+        // metaData: { company: {
+        //   name: "Xavier's School for Gifted Youngsters"
+        //   }
+        // },
 
         // because this is a demo app, below extends the default of 10 notifications per pageload. click away!
         maxEvents: 50
       })
 
 
+var handled: HTMLElement = document.getElementById('jsHandled')!
+handled.addEventListener('click', sendHandled)
+
+var unhandled: HTMLElement = document.getElementById('jsUnhandled')!
+unhandled.addEventListener('click', sendUnhandled)
+
 var el: HTMLInputElement = <HTMLInputElement> document.getElementById('jsondata')
 var rawjson: string = el.value || ''
 
-// below will send a handled error to your dashboard.  It will contain both the metadata added here (content) and the metadata added in the beforeSend above (company).
-try {
-  JSON.parse(rawjson)
-} catch (e) {
-  console.log('a handled error with 2 sets of metadata has been reported to your Bugsnag dashboard')
-  bugsnagClient.notify(e, {
-    metaData: {
-      content:  { rawjson: rawjson }
-    }
-  })
+function sendHandled() {
+  try {
+    // potentially buggy code goes here
+    JSON.parse(rawjson)
+  } catch (e) {
+    console.log('a handled error with 2 sets of metadata has been reported to your Bugsnag dashboard')
+    bugsnagClient.notify(e, {
+      metaData: {
+        content:  { rawjson: rawjson }
+      }
+    })
+  }
+}
+
+function sendUnhandled() {
+  console.log('an unhandled error has been reported to your Bugsnag dashboard')
+  // below is throwing and exception, but all data is missing. :(
+  throw('Bad thing!')
 }
 
 // below is the simplest notification syntax, akin to logging.
 console.log('a notification with 1 set of metadata has been reported to your Bugsnag dashboard')
-bugsnagClient.notify("End of file");
+bugsnagClient.notify("End of file")

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -4,15 +4,18 @@
 // www.bugsnag.com
 // https://github.com/bugsnag/bugsnag-js/tree/master/examples/typescript
 //
-// this example app demonstrates some of the basic syntax to get Bugsnag error reporting configured in your Javascript code.
+// this example app demonstrates some of the basic syntax to get Bugsnag error reporting configured in your Typescript code.
 // ***********************************************************
 
 var bugsnagClient = bugsnag({
         // get your own api key at bugsnag.com
-        apiKey: 'API_KEY',
+        apiKey: 'c2f4a83fbb63b9c09898191a3da3cabd',
 
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',
+
+        // Bugsnag can track the number of “sessions” that happen in your application, and calculate a crash rate for each release. This defaults to false.
+        autoCaptureSessions: true,
 
         // defines the release stage for all events that occur in this app.
         releaseStage: 'development',
@@ -21,23 +24,24 @@ var bugsnagClient = bugsnag({
         notifyReleaseStages: [ 'development', 'production'],
 
         // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending the error to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
+        // the below downgrades handled exceptions sent with the generic "Error" class to info. In this example, it only affects the notification called at the very end of this app.ts.
         beforeSend: function (report) {
-          if (report.errorClass === "Error") {
+          if (report.errorClass === "Error" && report.severity === "warning")  {
             report.severity = "info"
           }
         },
 
-        // user: {
-        //   name: "Grace Hopper",
-        //   email: "ghopper@code.com",
-        //   id: "123456789"
-        // },
+        user: {
+          name: "Grace Hopper",
+          email: "ghopper@code.com",
+          id: "123456789"
+        },
 
-        // // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify or in a beforeSend.
-        // metaData: { company: {
-        //   name: "Xavier's School for Gifted Youngsters"
-        //   }
-        // },
+        // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify or in a beforeSend.
+        metaData: { company: {
+          name: "Xavier's School for Gifted Youngsters"
+          }
+        },
 
         // because this is a demo app, below extends the default of 10 notifications per pageload. click away!
         maxEvents: 50
@@ -53,6 +57,8 @@ unhandled.addEventListener('click', sendUnhandled)
 var el: HTMLInputElement = <HTMLInputElement> document.getElementById('jsondata')
 var rawjson: string = el.value || ''
 
+// Below function will catch an error, and shows how you can add/modify information to the report right before sending.
+// Note that the beforeSend defined in the earlier initialization of bugsnag above will be applied *after* the statements executed here in notify().
 function sendHandled() {
   try {
     // potentially buggy code goes here
@@ -67,6 +73,7 @@ function sendHandled() {
   }
 }
 
+// Below function will trigger an unhandled error which will report to bugsnag, without any explcit reference to the client here.
 function sendUnhandled() {
   console.log('an unhandled error has been reported to your Bugsnag dashboard')
   // below is throwing and exception, but all data is missing. :(

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -48,62 +48,6 @@ var bugsnagClient = bugsnag({
       })
 
 
-var handled: HTMLElement = document.getElementById('jsHandled')!
-handled.addEventListener('click', sendHandled)
-
-var unhandled: HTMLElement = document.getElementById('jsUnhandled')!
-unhandled.addEventListener('click', sendUnhandled)
-
-// ***********************************************************
-// www.bugsnag.com
-// https://github.com/bugsnag/bugsnag-js/tree/master/examples/typescript
-//
-// this example app demonstrates some of the basic syntax to get Bugsnag error reporting configured in your Typescript code.
-// ***********************************************************
-
-// Note that bugsnag-js was loaded at the top of the index.html file, but is not active until initialized below.
-
-// Initialize bugsnag to begin tracking errors. Only an api key is required, but here are some other helpful configuration details:
-var bugsnagClient = bugsnag({
-    // get your own api key at bugsnag.com
-    apiKey: 'API_KEY',
-
-    // if you track deploys or use source maps, make sure to set the correct version.
-    appVersion: '1.2.3',
-
-    // defines the release stage for all events that occur in this app.
-    releaseStage: 'development',
-
-    //  defines which release stages bugsnag should report. e.g. ignore staging errors.
-    notifyReleaseStages: [ 'development', 'production'],
-
-    // one of the most powerful tools in our library, beforeSend lets you evaluate, modify, add and remove data before sending the error to bugsnag. The actions here will be applied to *all* errors, handled and unhandled.
-    beforeSend: function (report) {
-
-      // the below downgrades handled exceptions sent with the generic "Error" class to info. In this example, it only affects the notification called at the very end of this file.
-      if (report.errorClass === "Error" && report.severity === "warning") {
-        report.severity = "info"
-      }
-      // note that if you return false from the beforeSend, this will cancel the entire error report.
-    },
-
-    // attached any user data you'd like to report.
-    user: {
-      name: "Grace Hopper",
-      email: "ghopper@code.com",
-      id: "123456789"
-    },
-
-    // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify() or in a beforeSend.
-    metaData: { company: {
-      name: "Xavier's School for Gifted Youngsters"
-      }
-    },
-
-    // because this is a demo app, below extends the default of 10 notifications per pageload. click away!
-    maxEvents: 50
-  })
-
 // event listeners
 var handled: HTMLElement = document.getElementById('jsHandled')!
 handled.addEventListener('click', sendHandled)

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -14,8 +14,8 @@ var bugsnagClient = bugsnag({
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',
 
-        // // Bugsnag can track the number of “sessions” that happen in your application, and calculate a crash rate for each release. This defaults to false.
-        // autoCaptureSessions: true,
+        // Bugsnag can track the number of “sessions” that happen in your application, and calculate a crash rate for each release. This defaults to false.
+        autoCaptureSessions: true,
 
         // defines the release stage for all events that occur in this app.
         releaseStage: 'development',

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -9,7 +9,7 @@
 
 var bugsnagClient = bugsnag({
         // get your own api key at bugsnag.com
-        apiKey: 'API_KEU',
+        apiKey: '363658de4c5abbb27df673397aae3fdb',
 
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',
@@ -27,7 +27,7 @@ var bugsnagClient = bugsnag({
         beforeSend: function (report) {
           if (report.errorClass === 'Error' && report.severity === 'warning')  {
             //note that this overwrites the company metadata definted below.  beforeSend is the last code applied before an exception is sent.
-            report.metaData = {example: {thing: "one"}}
+            report.updateMetaData('example', {thing: "one"})
           }
         },
 

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -39,7 +39,7 @@ var bugsnagClient = bugsnag({
 
         // add any custom attributes relevant to your app. Note that metadata can be added here, in a specific notify or in a beforeSend.
         metaData: { company: {
-          name: 'Xavier's School for Gifted Youngsters'
+          name: 'Xavier\'s School for Gifted Youngsters'
           }
         },
 

--- a/examples/typescript/app.ts
+++ b/examples/typescript/app.ts
@@ -9,7 +9,7 @@
 
 var bugsnagClient = bugsnag({
         // get your own api key at bugsnag.com
-        apiKey: 'c2f4a83fbb63b9c09898191a3da3cabd',
+        apiKey: 'API_KEY',
 
         // if you track deploys or use source maps, make sure to set the correct version.
         appVersion: '1.2.3',

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -7,7 +7,7 @@
     <script src="node_modules/bugsnag-js/dist/bugsnag.js"></script>
   </head>
   <body>
-    <h1>Bugsnag JS: Plain JS example</h1>
+    <h1>Bugsnag JS: Typescript example with inline sourcemaps</h1>
       <p>
       This page is a basic example of how to include bugsnag-js on a Typescript page via a
       <code>&lt;script&gt;</code> tag.

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -5,11 +5,6 @@
 
     <!-- load bugsnag with a simple script tag -->
     <script src="node_modules/bugsnag-js/dist/bugsnag.js"></script>
-
-    <!-- For this example app, the above url refers to your local instance of bugsnag, so you can control the version and any customization you wish to make to our open source notifier.
-    In your live app, you can simply link to our public url to always get the most recent verison of the JS notifer:
-    <script src="//d2wy8f7a9ursnm.cloudfront.net/v4/bugsnag.min.js"></script>
-    -->
   </head>
   <body>
     <h1>Bugsnag JS: Plain JS example</h1>
@@ -23,7 +18,14 @@
       when an error is received.
     </p>
     <input type="hidden" value="{ 'some not quite': 'valid json' }" id="jsondata"/>
-    <!-- in app.js you'll find further syntax and configuration examples. -->
+    <div id="buttons">
+      <h3>Send some errors by clicking below:
+      </h3>
+      <button type="button" id="jsHandled">SEND HANDLED</button>
+        <br>
+      <button type="button" id="jsUnhandled">SEND UNHANDLED</button>
+    </div>
+    <!-- in app.ts you'll find further syntax and configuration examples. -->
     <script src="app.js"></script>
   </body>
 </html>

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -8,7 +8,7 @@
 
     <!-- For this example app, the above url refers to your local instance of bugsnag, so you can control the version and any customization you wish to make to our open source notifier.
     In your live app, you can simply link to our public url to always get the most recent verison of the JS notifer:
-    <script src="//d2wy8f7a9ursnm.cloudfront.net/v4/bugsnag.min.js"></script> 
+    <script src="//d2wy8f7a9ursnm.cloudfront.net/v4/bugsnag.min.js"></script>
     -->
   </head>
   <body>

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -10,7 +10,7 @@
   "author": "Bugsnag Inc.",
   "license": "MIT",
   "dependencies": {
-    "bugsnag-js": "^4.1.0",
+    "bugsnag-js": "^4.1.3",
     "serve": "^6.0.6",
     "typescript": "^2.6.1"
   }


### PR DESCRIPTION
changed the error examples as the unhandled throw() error wasn't providing interesting data for the dashboard.