### PR TITLE
Add process.versions to device data tab

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -16,7 +16,7 @@ Use the instructions below to run the application. When it runs, the output will
 ```
 [bugsnag] Loaded!
 
-  Welcome to the plain Node.js example app. Type one of the
+  Welcome to the plain TypeScript example app. Type one of the
   following keys, followed by enter, to perform each action:
 
   u = report an (u)nhandled error

--- a/packages/plugin-node-device/device.js
+++ b/packages/plugin-node-device/device.js
@@ -5,7 +5,7 @@ const { isoDate } = require('@bugsnag/core/lib/es-utils')
  */
 module.exports = {
   init: (client) => {
-    const device = { hostname: client.config.hostname }
+    const device = { hostname: client.config.hostname, versions: process.versions }
 
     // merge with anything already set on the client
     client.device = { ...device, ...client.device }

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -33,4 +33,13 @@ describe('plugin: node device', () => {
     })
     client.notify(new Error('noooo'))
   })
+
+  it('should attach the process.versions hash', () => {
+    const client = new Client(VALID_NOTIFIER)
+    client.setOptions({ apiKey: 'API_KEY_YEAH' })
+    client.configure(schema)
+    client.use(plugin)
+
+    expect(client.device.versions).toEqual(process.versions)
+  })
 })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/609579/48007755-2e75d280-e110-11e8-865a-62c3b7719501.png)

The version of Node was not present anywhere in the payload – what's more there are a whole bunch of other versions available in the case that Node happened to be compiled with any different binary internals.

The contents of the `process.versions` hash is now added to the device data tab verbatim.