### PR TITLE
fix(plugin-window-unhandled-rejection): Tolerate property access errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.x.x (TBD)
+
+### Fixed
+
+- Tolerate errors accessing properties of an unhandled rejection event (#394, #442)
+
 ## 5.0.1 (2018-11-29)
 
 ### Fixed

--- a/packages/plugin-window-unhandled-rejection/unhandled-rejection.js
+++ b/packages/plugin-window-unhandled-rejection/unhandled-rejection.js
@@ -12,10 +12,13 @@ exports.init = (client, win = window) => {
     let error = event.reason
     let isBluebird = false
 
-    if (event.detail && event.detail.reason) {
-      error = event.detail.reason
-      isBluebird = true
-    }
+    // accessing properties on event.detail can throw errors (see #394)
+    try {
+      if (event.detail && event.detail.reason) {
+        error = event.detail.reason
+        isBluebird = true
+      }
+    } catch (e) {}
 
     const handledState = {
       severity: 'error',


### PR DESCRIPTION
In the callback for unhandled rejection events, `event.detail` can be any unknown/untrusted object.
In some cases accessing the `reason` property on it has caused a security error – perhaps because
the event detail came from an iframe or something similar. This change wraps that access in a try
catch and adds a unit test for such a scenario.

Fixes #394.