### PR TITLE
Remove iOS from unit/integration browser matrix

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -72,9 +72,10 @@
   "bs_iphone": {
     "base": "BrowserStack",
     "browser": "iphone",
-    "device": "iPhone 4S (6.0)",
+    "device": "iPhone 7",
     "os": "ios",
-    "os_version": "6.0"
+    "os_version": "10.3",
+    "real_mobile": true
   },
   "bs_android": {
     "base": "BrowserStack",

--- a/browsers.json
+++ b/browsers.json
@@ -69,14 +69,6 @@
     "os": "OS X",
     "os_version": "high sierra"
   },
-  "bs_iphone": {
-    "base": "BrowserStack",
-    "browser": "iphone",
-    "device": "iPhone 7",
-    "os": "ios",
-    "os_version": "10.3",
-    "real_mobile": true
-  },
   "bs_android": {
     "base": "BrowserStack",
     "browser": "Android Browser",


### PR DESCRIPTION
Unfortunately it seems browserstack have removed all iOS simulators and real devices from their js testing matrix:

<img width="984" alt="image" src="https://user-images.githubusercontent.com/609579/41779382-8c3d0e76-7629-11e8-9eb9-4dc43aba642f.png">

This meant that the tests started failing on PR #360.

Our end-to-end maze runner tests are not affected by this because they use the selenium product, which supports testing on iOS real devices.
