### PR TITLE
Fix README for accessing ErrorBoundary

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -31,9 +31,10 @@ const bugsnagClient = bugsnag('API_KEY')
 import ReactDOM from 'react-dom'
 import React from 'react'
 import bugsnagReact from '@bugsnag/plugin-react'
+bugsnagClient.use(bugsnagReact, React)
 
 // wrap your entire app tree in the ErrorBoundary provided
-const ErrorBoundary = bugsnagClient.use(bugsnagReact, React)
+const ErrorBoundary = bugsnagClient.getPlugin('react');
 ReactDOM.render(
   <ErrorBoundary>
     <YourApp />


### PR DESCRIPTION
Not sure if the code in the README works as is (didn't test) but it's at least against typescript definitions and differs from the documented usage: https://docs.bugsnag.com/platforms/javascript/react/