### PR TITLE
chore: Remove "keywords" field from package.json and set "author": "Bugsnag"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0",

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0",

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0",

--- a/packages/plugin-browser-context/package.json
+++ b/packages/plugin-browser-context/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
   },

--- a/packages/plugin-browser-device/package.json
+++ b/packages/plugin-browser-device/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
   },

--- a/packages/plugin-browser-request/package.json
+++ b/packages/plugin-browser-request/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
   },

--- a/packages/plugin-browser-session/package.json
+++ b/packages/plugin-browser-session/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-client-ip/package.json
+++ b/packages/plugin-client-ip/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-console-breadcrumbs/package.json
+++ b/packages/plugin-console-breadcrumbs/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-interaction-breadcrumbs/package.json
+++ b/packages/plugin-interaction-breadcrumbs/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
   },

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
   },

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0",

--- a/packages/plugin-simple-throttle/package.json
+++ b/packages/plugin-simple-throttle/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-strip-query-string/package.json
+++ b/packages/plugin-strip-query-string/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0"

--- a/packages/plugin-window-onerror/package.json
+++ b/packages/plugin-window-onerror/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {

--- a/packages/plugin-window-unhandled-rejection/package.json
+++ b/packages/plugin-window-unhandled-rejection/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "error-stack-parser": "^2.0.2",


### PR DESCRIPTION
As discussed in https://github.com/bugsnag/bugsnag-js/pull/371#discussion_r205149357, this removes the keyword property from all of the modules we want to discourage people to discovering/installing. This is because these plugins are all internal and bundled into either @bugsnag/browser or @bugsnag/node.