### PR TITLE
fix(node): Remove unused and define missing config option

### DIFF
--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -10,7 +10,7 @@ declare module "@bugsnag/core" {
       onUnhandledRejection?: (err: any, report: Bugsnag.Report, logger: Bugsnag.ILogger) => void;
       proxy?: string;
       projectRoot?: string;
-      terminateOnUnhandledRejection?: boolean;
+      sendCode?: string;
     }
   }
 }

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -10,7 +10,7 @@ declare module "@bugsnag/core" {
       onUnhandledRejection?: (err: any, report: Bugsnag.Report, logger: Bugsnag.ILogger) => void;
       proxy?: string;
       projectRoot?: string;
-      sendCode?: string;
+      sendCode?: boolean;
     }
   }
 }


### PR DESCRIPTION
Remove unused and define missing config option.

`terminateOnUnhandledRejection` was never implemented (`onUnhandedRejection: () => {}` was implemented instead)