### PR TITLE
feat(core): Allow client.notify to be passed directly to callbacks

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -51,6 +51,12 @@ class BugsnagClient {
     this.BugsnagReport = BugsnagReport
     this.BugsnagBreadcrumb = BugsnagBreadcrumb
     this.BugsnagSession = BugsnagSession
+
+    var self = this
+    var notify = this.notify
+    this.notify = function () {
+      return notify.apply(self, arguments)
+    }
   }
 
   setOptions (opts) {


### PR DESCRIPTION
This allows the notify function to work even when called without the bugsnag instance as the callee:

```js
var bugsnagClient = bugsnag('API_KEY')
var notify = bugsnag.notify

notify(new Error('derp'))
```