### PR TITLE
feat(plugin-express): Ensure express plugin supports connect too

### DIFF
--- a/packages/node/features/connect.feature
+++ b/packages/node/features/connect.feature
@@ -148,7 +148,7 @@ Scenario Outline: a string passed to next(err)
   And the exception "errorClass" equals "Error"
   And the exception "message" matches "^Handled a non-error\."
   And the exception "type" equals "nodejs"
-  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-connect/dist/bugsnag-connect.js"
+  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-express/dist/bugsnag-express.js"
 
   Examples:
   | node version |
@@ -173,7 +173,7 @@ Scenario Outline: throwing non-Error error
   And the exception "errorClass" equals "Error"
   And the exception "message" matches "^Handled a non-error\."
   And the exception "type" equals "nodejs"
-  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-connect/dist/bugsnag-connect.js"
+  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-express/dist/bugsnag-express.js"
 
   Examples:
   | node version |

--- a/packages/node/features/connect.feature
+++ b/packages/node/features/connect.feature
@@ -1,4 +1,4 @@
-Feature: @bugsnag/plugin-express
+Feature: @bugsnag/plugin-express (connect)
 
 Background:
   Given I set environment variable "BUGSNAG_API_KEY" to "9c2151b65d615a3a95ba408142c8698f"
@@ -6,10 +6,10 @@ Background:
 
 Scenario Outline: a synchronous thrown error in a route
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/sync"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/sync"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -22,7 +22,7 @@ Scenario Outline: a synchronous thrown error in a route
   And the exception "message" equals "sync"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
-  And the event "request.url" equals "http://localhost:4312/sync"
+  And the event "request.url" equals "http://localhost:4318/sync"
   And the event "request.httpMethod" equals "GET"
 
   Examples:
@@ -33,10 +33,10 @@ Scenario Outline: a synchronous thrown error in a route
 
 Scenario Outline: an asynchronous thrown error in a route
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/async"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/async"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -58,10 +58,10 @@ Scenario Outline: an asynchronous thrown error in a route
 
 Scenario Outline: an error passed to next(err)
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/next"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/next"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -83,10 +83,10 @@ Scenario Outline: an error passed to next(err)
 
 Scenario Outline: a synchronous promise rejection in a route
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/rejection-sync"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/rejection-sync"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -108,10 +108,10 @@ Scenario Outline: a synchronous promise rejection in a route
 
 Scenario Outline: an asynchronous promise rejection in a route
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/rejection-async"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/rejection-async"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -133,10 +133,10 @@ Scenario Outline: an asynchronous promise rejection in a route
 
 Scenario Outline: a string passed to next(err)
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/string-as-error"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/string-as-error"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -148,7 +148,7 @@ Scenario Outline: a string passed to next(err)
   And the exception "errorClass" equals "Error"
   And the exception "message" matches "^Handled a non-error\."
   And the exception "type" equals "nodejs"
-  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-express/dist/bugsnag-express.js"
+  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-connect/dist/bugsnag-connect.js"
 
   Examples:
   | node version |
@@ -158,10 +158,10 @@ Scenario Outline: a string passed to next(err)
 
 Scenario Outline: throwing non-Error error
   And I set environment variable "NODE_VERSION" to "<node version>"
-  And I have built the service "express"
-  And I start the service "express"
-  And I wait for the app to respond on port "4312"
-  Then I open the URL "http://localhost:4312/throw-non-error"
+  And I have built the service "connect"
+  And I start the service "connect"
+  And I wait for the app to respond on port "4318"
+  Then I open the URL "http://localhost:4318/throw-non-error"
   And I wait for 2 seconds
   Then I should receive a request
   And the request used the Node notifier
@@ -173,7 +173,7 @@ Scenario Outline: throwing non-Error error
   And the exception "errorClass" equals "Error"
   And the exception "message" matches "^Handled a non-error\."
   And the exception "type" equals "nodejs"
-  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-express/dist/bugsnag-express.js"
+  And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-connect/dist/bugsnag-connect.js"
 
   Examples:
   | node version |

--- a/packages/node/features/fixtures/connect/Dockerfile
+++ b/packages/node/features/fixtures/connect/Dockerfile
@@ -1,0 +1,15 @@
+ARG NODE_VERSION=8
+FROM bugsnag_node_test:$NODE_VERSION
+
+WORKDIR /usr/src/app
+
+COPY package* /usr/src/app/
+RUN npm install
+
+COPY . /usr/src/app/
+
+RUN npm install --no-package-lock --no-save /tmp/bugsnag-node.tgz /tmp/bugsnag-plugin-express.tgz
+RUN node --version
+
+ENV NODE_ENV production
+CMD node scenarios/app

--- a/packages/node/features/fixtures/connect/package-lock.json
+++ b/packages/node/features/fixtures/connect/package-lock.json
@@ -1,0 +1,88 @@
+{
+  "name": "bugsnag-test",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    }
+  }
+}

--- a/packages/node/features/fixtures/connect/package.json
+++ b/packages/node/features/fixtures/connect/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bugsnag-test",
+  "dependencies": {
+    "connect": "^3.6.6"
+  }
+}

--- a/packages/node/features/fixtures/connect/scenarios/app.js
+++ b/packages/node/features/fixtures/connect/scenarios/app.js
@@ -1,0 +1,78 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagExpress = require('@bugsnag/plugin-express')
+var connect = require('connect')
+
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  }
+}).use(bugsnagExpress)
+
+var middleware = bugsnagClient.getPlugin('express')
+
+var app = connect()
+
+app.use(middleware.requestHandler)
+
+// If the server hasn't started sending something within 2 seconds
+// it probably won't. So end the request and hurry the failing test
+// along.
+app.use(function (req, res, next) {
+  setTimeout(function () {
+    if (!res.headersSent) {
+      res.statusCode = 500
+      res.end('Internal server error')
+    }
+  }, 2000)
+  next()
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/') return next()
+  res.end('ok')
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/sync') return next()
+  throw new Error('sync')
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/async') return next()
+  setTimeout(function () {
+    throw new Error('async')
+  }, 100)
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/next') return next()
+  next(new Error('next'))
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/rejection-sync') return next()
+  Promise.reject(new Error('reject sync')).catch(next)
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/rejection-async') return next()
+  setTimeout(function () {
+    Promise.reject(new Error('reject async')).catch(next)
+  }, 100)
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/string-as-error') return next()
+  next('errrr')
+})
+
+app.use(function (req, res, next) {
+  if (req.url !== '/throw-non-error') return next()
+  throw 1 // eslint-disable-line
+})
+
+app.use(middleware.errorHandler)
+
+app.listen(4318)

--- a/packages/node/features/fixtures/docker-compose.yml
+++ b/packages/node/features/fixtures/docker-compose.yml
@@ -69,6 +69,19 @@ services:
       - BUGSNAG_SESSIONS_ENDPOINT
     restart: "no"
 
+  connect:
+    build:
+      context: connect
+      args:
+        - NODE_VERSION
+    ports:
+      - "4318:4318"
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_SESSIONS_ENDPOINT
+    restart: "no"
+
   restify:
     build:
       context: restify

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -36,7 +36,10 @@ module.exports = {
           if (e) return client._logger('Failed to send report to Bugsnag')
           req.bugsnag.config.onUncaughtException(err, report, client._logger)
         })
-        if (!res.headersSent) res.sendStatus(500)
+        if (!res.headersSent) {
+          res.status = 500
+          res.end('Internal server error')
+        }
       })
 
       return dom.run(next)

--- a/packages/plugin-express/src/request-info.js
+++ b/packages/plugin-express/src/request-info.js
@@ -5,7 +5,9 @@ module.exports = req => {
   const address = connection && connection.address && connection.address()
   const portNumber = address && address.port
   const port = (!portNumber || portNumber === 80 || portNumber === 443) ? '' : `:${portNumber}`
-  const url = `${req.protocol}://${req.hostname || req.host}${port}${req.url}`
+  const protocol = typeof req.protocol !== 'undefined' ? req.protocol : (req.connection.encrypted ? 'https' : 'http')
+  const hostname = (req.hostname || req.host || req.headers.host || '').replace(/:\d+$/, '')
+  const url = `${protocol}://${hostname}${port}${req.url}`
   const request = {
     url: url,
     path: req.path || req.url,


### PR DESCRIPTION
When putting together the Nuxt example I noticed we used a couple of features of Express that Connect doesn't have:

- `res.sendStatus(n)`
- `req.host` or `req.hostname`

This PR keeps the same functionality but using Connect-compatible APIs.