### PR TITLE
fix(navigation-breadcrumbs): Ensure window reference is passed where necessary

### DIFF
--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -18,8 +18,8 @@ exports.init = (client, win = window) => {
   // hashchange has some metaData that we care about
   win.addEventListener('hashchange', event => {
     const metaData = event.oldURL
-      ? { from: relativeLocation(event.oldURL), to: relativeLocation(event.newURL), state: getCurrentState() }
-      : { to: relativeLocation(win.location.href) }
+      ? { from: relativeLocation(event.oldURL, win), to: relativeLocation(event.newURL, win), state: getCurrentState(win) }
+      : { to: relativeLocation(win.location.href, win) }
     client.leaveBreadcrumb('Hash changed', metaData, 'navigation')
   }, true)
 


### PR DESCRIPTION
As part of the universal refactor where unit tests were added to this module, a reference to window was passed in so it could be mocked. This updates the usage where window was _not_ passed in.