### PR TITLE
perf: Use streams for surrounding code loading

### DIFF
--- a/packages/plugin-node-surrounding-code/package-lock.json
+++ b/packages/plugin-node-surrounding-code/package-lock.json
@@ -123,6 +123,11 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"byline": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+		},
 		"chalk": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -157,6 +162,14 @@
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"requires": {
 				"ms": "2.0.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
 			}
 		},
 		"escape-string-regexp": {
@@ -2096,6 +2109,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"semver": {
 			"version": "5.5.0",

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -18,6 +18,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "byline": "^5.0.0",
+    "pump": "^3.0.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^1.0.0",

--- a/packages/plugin-node-surrounding-code/surrounding-code.js
+++ b/packages/plugin-node-surrounding-code/surrounding-code.js
@@ -1,5 +1,8 @@
 const SURROUNDING_LINES = 3
-const { readFile } = require('fs')
+const { createReadStream } = require('fs')
+const { Writable } = require('stream')
+const pump = require('pump')
+const byline = require('byline')
 
 module.exports = {
   init: client => {
@@ -28,16 +31,56 @@ module.exports = {
 }
 
 const getSurroundingCode = (file, lineNumber, cb) => {
-  readFile(file, 'utf8', (err, data) => {
-    if (err) return cb(err)
-    const lines = data.split('\n')
-    const start = Math.max(0, lineNumber - SURROUNDING_LINES - 1)
-    const end = Math.min(lines.length, lineNumber + SURROUNDING_LINES)
-    cb(null, lines
-      .slice(start, end)
-      .reduce((accum, line, i) => {
-        accum[start + (i + 1)] = line
-        return accum
-      }, {}))
+  const start = lineNumber - SURROUNDING_LINES
+  const end = lineNumber + SURROUNDING_LINES
+
+  const reader = createReadStream(file, { encoding: 'utf8' })
+  const splitter = new byline.LineStream({ keepEmptyLines: true })
+  const slicer = new CodeRange({ start, end })
+
+  // if the slicer has enough lines already, no need to keep reading from the file
+  slicer.on('done', () => reader.destroy())
+
+  pump(reader, splitter, slicer, (err) => {
+    // reader.destroy() causes a "premature close" error which we can tolerate
+    if (err && err.message !== 'premature close') return cb(err)
+    cb(null, slicer.getCode())
   })
+}
+
+// This writable stream takes { start, end } options specifying the
+// range of lines that should be extracted from a file. Pipe a readable
+// stream to it that provides source lines as each chunk. If the range
+// is satisfied before the end of the readable stream, it will emit the
+// 'done' event. Once a 'done' or 'finish' event has been seen, call getCode()
+// to get the range in the following format:
+// {
+//   '10': 'function getSquare (cb) {',
+//   '11': '  rectangles.find({',
+//   '12': '    length: 12',
+//   '13': '    width: 12',
+//   '14': '  }, err => cb)',
+//   '15': '}'
+// }
+class CodeRange extends Writable {
+  constructor (opts) {
+    super({ ...opts, decodeStrings: false })
+    this._start = opts.start
+    this._end = opts.end
+    this._n = 0
+    this._code = {}
+  }
+  _write (chunk, enc, cb) {
+    this._n++
+    if (this._n < this._start) return cb(null)
+    if (this._n <= this._end) {
+      this._code[String(this._n)] = chunk
+      return cb(null)
+    }
+    this.emit('done')
+    return cb(null)
+  }
+  getCode () {
+    return this._code
+  }
 }


### PR DESCRIPTION
Based on @fractalwrench's comment on #371, I've thrown together a streaming implementation for the surrounding code loading. I think it's very unlikely we'd run out of memory, but this would help in the fraction of cases where we would cross that threshold. As you can see it's more complex but it passes all the same tests.