### PR TITLE
Add "filters" option to support removing sensitive properties from payload

### DIFF
--- a/packages/browser/bin/minify
+++ b/packages/browser/bin/minify
@@ -4,5 +4,5 @@ cat - | ./node_modules/.bin/uglifyjs \
   --compress \
   --mangle \
   --ie8 \
-  --source-map "content=inline,url=$(basename $1).map" \
+  --source-map "includeSources,content=inline,url=$(basename $1).map" \
 --output $1

--- a/packages/browser/features/filters.feature
+++ b/packages/browser/features/filters.feature
@@ -14,7 +14,7 @@ Scenario Outline: "password" is filtered by default
       | type       |
       | script     |
 
-Scenario Outline: User setting can override defaults`
+Scenario Outline: User setting can override defaults
   When I navigate to the URL "/filters/<type>/b.html"
   And the test should run in this browser
   Then I let the test page run for up to 10 seconds
@@ -25,6 +25,37 @@ Scenario Outline: User setting can override defaults`
   And the event "user.password" equals "123456"
   And the event "user.secret" equals "[FILTERED]"
   And the event "metaData.details.api_key" equals "[FILTERED]"
+    Examples:
+      | type       |
+      | script     |
+
+Scenario Outline: it only removes properties from specific payload subtrees
+  When I navigate to the URL "/filters/<type>/c.html"
+  And the test should run in this browser
+  Then I let the test page run for up to 10 seconds
+  And I wait for 5 seconds
+  Then I should receive 1 request
+  And the request is a valid browser payload for the error reporting API
+  And the event "user.id" equals "21"
+  And the event "user.password" equals "123456"
+  And the event "user.secret" equals "[FILTERED]"
+  And the event "metaData.details.stacktrace" equals "[FILTERED]"
+  And the "file" of stack frame 0 ends with "c.html"
+    Examples:
+      | type       |
+      | script     |
+
+Scenario Outline: it works with regexes
+  When I navigate to the URL "/filters/<type>/d.html"
+  And the test should run in this browser
+  Then I let the test page run for up to 10 seconds
+  And I wait for 5 seconds
+  Then I should receive 1 request
+  And the request is a valid browser payload for the error reporting API
+  And the event "metaData.details0" equals "[FILTERED]"
+  And the event "metaData.details1" equals "[FILTERED]"
+  And the event "metaData.details2" equals "[FILTERED]"
+  And the event "metaData.detailsA" equals "aaaa"
     Examples:
       | type       |
       | script     |

--- a/packages/browser/features/filters.feature
+++ b/packages/browser/features/filters.feature
@@ -9,7 +9,7 @@ Scenario Outline: "password" is filtered by default
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
   And the event "user.id" equals "21"
-  And the event "user.password" equals "[FILTERED]"
+  And the event "user.password" equals "[Filtered]"
     Examples:
       | type       |
       | script     |
@@ -23,8 +23,8 @@ Scenario Outline: User setting can override defaults
   And the request is a valid browser payload for the error reporting API
   And the event "user.id" equals "21"
   And the event "user.password" equals "123456"
-  And the event "user.secret" equals "[FILTERED]"
-  And the event "metaData.details.api_key" equals "[FILTERED]"
+  And the event "user.secret" equals "[Filtered]"
+  And the event "metaData.details.api_key" equals "[Filtered]"
     Examples:
       | type       |
       | script     |
@@ -38,8 +38,8 @@ Scenario Outline: it only removes properties from specific payload subtrees
   And the request is a valid browser payload for the error reporting API
   And the event "user.id" equals "21"
   And the event "user.password" equals "123456"
-  And the event "user.secret" equals "[FILTERED]"
-  And the event "metaData.details.stacktrace" equals "[FILTERED]"
+  And the event "user.secret" equals "[Filtered]"
+  And the event "metaData.details.stacktrace" equals "[Filtered]"
   And the "method" of stack frame 0 equals "handle"
     Examples:
       | type       |
@@ -52,9 +52,9 @@ Scenario Outline: it works with regexes
   And I wait for 5 seconds
   Then I should receive 1 request
   And the request is a valid browser payload for the error reporting API
-  And the event "metaData.details0" equals "[FILTERED]"
-  And the event "metaData.details1" equals "[FILTERED]"
-  And the event "metaData.details2" equals "[FILTERED]"
+  And the event "metaData.details0" equals "[Filtered]"
+  And the event "metaData.details1" equals "[Filtered]"
+  And the event "metaData.details2" equals "[Filtered]"
   And the event "metaData.detailsA" equals "aaaa"
     Examples:
       | type       |

--- a/packages/browser/features/filters.feature
+++ b/packages/browser/features/filters.feature
@@ -40,7 +40,7 @@ Scenario Outline: it only removes properties from specific payload subtrees
   And the event "user.password" equals "123456"
   And the event "user.secret" equals "[FILTERED]"
   And the event "metaData.details.stacktrace" equals "[FILTERED]"
-  And the "file" of stack frame 0 ends with "c.html"
+  And the "method" of stack frame 0 equals "handle"
     Examples:
       | type       |
       | script     |

--- a/packages/browser/features/filters.feature
+++ b/packages/browser/features/filters.feature
@@ -1,0 +1,30 @@
+@filters
+Feature: Filtering sensitive content from payload
+
+Scenario Outline: "password" is filtered by default
+  When I navigate to the URL "/filters/<type>/a.html"
+  And the test should run in this browser
+  Then I let the test page run for up to 10 seconds
+  And I wait for 5 seconds
+  Then I should receive 1 request
+  And the request is a valid browser payload for the error reporting API
+  And the event "user.id" equals "21"
+  And the event "user.password" equals "[FILTERED]"
+    Examples:
+      | type       |
+      | script     |
+
+Scenario Outline: User setting can override defaults`
+  When I navigate to the URL "/filters/<type>/b.html"
+  And the test should run in this browser
+  Then I let the test page run for up to 10 seconds
+  And I wait for 5 seconds
+  Then I should receive 1 request
+  And the request is a valid browser payload for the error reporting API
+  And the event "user.id" equals "21"
+  And the event "user.password" equals "123456"
+  And the event "user.secret" equals "[FILTERED]"
+  And the event "metaData.details.api_key" equals "[FILTERED]"
+    Examples:
+      | type       |
+      | script     |

--- a/packages/browser/features/fixtures/filters/script/a.html
+++ b/packages/browser/features/fixtures/filters/script/a.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=(.+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: 'ABC',
+        endpoints: {
+          notify: ENDPOINT,
+          sessions: ENDPOINT
+        },
+        autoCaptureSessions: false
+      })
+    </script>
+  </head>
+  <body>
+    <pre id="bugsnag-test-should-run">YES</pre>
+    <pre id="bugsnag-test-state">PENDING</pre>
+    <script>
+      bugsnagClient.notify(new Error('sensitive?'), {
+        user: { id: '21', password: '123456' }
+      })
+    </script>
+    <script>
+      setTimeout(function () {
+        var el = document.getElementById('bugsnag-test-state')
+        el.textContent = el.innerText = 'DONE'
+      }, 5000)
+    </script>
+  </body>
+</html>

--- a/packages/browser/features/fixtures/filters/script/b.html
+++ b/packages/browser/features/fixtures/filters/script/b.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=(.+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: 'ABC',
+        endpoints: {
+          notify: ENDPOINT,
+          sessions: ENDPOINT
+        },
+        autoCaptureSessions: false,
+        filters: [ 'api_key', 'secret' ]
+      })
+    </script>
+  </head>
+  <body>
+    <pre id="bugsnag-test-should-run">YES</pre>
+    <pre id="bugsnag-test-state">PENDING</pre>
+    <script>
+      bugsnagClient.metaData = {
+        details: {
+          api_key: 'fffffffff'
+        }
+      }
+      bugsnagClient.notify(new Error('sensitive?'), {
+        user: { id: '21', password: '123456', secret: 'don’t tell anyone' }
+      })
+    </script>
+    <script>
+      setTimeout(function () {
+        var el = document.getElementById('bugsnag-test-state')
+        el.textContent = el.innerText = 'DONE'
+      }, 5000)
+    </script>
+  </body>
+</html>

--- a/packages/browser/features/fixtures/filters/script/c.html
+++ b/packages/browser/features/fixtures/filters/script/c.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=(.+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: 'ABC',
+        endpoints: {
+          notify: ENDPOINT,
+          sessions: ENDPOINT
+        },
+        autoCaptureSessions: false,
+        filters: [ 'stacktrace', 'secret' ]
+      })
+    </script>
+  </head>
+  <body>
+    <pre id="bugsnag-test-should-run">YES</pre>
+    <pre id="bugsnag-test-state">PENDING</pre>
+    <script>
+      bugsnagClient.metaData = {
+        details: {
+          stacktrace: [ 'a', 'b' ]
+        }
+      }
+      bugsnagClient.notify(new Error('sensitive?'), {
+        user: { id: '21', password: '123456', secret: 'don’t tell anyone' }
+      })
+    </script>
+    <script>
+      setTimeout(function () {
+        var el = document.getElementById('bugsnag-test-state')
+        el.textContent = el.innerText = 'DONE'
+      }, 5000)
+    </script>
+  </body>
+</html>

--- a/packages/browser/features/fixtures/filters/script/c.html
+++ b/packages/browser/features/fixtures/filters/script/c.html
@@ -24,9 +24,13 @@
           stacktrace: [ 'a', 'b' ]
         }
       }
-      bugsnagClient.notify(new Error('sensitive?'), {
-        user: { id: '21', password: '123456', secret: 'don’t tell anyone' }
-      })
+      function handle () {
+        bugsnagClient.notify(new Error('sensitive?'), {
+          user: { id: '21', password: '123456', secret: 'don’t tell anyone' }
+        })
+      }
+
+      handle()
     </script>
     <script>
       setTimeout(function () {

--- a/packages/browser/features/fixtures/filters/script/d.html
+++ b/packages/browser/features/fixtures/filters/script/d.html
@@ -21,8 +21,8 @@
     <script>
       bugsnagClient.metaData = {
         details0: {},
-        details1: {},
-        details2: {},
+        details1: /foobar/,
+        details2: { unlucky: [ 13 ]  },
         detailsA: 'aaaa'
       }
       bugsnagClient.notify(new Error('sensitive?'))

--- a/packages/browser/features/fixtures/filters/script/d.html
+++ b/packages/browser/features/fixtures/filters/script/d.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=(.+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: 'ABC',
+        endpoints: {
+          notify: ENDPOINT,
+          sessions: ENDPOINT
+        },
+        autoCaptureSessions: false,
+        filters: [ /details\d/ ]
+      })
+    </script>
+  </head>
+  <body>
+    <pre id="bugsnag-test-should-run">YES</pre>
+    <pre id="bugsnag-test-state">PENDING</pre>
+    <script>
+      bugsnagClient.metaData = {
+        details0: {},
+        details1: {},
+        details2: {},
+        detailsA: 'aaaa'
+      }
+      bugsnagClient.notify(new Error('sensitive?'))
+    </script>
+    <script>
+      setTimeout(function () {
+        var el = document.getElementById('bugsnag-test-state')
+        el.textContent = el.innerText = 'DONE'
+      }, 5000)
+    </script>
+  </body>
+</html>

--- a/packages/browser/features/fixtures/filters/script/package.json
+++ b/packages/browser/features/fixtures/filters/script/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bugsnag-js-fixtures-csp-script",
+  "private": true,
+  "scripts": {
+    "build": "echo 'Done'"
+  },
+  "dependencies": {}
+}

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -93,8 +93,11 @@ module.exports.schema = {
   },
   filters: {
     defaultValue: () => [ 'password' ],
-    message: 'should be an array of strings',
-    validate: value => isArray(value) && value.length === filter(value, s => typeof s === 'string').length
+    message: 'should be an array of strings|regexes',
+    validate: value =>
+      isArray(value) && value.length === filter(value, s =>
+        (typeof s === 'string' || (s && typeof s.test === 'function'))
+      ).length
   }
 }
 

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -90,6 +90,11 @@ module.exports.schema = {
         (accum, method) => accum && typeof value[method] === 'function',
         true
       ))
+  },
+  filters: {
+    defaultValue: () => [ 'password' ],
+    message: 'should be an array of strings',
+    validate: value => isArray(value) && value.length === filter(value, s => typeof s === 'string').length
   }
 }
 

--- a/packages/core/lib/json-payload.js
+++ b/packages/core/lib/json-payload.js
@@ -1,20 +1,20 @@
 const jsonStringify = require('@bugsnag/safe-json-stringify')
-const filterPaths = [
-  // report
+const REPORT_FILTER_PATHS = [
   'events.[].app',
   'events.[].metaData',
   'events.[].user',
   'events.[].breadcrumbs',
   'events.[].request',
-  'events.[].device',
-  // session
+  'events.[].device'
+]
+const SESSION_FILTER_PATHS = [
   'device',
   'app',
   'user'
 ]
 
 module.exports.report = (report, filterKeys) => {
-  let payload = jsonStringify(report, null, null, { filterPaths, filterKeys })
+  let payload = jsonStringify(report, null, null, { filterPaths: REPORT_FILTER_PATHS, filterKeys })
   if (payload.length > 10e5) {
     delete report.events[0].metaData
     report.events[0].metaData = {
@@ -23,12 +23,14 @@ module.exports.report = (report, filterKeys) => {
 Serialized payload was ${payload.length / 10e5}MB (limit = 1MB)
 metaData was removed`
     }
-    payload = jsonStringify(report, null, null, { filterPaths, filterKeys })
+    payload = jsonStringify(report, null, null, { filterPaths: REPORT_FILTER_PATHS, filterKeys })
     if (payload.length > 10e5) throw new Error('payload exceeded 1MB limit')
   }
   return payload
 }
 
 module.exports.session = (report, filterKeys) => {
-  return jsonStringify(report, null, null, { filterPaths, filterKeys })
+  const payload = jsonStringify(report, null, null, { filterPaths: SESSION_FILTER_PATHS, filterKeys })
+  if (payload.length > 10e5) throw new Error('payload exceeded 1MB limit')
+  return payload
 }

--- a/packages/core/lib/json-payload.js
+++ b/packages/core/lib/json-payload.js
@@ -1,7 +1,9 @@
 const jsonStringify = require('@bugsnag/safe-json-stringify')
+const { includes } = require('./es-utils')
 
-module.exports = report => {
-  let payload = jsonStringify(report)
+module.exports.report = (report, filters) => {
+  const replacer = (key, value) => !includes(filters, key) ? value : '[FILTERED]'
+  let payload = jsonStringify(report, replacer)
   if (payload.length > 10e5) {
     delete report.events[0].metaData
     report.events[0].metaData = {
@@ -10,8 +12,12 @@ module.exports = report => {
 Serialized payload was ${payload.length / 10e5}MB (limit = 1MB)
 metaData was removed`
     }
-    payload = jsonStringify(report)
+    payload = jsonStringify(report, replacer)
     if (payload.length > 10e5) throw new Error('payload exceeded 1MB limit')
   }
   return payload
+}
+
+module.exports.session = (report, filters) => {
+  return jsonStringify(report, (key, value) => !includes(filters, key) ? value : '[FILTERED]')
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -117,9 +117,9 @@
 			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
 		},
 		"@bugsnag/safe-json-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-2.1.0.tgz",
-			"integrity": "sha512-tE2cPhAq+WFnA9XrfMfP+u/6L63eH7+PmONMNSXtP6kPt/iUXnwkDsxc1Q6lUP1oM3LsmWBrxn+/93M8JE6fpA=="
+			"version": "3.0.0-0",
+			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-3.0.0-0.tgz",
+			"integrity": "sha512-r1hxCBSdYcb17AmTda9gt6fvL/iaVIZsPITC/uKtaWqS79vjoaMc5J1VAbVAIYidVZfcOUZ4/Ught1anpYBFoQ=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -117,9 +117,9 @@
 			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
 		},
 		"@bugsnag/safe-json-stringify": {
-			"version": "3.0.0-0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-3.0.0-0.tgz",
-			"integrity": "sha512-r1hxCBSdYcb17AmTda9gt6fvL/iaVIZsPITC/uKtaWqS79vjoaMc5J1VAbVAIYidVZfcOUZ4/Ught1anpYBFoQ=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-3.0.0.tgz",
+			"integrity": "sha512-9iJyYUewe3cOAmvF8ySTrv3rSg0OUrVVKoj6lE1zPsOjCqzGsjCIsgHP9vNeev9JXDQt4cxqJXLAqOlCLuDdqQ=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/cuid": "^3.0.0",
-    "@bugsnag/safe-json-stringify": "^2.1.0",
+    "@bugsnag/safe-json-stringify": "3.0.0-0",
     "error-stack-parser": "^2.0.2",
     "iserror": "0.0.2",
     "stack-generator": "^2.0.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/cuid": "^3.0.0",
-    "@bugsnag/safe-json-stringify": "3.0.0-0",
+    "@bugsnag/safe-json-stringify": "3.0.0",
     "error-stack-parser": "^2.0.2",
     "iserror": "0.0.2",
     "stack-generator": "^2.0.3"

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -16,7 +16,7 @@ export interface IConfig {
   user?: object | null;
   metaData?: object | null;
   logger?: ILogger | null;
-  filters?: string[];
+  filters?: Array<string | RegExp>;
   [key: string]: any;
 }
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -16,6 +16,7 @@ export interface IConfig {
   user?: object | null;
   metaData?: object | null;
   logger?: ILogger | null;
+  filters?: string[];
   [key: string]: any;
 }
 

--- a/packages/delivery-node/delivery.js
+++ b/packages/delivery-node/delivery.js
@@ -1,5 +1,4 @@
-const jsonStringify = require('@bugsnag/safe-json-stringify')
-const makePayload = require('@bugsnag/core/lib/json-payload')
+const payload = require('@bugsnag/core/lib/json-payload')
 const { isoDate } = require('@bugsnag/core/lib/es-utils')
 const request = require('request')
 
@@ -15,7 +14,7 @@ module.exports = () => ({
           'Bugsnag-Payload-Version': '4.0',
           'Bugsnag-Sent-At': isoDate()
         },
-        body: makePayload(report),
+        body: payload.report(report, config.filters),
         proxy: config.proxy
       }, (err, res, body) => {
         if (err) logger.error(err)
@@ -37,7 +36,7 @@ module.exports = () => ({
           'Bugsnag-Payload-Version': '1.0',
           'Bugsnag-Sent-At': isoDate()
         },
-        body: jsonStringify(session),
+        body: payload.session(session, config.filters),
         proxy: config.proxy
       }, err => {
         if (err) logger.error(err)

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^1.0.0",
-    "@bugsnag/safe-json-stringify": "^2.1.0",
     "request": "^2.87.0"
   },
   "devDependencies": {

--- a/packages/delivery-node/test/delivery.test.js
+++ b/packages/delivery-node/test/delivery.test.js
@@ -32,7 +32,8 @@ describe('delivery:node', () => {
       const payload = { sample: 'payload' }
       const config = {
         apiKey: 'aaaaaaaa',
-        endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` }
+        endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` },
+        filters: []
       }
       delivery().sendReport({}, config, payload, (err) => {
         expect(err).toBe(null)
@@ -59,7 +60,8 @@ describe('delivery:node', () => {
       const payload = { sample: 'payload' }
       const config = {
         apiKey: 'aaaaaaaa',
-        endpoints: { notify: 'blah', sessions: `http://0.0.0.0:${server.address().port}/sessions/` }
+        endpoints: { notify: 'blah', sessions: `http://0.0.0.0:${server.address().port}/sessions/` },
+        filters: []
       }
       delivery().sendSession({}, config, payload, (err) => {
         expect(err).toBe(null)

--- a/packages/delivery-x-domain-request/delivery.js
+++ b/packages/delivery-x-domain-request/delivery.js
@@ -1,5 +1,4 @@
-const jsonStringify = require('@bugsnag/safe-json-stringify')
-const makePayload = require('@bugsnag/core/lib/json-payload')
+const payload = require('@bugsnag/core/lib/json-payload')
 const { isoDate } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = (win = window) => ({
@@ -12,7 +11,7 @@ module.exports = (win = window) => ({
     req.open('POST', url)
     setTimeout(() => {
       try {
-        req.send(makePayload(report))
+        req.send(payload.report(report, config.filters))
       } catch (e) {
         logger.error(e)
         cb(e)
@@ -28,7 +27,7 @@ module.exports = (win = window) => ({
     req.open('POST', url)
     setTimeout(() => {
       try {
-        req.send(jsonStringify(session))
+        req.send(payload.session(session, config.filters))
       } catch (e) {
         logger.error(e)
         cb(e)

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -17,8 +17,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "^1.0.0",
-    "@bugsnag/safe-json-stringify": "^2.1.0"
+    "@bugsnag/core": "^1.0.0"
   },
   "devDependencies": {
     "jasmine": "^3.1.0",

--- a/packages/delivery-x-domain-request/test/delivery.test.js
+++ b/packages/delivery-x-domain-request/test/delivery.test.js
@@ -27,7 +27,8 @@ describe('delivery:XDomainRequest', () => {
     const payload = { sample: 'payload' }
     const config = {
       apiKey: 'aaaaaaaa',
-      endpoints: { notify: '/echo/' }
+      endpoints: { notify: '/echo/' },
+      filters: []
     }
     delivery(window).sendReport({}, config, payload, (err) => {
       expect(err).toBe(null)
@@ -65,7 +66,8 @@ describe('delivery:XDomainRequest', () => {
     const payload = { sample: 'payload' }
     const config = {
       apiKey: 'aaaaaaaa',
-      endpoints: { notify: '/echo/', sessions: '/sessions/' }
+      endpoints: { notify: '/echo/', sessions: '/sessions/' },
+      filters: []
     }
     delivery(window).sendSession({}, config, payload, (err) => {
       expect(err).toBe(null)

--- a/packages/delivery-xml-http-request/delivery.js
+++ b/packages/delivery-xml-http-request/delivery.js
@@ -1,5 +1,4 @@
-const jsonStringify = require('@bugsnag/safe-json-stringify')
-const makePayload = require('@bugsnag/core/lib/json-payload')
+const payload = require('@bugsnag/core/lib/json-payload')
 const { isoDate } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = (win = window) => ({
@@ -15,7 +14,7 @@ module.exports = (win = window) => ({
       req.setRequestHeader('Bugsnag-Api-Key', report.apiKey || config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '4.0')
       req.setRequestHeader('Bugsnag-Sent-At', isoDate())
-      req.send(makePayload(report))
+      req.send(payload.report(report, config.filters))
     } catch (e) {
       logger.error(e)
     }
@@ -32,7 +31,7 @@ module.exports = (win = window) => ({
       req.setRequestHeader('Bugsnag-Api-Key', config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '1.0')
       req.setRequestHeader('Bugsnag-Sent-At', isoDate())
-      req.send(jsonStringify(session))
+      req.send(payload.session(session, config.filters))
     } catch (e) {
       logger.error(e)
     }

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -17,8 +17,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "^1.0.0",
-    "@bugsnag/safe-json-stringify": "^2.1.0"
+    "@bugsnag/core": "^1.0.0"
   },
   "devDependencies": {
     "jasmine": "^3.1.0",

--- a/packages/delivery-xml-http-request/test/delivery.test.js
+++ b/packages/delivery-xml-http-request/test/delivery.test.js
@@ -32,7 +32,8 @@ describe('delivery:XMLHttpRequest', () => {
     const payload = { sample: 'payload' }
     const config = {
       apiKey: 'aaaaaaaa',
-      endpoints: { notify: '/echo/' }
+      endpoints: { notify: '/echo/' },
+      filters: []
     }
     delivery({ XMLHttpRequest }).sendReport({}, config, payload, (err) => {
       expect(err).toBe(null)
@@ -77,7 +78,8 @@ describe('delivery:XMLHttpRequest', () => {
     const payload = { sample: 'payload' }
     const config = {
       apiKey: 'aaaaaaaa',
-      endpoints: { notify: '/', sessions: '/echo/' }
+      endpoints: { notify: '/', sessions: '/echo/' },
+      filters: []
     }
     delivery({ XMLHttpRequest }).sendSession({}, config, payload, (err) => {
       expect(err).toBe(null)


### PR DESCRIPTION
### Why?

This is an existing feature of most notifiers, including bugsnag-node, but was not yet implemented in the browser notifier.

### What?

The option can be used like so:

```js
const bugsnagClient = bugsnag({
  apiKey: 'api_key',
  filters: [ 'password', 'access_token', 'refresh_token' ]
})
```

If not supplied, the default value is `[ 'password' ]`. __Should we add anything else to the default list?__

### How?

This feature is implemented as a configurable array of property names. The content of any property in the payload whose key name matches an entry in the array will be replaced with the string `[FILTERED]`.


This implementation – rather than traversing specific parts of the payload – will replace any matching properties anywhere. 

#### Known drawback

This means that if a value is provided such as 'events' or 'stacktrace', then the resulting payload will not be valid for the error reporting api. __Is this a problem?__

The advantage of doing it this way means that we can leverage the built in [`JSON.stringify(obj, REPLACER)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter#The_replacer_parameter) functionality, meaning:
- it's a simpler implementation than writing our own
- it's more performant (using the serialisation traversal to do the filtering means the data structure is only walked once)
- it results smaller output for the browser bundle