### PR TITLE
Ensure manual startSession() calls result in delivered sessions

### DIFF
--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -1,0 +1,22 @@
+module.exports = (client) => {
+  const clone = new client.BugsnagClient(client.notifier)
+  clone.configure({})
+
+  // changes to these properties should be reflected in the original client
+  clone.config = client.config
+  clone.app = client.app
+  clone.context = client.context
+  clone.device = client.device
+
+  // changes to these properties should not be reflected in the original client,
+  // so ensure they are are (shallow) cloned
+  clone.breadcrumbs = client.breadcrumbs.slice()
+  clone.metaData = { ...client.metaData }
+  clone.request = { ...client.request }
+  clone.user = { ...client.user }
+
+  clone.logger(client._logger)
+  clone.delivery(client._delivery)
+
+  return clone
+}

--- a/packages/node/features/fixtures/sessions/scenarios/start-session-auto-off.js
+++ b/packages/node/features/fixtures/sessions/scenarios/start-session-auto-off.js
@@ -1,0 +1,15 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  autoCaptureSessions: false,
+  sessionSummaryInterval: 1000
+})
+
+bugsnagClient.startSession()
+
+// keep the process open a little bit so that the session has time to get sent
+setTimeout(function () {}, 5000)

--- a/packages/node/features/sessions.feature
+++ b/packages/node/features/sessions.feature
@@ -23,6 +23,24 @@ Scenario Outline: calling startSession() manually
   | 6            |
   | 8            |
 
+Scenario Outline: calling startSession() when autoCaptureSessions=false
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "sessions"
+  And I run the service "sessions" with the command "node scenarios/start-session-auto-off"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the request is a valid for the session tracking API
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
+
+  Examples:
+  | node version |
+  | 4            |
+  | 6            |
+  | 8            |
+
 Scenario Outline: calling startSession() manually 100x
   And I set environment variable "NODE_VERSION" to "<node version>"
   And I have built the service "sessions"

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -1,6 +1,7 @@
 const domain = require('domain') // eslint-disable-line
 const extractRequestInfo = require('./request-info')
 const createReportFromErr = require('@bugsnag/core/lib/report-from-error')
+const clone = require('@bugsnag/core/lib/clone-client')
 const handledState = {
   severity: 'error',
   unhandled: true,
@@ -16,17 +17,17 @@ module.exports = {
     const requestHandler = (req, res, next) => {
       const dom = domain.create()
 
-      // Start a session whether sessions are used or not. We use this
-      // to store request-specific info, in case of any errors.
-      const sessionClient = client.startSession()
+      // Get a client to be scoped to this request. If sessions are enabled, use the
+      // startSession() call to get a session client, otherwise, clone the existing client.
+      const requestClient = client.config.autoCaptureSessions ? client.startSession() : clone(client)
 
       // attach it to the request
-      req.bugsnag = sessionClient
+      req.bugsnag = requestClient
 
       // extract request info and pass it to the relevant bugsnag properties
       const { request, metaData } = getRequestAndMetaDataFromReq(req)
-      sessionClient.metaData = { ...sessionClient.metaData, request: metaData }
-      sessionClient.request = request
+      requestClient.metaData = { ...requestClient.metaData, request: metaData }
+      requestClient.request = request
 
       // unhandled errors caused by this request
       dom.on('error', (err) => {


### PR DESCRIPTION
In the implementation of the three server-side integrations:

- koa
- express
- restify

…I used the `client.startSession()` call regardless of whether auto session tracking was enabled. This was to provide a clone of a client that was scoped to a request. In the node session tracking plugin the `autoCaptureSessions` config value was checked to decide whether to send the sessions or not. The problem with this is that manual calls to `startSession()` were not delivered. Really, I had interpreted `autoCaptureSessions` as just `captureSessions` which is incorrect.

To solve this I factored out the clone logic from the node `startSession()` implementation which the server plugin now use if auto session tracking is not enabled.

I added a failing end to end test to confirm the problem which is fixed by this change.