### PR TITLE
fix(plugin-console-breadcrumbs): String(val) can throw for some values

### DIFF
--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -9,7 +9,11 @@ exports.init = (client) => {
     console[method] = (...args) => {
       client.leaveBreadcrumb('Console output', reduce(args, (accum, arg, i) => {
         // do the best/simplest stringification of each argument
-        let stringified = String(arg)
+        let stringified = '[Unknown value]'
+        // this may fail if the input is:
+        // - an object whose [[Prototype]] is null (no toString)
+        // - an object with a broken toString or @@toPrimitive implementation
+        try { stringified = String(arg) } catch (e) {}
         // if it stringifies to [object Object] attempt to JSON stringify
         if (stringified === '[object Object]') {
           // catch stringify errors and fallback to [object Object]

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
@@ -31,4 +31,13 @@ describe('plugin: console breadcrumbs', () => {
     // undo the global side effects of wrapping console.* for the rest of the tests
     plugin.destroy()
   })
+
+  it('should not throw when an object without toString is logged', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
+    c.configure()
+    c.use(plugin)
+    expect(() => console.log(Object.create(null))).not.toThrow()
+    plugin.destroy()
+  })
 })


### PR DESCRIPTION
Wrap a try/catch around the call to `String(val)` in console breadcrumbs. This fix was supplied by
@bathos-wistia in a PR that targeted a different branch, thanks!