### PR TITLE
Add surrounding code plugin for node notifier

### DIFF
--- a/packages/core/lib/run-before-send.js
+++ b/packages/core/lib/run-before-send.js
@@ -8,11 +8,13 @@ module.exports = (report, onError) => (fn, cb) => {
       if (ret && typeof ret.then === 'function') {
         return ret.then(
           // resolve
-          val => cb(null, shouldPreventSend(report, val)),
+          val => setTimeout(() => cb(null, shouldPreventSend(report, val)), 0),
           // reject
           err => {
-            onError(err)
-            return cb(null, false)
+            setTimeout(() => {
+              onError(err)
+              return cb(null, false)
+            })
           }
         )
       }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -22,6 +22,7 @@
     "@babel/cli": "^7.0.0-beta.51",
     "@bugsnag/core": "^1.0.0",
     "@bugsnag/delivery-node": "^1.0.0",
+    "@bugsnag/plugin-node-surrounding-code": "^1.0.0",
     "@bugsnag/plugin-server-session": "^1.0.0",
     "babelify": "9.0.0",
     "browserify": "^16.2.2",

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -2,8 +2,14 @@ const { schema } = require('@bugsnag/core/config')
 const { reduce } = require('@bugsnag/core/lib/es-utils')
 const { stringWithLength } = require('@bugsnag/core/lib/validators')
 const os = require('os')
+const process = require('process')
 
 module.exports = {
+  projectRoot: {
+    defaultValue: () => process.cwd(),
+    validate: value => stringWithLength(value),
+    message: 'should be string'
+  },
   hostname: {
     defaultValue: () => os.hostname(),
     message: 'should be a string',

--- a/packages/plugin-node-surrounding-code/LICENSE.txt
+++ b/packages/plugin-node-surrounding-code/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/plugin-node-surrounding-code/README.md
+++ b/packages/plugin-node-surrounding-code/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/plugin-node-surrounding-code
+
+This plugin loads the surrounding code each stackframe in an error report, if it is available. It is included in the Node notifier.
+
+## License
+MIT

--- a/packages/plugin-node-surrounding-code/package-lock.json
+++ b/packages/plugin-node-surrounding-code/package-lock.json
@@ -1,0 +1,2134 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.51"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY="
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/helper-function-name": "7.0.0-beta.51",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"requires": {
+				"color-name": "1.1.1"
+			}
+		},
+		"color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA=="
+		},
+		"istanbul-lib-instrument": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz",
+			"integrity": "sha512-h9Vg3nfbxrF0PK0kZiNiMAyL8zXaLiBP/BXniaKSwVvAi1TaumYV2b0wPdmy1CRX3irYbYD1p4Wjbv4uyECiiQ==",
+			"requires": {
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/traverse": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"istanbul-lib-coverage": "^2.0.1",
+				"semver": "^5.5.0"
+			}
+		},
+		"jasmine": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+			"integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+			"requires": {
+				"glob": "^7.0.6",
+				"jasmine-core": "~3.1.0"
+			}
+		},
+		"jasmine-core": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+			"integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+		},
+		"lodash": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"nyc": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"requires": {
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^2.1.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.5",
+				"istanbul-reports": "^1.4.1",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
+				"yargs": "11.1.0",
+				"yargs-parser": "^8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"requires": {
+						"default-require-extensions": "^1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"bundled": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"bundled": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"requires": {
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"requires": {
+								"amdefine": ">=0.0.4"
+							}
+						}
+					}
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"append-transform": "^0.4.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"requires": {
+								"has-flag": "^1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.5",
+					"bundled": true,
+					"requires": {
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"handlebars": "^4.0.3"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"md5-o-matic": "^0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.2",
+					"bundled": true,
+					"requires": {
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						}
+					}
+				}
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		}
+	}
+}

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bugsnag/plugin-node-surrounding-code",
+  "version": "1.0.0",
+  "main": "surrounding-code.js",
+  "description": "@bugsnag/js plugin to load surrounding code in Node stacktraces",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@bugsnag/core": "^1.0.0",
+    "jasmine": "^3.1.0",
+    "nyc": "^12.0.2"
+  }
+}

--- a/packages/plugin-node-surrounding-code/surrounding-code.js
+++ b/packages/plugin-node-surrounding-code/surrounding-code.js
@@ -1,3 +1,4 @@
+const SURROUNDING_LINES = 3
 const { readFile } = require('fs')
 
 module.exports = {
@@ -30,8 +31,8 @@ const getSurroundingCode = (file, lineNumber, cb) => {
   readFile(file, 'utf8', (err, data) => {
     if (err) return cb(err)
     const lines = data.split('\n')
-    const start = Math.max(0, lineNumber - 4)
-    const end = Math.min(lines.length, lineNumber + 3)
+    const start = Math.max(0, lineNumber - SURROUNDING_LINES - 1)
+    const end = Math.min(lines.length, lineNumber + SURROUNDING_LINES)
     cb(null, lines
       .slice(start, end)
       .reduce((accum, line, i) => {

--- a/packages/plugin-node-surrounding-code/surrounding-code.js
+++ b/packages/plugin-node-surrounding-code/surrounding-code.js
@@ -1,0 +1,42 @@
+const { readFile } = require('fs')
+
+module.exports = {
+  init: client => {
+    const loadSurroundingCode = stackframe => new Promise((resolve, reject) => {
+      try {
+        if (!stackframe.lineNumber || !stackframe.file) return resolve(stackframe)
+        getSurroundingCode(stackframe.file, stackframe.lineNumber, (err, code) => {
+          if (err) return resolve(stackframe)
+          stackframe.code = code
+          return resolve(stackframe)
+        })
+      } catch (e) {
+        return resolve(stackframe)
+      }
+    })
+
+    client.config.beforeSend.push(report => new Promise((resolve, reject) => {
+      Promise.all(report.stacktrace.map(loadSurroundingCode))
+        .then(stacktrace => {
+          report.stacktrace = stacktrace
+          resolve()
+        })
+        .catch(reject)
+    }))
+  }
+}
+
+const getSurroundingCode = (file, lineNumber, cb) => {
+  readFile(file, 'utf8', (err, data) => {
+    if (err) return cb(err)
+    const lines = data.split('\n')
+    const start = Math.max(0, lineNumber - 4)
+    const end = Math.min(lines.length, lineNumber + 3)
+    cb(null, lines
+      .slice(start, end)
+      .reduce((accum, line, i) => {
+        accum[start + (i + 1)] = line
+        return accum
+      }, {}))
+  })
+}

--- a/packages/plugin-node-surrounding-code/test/fixtures/.gitignore
+++ b/packages/plugin-node-surrounding-code/test/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/plugin-node-surrounding-code/test/fixtures/01.js
+++ b/packages/plugin-node-surrounding-code/test/fixtures/01.js
@@ -1,0 +1,70 @@
+// this is just some arbitrary (but real) javascript for testing, taken from
+// https://github.com/bengourley/source-map-decoder/
+
+//
+// This Writable steam reads a source map. It will buffer the entire
+// input, and once the writable side is closed, it will output the map
+// replacing the "mappings" property with human readable content.
+//
+
+const { Writable } = require('stream')
+const vlq = require('vlq')
+
+class SourceMapDecoder extends Writable {
+  constructor (opts, cb) {
+    if (typeof opts === 'function') {
+      cb = opts
+      opts = { encoding: 'utf8' }
+    }
+    if (!cb) throw new Error('new SourceMapDecoder(opts, cb): cb is required')
+    super(opts)
+    this.input = ''
+    if (cb) this.on('finish', () => cb(this.output()))
+  }
+
+  _write (chunk, enc, next) {
+    this.input += chunk
+    next()
+  }
+
+  output () {
+    try {
+      const map = JSON.parse(this.input)
+      if (!map.mappings) throw new Error('source map had no "mappings" property')
+      if (!Array.isArray(map.sources)) throw new Error('source map had no "sources" property')
+      if (!Array.isArray(map.names)) throw new Error('source map had no "names" property')
+      return JSON.stringify({
+        ...map,
+        mappings: formatMappings(map.mappings, map.sources, map.names)
+      })
+    } catch (e) {
+      this.emit('error', e)
+    }
+  }
+}
+
+module.exports = SourceMapDecoder
+
+const formatMappings = (mappings, sources, names) => {
+  const vlqState = [ 0, 0, 0, 0, 0 ]
+  return mappings.split(';').reduce((accum, line, i) => {
+    accum[i + 1] = formatLine(line, vlqState, sources, names)
+    vlqState[0] = 0
+    return accum
+  }, {})
+}
+
+const formatLine = (line, state, sources, names) => {
+  const segs = line.split(',')
+  return segs.map(seg => {
+    if (!seg) return ''
+    const decoded = vlq.decode(seg)
+    for (var i = 0; i < 5; i++) {
+      state[i] = typeof decoded[i] === 'number' ? state[i] + decoded[i] : state[i]
+    }
+    return formatSegment(...state.concat([ sources, names ]))
+  })
+}
+
+const formatSegment = (col, source, sourceLine, sourceCol, name, sources, names) =>
+  `${col + 1} => ${sources[source]} ${sourceLine + 1}:${sourceCol + 1}${names[name] ? ` ${names[name]}` : ``}`

--- a/packages/plugin-node-surrounding-code/test/fixtures/02.js
+++ b/packages/plugin-node-surrounding-code/test/fixtures/02.js
@@ -1,0 +1,44 @@
+// this is just some arbitrary (but real) javascript for testing, taken from
+// https://github.com/bengourley/find-nearest-file/
+
+module.exports = find
+
+var fs = require('fs')
+  , path = require('path')
+
+function find(filename, root) {
+
+  root = root || process.cwd();
+
+  if (!filename) throw new Error('filename is required')
+
+  if (filename.indexOf('/') !== -1 || filename === '..') {
+    throw new Error('filename must be just a filename and not a path')
+  }
+
+
+  function findFile(directory, filename) {
+
+    var file = path.join(directory, filename)
+
+    try {
+      // Get the stat for the path, and if this doesn't throw, make sure it's a file
+      if (fs.statSync(file).isFile()) return file
+      // stat existed, but isFile() returned false
+      return nextLevelUp()
+    } catch (e) {
+      // stat did not exist
+      return nextLevelUp()
+    }
+
+    function nextLevelUp() {
+      // Don't proceed to the next directory when already at the fs root
+      if (directory === path.resolve('/')) return null
+      return findFile(path.dirname(directory), filename)
+    }
+
+  }
+
+  return findFile(root, filename)
+
+}

--- a/packages/plugin-node-surrounding-code/test/fixtures/03.js
+++ b/packages/plugin-node-surrounding-code/test/fixtures/03.js
@@ -1,0 +1,136 @@
+// this is just some arbitrary (but real) javascript for testing, taken from
+// https://github.com/bengourley/slugg/
+
+(function (root) {
+
+var defaultSeparator = '-'
+var defaultToStrip = /['"’‘”“]/g
+var defaultToLowerCase = true
+
+function slugg(string, separator, toStrip) {
+  // Coerce the value into a string.
+  if ([ undefined, null ].indexOf(string) !== -1) string = ''
+  string = typeof string.toString === 'function' ? string.toString() : ''
+
+  var options = {}
+
+  if (typeof separator === 'object') {
+    options = separator
+  } else {
+    options.separator = separator
+    options.toStrip = toStrip
+
+    // Separator might be omitted and toStrip in its place
+    if (options.separator instanceof RegExp) {
+      options.toStrip = separator
+      options.separator = defaultSeparator
+    }
+
+    // Only a separator was passed
+    if (typeof options.toStrip === 'undefined') options.toStrip = /['"’‘”“]/g
+  }
+
+  // Separator is optional
+  if (typeof options.separator === 'undefined') options.separator = defaultSeparator
+
+  // toStrip is optional
+  if (typeof options.toStrip === 'undefined') options.toStrip = defaultToStrip
+
+  // toLowerCase is optional
+  if (typeof options.toLowerCase === 'undefined') options.toLowerCase = defaultToLowerCase
+
+  // Make lower-case
+  if (options.toLowerCase) string = string.toLowerCase()
+
+  // Swap out non-english characters for their english equivalent
+  for (var i = 0, len = string.length; i < len; i++) {
+    if (chars[string.charAt(i)]) {
+      string = string.replace(string.charAt(i), chars[string.charAt(i)])
+    }
+  }
+
+  string = string
+    // Strip chars that shouldn't be replaced with separator
+    .replace(options.toStrip, '')
+    // Replace non-word characters with separator
+    .replace(/[\W|_]+/g, options.separator)
+    // Strip dashes from the beginning
+    .replace(new RegExp('^' + options.separator + '+'), '')
+    // Strip dashes from the end
+    .replace(new RegExp(options.separator + '+$'), '')
+
+  return string
+
+}
+
+// Conversion table. Modified version of:
+// https://github.com/dodo/node-slug/blob/master/src/slug.coffee
+var chars = slugg.chars = {
+  // Latin
+  'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'A', 'Å': 'A', 'Æ': 'AE',
+  'Ç': 'C', 'È': 'E', 'É': 'E', 'Ê': 'E', 'Ë': 'E', 'Ì': 'I', 'Í': 'I',
+  'Î': 'I', 'Ï': 'I', 'Ð': 'D', 'Ñ': 'N', 'Ò': 'O', 'Ó': 'O', 'Ô': 'O',
+  'Õ': 'O', 'Ö': 'O', 'Ő': 'O', 'Ø': 'O', 'Ù': 'U', 'Ú': 'U', 'Û': 'U',
+  'Ü': 'U', 'Ű': 'U', 'Ý': 'Y', 'Þ': 'TH', 'ß': 'ss', 'à': 'a', 'á': 'a',
+  'â': 'a', 'ã': 'a', 'ä': 'a', 'å': 'a', 'æ': 'ae', 'ç': 'c', 'è': 'e',
+  'é': 'e', 'ê': 'e', 'ë': 'e', 'ì': 'i', 'í': 'i', 'î': 'i', 'ï': 'i',
+  'ð': 'd', 'ñ': 'n', 'ò': 'o', 'ó': 'o', 'ô': 'o', 'õ': 'o', 'ö': 'o',
+  'ő': 'o', 'ø': 'o', 'ù': 'u', 'ú': 'u', 'û': 'u', 'ü': 'u', 'ű': 'u',
+  'ý': 'y', 'þ': 'th', 'ÿ': 'y', 'ẞ': 'SS', 'œ': 'oe', 'Œ': 'OE',
+  // Greek
+  'α': 'a', 'β': 'b', 'γ': 'g', 'δ': 'd', 'ε': 'e', 'ζ': 'z', 'η': 'h',
+  'θ': '8', 'ι': 'i', 'κ': 'k', 'λ': 'l', 'μ': 'm', 'ν': 'n', 'ξ': '3',
+  'ο': 'o', 'π': 'p', 'ρ': 'r', 'σ': 's', 'τ': 't', 'υ': 'y', 'φ': 'f',
+  'χ': 'x', 'ψ': 'ps', 'ω': 'w', 'ά': 'a', 'έ': 'e', 'ί': 'i', 'ό': 'o',
+  'ύ': 'y', 'ή': 'h', 'ώ': 'w', 'ς': 's', 'ϊ': 'i', 'ΰ': 'y', 'ϋ': 'y',
+  'ΐ': 'i', 'Α': 'A', 'Β': 'B', 'Γ': 'G', 'Δ': 'D', 'Ε': 'E', 'Ζ': 'Z',
+  'Η': 'H', 'Θ': '8', 'Ι': 'I', 'Κ': 'K', 'Λ': 'L', 'Μ': 'M', 'Ν': 'N',
+  'Ξ': '3', 'Ο': 'O', 'Π': 'P', 'Ρ': 'R', 'Σ': 'S', 'Τ': 'T', 'Υ': 'Y',
+  'Φ': 'F', 'Χ': 'X', 'Ψ': 'PS', 'Ω': 'W', 'Ά': 'A', 'Έ': 'E', 'Ί': 'I',
+  'Ό': 'O', 'Ύ': 'Y', 'Ή': 'H', 'Ώ': 'W', 'Ϊ': 'I', 'Ϋ': 'Y',
+  // Turkish
+  'ş': 's', 'Ş': 'S', 'ı': 'i', 'İ': 'I', 'ğ': 'g', 'Ğ': 'G',
+  // Russian
+  'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'yo',
+  'ж': 'zh', 'з': 'z', 'и': 'i', 'й': 'j', 'к': 'k', 'л': 'l', 'м': 'm',
+  'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u',
+  'ф': 'f', 'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sh', 'ъ': 'u',
+  'ы': 'y', 'э': 'e', 'ю': 'yu', 'я': 'ya', 'А': 'A', 'Б': 'B',
+  'В': 'V', 'Г': 'G', 'Д': 'D', 'Е': 'E', 'Ё': 'Yo', 'Ж': 'Zh', 'З': 'Z',
+  'И': 'I', 'Й': 'J', 'К': 'K', 'Л': 'L', 'М': 'M', 'Н': 'N', 'О': 'O',
+  'П': 'P', 'Р': 'R', 'С': 'S', 'Т': 'T', 'У': 'U', 'Ф': 'F', 'Х': 'H',
+  'Ц': 'C', 'Ч': 'Ch', 'Ш': 'Sh', 'Щ': 'Sh', 'Ъ': 'U', 'Ы': 'Y',
+  'Э': 'E', 'Ю': 'Yu', 'Я': 'Ya',
+  // Ukranian
+  'Є': 'Ye', 'І': 'I', 'Ї': 'Yi', 'Ґ': 'G',
+  'є': 'ye', 'і': 'i', 'ї': 'yi', 'ґ': 'g',
+  // Czech
+  'č': 'c', 'ď': 'd', 'ě': 'e', 'ň': 'n', 'ř': 'r', 'š': 's',
+  'ť': 't', 'ů': 'u', 'ž': 'z', 'Č': 'C', 'Ď': 'D', 'Ě': 'E',
+  'Ň': 'N', 'Ř': 'R', 'Š': 'S', 'Ť': 'T', 'Ů': 'U', 'Ž': 'Z',
+  // Polish
+  'ą': 'a', 'ć': 'c', 'ę': 'e', 'ł': 'l', 'ń': 'n', 'ś': 's',
+  'ź': 'z', 'ż': 'z', 'Ą': 'A', 'Ć': 'C', 'Ę': 'e', 'Ł': 'L',
+  'Ń': 'N', 'Ś': 'S', 'Ź': 'Z', 'Ż': 'Z',
+  // Latvian
+  'ā': 'a', 'ē': 'e', 'ģ': 'g', 'ī': 'i', 'ķ': 'k', 'ļ': 'l',
+  'ņ': 'n', 'ū': 'u', 'Ā': 'A', 'Ē': 'E', 'Ģ': 'G', 'Ī': 'i',
+  'Ķ': 'k', 'Ļ': 'L', 'Ņ': 'N', 'Ū': 'u'
+}
+
+// Be compatible with different module systems
+
+if (typeof define !== 'undefined' && define.amd) {
+  // AMD
+  define([], function () {
+    return slugg
+  })
+} else if (typeof module !== 'undefined' && module.exports) {
+  // CommonJS
+  module.exports = slugg
+} else {
+  // Script tag
+  root.slugg = slugg
+}
+
+}(this))

--- a/packages/plugin-node-surrounding-code/test/fixtures/node_modules/mock-module/index.js
+++ b/packages/plugin-node-surrounding-code/test/fixtures/node_modules/mock-module/index.js
@@ -1,0 +1,3 @@
+function doNotLoadMe(a, b, c) {
+  console.log('this file should not be loaded by the surrounding code plugin')
+}

--- a/packages/plugin-node-surrounding-code/test/surrounding-code.test.js
+++ b/packages/plugin-node-surrounding-code/test/surrounding-code.test.js
@@ -1,0 +1,129 @@
+const { describe, it, expect } = global
+
+const plugin = require('../')
+const { join } = require('path')
+const Report = require('@bugsnag/core/report')
+const Client = require('@bugsnag/core/client')
+const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
+
+describe('plugin: node surrounding code', () => {
+  it('should load code successfully for stackframes whose files exist', done => {
+    const client = new Client(VALID_NOTIFIER)
+
+    client.delivery({
+      sendReport: (logger, config, report) => {
+        const evt = report.events[0]
+        expect(Object.keys(evt.stacktrace[0].code))
+          .toEqual([ '19', '20', '21', '22', '23', '24', '25' ])
+        expect(evt.stacktrace[0].code['22'])
+          .toBe('    if (cb) this.on(\'finish\', () => cb(this.output()))')
+
+        expect(Object.keys(evt.stacktrace[1].code))
+          .toEqual([ '28', '29', '30', '31', '32', '33', '34' ])
+        expect(evt.stacktrace[1].code['31'])
+          .toBe('      return nextLevelUp()')
+
+        expect(Object.keys(evt.stacktrace[2].code))
+          .toEqual([ '115', '116', '117', '118', '119', '120', '121' ])
+        expect(evt.stacktrace[2].code['118'])
+          .toBe('  \'Ķ\': \'k\', \'Ļ\': \'L\', \'Ņ\': \'N\', \'Ū\': \'u\'')
+
+        done()
+      },
+      sendSession: () => {}
+    })
+
+    client.configure({ apiKey: 'api_key' })
+    plugin.init(client)
+
+    client.notify(new Report('Error', 'surrounding code loading test', [
+      {
+        lineNumber: 22,
+        columnNumber: 18,
+        fileName: join(__dirname, 'fixtures', '01.js')
+      }, {
+        lineNumber: 31,
+        columnNumber: 7,
+        fileName: join(__dirname, 'fixtures', '02.js')
+      }, {
+        lineNumber: 118,
+        columnNumber: 28,
+        fileName: join(__dirname, 'fixtures', '03.js')
+      }
+    ]))
+  })
+
+  it('should tolerate missing files for some stackframes', done => {
+    const client = new Client(VALID_NOTIFIER)
+
+    client.delivery({
+      sendReport: (logger, config, report) => {
+        const evt = report.events[0]
+        expect(evt.stacktrace[0].code).toBeTruthy()
+        expect(evt.stacktrace[1].code).toBeUndefined()
+        expect(evt.stacktrace[2].code).toBeTruthy()
+        done()
+      },
+      sendSession: () => {}
+    })
+
+    client.configure({ apiKey: 'api_key' })
+    plugin.init(client)
+
+    client.notify(new Report('Error', 'surrounding code loading test', [
+      {
+        lineNumber: 22,
+        columnNumber: 18,
+        fileName: join(__dirname, 'fixtures', '01.js')
+      }, {
+        lineNumber: 31,
+        columnNumber: 7,
+        fileName: join(__dirname, 'fixtures', '0000000.js')
+      }, {
+        lineNumber: 118,
+        columnNumber: 28,
+        fileName: join(__dirname, 'fixtures', '03.js')
+      }
+    ]))
+  })
+
+  it('behaves sensibly for code at the beginning and end of a file', done => {
+    const client = new Client(VALID_NOTIFIER)
+
+    client.delivery({
+      sendReport: (logger, config, report) => {
+        const evt = report.events[0]
+        expect(evt.stacktrace[0].code).toEqual({
+          '1': '// this is just some arbitrary (but real) javascript for testing, taken from',
+          '2': '// https://github.com/bengourley/source-map-decoder/',
+          '3': '',
+          '4': '//'
+        })
+        expect(evt.stacktrace[1].code).toEqual({
+          '42': '  return findFile(root, filename)',
+          '43': '',
+          '44': '}',
+          '45': ''
+        })
+        done()
+      },
+      sendSession: () => {}
+    })
+
+    client.configure({ apiKey: 'api_key' })
+    plugin.init(client)
+
+    client.notify(new Report('Error', 'surrounding code loading test', [
+      {
+        lineNumber: 1,
+        columnNumber: 1,
+        fileName: join(__dirname, 'fixtures', '01.js')
+      },
+      {
+        lineNumber: 45,
+        columnNumber: 1,
+        fileName: join(__dirname, 'fixtures', '02.js')
+      }
+    ]))
+  })
+})


### PR DESCRIPTION
Using the async support in `beforeSend` callbacks, this adds a callback which attempts to load the `file` at each stackframe and adds up to 3 lines code either side, if available, to the frame.