### PR TITLE
feat: Implement asynchronous beforeSend callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
         - npm install
         - lerna bootstrap
       script:
-        - npm run test:unit
+        - npm run test:unit && npm run test:types
       env: BROWSER=na
 
 stages:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "test:lint": "standard",
     "test:unit": "lerna run test --ignore '@bugsnag/browser' '@bugsnag/node'",
-    "test:browser": "lerna run test --scope '@bugsnag/browser' --stream"
+    "test:browser": "lerna run test --scope '@bugsnag/browser' --stream",
+    "test:types": "lerna run test:types"
   },
   "standard": {
     "ignore": [

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -18,6 +18,7 @@
     "build": "npm run clean && npm run build:dist && npm run build:dist:min",
     "build:dist": "NODE_ENV=production bin/bundle | exorcist dist/bugsnag.js.map > dist/bugsnag.js",
     "build:dist:min": "NODE_ENV=production bin/bundle | bin/minify dist/bugsnag.min.js",
+    "test:types": "jasmine 'types/**/*.test.js'",
     "test": "bundle exec maze-runner"
   },
   "author": "Bugsnag",

--- a/packages/core/lib/async-some.js
+++ b/packages/core/lib/async-some.js
@@ -1,0 +1,30 @@
+// This is a heavily modified/simplified version of
+//   https://github.com/othiym23/async-some
+//
+// We can't use that because:
+//   a) it inflates the bundle size to over 10kB
+//   b) it depends on a module that uses Object.keys()
+//      (which we can't use due to ie8 support)
+
+// run the asynchronous test function (fn) over each item in the array (arr)
+// in series until:
+//   - fn(item, cb) => calls cb(null, true)
+//   - or the end of the array is reached
+// the callback (cb) will be passed true if any of the items resulted in a true
+// callback, otherwise false
+module.exports = (arr, fn, cb) => {
+  const length = arr.length
+  let index = 0
+
+  const next = () => {
+    if (index >= length) return cb(null, false)
+    fn(arr[index], (err, result) => {
+      if (err) return cb(err, false)
+      if (result === true) return cb(null, true)
+      index++
+      next()
+    })
+  }
+
+  next()
+}

--- a/packages/core/lib/run-before-send.js
+++ b/packages/core/lib/run-before-send.js
@@ -1,0 +1,35 @@
+module.exports = (report, onError) => (fn, cb) => {
+  if (typeof fn !== 'function') return cb(null, false)
+  try {
+    // if function appears sync…
+    if (fn.length !== 2) {
+      const ret = fn(report)
+      // check if it returned a "thenable" (promise)
+      if (ret && typeof ret.then === 'function') {
+        return ret.then(
+          // resolve
+          val => cb(null, shouldPreventSend(report, val)),
+          // reject
+          err => {
+            onError(err)
+            return cb(null, false)
+          }
+        )
+      }
+      return cb(null, shouldPreventSend(report, ret))
+    }
+    // if function is async…
+    fn(report, (err, result) => {
+      if (err) {
+        onError(err)
+        return cb(null, false)
+      }
+      cb(null, shouldPreventSend(report, result))
+    })
+  } catch (e) {
+    onError(e)
+    cb(null, false)
+  }
+}
+
+const shouldPreventSend = (report, value) => report.isIgnored() || value === false

--- a/packages/core/lib/test/async-some.test.js
+++ b/packages/core/lib/test/async-some.test.js
@@ -15,7 +15,7 @@ describe('async-some', () => {
           resolve()
         })
       ]
-      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+      some(beforeSendFns, runBeforeSend(report, () => {}), (err, result) => {
         expect(!err)
         expect(result).toBe(false)
         expect(report.name).toBe('ben')
@@ -41,7 +41,7 @@ describe('async-some', () => {
         (report) => { throw new Error('derp') },
         (report) => { called = true }
       ]
-      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+      some(beforeSendFns, runBeforeSend(report, () => {}), (err, result) => {
         expect(!err)
         expect(called).toBe(true)
         done()
@@ -59,7 +59,7 @@ describe('async-some', () => {
           resolve()
         })
       ]
-      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+      some(beforeSendFns, runBeforeSend(report, () => {}), (err, result) => {
         expect(!err)
         expect(called).toBe(true)
         done()
@@ -77,7 +77,7 @@ describe('async-some', () => {
           cb(null)
         }
       ]
-      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+      some(beforeSendFns, runBeforeSend(report, () => {}), (err, result) => {
         expect(!err)
         expect(called).toBe(true)
         done()

--- a/packages/core/lib/test/async-some.test.js
+++ b/packages/core/lib/test/async-some.test.js
@@ -1,0 +1,87 @@
+const { describe, it, expect } = global
+
+const some = require('../async-some')
+const runBeforeSend = require('../run-before-send')
+
+describe('async-some', () => {
+  describe('reduce(arr, fn, accum)', () => {
+    it('works with sync/async/promises', done => {
+      const report = { name: 'ben', isIgnored: () => false }
+      const beforeSendFns = [
+        (report) => { report.age = 10 },
+        (report, cb) => { setTimeout(() => cb(null, true), 5) },
+        (report) => new Promise((resolve) => {
+          report.promiseRan = 'yes'
+          resolve()
+        })
+      ]
+      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+        expect(!err)
+        expect(result).toBe(false)
+        expect(report.name).toBe('ben')
+        expect(report.age).toBe(10)
+        expect(report.promiseRan).toBe('yes')
+        done()
+      })
+    })
+
+    it('handles iterator errors', done => {
+      some(1, (item, cb) => cb(new Error('derp')), (err, result) => {
+        expect(err)
+        expect(err.message).toBe('derp')
+        done()
+      })
+    })
+
+    it('handles continues after runBeforeSend errors (throw)', done => {
+      const report = { isIgnored: () => false }
+      let called = false
+      const beforeSendFns = [
+        (report) => {},
+        (report) => { throw new Error('derp') },
+        (report) => { called = true }
+      ]
+      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+        expect(!err)
+        expect(called).toBe(true)
+        done()
+      })
+    })
+
+    it('handles continues after runBeforeSend errors (promise reject)', done => {
+      const report = { isIgnored: () => false }
+      let called = false
+      const beforeSendFns = [
+        (report) => new Promise((resolve) => resolve()),
+        (report) => new Promise((resolve, reject) => reject(new Error('derp'))),
+        (report) => new Promise((resolve) => {
+          called = true
+          resolve()
+        })
+      ]
+      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+        expect(!err)
+        expect(called).toBe(true)
+        done()
+      })
+    })
+
+    it('handles continues after runBeforeSend errors (cb(err))', done => {
+      const report = { isIgnored: () => false }
+      let called = false
+      const beforeSendFns = [
+        (report, cb) => cb(null),
+        (report, cb) => cb(new Error('derp')),
+        (report, cb) => {
+          called = true
+          cb(null)
+        }
+      ]
+      some(beforeSendFns, runBeforeSend(report, err => {}), (err, result) => {
+        expect(!err)
+        expect(called).toBe(true)
+        done()
+      })
+    })
+  })
+})

--- a/packages/core/lib/test/es-utils.test.js
+++ b/packages/core/lib/test/es-utils.test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = global
 
 const { map, reduce, filter, keys, isArray, includes } = require('../es-utils')
 
-describe('us-utils', () => {
+describe('es-utils', () => {
   describe('reduce(arr, fn, accum)', () => {
     it('works with a variety of examples', () => {
       expect(reduce([ 1, 2, 3, 4, 5 ], (accum, x) => accum + x, 0)).toBe(15)

--- a/packages/core/test/breadcrumb.test.js
+++ b/packages/core/test/breadcrumb.test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = global
 
 const Breadcrumb = require('../breadcrumb')
 
-describe('base/breadcrumb', () => {
+describe('@bugsnag/core/breadcrumb', () => {
   describe('toJSON()', () => {
     it('returns the correct data structure', () => {
       const d = (new Date()).toISOString()

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -147,7 +147,7 @@ describe('@bugsnag/core/client', () => {
       })
       client.configure({ apiKey: 'API_KEY_YEAH' })
 
-      client.notify(new Error('oh em gee'), { beforeSend: report => report.ignore() }),
+      client.notify(new Error('oh em gee'), { beforeSend: report => report.ignore() })
       client.notify(new Error('oh em eff gee'), { beforeSend: report => false })
 
       // give the event loop a tick to see if the reports get send

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -6,7 +6,7 @@ const Session = require('../session')
 
 const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
-describe('base/client', () => {
+describe('@bugsnag/core/client', () => {
   describe('constructor', () => {
     it('can handle bad input', () => {
       expect(() => new Client()).toThrow()
@@ -99,8 +99,7 @@ describe('base/client', () => {
         }
       })
       client.configure({ apiKey: 'API_KEY_YEAH' })
-      const sent = client.notify(new Error('oh em gee'))
-      expect(sent).toBe(true)
+      client.notify(new Error('oh em gee'))
     })
 
     it('supports manually setting severity', done => {
@@ -148,12 +147,8 @@ describe('base/client', () => {
       })
       client.configure({ apiKey: 'API_KEY_YEAH' })
 
-      const sent = [
-        client.notify(new Error('oh em gee'), { beforeSend: report => report.ignore() }),
-        client.notify(new Error('oh em eff gee'), { beforeSend: report => false })
-      ]
-
-      expect(sent).toEqual([ false, false ])
+      client.notify(new Error('oh em gee'), { beforeSend: report => report.ignore() }),
+      client.notify(new Error('oh em eff gee'), { beforeSend: report => false })
 
       // give the event loop a tick to see if the reports get send
       process.nextTick(() => done())

--- a/packages/core/test/config.test.js
+++ b/packages/core/test/config.test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = global
 
 const config = require('../config')
 
-describe('base/config', () => {
+describe('@bugsnag/core/config', () => {
   describe('validate()', () => {
     it('needs opts/schema', () => {
       expect(() => config.validate()).toThrow()

--- a/packages/core/test/report.test.js
+++ b/packages/core/test/report.test.js
@@ -3,7 +3,7 @@ const { describe, it, expect } = global
 const proxyquire = require('proxyquire').noPreserveCache()
 const ErrorStackParser = require('error-stack-parser')
 
-describe('base/report', () => {
+describe('@bugsnag/core/report', () => {
   describe('constructor', () => {
     it('sets default handledState', () => {
       const Report = require('../report')

--- a/packages/core/test/session.test.js
+++ b/packages/core/test/session.test.js
@@ -2,7 +2,7 @@ const { describe, it, expect } = global
 
 const Session = require('../session')
 
-describe('base/session', () => {
+describe('@bugsnag/core/session', () => {
   describe('toJSON()', () => {
     it('returns the correct data structure', () => {
       const s = new Session().toJSON()

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -45,7 +45,11 @@ export interface IFinalConfig extends IConfig {
   logger?: ILogger | null;
 }
 
-export type BeforeSend = (report: Report) => boolean | void;
+type SyncBeforeSend = (report: Report) => void;
+type AsyncBeforeSend = (report: Report, cb: (err: null | Error) => void) => void;
+type PromiseBeforeSend = (report: Report) => Promise<void>;
+
+export type BeforeSend = SyncBeforeSend | AsyncBeforeSend | PromiseBeforeSend;
 export type BeforeSession = (client: Client) => void;
 
 export interface IPlugin {


### PR DESCRIPTION
This was previously implemented in #314 but was not merged because of the size increase. Now this feature is essential to support code loading for stackframes in Node. This implementation supports Node-style error first callbacks and Promises, whilst retaining support for synchronous callbacks.