### PR TITLE
Add maze runner tests for server session tracking

### DIFF
--- a/packages/browser/Gemfile.lock
+++ b/packages/browser/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 5a62c4d5efc1c8bf27465d3a01240e602a181cc2
+  revision: 4ae4bc4821968f26c7f1e6341c463527f0ffd271
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
@@ -34,21 +34,21 @@ GEM
     cucumber-expressions (5.0.15)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    curb (0.9.4)
+    curb (0.9.6)
     diff-lcs (1.3)
-    ffi (1.9.23)
-    gherkin (5.0.0)
+    ffi (1.9.25)
+    gherkin (5.1.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
-    power_assert (1.1.1)
+    power_assert (1.1.3)
     rack (2.0.5)
     rake (12.3.1)
     rubyzip (1.2.1)
-    selenium-webdriver (3.11.0)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    test-unit (3.2.7)
+    test-unit (3.2.8)
       power_assert
 
 PLATFORMS
@@ -61,4 +61,4 @@ DEPENDENCIES
   selenium-webdriver (~> 3.11)
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -1,5 +1,5 @@
 const { filter, reduce, keys, isArray, includes } = require('./lib/es-utils')
-const { positiveIntIfDefined, stringWithLength } = require('./lib/validators')
+const { intRange, stringWithLength } = require('./lib/validators')
 
 module.exports.schema = {
   apiKey: {
@@ -63,7 +63,7 @@ module.exports.schema = {
   maxBreadcrumbs: {
     defaultValue: () => 20,
     message: 'should be a number ≤40',
-    validate: value => value === 0 || (positiveIntIfDefined(value) && (value === undefined || value <= 40))
+    validate: value => intRange(0, 40)(value)
   },
   autoBreadcrumbs: {
     defaultValue: () => true,

--- a/packages/core/lib/test/validators.test.js
+++ b/packages/core/lib/test/validators.test.js
@@ -1,17 +1,24 @@
 const { describe, it, expect } = global
 
-const { positiveIntIfDefined, stringWithLength } = require('../validators')
+const { intRange, stringWithLength } = require('../validators')
 
-describe('positiveIntIfDefined(val)', () => {
+describe('intRange(min, max)(val)', () => {
   it('work with various values', () => {
-    expect(positiveIntIfDefined(10)).toBe(true)
-    expect(positiveIntIfDefined(1e5)).toBe(true)
-    for (let i = 1; i <= 1000; i++) expect(positiveIntIfDefined(i)).toBe(true)
-    expect(positiveIntIfDefined(-10)).toBe(false)
-    expect(positiveIntIfDefined(0)).toBe(false)
-    expect(positiveIntIfDefined(1.123)).toBe(false)
-    expect(positiveIntIfDefined('')).toBe(false)
-    expect(positiveIntIfDefined('100')).toBe(false)
+    // default min/max: 1 to Infinity
+    expect(intRange()(10)).toBe(true)
+    expect(intRange()(1e5)).toBe(true)
+    for (let i = 1; i <= 1000; i++) expect(intRange()(i)).toBe(true)
+    expect(intRange()(-10)).toBe(false)
+    expect(intRange()(0)).toBe(false)
+    expect(intRange()(1.123)).toBe(false)
+    expect(intRange()('')).toBe(false)
+    expect(intRange()('100')).toBe(false)
+
+    // custom min/max
+    expect(intRange(-10, 20)(11)).toBe(true)
+    expect(intRange(-10, 20)(-13)).toBe(false)
+    expect(intRange(-10, 20)(20)).toBe(true)
+    expect(intRange(-10, 20)(21)).toBe(false)
   })
 })
 

--- a/packages/core/lib/validators.js
+++ b/packages/core/lib/validators.js
@@ -1,8 +1,6 @@
-const { includes } = require('./es-utils')
-
-exports.positiveIntIfDefined = value =>
-  includes([ 'undefined', 'number' ], typeof value) &&
+exports.intRange = (min = 1, max = Infinity) => value =>
+  typeof value === 'number' &&
   parseInt('' + value, 10) === value &&
-  value > 0
+  value >= min && value <= max
 
 exports.stringWithLength = value => typeof value === 'string' && !!value.length

--- a/packages/node/Gemfile.lock
+++ b/packages/node/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 2870cbf4f7bdd49a8658c43ea065665345b4ae11
+  revision: 3015ffa92e6f17d9aa4c8bfa4f69e4a2089a53f5
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)

--- a/packages/node/Gemfile.lock
+++ b/packages/node/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 3015ffa92e6f17d9aa4c8bfa4f69e4a2089a53f5
+  revision: 4ae4bc4821968f26c7f1e6341c463527f0ffd271
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)

--- a/packages/node/features/fixtures/docker-compose.yml
+++ b/packages/node/features/fixtures/docker-compose.yml
@@ -33,3 +33,14 @@ services:
       - BUGSNAG_NOTIFY_ENDPOINT
       - BUGSNAG_SESSIONS_ENDPOINT
     restart: "no"
+
+  sessions:
+    build:
+      context: sessions
+      args:
+        - NODE_VERSION
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_SESSIONS_ENDPOINT
+    restart: "no"

--- a/packages/node/features/fixtures/sessions/Dockerfile
+++ b/packages/node/features/fixtures/sessions/Dockerfile
@@ -1,0 +1,13 @@
+ARG NODE_VERSION=8
+FROM bugsnag_node_test:$NODE_VERSION
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package* /usr/src/app/
+RUN npm install
+
+COPY . /usr/src/app/
+
+RUN npm install --no-package-lock --no-save /tmp/bugsnag-node.tgz
+RUN node --version

--- a/packages/node/features/fixtures/sessions/package-lock.json
+++ b/packages/node/features/fixtures/sessions/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "bugsnag-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/packages/node/features/fixtures/sessions/package.json
+++ b/packages/node/features/fixtures/sessions/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "bugsnag-test"
+}

--- a/packages/node/features/fixtures/sessions/scenarios/start-session-100.js
+++ b/packages/node/features/fixtures/sessions/scenarios/start-session-100.js
@@ -1,0 +1,14 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  sessionSummaryInterval: 1000
+})
+
+for (var i = 0; i < 100; i++) bugsnagClient.startSession()
+
+// keep the process open a little bit so that the session has time to get sent
+setTimeout(function () {}, 5000)

--- a/packages/node/features/fixtures/sessions/scenarios/start-session-async.js
+++ b/packages/node/features/fixtures/sessions/scenarios/start-session-async.js
@@ -1,0 +1,17 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  sessionSummaryInterval: 1000
+})
+
+for (var i = 0; i < 50; i++) bugsnagClient.startSession()
+setTimeout(function () {
+  for (var i = 0; i < 50; i++) bugsnagClient.startSession()
+}, 1500)
+
+// keep the process open a little bit so that the session has time to get sent
+setTimeout(function () {}, 5000)

--- a/packages/node/features/fixtures/sessions/scenarios/start-session-notify.js
+++ b/packages/node/features/fixtures/sessions/scenarios/start-session-notify.js
@@ -1,0 +1,17 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  sessionSummaryInterval: 1000
+})
+
+var sessionClient = bugsnagClient.startSession()
+setTimeout(function () {
+  sessionClient.notify(new Error('in a session'))
+}, 1500)
+
+// keep the process open a little bit so that the session has time to get sent
+setTimeout(function () {}, 5000)

--- a/packages/node/features/fixtures/sessions/scenarios/start-session.js
+++ b/packages/node/features/fixtures/sessions/scenarios/start-session.js
@@ -1,0 +1,14 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  sessionSummaryInterval: 1000
+})
+
+bugsnagClient.startSession()
+
+// keep the process open a little bit so that the session has time to get sent
+setTimeout(function () {}, 5000)

--- a/packages/node/features/handled_errors.feature
+++ b/packages/node/features/handled_errors.feature
@@ -2,7 +2,7 @@ Feature: Reporting handled errors
 
 Background:
   Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
-  And I configure the bugsnag endpoint
+  And I configure the bugsnag notify endpoint
 
 Scenario Outline: calling notify() with an error
   And I set environment variable "NODE_VERSION" to "<node version>"

--- a/packages/node/features/project_root.feature
+++ b/packages/node/features/project_root.feature
@@ -2,7 +2,7 @@ Feature: Setting project root
 
 Background:
   Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
-  And I configure the bugsnag endpoint
+  And I configure the bugsnag notify endpoint
 
 Scenario Outline: project root should default to the current working directory
   And I set environment variable "NODE_VERSION" to "<node version>"

--- a/packages/node/features/sessions.feature
+++ b/packages/node/features/sessions.feature
@@ -14,6 +14,48 @@ Scenario Outline: calling startSession() manually
   And the request used the Node notifier
   And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
   And the request is a valid for the session tracking API
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
+Scenario Outline: calling startSession() manually 100x
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "sessions"
+  And I run the service "sessions" with the command "node scenarios/start-session-100"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the request is a valid for the session tracking API
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 100
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
+Scenario Outline: calling notify() on a sessionClient
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "sessions"
+  And I run the service "sessions" with the command "node scenarios/start-session-notify"
+  And I wait for 3 seconds
+  Then I should receive 2 requests
+  And the request used the Node notifier
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the request is a valid for the session tracking API
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
+  # the second request should be an error report
+  And the payload field "events.0.session" is not null for request 1
+  And the payload field "events.0.session.events.handled" equals 1 for request 1
+  And the payload field "events.0.session.events.unhandled" equals 0 for request 1
 
   Examples:
   | node version |

--- a/packages/node/features/sessions.feature
+++ b/packages/node/features/sessions.feature
@@ -1,0 +1,22 @@
+Feature: Server side session tracking
+
+Background:
+  Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
+  And I configure the bugsnag notify endpoint
+  And I configure the bugsnag sessions endpoint
+
+Scenario Outline: calling startSession() manually
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "sessions"
+  And I run the service "sessions" with the command "node scenarios/start-session"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the request is a valid for the session tracking API
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |

--- a/packages/node/features/sessions.feature
+++ b/packages/node/features/sessions.feature
@@ -41,6 +41,32 @@ Scenario Outline: calling startSession() manually 100x
   | 6            |
   | 8            |
 
+Scenario Outline: calling startSession() repeatedly across summary interval boundaries
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "sessions"
+  And I run the service "sessions" with the command "node scenarios/start-session-async"
+  And I wait for 3 seconds
+  Then I should receive 2 requests
+  And the request used the Node notifier
+
+  # first batch
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f" for request 0
+  And request 0 is a valid for the session tracking API
+  And the payload has a valid sessions array for request 0
+  And the sessionCount "sessionsStarted" equals 50 for request 0
+
+  # second batch
+  And request 1 is a valid for the session tracking API
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f" for request 1
+  And the payload has a valid sessions array for request 1
+  And the sessionCount "sessionsStarted" equals 50 for request 1
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
 Scenario Outline: calling notify() on a sessionClient
   And I set environment variable "NODE_VERSION" to "<node version>"
   And I have built the service "sessions"

--- a/packages/node/features/steps/node_notifier_steps.rb
+++ b/packages/node/features/steps/node_notifier_steps.rb
@@ -1,6 +1,12 @@
-When("I configure the bugsnag endpoint") do
+When("I configure the bugsnag notify endpoint") do
   steps %Q{
     When I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://#{current_ip}:#{MOCK_API_PORT}"
+  }
+end
+
+When("I configure the bugsnag sessions endpoint") do
+  steps %Q{
+    When I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to "http://#{current_ip}:#{MOCK_API_PORT}"
   }
 end
 

--- a/packages/node/features/surrounding_code.feature
+++ b/packages/node/features/surrounding_code.feature
@@ -2,7 +2,7 @@ Feature: Loading surrounding code for stackframes
 
 Background:
   Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
-  And I configure the bugsnag endpoint
+  And I configure the bugsnag notify endpoint
 
 Scenario Outline: loading surrounding code by default
   And I set environment variable "NODE_VERSION" to "<node version>"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,6 +23,7 @@
     "@babel/cli": "^7.0.0-beta.51",
     "@bugsnag/core": "^1.0.0",
     "@bugsnag/delivery-node": "^1.0.0",
+    "@bugsnag/plugin-node-device": "^1.0.0",
     "@bugsnag/plugin-node-in-project": "^1.0.0",
     "@bugsnag/plugin-node-surrounding-code": "^1.0.0",
     "@bugsnag/plugin-server-session": "^1.0.0",

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -14,12 +14,14 @@ const pluginSurroundingCode = require('@bugsnag/plugin-node-surrounding-code')
 const pluginInProject = require('@bugsnag/plugin-node-in-project')
 const pluginStripProjectRoot = require('@bugsnag/plugin-strip-project-root')
 const pluginServerSession = require('@bugsnag/plugin-server-session')
+const pluginNodeDevice = require('@bugsnag/plugin-node-device')
 
 const plugins = [
   pluginSurroundingCode,
   pluginInProject,
   pluginStripProjectRoot,
-  pluginServerSession
+  pluginServerSession,
+  pluginNodeDevice
 ]
 
 module.exports = (opts, userPlugins = []) => {

--- a/packages/plugin-node-device/README.md
+++ b/packages/plugin-node-device/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/plugin-browser-node
+
+This plugin adds the device time and hostname to the `device` section of each error report, and the hostname to session payloads. It is included in the node notifier.
+
+## License
+MIT

--- a/packages/plugin-node-device/device.js
+++ b/packages/plugin-node-device/device.js
@@ -1,0 +1,18 @@
+const { isoDate } = require('@bugsnag/core/lib/es-utils')
+
+/*
+ * Automatically detects browser device details
+ */
+module.exports = {
+  init: (client) => {
+    const device = { hostname: client.config.hostname }
+
+    // merge with anything already set on the client
+    client.device = { ...device, ...client.device }
+
+    // add time just as the report is sent
+    client.config.beforeSend.unshift((report) => {
+      report.device = { ...report.device, time: isoDate() }
+    })
+  }
+}

--- a/packages/plugin-node-device/package-lock.json
+++ b/packages/plugin-node-device/package-lock.json
@@ -1,0 +1,2134 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.51"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY="
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/helper-function-name": "7.0.0-beta.51",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"requires": {
+				"color-name": "1.1.1"
+			}
+		},
+		"color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA=="
+		},
+		"istanbul-lib-instrument": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
+			"integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+			"requires": {
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/traverse": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"istanbul-lib-coverage": "^2.0.1",
+				"semver": "^5.5.0"
+			}
+		},
+		"jasmine": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+			"integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+			"requires": {
+				"glob": "^7.0.6",
+				"jasmine-core": "~3.1.0"
+			}
+		},
+		"jasmine-core": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+			"integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+		},
+		"lodash": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"nyc": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"requires": {
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^2.1.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.5",
+				"istanbul-reports": "^1.4.1",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
+				"yargs": "11.1.0",
+				"yargs-parser": "^8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"requires": {
+						"default-require-extensions": "^1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"bundled": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"bundled": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"requires": {
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"requires": {
+								"amdefine": ">=0.0.4"
+							}
+						}
+					}
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"append-transform": "^0.4.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"requires": {
+								"has-flag": "^1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.5",
+					"bundled": true,
+					"requires": {
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"handlebars": "^4.0.3"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"md5-o-matic": "^0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.2",
+					"bundled": true,
+					"requires": {
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						}
+					}
+				}
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		}
+	}
+}

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@bugsnag/plugin-node-device",
+  "version": "1.0.0",
+  "main": "device.js",
+  "description": "@bugsnag/js plugin to set device info in node",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
+  },
+  "author": "Bugsnag",
+  "license": "MIT",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@bugsnag/core": "^1.0.0",
+    "jasmine": "^3.1.0",
+    "nyc": "^12.0.2"
+  }
+}

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -15,7 +15,7 @@ const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const ISO_8601 = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
 
 describe('plugin: node device', () => {
-  it('should add a beforeSend callback which sets device time', done => {
+  it('should set device = { hostname} and add a beforeSend callback which adds device time', done => {
     const client = new Client(VALID_NOTIFIER, schema)
     client.configure({ apiKey: 'API_KEY_YEAH' })
     plugin.init(client)

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -1,0 +1,35 @@
+const { describe, it, expect } = global
+
+const plugin = require('../device')
+
+const Client = require('@bugsnag/core/client')
+const schema = {
+  ...require('@bugsnag/core/config').schema,
+  hostname: {
+    defaultValue: () => 'foo',
+    validate: () => true,
+    message: 'should be a string'
+  }
+}
+const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
+const ISO_8601 = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
+
+describe('plugin: node device', () => {
+  it('should add a beforeSend callback which sets device time', done => {
+    const client = new Client(VALID_NOTIFIER, schema)
+    client.configure({ apiKey: 'API_KEY_YEAH' })
+    plugin.init(client)
+
+    expect(client.config.beforeSend.length).toBe(1)
+    expect(client.device.hostname).toBeDefined()
+
+    client.delivery({
+      sendReport: (logger, config, payload) => {
+        expect(payload.events[0].device).toBeDefined()
+        expect(payload.events[0].device.time).toMatch(ISO_8601)
+        done()
+      }
+    })
+    client.notify(new Error('noooo'))
+  })
+})

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -6,7 +6,7 @@ const Client = require('@bugsnag/core/client')
 const schema = {
   ...require('@bugsnag/core/config').schema,
   hostname: {
-    defaultValue: () => 'foo',
+    defaultValue: () => 'test-machine.local',
     validate: () => true,
     message: 'should be a string'
   }
@@ -21,7 +21,7 @@ describe('plugin: node device', () => {
     plugin.init(client)
 
     expect(client.config.beforeSend.length).toBe(1)
-    expect(client.device.hostname).toBeDefined()
+    expect(client.device.hostname).toBe('test-machine.local')
 
     client.delivery({
       sendReport: (logger, config, payload) => {

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -1,6 +1,6 @@
 const { isArray, includes } = require('@bugsnag/core/lib/es-utils')
 const inferReleaseStage = require('@bugsnag/core/lib/infer-release-stage')
-const { positiveIntIfDefined } = require('@bugsnag/core/lib/validators')
+const { intRange } = require('@bugsnag/core/lib/validators')
 const SessionTracker = require('./tracker')
 const Backoff = require('backo')
 
@@ -32,7 +32,7 @@ module.exports = {
   configSchema: {
     sessionSummaryInterval: {
       defaultValue: () => undefined,
-      validate: value => positiveIntIfDefined(value),
+      validate: value => value === undefined || intRange()(value),
       message: 'should be a positive integer'
     }
   }

--- a/packages/plugin-server-session/tracker.js
+++ b/packages/plugin-server-session/tracker.js
@@ -30,13 +30,10 @@ module.exports = class SessionTracker extends Emitter {
   }
 
   _summarize () {
-    const thisMin = dateToMsKey(new Date())
     const summary = []
     this._sessions.forEach((val, key) => {
-      if (key !== thisMin) {
-        summary.push({ startedAt: key, sessionsStarted: val })
-        this._sessions.delete(key)
-      }
+      summary.push({ startedAt: key, sessionsStarted: val })
+      this._sessions.delete(key)
     })
     if (!summary.length) return
     this.emit('summary', summary)

--- a/packages/plugin-simple-throttle/throttle.js
+++ b/packages/plugin-simple-throttle/throttle.js
@@ -1,4 +1,4 @@
-const { positiveIntIfDefined } = require('@bugsnag/core/lib/validators')
+const { intRange } = require('@bugsnag/core/lib/validators')
 
 /*
  * Throttles and dedupes error reports
@@ -22,7 +22,7 @@ module.exports = {
     maxEvents: {
       defaultValue: () => 10,
       message: 'should be a positive integer ≤100',
-      validate: val => positiveIntIfDefined(val) && val < 100
+      validate: val => intRange(1, 100)(val)
     }
   }
 }


### PR DESCRIPTION
Adds a session tracking feature file with tests for session summary payloads.

As part of the validation for a session tracking payload, the `device` property was required, so I added the `@bugsnag/plugin-node-device` package to ensure that was populated.

This also refactors the `positiveIntIfDefined` validator, because as some point the implementation of that function and its name diverged. It is now an int range validator, which means it is more generalisable (see 7ff0f91 for more detail).