### PR TITLE
feat: Make exception type dynamic

### DIFF
--- a/packages/browser/features/auto_notify.feature
+++ b/packages/browser/features/auto_notify.feature
@@ -11,6 +11,7 @@ Scenario Outline: setting autoNotify option to false
   And the event "unhandled" is false
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "auto notify does work"
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |

--- a/packages/browser/features/handled_errors.feature
+++ b/packages/browser/features/handled_errors.feature
@@ -10,6 +10,7 @@ Scenario Outline: calling notify() with Error
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "bad things"
+  And the exception "type" equals "browserjs"
 
   Examples:
     | type       |
@@ -28,6 +29,7 @@ Scenario Outline: calling notify() with Error within try/catch
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "handled" values for the current browser
+  And the exception "type" equals "browserjs"
 
   Examples:
     | type       |
@@ -47,6 +49,7 @@ Scenario Outline: calling notify() with Error within Promise catch
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "bad things"
+  And the exception "type" equals "browserjs"
 
   Examples:
     | type       |

--- a/packages/browser/features/unhandled_errors.feature
+++ b/packages/browser/features/unhandled_errors.feature
@@ -9,6 +9,7 @@ Scenario Outline: syntax errors
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_syntax" values for the current browser
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |
@@ -21,6 +22,7 @@ Scenario Outline: thrown errors
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_thrown" values for the current browser
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |
@@ -34,6 +36,7 @@ Scenario Outline: unhandled promise rejections
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "broken promises"
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |
@@ -46,6 +49,7 @@ Scenario Outline: undefined function invocation
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_undefined_function" values for the current browser
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |
@@ -58,6 +62,7 @@ Scenario Outline: decoding malformed URI component
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_malformed_uri" values for the current browser
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |
@@ -71,6 +76,7 @@ Scenario Outline: detecting unhandled promise rejections with bluebird
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "broken bluebird promises"
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |
@@ -84,6 +90,7 @@ Scenario Outline: parsing stacks correctly with "@" in filename
   And the request is a valid browser payload for the error reporting API
   And the exception "message" ends with "at in filename"
   And the "file" of stack frame 0 ends with "unhandled/script/@dist/g.js"
+  And the exception "type" equals "browserjs"
     Examples:
       | type       |
       | script     |

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -16,8 +16,8 @@
     "size": "./bin/size",
     "clean": "rm -fr dist && mkdir dist",
     "build": "npm run clean && npm run build:dist && npm run build:dist:min",
-    "build:dist": "NODE_ENV=production bin/bundle | exorcist dist/bugsnag.js.map > dist/bugsnag.js",
-    "build:dist:min": "NODE_ENV=production bin/bundle | bin/minify dist/bugsnag.min.js",
+    "build:dist": "NODE_ENV=production IS_BROWSER=yes bin/bundle | exorcist dist/bugsnag.js.map > dist/bugsnag.js",
+    "build:dist:min": "NODE_ENV=production IS_BROWSER=yes bin/bundle | bin/minify dist/bugsnag.min.js",
     "test": "bundle exec maze-runner"
   },
   "author": "Bugsnag",

--- a/packages/core/report.js
+++ b/packages/core/report.js
@@ -99,7 +99,7 @@ class BugsnagReport {
           errorClass: this.errorClass,
           message: this.errorMessage,
           stacktrace: this.stacktrace,
-          type: 'browserjs'
+          type: process.env.IS_BROWSER ? 'browserjs' : 'nodejs'
         }
       ],
       severity: this.severity,


### PR DESCRIPTION
For the pipeline to differentiate between Node/browser errors coming from same notifier, the exception type needs to discern the platform of the error. This is implemented by checking for the existence of the `IS_BROWSER` env var. In the browser build, it is set to a truthy value and replaced using the envify transform, which is then optimised away in the uglified bundle.