### PR TITLE
 fix(breadcrumbs): Fix granular breadcrumb config logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support serialising error objects (via. @bugsnag/safe-json-stringify@v4.0.0) (#356, #458)
 
+### Fixed
+
+- Fixed granular breadcrumb config logic (#461, #465, #466)
+
 ## 5.1.0 (2018-12-19)
 
 ### Fixed

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/browser",
-	"version": "5.0.0-alpha.1",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -82,23 +82,10 @@ module.exports = (opts) => {
     bugsnag.use(pluginUnhandledRejection)
   }
 
-  if (inferBreadcrumbSetting(bugsnag.config, 'navigationBreadcrumbsEnabled')) {
-    bugsnag.use(pluginNavigationBreadcrumbs)
-  }
-
-  if (inferBreadcrumbSetting(bugsnag.config, 'interactionBreadcrumbsEnabled')) {
-    bugsnag.use(pluginInteractionBreadcrumbs)
-  }
-
-  if (inferBreadcrumbSetting(bugsnag.config, 'networkBreadcrumbsEnabled')) {
-    bugsnag.use(pluginNetworkBreadcrumbs)
-  }
-
-  // because console breadcrumbs play havoc with line numbers,
-  // if not explicitly enabled, only setup on non-development evironments
-  if (inferBreadcrumbSetting(bugsnag.config, 'consoleBreadcrumbsEnabled', false)) {
-    bugsnag.use(pluginConsoleBreadcrumbs)
-  }
+  bugsnag.use(pluginNavigationBreadcrumbs)
+  bugsnag.use(pluginInteractionBreadcrumbs)
+  bugsnag.use(pluginNetworkBreadcrumbs)
+  bugsnag.use(pluginConsoleBreadcrumbs)
 
   bugsnag._logger.debug(`Loaded!`)
 
@@ -106,12 +93,6 @@ module.exports = (opts) => {
     ? bugsnag.startSession()
     : bugsnag
 }
-
-const inferBreadcrumbSetting = (config, val, defaultInDev = true) =>
-  typeof config[val] === 'boolean'
-    ? config[val]
-    : (config.autoBreadcrumbs &&
-        (defaultInDev || !/^dev(elopment)?$/.test(config.releaseStage)))
 
 // Stub this value because this is what the type interface looks like
 // (types/bugsnag.d.ts). This is only an issue in Angular's development

--- a/packages/delivery-node/package-lock.json
+++ b/packages/delivery-node/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/delivery-node",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/delivery-x-domain-request/package-lock.json
+++ b/packages/delivery-x-domain-request/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/delivery-x-domain-request",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/delivery-xml-http-request/package-lock.json
+++ b/packages/delivery-xml-http-request/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/delivery-xml-http-request",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/js",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/node",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-angular/package-lock.json
+++ b/packages/plugin-angular/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-angular",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-browser-context/package-lock.json
+++ b/packages/plugin-browser-context/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-browser-context",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-browser-device/package-lock.json
+++ b/packages/plugin-browser-device/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-browser-device",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-browser-request/package-lock.json
+++ b/packages/plugin-browser-request/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-browser-request",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-browser-session/package-lock.json
+++ b/packages/plugin-browser-session/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-browser-session",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-client-ip/package-lock.json
+++ b/packages/plugin-client-ip/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-client-ip",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -4,6 +4,12 @@ const { map, reduce, filter } = require('@bugsnag/core/lib/es-utils')
  * Leaves breadcrumbs when console log methods are called
  */
 exports.init = (client) => {
+  const isDev = /^dev(elopment)?$/.test(client.config.releaseStage)
+
+  const explicitlyDisabled = client.config.consoleBreadcrumbsEnabled === false
+  const implicitlyDisabled = (client.config.autoBreadcrumbs === false || isDev) && client.config.consoleBreadcrumbsEnabled !== true
+  if (explicitlyDisabled || implicitlyDisabled) return
+
   map(CONSOLE_LOG_METHODS, method => {
     const original = console[method]
     console[method] = (...args) => {

--- a/packages/plugin-console-breadcrumbs/package-lock.json
+++ b/packages/plugin-console-breadcrumbs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-console-breadcrumbs",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
@@ -43,4 +43,44 @@ describe('plugin: console breadcrumbs', () => {
     expect(c.breadcrumbs[0].metaData['[0]']).toBe('[Unknown value]')
     plugin.destroy()
   })
+
+  it('should not be enabled when autoBreadcrumbs=false', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    c.configure()
+    c.use(plugin)
+    console.log(123)
+    expect(c.breadcrumbs.length).toBe(0)
+    plugin.destroy()
+  })
+
+  it('should be enabled when autoBreadcrumbs=false, consoleBreadcrumbsEnabled=true', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, consoleBreadcrumbsEnabled: true })
+    c.configure()
+    c.use(plugin)
+    console.log(123)
+    expect(c.breadcrumbs.length).toBe(1)
+    plugin.destroy()
+  })
+
+  it('should be not enabled by default when releaseStage=development', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'development' })
+    c.configure()
+    c.use(plugin)
+    console.log(123)
+    expect(c.breadcrumbs.length).toBe(0)
+    plugin.destroy()
+  })
+
+  it('can be enabled when releaseStage=development', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'development', consoleBreadcrumbsEnabled: true })
+    c.configure()
+    c.use(plugin)
+    console.log(123)
+    expect(c.breadcrumbs.length).toBe(1)
+    plugin.destroy()
+  })
 })

--- a/packages/plugin-contextualize/package-lock.json
+++ b/packages/plugin-contextualize/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-contextualize",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-express/package-lock.json
+++ b/packages/plugin-express/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-express",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-inline-script-content/package-lock.json
+++ b/packages/plugin-inline-script-content/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-inline-script-content",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
+++ b/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
@@ -5,6 +5,10 @@ module.exports = {
   init: (client, win = window) => {
     if (!('addEventListener' in win)) return
 
+    const explicitlyDisabled = client.config.interactionBreadcrumbsEnabled === false
+    const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.interactionBreadcrumbsEnabled !== true
+    if (explicitlyDisabled || implicitlyDisabled) return
+
     win.addEventListener('click', (event) => {
       let targetText, targetSelector
       try {

--- a/packages/plugin-interaction-breadcrumbs/package-lock.json
+++ b/packages/plugin-interaction-breadcrumbs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-interaction-breadcrumbs",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
@@ -7,54 +7,78 @@ const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: interaction breadcrumbs', () => {
   it('should drop a breadcrumb when an element is clicked', () => {
-    const els = [
-      {
-        tagName: 'BUTTON',
-        className: 'button',
-        textContent: 'Click me',
-        parentNode: null
-      },
-      {
-        tagName: 'BUTTON',
-        className: 'button',
-        textContent: 'or me',
-        parentNode: null
-      }
-    ]
-
-    const parent = {
-      tagName: 'DIV',
-      id: 'buttons',
-      childNodes: els,
-      className: '',
-      parentNode: null
-    }
-
-    parent.parentNode = { childNodes: [ parent ] }
-    els.forEach(el => { el.parentNode = parent })
-
-    const winHandlers = {}
-    const window = {
-      addEventListener: function (evt, handler) {
-        winHandlers[evt] = winHandlers[evt] ? winHandlers[evt].concat(handler) : [ handler ]
-      },
-      document: {
-        querySelectorAll: function (query) {
-          switch (query) {
-            case 'BUTTON.button': return els
-            case 'BUTTON.button:nth-child(1)': return [ els[0] ]
-            case 'DIV#buttons': return [ parent ]
-            default: return []
-          }
-        }
-      }
-    }
-
     const c = new Client(VALID_NOTIFIER)
     c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.configure()
+    const { window, winHandlers, els } = getMockWindow()
+    c.use(plugin, window)
+    winHandlers['click'].forEach(fn => fn.call(window, { target: els[0] }))
+    expect(c.breadcrumbs.length).toBe(1)
+  })
+
+  it('should not be enabled when autoBreadcrumbs=false', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    c.configure()
+    const { window, winHandlers, els } = getMockWindow()
+    c.use(plugin, window)
+    winHandlers['click'].forEach(fn => fn.call(window, { target: els[0] }))
+    expect(c.breadcrumbs.length).toBe(0)
+  })
+
+  it('should be enabled when autoBreadcrumbs=false and interactionBreadcrumbsEnabled=true', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, interactionBreadcrumbsEnabled: true })
+    c.configure()
+    const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers['click'].forEach(fn => fn.call(window, { target: els[0] }))
     expect(c.breadcrumbs.length).toBe(1)
   })
 })
+
+const getMockWindow = () => {
+  const els = [
+    {
+      tagName: 'BUTTON',
+      className: 'button',
+      textContent: 'Click me',
+      parentNode: null
+    },
+    {
+      tagName: 'BUTTON',
+      className: 'button',
+      textContent: 'or me',
+      parentNode: null
+    }
+  ]
+
+  const parent = {
+    tagName: 'DIV',
+    id: 'buttons',
+    childNodes: els,
+    className: '',
+    parentNode: null
+  }
+
+  parent.parentNode = { childNodes: [ parent ] }
+  els.forEach(el => { el.parentNode = parent })
+
+  let winHandlers = { 'click': [] }
+  const window = {
+    addEventListener: function (evt, handler) {
+      winHandlers[evt] = winHandlers[evt] ? winHandlers[evt].concat(handler) : [ handler ]
+    },
+    document: {
+      querySelectorAll: function (query) {
+        switch (query) {
+          case 'BUTTON.button': return els
+          case 'BUTTON.button:nth-child(1)': return [ els[0] ]
+          case 'DIV#buttons': return [ parent ]
+          default: return []
+        }
+      }
+    }
+  }
+  return { els, window, winHandlers }
+}

--- a/packages/plugin-intercept/package-lock.json
+++ b/packages/plugin-intercept/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-intercept",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-koa/package-lock.json
+++ b/packages/plugin-koa/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-koa",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -4,6 +4,10 @@
 exports.init = (client, win = window) => {
   if (!('addEventListener' in win)) return
 
+  const explicitlyDisabled = client.config.navigationBreadcrumbsEnabled === false
+  const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.navigationBreadcrumbsEnabled !== true
+  if (explicitlyDisabled || implicitlyDisabled) return
+
   // returns a function that will drop a breadcrumb with a given name
   const drop = name => () => client.leaveBreadcrumb(name, {}, 'navigation')
 

--- a/packages/plugin-navigation-breadcrumbs/package-lock.json
+++ b/packages/plugin-navigation-breadcrumbs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-navigation-breadcrumbs",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -5,62 +5,14 @@ const plugin = require('../navigation-breadcrumbs')
 const Client = require('@bugsnag/core/client')
 const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
-const winHandlers = {}
-const docHandlers = {}
-
-// mock the window stuff this plugin uses
-const window = {
-  document: {
-    createElement: function (tag) {
-      const el = { href: '' }
-      Object.defineProperties(el, {
-        pathname: {
-          get: () => {
-            const path = el.href.split('/').pop()
-            return path ? `/${path.split('?')[0] || ''}` : ''
-          }
-        },
-        search: {
-          get: () => {
-            const search = el.href.split('?')[1]
-            return search ? `?${search.split('#')[0] || ''}` : ''
-          }
-        },
-        hash: {
-          get: () => {
-            const hash = el.href.split('#')[1]
-            return hash ? `#${hash}` : ''
-          }
-        }
-      })
-      return el
-    },
-    addEventListener: function (evt, handler) {
-      docHandlers[evt] = docHandlers[evt] ? docHandlers[evt].concat(handler) : [ handler ]
-    }
-  },
-  location: {
-    href: 'https://app.bugsnag.com/errors'
-  },
-  history: {
-    replaceState: function (state, title, url) {
-      window.location.href = `https://app.bugsnag.com/${url}`
-    },
-    pushState: function () {},
-    popState: function () {}
-  },
-  addEventListener: function (evt, handler) {
-    winHandlers[evt] = winHandlers[evt] ? winHandlers[evt].concat(handler) : [ handler ]
-  }
-}
-
 describe('plugin: navigation breadcrumbs', () => {
   it('should drop breadcrumb for navigational activity', done => {
     const c = new Client(VALID_NOTIFIER)
     c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.configure()
-    c.use(plugin, window)
 
+    const { winHandlers, docHandlers, window } = getMockWindow()
+    c.use(plugin, window)
     winHandlers['load'].forEach((h) => h.call(window))
     docHandlers['DOMContentLoaded'].forEach((h) => h.call(window.document))
 
@@ -81,4 +33,82 @@ describe('plugin: navigation breadcrumbs', () => {
 
     done()
   })
+
+  it('should not be enabled when autoBreadcrumbs=false', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    c.configure()
+    const { winHandlers, docHandlers, window } = getMockWindow()
+    c.use(plugin, window)
+    winHandlers['load'].forEach((h) => h.call(window))
+    docHandlers['DOMContentLoaded'].forEach((h) => h.call(window.document))
+    window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
+    window.history.replaceState({}, 'bar')
+    expect(c.breadcrumbs.length).toBe(0)
+  })
+
+  it('should be enabled when autoBreadcrumbs=false and navigationBreadcrumbsEnabled=true', () => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, navigationBreadcrumbsEnabled: true })
+    c.configure()
+    const { winHandlers, docHandlers, window } = getMockWindow()
+    c.use(plugin, window)
+    winHandlers['load'].forEach((h) => h.call(window))
+    docHandlers['DOMContentLoaded'].forEach((h) => h.call(window.document))
+    window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
+    window.history.replaceState({}, 'bar')
+    expect(c.breadcrumbs.length).toBe(5)
+  })
 })
+
+const getMockWindow = () => {
+  const winHandlers = { load: [] }
+  const docHandlers = { DOMContentLoaded: [] }
+
+  // mock the window stuff this plugin uses
+  const window = {
+    document: {
+      createElement: function (tag) {
+        const el = { href: '' }
+        Object.defineProperties(el, {
+          pathname: {
+            get: () => {
+              const path = el.href.split('/').pop()
+              return path ? `/${path.split('?')[0] || ''}` : ''
+            }
+          },
+          search: {
+            get: () => {
+              const search = el.href.split('?')[1]
+              return search ? `?${search.split('#')[0] || ''}` : ''
+            }
+          },
+          hash: {
+            get: () => {
+              const hash = el.href.split('#')[1]
+              return hash ? `#${hash}` : ''
+            }
+          }
+        })
+        return el
+      },
+      addEventListener: function (evt, handler) {
+        docHandlers[evt] = docHandlers[evt] ? docHandlers[evt].concat(handler) : [ handler ]
+      }
+    },
+    location: {
+      href: 'https://app.bugsnag.com/errors'
+    },
+    history: {
+      replaceState: function (state, title, url) {
+        window.location.href = `https://app.bugsnag.com/${url}`
+      },
+      pushState: function () {},
+      popState: function () {}
+    },
+    addEventListener: function (evt, handler) {
+      winHandlers[evt] = winHandlers[evt] ? winHandlers[evt].concat(handler) : [ handler ]
+    }
+  }
+  return { winHandlers, docHandlers, window }
+}

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -18,6 +18,10 @@ const getEndpoints = () =>
  * Leaves breadcrumbs when network requests occur
  */
 exports.init = (_client, _win = window) => {
+  const explicitlyDisabled = _client.config.networkBreadcrumbsEnabled === false
+  const implicitlyDisabled = _client.config.autoBreadcrumbs === false && _client.config.networkBreadcrumbsEnabled !== true
+  if (explicitlyDisabled || implicitlyDisabled) return
+
   client = _client
   win = _win
   monkeyPatchXMLHttpRequest()

--- a/packages/plugin-network-breadcrumbs/package-lock.json
+++ b/packages/plugin-network-breadcrumbs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-network-breadcrumbs",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
@@ -7,7 +7,7 @@ const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 // mock XMLHttpRequest
 function XMLHttpRequest () {
-  this._listeners = {}
+  this._listeners = { load: () => {}, error: () => {} }
   this.status = null
 }
 XMLHttpRequest.prototype.open = function (method, url) {
@@ -220,5 +220,35 @@ describe('plugin: network breadcrumbs', () => {
       }))
       done()
     })
+  })
+
+  it('should not be enabled when autoBreadcrumbs=false', () => {
+    const window = { XMLHttpRequest }
+
+    const client = new Client(VALID_NOTIFIER)
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    client.configure()
+    client.use(plugin, window)
+
+    const request = new window.XMLHttpRequest()
+    request.open('GET', '/')
+    request.send(false, 200)
+
+    expect(client.breadcrumbs.length).toBe(0)
+  })
+
+  it('should be enabled when autoBreadcrumbs=false and networkBreadcrumbsEnabled=true', () => {
+    const window = { XMLHttpRequest }
+
+    const client = new Client(VALID_NOTIFIER)
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, networkBreadcrumbsEnabled: true })
+    client.configure()
+    client.use(plugin, window)
+
+    const request = new window.XMLHttpRequest()
+    request.open('GET', '/')
+    request.send(false, 200)
+
+    expect(client.breadcrumbs.length).toBe(1)
   })
 })

--- a/packages/plugin-node-device/package-lock.json
+++ b/packages/plugin-node-device/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-node-device",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-node-in-project/package-lock.json
+++ b/packages/plugin-node-in-project/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-node-in-project",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-node-surrounding-code/package-lock.json
+++ b/packages/plugin-node-surrounding-code/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-node-surrounding-code",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-node-uncaught-exception/package-lock.json
+++ b/packages/plugin-node-uncaught-exception/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-node-uncaught-exception",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-node-unhandled-rejection/package-lock.json
+++ b/packages/plugin-node-unhandled-rejection/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-node-unhandled-rejection",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-react/package-lock.json
+++ b/packages/plugin-react/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-react",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-restify/package-lock.json
+++ b/packages/plugin-restify/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-restify",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-server-session/package-lock.json
+++ b/packages/plugin-server-session/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-server-session",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-simple-throttle/package-lock.json
+++ b/packages/plugin-simple-throttle/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/plugin-simple-throttle",
-  "version": "5.0.0-alpha.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/plugin-strip-project-root/package-lock.json
+++ b/packages/plugin-strip-project-root/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-strip-project-root",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-strip-query-string/package-lock.json
+++ b/packages/plugin-strip-query-string/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-strip-query-string",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-vue/package-lock.json
+++ b/packages/plugin-vue/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-vue",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-window-onerror/package-lock.json
+++ b/packages/plugin-window-onerror/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-window-onerror",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/plugin-window-unhandled-rejection/package-lock.json
+++ b/packages/plugin-window-unhandled-rejection/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/plugin-window-unhandled-rejection",
-	"version": "5.0.0-alpha.0",
+	"version": "5.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
The way config has worked since v5.0.0 meant that the granular browser settings for console, network, interaction and navigation breadcrumbs was no longer functioning. This change fixes the logic and adds unit tests for each type of breadcrumb setting.

Fixes #461 and #465.