### PR TITLE
Dont send stacktrace as breadcrumb metadata

### DIFF
--- a/base/client.js
+++ b/base/client.js
@@ -185,8 +185,7 @@ class BugsnagClient {
       this.leaveBreadcrumb(report.errorClass, {
         errorClass: report.errorClass,
         errorMessage: report.errorMessage,
-        severity: report.severity,
-        stacktrace: report.stacktrace
+        severity: report.severity
       }, 'error')
     }
 


### PR DESCRIPTION
This is dropped by the UI and never shown as we can't render arrays in the breadcrumbs from what I can see.
