### PR TITLE
window.onerror handler improvements

### DIFF
--- a/packages/plugin-window-onerror/onerror.js
+++ b/packages/plugin-window-onerror/onerror.js
@@ -44,14 +44,16 @@ module.exports = {
 const decorateStack = (stack, url, lineNo, charNo) => {
   const culprit = stack[0]
   if (!culprit) return stack
-  if (!culprit.fileName) culprit.setFileName(url)
-  if (!culprit.lineNumber) culprit.setLineNumber(lineNo)
+  if (!culprit.fileName && typeof url === 'string') culprit.setFileName(url)
+  if (!culprit.lineNumber && isActualNumber(lineNo)) culprit.setLineNumber(lineNo)
   if (!culprit.columnNumber) {
-    if (charNo !== undefined) {
+    if (isActualNumber(charNo)) {
       culprit.setColumnNumber(charNo)
-    } else if (window.event && window.event.errorCharacter) {
-      culprit.setColumnNumber(window.event && window.event.errorCharacter)
+    } else if (window.event && isActualNumber(window.event.errorCharacter)) {
+      culprit.setColumnNumber(window.event.errorCharacter)
     }
   }
   return stack
 }
+
+const isActualNumber = (n) => typeof n === 'number' && String.call(n) !== 'NaN'

--- a/packages/plugin-window-onerror/onerror.js
+++ b/packages/plugin-window-onerror/onerror.js
@@ -13,20 +13,70 @@ module.exports = {
         const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
 
         let report
+
+        // window.onerror can be called in a number of ways. This big if-else is how we
+        // figure out which arguments were supplied, and what kind of values it received.
+
         if (error) {
+          // if the last parameter (error) was supplied, this is a modern browser's
+          // way of saying "this value was thrown and not caught"
+
           if (error.name && error.message) {
-            report = new client.BugsnagReport(error.name, error.message, decorateStack(client.BugsnagReport.getStacktrace(error), url, lineNo, charNo), handledState)
+            // if it looks like an error, construct a report object using its stack
+            report = new client.BugsnagReport(
+              error.name,
+              error.message,
+              decorateStack(client.BugsnagReport.getStacktrace(error), url, lineNo, charNo),
+              handledState
+            )
           } else {
-            report = new client.BugsnagReport('window.onerror', String(error), decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo), handledState)
+            // otherwise, for non error values that were thrown, stringify it for
+            // use as the error message and get/generate a stacktrace
+            report = new client.BugsnagReport(
+              'window.onerror',
+              String(error),
+              decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo),
+              handledState
+            )
+            // include the raw input as metadata
             report.updateMetaData('window onerror', { error })
           }
-        } else if ((typeof messageOrEvent === 'object' && messageOrEvent !== null) && (!url || typeof url !== 'string') && !lineNo && !charNo && !error) {
+        } else if (
+          // This complex case detects "error" events that are typically synthesised
+          // by jquery's trigger method (although can be created in other ways). In
+          // order to detect this:
+          // - the first argument (message) must exist and be an object (most likely it's a jQuery event)
+          // - the second argument (url) must either not exist or be something other than a string (if it
+          //    exists and is not a string, it'll be the extraParameters argument from jQuery's trigger()
+          //    function)
+          // - the third, fourth and fifth arguments must not exist (lineNo, charNo and error)
+          (typeof messageOrEvent === 'object' && messageOrEvent !== null) &&
+          (!url || typeof url !== 'string') &&
+          !lineNo && !charNo && !error
+        ) {
+          // The jQuery event may have a "type" property, if so use it as part of the error message
           const name = messageOrEvent.type ? `Event: ${messageOrEvent.type}` : 'window.onerror'
+          // attempt to find a message from one of the conventional properties, but
+          // default to empty string (the report will fill it with a placeholder)
           const message = messageOrEvent.message || messageOrEvent.detail || ''
-          report = new client.BugsnagReport(name, message, client.BugsnagReport.getStacktrace(new Error(), 1).slice(1), handledState)
+          report = new client.BugsnagReport(
+            name,
+            message,
+            client.BugsnagReport.getStacktrace(new Error(), 1).slice(1),
+            handledState
+          )
+          // include the raw input as metadata – it might contain more info than we extracted
           report.updateMetaData('window onerror', { event: messageOrEvent, extraParameters: url })
         } else {
-          report = new client.BugsnagReport('window.onerror', String(messageOrEvent), decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo), handledState)
+          // Lastly, if there was no "error" parameter this event was probably from an old
+          // browser that doesn't support that. Instead we need to generate a stacktrace.
+          report = new client.BugsnagReport(
+            'window.onerror',
+            String(messageOrEvent),
+            decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo),
+            handledState
+          )
+          // include the raw input as metadata – it might contain more info than we extracted
           report.updateMetaData('window onerror', { event: messageOrEvent })
         }
 
@@ -41,6 +91,9 @@ module.exports = {
   }
 }
 
+// Sometimes the stacktrace has less information than was passed to window.onerror.
+// This function will augment the first stackframe with any useful info that was
+// received as arguments to the onerror callback.
 const decorateStack = (stack, url, lineNo, charNo) => {
   const culprit = stack[0]
   if (!culprit) return stack

--- a/packages/plugin-window-onerror/onerror.js
+++ b/packages/plugin-window-onerror/onerror.js
@@ -20,11 +20,11 @@ module.exports = {
             report = new client.BugsnagReport('window.onerror', String(error), decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo), handledState)
             report.updateMetaData('window onerror', { error })
           }
-        } else if ((typeof messageOrEvent === 'object' && messageOrEvent !== null) && !url && !lineNo && !charNo && !error) {
+        } else if ((typeof messageOrEvent === 'object' && messageOrEvent !== null) && (!url || typeof url !== 'string') && !lineNo && !charNo && !error) {
           const name = messageOrEvent.type ? `Event: ${messageOrEvent.type}` : 'window.onerror'
           const message = messageOrEvent.message || messageOrEvent.detail || ''
           report = new client.BugsnagReport(name, message, client.BugsnagReport.getStacktrace(new Error(), 1).slice(1), handledState)
-          report.updateMetaData('window onerror', { event: messageOrEvent })
+          report.updateMetaData('window onerror', { event: messageOrEvent, extraParameters: url })
         } else {
           report = new client.BugsnagReport('window.onerror', String(messageOrEvent), decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo), handledState)
           report.updateMetaData('window onerror', { event: messageOrEvent })

--- a/packages/plugin-window-onerror/test/onerror.test.js
+++ b/packages/plugin-window-onerror/test/onerror.test.js
@@ -100,6 +100,30 @@ describe('plugin: window onerror', () => {
       expect(report.exceptions[0].message).toBe('something bad happened')
       expect(report.severityReason).toEqual({ type: 'unhandledException' })
     })
+
+    it('handles single argument usage of window.onerror with extra parameter', () => {
+      const client = new Client(VALID_NOTIFIER)
+      const payloads = []
+      client.setOptions({ apiKey: 'API_KEY_YEAH' })
+      client.configure()
+      client.use(plugin, window)
+      client.delivery({ sendReport: (logger, config, payload) => payloads.push(payload) })
+
+      // this situation is caused by the following kind of jQuery call:
+      // jQuery('select.province').trigger(jQuery.Event('error.validator.bv'), { valid: false })
+      const event = { type: 'error', detail: 'something bad happened' }
+      const extra = { valid: false }
+      window.onerror(event, extra)
+
+      expect(payloads.length).toBe(1)
+      const report = payloads[0].events[0].toJSON()
+      expect(report.severity).toBe('error')
+      expect(report.unhandled).toBe(true)
+      expect(report.exceptions[0].errorClass).toBe('Event: error')
+      expect(report.exceptions[0].message).toBe('something bad happened')
+      expect(report.severityReason).toEqual({ type: 'unhandledException' })
+    })
+
     //
     // if ('addEventListener' in window) {
     //   it('captures uncaught errors in DOM (level 3) event handlers', done => {


### PR DESCRIPTION
A couple of related fixes:

c8ace7c: fix(plugin-window-onerror): Make decorateStack more robust

Only supply values that are of the expected type, as the stacktrace module can throw if given input
of the wrong kind.

Fixes #393.

---

7087fe9: fix(plugin-window-onerror): Support additional onerror call signature

For some events triggered by jQuery, the second argument to onerror can be an object. This
previously caused the onerror handler to misidentify the kind of error that had happened. This fix
amends the check on the "url" argument, only determining it to be a url if it is defined and is a
string.

Fixes #392.