### PR TITLE
feat(node): Use NODE_ENV as releaseStage if set

### DIFF
--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -19,6 +19,10 @@ module.exports = {
     ...schema.logger,
     defaultValue: () => getPrefixedConsole()
   },
+  releaseStage: {
+    ...schema.releaseStage,
+    defaultValue: () => process.env.NODE_ENV || 'production'
+  },
   proxy: {
     defaultValue: () => undefined,
     message: 'should be a string',


### PR DESCRIPTION
Use the NODE_ENV environment variable as the release stage if it is set.