### PR TITLE
Fix <script> start regex

### DIFF
--- a/browser/plugins/inline-script-content.js
+++ b/browser/plugins/inline-script-content.js
@@ -38,20 +38,22 @@ module.exports = {
   }
 }
 
-const extractScriptContent = (lines, startLine) => {
+const scriptStartRe = /^.*<script.*?>/
+const scriptEndRe = /<\/script>.*$/
+const extractScriptContent = module.exports.extractScriptContent = (lines, startLine) => {
   // search down for </script>
   let line = startLine
-  while (line < lines.length && !/<\/script>/.test(lines[line])) line++
+  while (line < lines.length && !scriptEndRe.test(lines[line])) line++
 
   // search up for <script>
   const end = line
-  while (line > 0 && !/<script.*>/.test(lines[line])) line--
+  while (line > 0 && !scriptStartRe.test(lines[line])) line--
   const start = line
 
   // strip <script> tags so that lines just contain js content
   const script = lines.slice(start, end + 1)
-  script[0] = script[0].replace(/^.*<script.*>/, '')
-  script[script.length - 1] = script[script.length - 1].replace(/<\/script>.*$/, '')
+  script[0] = script[0].replace(scriptStartRe, '')
+  script[script.length - 1] = script[script.length - 1].replace(scriptEndRe, '')
 
   // return the array of lines, and the line number the script started at
   return { script, start }

--- a/browser/plugins/test/inline-script-content.test.js
+++ b/browser/plugins/test/inline-script-content.test.js
@@ -24,4 +24,48 @@ describe('plugin: inline script content', () => {
     expect(payloads[0].events[0].metaData.script).toBeDefined()
     expect(payloads[0].events[0].metaData.script.content).toBeDefined()
   })
+
+  it('should find scripts content successfully', () => {
+    const a = plugin.extractScriptContent([
+      'some stuff before script',
+      '<script>',
+      '',
+      '// hello just',
+      '// some js here',
+      '1 + 2 + 3',
+      '',
+      '</script>'
+    ], 4)
+    expect(a.script.length).toBe(7)
+    expect(a.start).toBe(1)
+
+    const b = plugin.extractScriptContent([
+      'some stuff before script',
+      '<script>',
+      '1+1+1+1',
+      'what(function () {',
+      '  1>2',
+      '  func()',
+      '})',
+      '</script>',
+      'some stuff after script'
+    ], 4)
+    expect(b.script.length).toBe(7)
+    expect(b.start).toBe(1)
+
+    const c = plugin.extractScriptContent([
+      'some stuff before script',
+      '<script nonce="1cd2dsf312gfd31dfg23">',
+      '1+1+1+1',
+      'what(function () {',
+      '  1>2',
+      '  func()',
+      '})',
+      '</script>',
+      'some stuff after script'
+    ], 4)
+    console.log(c.script)
+    expect(c.script.length).toBe(7)
+    expect(c.start).toBe(1)
+  })
 })


### PR DESCRIPTION
Found this small issue debugging inline-script sending. Regex was a bit greedy so sometimes missed the start of scripts.

This makes the `.` wildcard (for script tag attributes) non-greedy. Stops an issue with code like this example:

```
  <script>
    if (a > 2) console.log('nice')
  </script>
```

resulting in an inline block like:

```
   >2) console.log('nice')
```