### PR TITLE
Add node delivery mechanism

### DIFF
--- a/packages/browser/LICENSE.txt
+++ b/packages/browser/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/core/LICENSE.txt
+++ b/packages/core/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/delivery-node/LICENSE.txt
+++ b/packages/delivery-node/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/delivery-node/README.md
+++ b/packages/delivery-node/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/delivery-node
 
-This delivery mechanism uses ??? to send error reports to Bugsnag's API. It is included in the node notifier.
+This delivery mechanism uses [request](https://github.com/request/request) to send error reports to Bugsnag's API. It is included in the node notifier.
 
 ## License
 MIT

--- a/packages/delivery-node/README.md
+++ b/packages/delivery-node/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/delivery-node
+
+This delivery mechanism uses ??? to send error reports to Bugsnag's API. It is included in the node notifier.
+
+## License
+MIT

--- a/packages/delivery-node/delivery.js
+++ b/packages/delivery-node/delivery.js
@@ -1,0 +1,43 @@
+const jsonStringify = require('@bugsnag/safe-json-stringify')
+const makePayload = require('@bugsnag/core/lib/json-payload')
+const { isoDate } = require('@bugsnag/core/lib/es-utils')
+const request = require('request')
+
+module.exports = () => ({
+  sendReport: (logger, config, report, cb = () => {}) => {
+    try {
+      request({
+        method: 'POST',
+        url: config.endpoints.notify,
+        headers: {
+          'Content-Type': 'application/json',
+          'Bugsnag-Api-Key': report.apiKey || config.apiKey,
+          'Bugsnag-Payload-Version': '4.0',
+          'Bugsnag-Sent-At': isoDate()
+        },
+        body: makePayload(report),
+        proxy: config.proxy
+      }, cb)
+    } catch (e) {
+      logger.error(e)
+    }
+  },
+  sendSession: (logger, config, session, cb = () => {}) => {
+    try {
+      request({
+        method: 'POST',
+        url: config.endpoints.sessions,
+        headers: {
+          'Content-Type': 'application/json',
+          'Bugsnag-Api-Key': config.apiKey,
+          'Bugsnag-Payload-Version': '1.0',
+          'Bugsnag-Sent-At': isoDate()
+        },
+        body: jsonStringify(session),
+        proxy: config.proxy
+      }, cb)
+    } catch (e) {
+      logger.error(e)
+    }
+  }
+})

--- a/packages/delivery-node/package-lock.json
+++ b/packages/delivery-node/package-lock.json
@@ -1,0 +1,2461 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.51"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY="
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/helper-function-name": "7.0.0-beta.51",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@bugsnag/safe-json-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-2.1.0.tgz",
+			"integrity": "sha512-tE2cPhAq+WFnA9XrfMfP+u/6L63eH7+PmONMNSXtP6kPt/iUXnwkDsxc1Q6lUP1oM3LsmWBrxn+/93M8JE6fpA=="
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"chalk": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"color-convert": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"requires": {
+				"color-name": "1.1.1"
+			}
+		},
+		"color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "~0.1.0"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA=="
+		},
+		"istanbul-lib-instrument": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz",
+			"integrity": "sha512-h9Vg3nfbxrF0PK0kZiNiMAyL8zXaLiBP/BXniaKSwVvAi1TaumYV2b0wPdmy1CRX3irYbYD1p4Wjbv4uyECiiQ==",
+			"requires": {
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/traverse": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"istanbul-lib-coverage": "^2.0.1",
+				"semver": "^5.5.0"
+			}
+		},
+		"jasmine": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+			"integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+			"requires": {
+				"glob": "^7.0.6",
+				"jasmine-core": "~3.1.0"
+			}
+		},
+		"jasmine-core": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+			"integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"mime-db": {
+			"version": "1.35.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+			"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+		},
+		"mime-types": {
+			"version": "2.1.19",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+			"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+			"requires": {
+				"mime-db": "~1.35.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"nyc": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"requires": {
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^2.1.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.5",
+				"istanbul-reports": "^1.4.1",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
+				"yargs": "11.1.0",
+				"yargs-parser": "^8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"requires": {
+						"default-require-extensions": "^1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"bundled": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"bundled": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"requires": {
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"requires": {
+								"amdefine": ">=0.0.4"
+							}
+						}
+					}
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"append-transform": "^0.4.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"requires": {
+								"has-flag": "^1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.5",
+					"bundled": true,
+					"requires": {
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"handlebars": "^4.0.3"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"md5-o-matic": "^0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.2",
+					"bundled": true,
+					"requires": {
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						}
+					}
+				}
+			}
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"request": {
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"sshpk": {
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "^1.4.1"
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		}
+	}
+}

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@bugsnag/delivery-node",
+  "version": "1.0.0",
+  "main": "delivery.js",
+  "description": "@bugsnag/node delivery mechanism",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@bugsnag/core": "^1.0.0",
+    "@bugsnag/safe-json-stringify": "^2.1.0",
+    "request": "^2.87.0"
+  },
+  "devDependencies": {
+    "jasmine": "^3.1.0",
+    "nyc": "^12.0.2"
+  }
+}

--- a/packages/delivery-node/test/delivery.test.js
+++ b/packages/delivery-node/test/delivery.test.js
@@ -1,0 +1,80 @@
+const { describe, it, expect } = global
+
+const delivery = require('../')
+const http = require('http')
+
+const mockServer = () => {
+  const requests = []
+  return {
+    requests,
+    server: http.createServer((req, res) => {
+      let body = ''
+      req.on('data', b => { body += b })
+      req.on('end', () => {
+        requests.push({
+          url: req.url,
+          method: req.method,
+          headers: req.headers,
+          body
+        })
+        res.end('OK')
+      })
+    })
+  }
+}
+
+describe('delivery:node', () => {
+  it('sends reports successfully', done => {
+    const { requests, server } = mockServer()
+    server.listen((err) => {
+      expect(err).toBeUndefined()
+
+      const payload = { sample: 'payload' }
+      const config = {
+        apiKey: 'aaaaaaaa',
+        endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` }
+      }
+      delivery().sendReport({}, config, payload, (err) => {
+        expect(err).toBe(null)
+        expect(requests.length).toBe(1)
+        expect(requests[0].method).toBe('POST')
+        expect(requests[0].url).toMatch('/notify/')
+        expect(requests[0].headers['content-type']).toEqual('application/json')
+        expect(requests[0].headers['bugsnag-api-key']).toEqual('aaaaaaaa')
+        expect(requests[0].headers['bugsnag-payload-version']).toEqual('4.0')
+        expect(requests[0].headers['bugsnag-sent-at']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+        expect(requests[0].body).toBe(JSON.stringify(payload))
+
+        server.close()
+        done()
+      })
+    })
+  })
+
+  it('sends sessions successfully', done => {
+    const { requests, server } = mockServer()
+    server.listen((err) => {
+      expect(err).toBeUndefined()
+
+      const payload = { sample: 'payload' }
+      const config = {
+        apiKey: 'aaaaaaaa',
+        endpoints: { notify: 'blah', sessions: `http://0.0.0.0:${server.address().port}/sessions/` }
+      }
+      delivery().sendSession({}, config, payload, (err) => {
+        expect(err).toBe(null)
+        expect(requests.length).toBe(1)
+        expect(requests[0].method).toBe('POST')
+        expect(requests[0].url).toMatch('/sessions/')
+        expect(requests[0].headers['content-type']).toEqual('application/json')
+        expect(requests[0].headers['bugsnag-api-key']).toEqual('aaaaaaaa')
+        expect(requests[0].headers['bugsnag-payload-version']).toEqual('1.0')
+        expect(requests[0].headers['bugsnag-sent-at']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+        expect(requests[0].body).toBe(JSON.stringify(payload))
+
+        server.close()
+        done()
+      })
+    })
+  })
+})

--- a/packages/delivery-x-domain-request/LICENSE.txt
+++ b/packages/delivery-x-domain-request/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/delivery-xml-http-request/LICENSE.txt
+++ b/packages/delivery-xml-http-request/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/js/LICENSE.txt
+++ b/packages/js/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/node/LICENSE.txt
+++ b/packages/node/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/node/bin/bundle
+++ b/packages/node/bin/bundle
@@ -2,11 +2,7 @@
 
 const browserify = require('browserify')
 const babelConfig = require('../../../babel.config.js')()
-browserify('src/notifier.js', {
-    debug: true,
-    standalone: 'bugsnag',
-    node: true
-  })
+browserify('src/notifier.js', { debug: true, standalone: 'bugsnag', node: true })
   .transform('babelify', { global: true, ...babelConfig })
   .transform('browserify-versionify')
   .exclude([
@@ -14,7 +10,8 @@ browserify('src/notifier.js', {
     // be added to package.json as a dependency
     'iserror',
     'stack-generator',
-    'error-stack-parser'
+    'error-stack-parser',
+    'request'
   ])
   .bundle()
   .pipe(process.stdout)

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -149,6 +149,17 @@
 				"xtend": "^4.0.1"
 			}
 		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
+		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -202,6 +213,11 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
 		"asn1.js": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -235,6 +251,11 @@
 				}
 			}
 		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -246,10 +267,25 @@
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
 			"optional": true
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
 		"atob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
 			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
 		},
 		"babelify": {
 			"version": "9.0.0",
@@ -315,6 +351,15 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
@@ -601,6 +646,11 @@
 			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
 			"integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
 		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
 		"chalk": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -662,6 +712,11 @@
 				}
 			}
 		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -700,6 +755,14 @@
 					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
 					"integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
 				}
+			}
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -808,6 +871,14 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -868,6 +939,11 @@
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
 		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
 		"deps-sort": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
@@ -926,6 +1002,15 @@
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
 			"requires": {
 				"readable-stream": "^2.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "~0.1.0"
 			}
 		},
 		"elliptic": {
@@ -1036,6 +1121,11 @@
 				}
 			}
 		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -1120,6 +1210,21 @@
 				}
 			}
 		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1150,6 +1255,21 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "^2.1.12"
+			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -1646,6 +1766,14 @@
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1689,6 +1817,20 @@
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
+			}
 		},
 		"has": {
 			"version": "1.0.3",
@@ -1764,6 +1906,16 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
 			"integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
 		},
 		"https-browserify": {
 			"version": "1.0.0",
@@ -1944,6 +2096,11 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -1964,6 +2121,11 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.0",
@@ -2003,10 +2165,26 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
 		"jsesc": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
 			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"json-stable-stringify": {
 			"version": "0.0.1",
@@ -2015,6 +2193,11 @@
 			"requires": {
 				"jsonify": "~0.0.0"
 			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"jsonify": {
 			"version": "0.0.0",
@@ -2025,6 +2208,17 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
 		},
 		"kind-of": {
 			"version": "6.0.2",
@@ -2122,6 +2316,19 @@
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
+			}
+		},
+		"mime-db": {
+			"version": "1.35.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+			"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+		},
+		"mime-types": {
+			"version": "2.1.19",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+			"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+			"requires": {
+				"mime-db": "~1.35.0"
 			}
 		},
 		"minimalistic-assert": {
@@ -4046,6 +4253,11 @@
 				}
 			}
 		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4181,6 +4393,11 @@
 				"sha.js": "^2.4.8"
 			}
 		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -4213,6 +4430,11 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -4299,6 +4521,33 @@
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
+		"request": {
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
+			}
+		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -4338,6 +4587,11 @@
 			"requires": {
 				"ret": "~0.1.10"
 			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"semver": {
 			"version": "5.5.0",
@@ -4545,6 +4799,22 @@
 				"extend-shallow": "^3.0.0"
 			}
 		},
+		"sshpk": {
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
 		"stack-generator": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
@@ -4725,6 +4995,14 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "^1.4.1"
+			}
+		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -4734,6 +5012,20 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
 			"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -4871,6 +5163,21 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
 		},
 		"vm-browserify": {
 			"version": "1.1.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.51",
     "@bugsnag/core": "^1.0.0",
+    "@bugsnag/delivery-node": "^1.0.0",
+    "@bugsnag/plugin-server-session": "^1.0.0",
     "babelify": "9.0.0",
     "browserify": "^16.2.2",
     "browserify-versionify": "^1.0.6",
@@ -31,6 +33,7 @@
   "dependencies": {
     "error-stack-parser": "^2.0.2",
     "iserror": "^0.0.2",
+    "request": "^2.87.0",
     "stack-generator": "^2.0.3"
   }
 }

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -11,19 +11,14 @@ module.exports = {
   },
   logger: {
     ...schema.logger,
-    defaultValue: () =>
-      // set logger based on browser capability
-      (typeof console !== 'undefined' && typeof console.debug === 'function')
-        ? getPrefixedConsole()
-        : undefined
+    defaultValue: () => getPrefixedConsole()
   }
 }
 
 const getPrefixedConsole = () => {
-  const logger = {}
   return reduce([ 'debug', 'info', 'warn', 'error' ], (accum, method) => {
     const consoleMethod = console[method]
-    logger[method] = consoleMethod.bind(console, '[bugsnag]')
+    accum[method] = consoleMethod.bind(console, '[bugsnag]')
     return accum
   }, {})
 }

--- a/packages/plugin-browser-context/LICENSE.txt
+++ b/packages/plugin-browser-context/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-browser-device/LICENSE.txt
+++ b/packages/plugin-browser-device/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-browser-request/LICENSE.txt
+++ b/packages/plugin-browser-request/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-browser-session/LICENSE.txt
+++ b/packages/plugin-browser-session/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-client-ip/LICENSE.txt
+++ b/packages/plugin-client-ip/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-console-breadcrumbs/LICENSE.txt
+++ b/packages/plugin-console-breadcrumbs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-inline-script-content/LICENSE.txt
+++ b/packages/plugin-inline-script-content/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-interaction-breadcrumbs/LICENSE.txt
+++ b/packages/plugin-interaction-breadcrumbs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-navigation-breadcrumbs/LICENSE.txt
+++ b/packages/plugin-navigation-breadcrumbs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-network-breadcrumbs/LICENSE.txt
+++ b/packages/plugin-network-breadcrumbs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-server-session/LICENSE.txt
+++ b/packages/plugin-server-session/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -12,7 +12,8 @@ module.exports = {
     client.sessionDelegate({
       startSession: client => {
         const sessionClient = new client.BugsnagClient(client.notifier, {}, new client.BugsnagSession())
-        sessionClient.configure(client.config)
+        sessionClient.configure({})
+        sessionClient.config = client.config
         sessionClient.breadcrumbs = client.breadcrumbs
         sessionClient.app = client.app
         sessionClient.context = client.context
@@ -20,7 +21,6 @@ module.exports = {
         sessionClient.metaData = client.metaData
         sessionClient.request = client.request
         sessionClient.user = client.user
-        sessionClient.beforeSend = sessionClient.beforeSend
         sessionClient.logger(client._logger)
         sessionClient.delivery(client._delivery)
         sessionTracker.track(sessionClient.session)
@@ -51,12 +51,12 @@ const sendSessionSummary = client => sessionCounts => {
   req(handleRes)
 
   function handleRes (err) {
-    if (!err) return client.logger.info('Session delivered')
+    if (!err) return client._logger.info('Session delivered')
     if (backoff.attempts === 10) {
-      client.logger.error('Session delivery failed, max retries exceeded', err)
+      client._logger.error('Session delivery failed, max retries exceeded', err)
       return
     }
-    client.logger.info('Session delivery failed, retry #' + (backoff.attempts + 1) + '/' + maxAttempts, err)
+    client._logger.info('Session delivery failed, retry #' + (backoff.attempts + 1) + '/' + maxAttempts, err)
     setTimeout(() => req(handleRes), backoff.duration())
   }
 

--- a/packages/plugin-simple-throttle/LICENSE.txt
+++ b/packages/plugin-simple-throttle/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-strip-query-string/LICENSE.txt
+++ b/packages/plugin-strip-query-string/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-window-onerror/LICENSE.txt
+++ b/packages/plugin-window-onerror/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/packages/plugin-window-unhandled-rejection/LICENSE.txt
+++ b/packages/plugin-window-unhandled-rejection/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Bugsnag, https://www.bugsnag.com/
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Adds @bugsnag/delivery-node package which sends error reports/sessions using request.

Since request is quite big (5MB on disk!) we discussed alternatives, but went with it for now as it's the most widely used and reliable for proxy support (which we need to support out of the box).