### PR TITLE
build(yarn): Prevent erroneous peerDependency warnings

### DIFF
--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -26,7 +26,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/node": "* || >=5.0.0-alpha.0"
+    "@bugsnag/js": "*"
   },
   "devDependencies": {
     "@bugsnag/core": "^5.2.0",

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -26,7 +26,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/node": "* || >=5.0.0-alpha.0"
+    "@bugsnag/js": "*"
   },
   "devDependencies": {
     "@bugsnag/core": "^5.2.0",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -28,7 +28,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/browser": "* || >=5.0.0-rc.1"
+    "@bugsnag/js": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.0.1",

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -26,7 +26,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/node": "* || >=5.0.0-alpha.0"
+    "@bugsnag/js": "*"
   },
   "devDependencies": {
     "@bugsnag/core": "^5.2.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -28,7 +28,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/browser": "* || >=5.0.0-rc.1"
+    "@bugsnag/js": "*"
   },
   "devDependencies": {
     "@bugsnag/core": "^5.2.0",


### PR DESCRIPTION
Mark the parent package (@bugsnag/js) as the peerDependency rather than the platform-specific
package. This makes the warning go away when installing with yarn, which just appears to look at the
top level dependencies rather than the transient dependency tree.

Fixes #473 and #438