### PR TITLE
feat: Add proxy config option and add tests for proxy support

### DIFF
--- a/packages/node/features/fixtures/docker-compose.yml
+++ b/packages/node/features/fixtures/docker-compose.yml
@@ -81,3 +81,21 @@ services:
       - BUGSNAG_NOTIFY_ENDPOINT
       - BUGSNAG_SESSIONS_ENDPOINT
     restart: "no"
+
+  proxy:
+    build:
+      context: proxy
+      args:
+        - NODE_VERSION
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_SESSIONS_ENDPOINT
+      - HTTP_PROXY
+    restart: "no"
+    depends_on:
+      - corporate-proxy
+
+  corporate-proxy:
+    image: minimum2scp/squid
+    restart: "no"

--- a/packages/node/features/fixtures/proxy/Dockerfile
+++ b/packages/node/features/fixtures/proxy/Dockerfile
@@ -1,0 +1,13 @@
+ARG NODE_VERSION=8
+FROM bugsnag_node_test:$NODE_VERSION
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package* /usr/src/app/
+RUN npm install
+
+COPY . /usr/src/app/
+
+RUN npm install --no-package-lock --no-save /tmp/bugsnag-node.tgz
+RUN node --version

--- a/packages/node/features/fixtures/proxy/package-lock.json
+++ b/packages/node/features/fixtures/proxy/package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "bugsnag-test",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+  }
+}

--- a/packages/node/features/fixtures/proxy/package.json
+++ b/packages/node/features/fixtures/proxy/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bugsnag-test",
+  "dependencies": {
+  }
+}

--- a/packages/node/features/fixtures/proxy/scenarios/config-misconfigured-proxy.js
+++ b/packages/node/features/fixtures/proxy/scenarios/config-misconfigured-proxy.js
@@ -1,0 +1,11 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  proxy: 'http://not-a-proxy:3128'
+})
+
+bugsnagClient.notify(new Error('hi via proxy'))

--- a/packages/node/features/fixtures/proxy/scenarios/config-proxy.js
+++ b/packages/node/features/fixtures/proxy/scenarios/config-proxy.js
@@ -1,0 +1,11 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  proxy: 'http://corporate-proxy:3128'
+})
+
+bugsnagClient.notify(new Error('hi via proxy'))

--- a/packages/node/features/fixtures/proxy/scenarios/environment-proxy.js
+++ b/packages/node/features/fixtures/proxy/scenarios/environment-proxy.js
@@ -1,0 +1,10 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  }
+})
+
+bugsnagClient.notify(new Error('hi via proxy'))

--- a/packages/node/features/proxy.feature
+++ b/packages/node/features/proxy.feature
@@ -1,0 +1,75 @@
+Feature: Proxy support
+
+Background:
+  Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
+  And I configure the bugsnag notify endpoint
+
+Scenario Outline: using environment variables to configure a proxy
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I set environment variable "HTTP_PROXY" to "http://corporate-proxy:3128"
+  And I have built the service "proxy"
+  And I run the service "proxy" with the command "node scenarios/environment-proxy"
+  And I wait for 1 second
+  Then I should receive a request
+  And the request used the Node notifier
+  And the request used payload v4 headers
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "severityReason.type" equals "handledException"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "hi via proxy"
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
+Scenario Outline: making sure no request get through a bad proxy
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I set environment variable "HTTP_PROXY" to "http://not-a-proxy:3128"
+  And I have built the service "proxy"
+  And I run the service "proxy" with the command "node scenarios/environment-proxy"
+  And I wait for 1 second
+  Then I should receive 0 requests
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
+Scenario Outline: using options to configure a proxy
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "proxy"
+  And I run the service "proxy" with the command "node scenarios/config-proxy"
+  And I wait for 1 second
+  Then I should receive a request
+  And the request used the Node notifier
+  And the request used payload v4 headers
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "severityReason.type" equals "handledException"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "hi via proxy"
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
+Scenario Outline: making sure no request get through a misconfigured proxy
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "proxy"
+  And I run the service "proxy" with the command "node scenarios/config-misconfigured-proxy"
+  And I wait for 1 second
+  Then I should receive 0 requests
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -19,6 +19,11 @@ module.exports = {
     ...schema.logger,
     defaultValue: () => getPrefixedConsole()
   },
+  proxy: {
+    defaultValue: () => undefined,
+    message: 'should be a string',
+    validate: value => value === undefined || stringWithLength(value)
+  },
   onUncaughtException: {
     defaultValue: () => (err, report, logger) => {
       logger.error(`Reported an uncaught exception${getContext(report)}, the process will now terminate…\n${err ? err.stack : err}`)


### PR DESCRIPTION
## What?

This adds the configuration option `proxy` to the node notifier. It can be used to route error reports and sessions via the specified URL.

## How?

The [`request`](https://github.com/request/request) which is used in the `@bugsnag/delivery-node` component supports proxies out of the box. The `config.proxy` option is simply passed on to that.

Additionally, request supports `HTTP_PROXY` `http_proxy` etc. environment variables, so feature tests were added for that.

## QA

This is tested and ready for full review.

The tests stand up an instance of "Squid" – a common forward proxy implementation – to do an as-real-as-possible feature test. Tests were also added with a misconfigured proxy url to ensure that the proxied scenarios aren't false positives (i.e. to ensure they are not ignoring the proxy config and directly hitting the mock notify endpoint).