### PR TITLE
Support Koa 1.x versions

### DIFF
--- a/packages/node/features/fixtures/docker-compose.yml
+++ b/packages/node/features/fixtures/docker-compose.yml
@@ -95,6 +95,19 @@ services:
       - BUGSNAG_SESSIONS_ENDPOINT
     restart: "no"
 
+  koa-1x:
+    build:
+      context: koa-1x
+      args:
+        - NODE_VERSION
+    ports:
+      - "4320:4320"
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_SESSIONS_ENDPOINT
+    restart: "no"
+
   proxy:
     build:
       context: proxy

--- a/packages/node/features/fixtures/koa-1x/Dockerfile
+++ b/packages/node/features/fixtures/koa-1x/Dockerfile
@@ -1,0 +1,15 @@
+ARG NODE_VERSION=8
+FROM bugsnag_node_test:$NODE_VERSION
+
+WORKDIR /usr/src/app
+
+COPY package* /usr/src/app/
+RUN npm install
+
+COPY . /usr/src/app/
+
+RUN npm install --no-package-lock --no-save /tmp/bugsnag-node.tgz /tmp/bugsnag-plugin-koa.tgz
+RUN node --version
+
+ENV NODE_ENV production
+CMD node scenarios/app

--- a/packages/node/features/fixtures/koa-1x/package-lock.json
+++ b/packages/node/features/fixtures/koa-1x/package-lock.json
@@ -1,0 +1,248 @@
+{
+  "name": "bugsnag-test",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "composition": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/composition/-/composition-2.3.0.tgz",
+      "integrity": "sha1-dCgFN0yrVQxSCjNmL1pzLgII1vI=",
+      "requires": {
+        "any-promise": "^1.1.0",
+        "co": "^4.0.2"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookies": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
+      "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
+      "requires": {
+        "depd": "~1.1.2",
+        "keygrip": "~1.0.3"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "error-inject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-assert": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.0.tgz",
+      "integrity": "sha512-tPVv62a6l3BbQoM/N5qo969l0OFxqpnQzNUPeYfTP6Spo4zkgWeDBD1D5thI7sDLg7jCCihXTLB0X8UtdyAy8A==",
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.7.1"
+      }
+    },
+    "http-errors": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
+      "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "keygrip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
+      "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
+    },
+    "koa": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-1.6.2.tgz",
+      "integrity": "sha512-oeH9b78oNQeDzmgXSmjzHIw7eT9584Lhp9h+r7zcXnzNf+2vJf021GEJsIQ5owj8Wu2x5pArrYjURnp37rv+5Q==",
+      "requires": {
+        "accepts": "^1.2.2",
+        "co": "^4.4.0",
+        "composition": "^2.1.1",
+        "content-disposition": "~0.5.0",
+        "content-type": "^1.0.0",
+        "cookies": "~0.7.0",
+        "debug": "^2.6.9",
+        "delegates": "^1.0.0",
+        "destroy": "^1.0.3",
+        "error-inject": "~1.0.0",
+        "escape-html": "~1.0.1",
+        "fresh": "^0.5.2",
+        "http-assert": "^1.1.0",
+        "http-errors": "^1.2.8",
+        "koa-compose": "^2.3.0",
+        "koa-is-json": "^1.0.0",
+        "mime-types": "^2.0.7",
+        "on-finished": "^2.1.0",
+        "only": "0.0.2",
+        "parseurl": "^1.3.0",
+        "statuses": "^1.2.0",
+        "type-is": "^1.5.5",
+        "vary": "^1.0.0"
+      }
+    },
+    "koa-compose": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-2.5.1.tgz",
+      "integrity": "sha1-cmz7F2lN5cufvwPArfFyMD+D8VY="
+    },
+    "koa-is-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
+      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "requires": {
+        "mime-db": "~1.37.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/packages/node/features/fixtures/koa-1x/package.json
+++ b/packages/node/features/fixtures/koa-1x/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bugsnag-test",
+  "dependencies": {
+    "koa": "^1.6.2"
+  }
+}

--- a/packages/node/features/fixtures/koa-1x/scenarios/app.js
+++ b/packages/node/features/fixtures/koa-1x/scenarios/app.js
@@ -1,0 +1,55 @@
+const bugsnag = require('@bugsnag/node')
+const bugsnagKoa = require('@bugsnag/plugin-koa')
+const Koa = require('koa')
+
+const bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  }
+}).use(bugsnagKoa)
+
+const middleware = bugsnagClient.getPlugin('koa')
+
+const app = new Koa()
+
+// If the server hasn't started sending something within 2 seconds
+// it probably won't. So end the request and hurry the failing test
+// along.
+app.use(function * (next) {
+  console.log('[req]', this.url, this.path)
+  var ctx = this
+  setTimeout(function () {
+    if (!ctx.headerSent) ctx.status = 500
+  }, 2000)
+  yield next
+})
+
+app.use(function * (next) {
+  if (this.path === '/error-before-handler') {
+    throw new Error('nope')
+  } else {
+    yield next
+  }
+})
+
+app.use(middleware.requestHandler.v1)
+
+app.use(function * (next) {
+  if (this.path === '/') {
+    this.body = 'ok'
+  } else if (this.path === '/err') {
+    throw new Error('noooop')
+  } else if (this.path === '/ctx-throw') {
+    this.throw(500, 'thrown')
+  } else if (this.path === '/throw-non-error') {
+    throw 'error' // eslint-disable-line
+  } else {
+    yield next
+  }
+})
+
+app.on('error', middleware.errorHandler)
+
+app.listen(4320)

--- a/packages/node/features/koa-1x.feature
+++ b/packages/node/features/koa-1x.feature
@@ -1,0 +1,100 @@
+Feature: @bugsnag/plugin-koa (koa v1.x support)
+
+Background:
+  Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
+  And I configure the bugsnag notify endpoint
+
+Scenario Outline: a synchronous thrown error in a route
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "koa-1x"
+  And I start the service "koa-1x"
+  And I wait for the app to respond on port "4320"
+  Then I open the URL "http://localhost:4320/err"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the request used payload v4 headers
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledErrorMiddleware"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "noooop"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://localhost:4320/err"
+  And the event "request.httpMethod" equals "GET"
+
+  Examples:
+  | node version |
+  | 8            |
+
+Scenario Outline: An error created with with ctx.throw()
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "koa-1x"
+  And I start the service "koa-1x"
+  And I wait for the app to respond on port "4320"
+  Then I open the URL "http://localhost:4320/ctx-throw"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the request used payload v4 headers
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledErrorMiddleware"
+  And the exception "errorClass" equals "InternalServerError"
+  And the exception "message" equals "thrown"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "node_modules/koa/lib/context.js"
+  And the "file" of stack frame 1 equals "scenarios/app.js"
+
+  Examples:
+  | node version |
+  | 8            |
+
+Scenario Outline: an error thrown before the requestHandler middleware
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "koa-1x"
+  And I start the service "koa-1x"
+  And I wait for the app to respond on port "4320"
+  Then I open the URL "http://localhost:4320/error-before-handler"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the request used payload v4 headers
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledErrorMiddleware"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "nope"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+
+  Examples:
+  | node version |
+  | 8            |
+
+Scenario Outline: throwing non-Error error
+  And I set environment variable "NODE_VERSION" to "<node version>"
+  And I have built the service "koa-1x"
+  And I start the service "koa-1x"
+  And I wait for the app to respond on port "4320"
+  Then I open the URL "http://localhost:4320/throw-non-error"
+  And I wait for 2 seconds
+  Then I should receive a request
+  And the request used the Node notifier
+  And the request used payload v4 headers
+  And the "bugsnag-api-key" header equals "9c2151b65d615a3a95ba408142c8698f"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledErrorMiddleware"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" matches "^Handled a non-error\."
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-koa/dist/bugsnag-koa.js"
+
+  Examples:
+  | node version |
+  | 8            |


### PR DESCRIPTION
The Koa plugin only supported the middleware interface introduced in Koa 2.0. This PR adds support for previous versions of Koa, which although deprecated, still receive security and bug fixes.

It wasn't possible to use the same piece of middleware to do both, because Koa 1.x checks to see that the middleware is a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) function, so the following api was introduced:

```js
// koa >=2
const { requestHandler, errorHandler } = bugsnagClient.getPlugin('koa')
app.use(requestHandler)
//...
app.use(errorHandler)

// koa 1.x
const { requestHandler, errorHandler } = bugsnagClient.getPlugin('koa')
app.use(requestHandler.v1)
//...
app.use(errorHandler)
```

Note the `errorHandler` function is compatible between versions.