### PR TITLE
fix(plugin-user-ip): Ensure client IP is not collected when user.id=undefined

### DIFF
--- a/packages/plugin-client-ip/client-ip.js
+++ b/packages/plugin-client-ip/client-ip.js
@@ -6,6 +6,9 @@ module.exports = {
     if (client.config.collectUserIp) return
 
     client.config.beforeSend.push(report => {
+      // If user.id is explicitly undefined, it will be missing from the payload. It needs
+      // removing so that the following line replaces it
+      if (report.user && typeof report.user.id === 'undefined') delete report.user.id
       report.user = { id: '[NOT COLLECTED]', ...report.user }
       report.request = { clientIp: '[NOT COLLECTED]', ...report.request }
     })

--- a/packages/plugin-client-ip/test/client-ip.test.js
+++ b/packages/plugin-client-ip/test/client-ip.test.js
@@ -39,6 +39,23 @@ describe('plugin: ip', () => {
     expect(payloads[0].events[0].request).toEqual({ clientIp: '[NOT COLLECTED]' })
   })
 
+  it('overwrites a user id if it is explicitly `undefined`', () => {
+    const client = new Client(VALID_NOTIFIER)
+    const payloads = []
+    client.setOptions({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
+    client.configure()
+    client.use(plugin)
+
+    client.user = { id: undefined }
+
+    client.delivery({ sendReport: (logger, config, payload) => payloads.push(payload) })
+    client.notify(new Error('noooo'))
+
+    expect(payloads.length).toEqual(1)
+    expect(payloads[0].events[0].user).toEqual({ id: '[NOT COLLECTED]' })
+    expect(payloads[0].events[0].request).toEqual({ clientIp: '[NOT COLLECTED]' })
+  })
+
   it('redacts user IP if none is provided', () => {
     const client = new Client(VALID_NOTIFIER)
     const payloads = []


### PR DESCRIPTION
Values that are explicitly `undefined` would not previously have been replaced with the [Not
collected] string, meaning the backend would record the IP. This change means that explicitly
`undefined` user ids are replaced correctly when `collectUserIp=false`