### PR TITLE
feat(plugin-expo-app): Add Expo-specific app plugin

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@bugsnag/core": "^6.0.0",
+    "@bugsnag/plugin-expo-app": "^6.0.0",
     "@bugsnag/plugin-react-native-global-error-handler": "^6.0.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^6.0.0",
     "bugsnag-build-reporter": "^1.0.1",

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -8,7 +8,8 @@ const schema = { ...require('@bugsnag/core/config').schema, ...require('./config
 
 const plugins = [
   require('@bugsnag/plugin-react-native-global-error-handler'),
-  require('@bugsnag/plugin-react-native-unhandled-rejection')
+  require('@bugsnag/plugin-react-native-unhandled-rejection'),
+  require('@bugsnag/plugin-expo-app')
 ]
 
 module.exports = (opts) => {

--- a/packages/plugin-expo-app/LICENSE.txt
+++ b/packages/plugin-expo-app/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/plugin-expo-app/README.md
+++ b/packages/plugin-expo-app/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/plugin-expo-app
+
+A plugin to provide information about an Expo app, including version, bundle id and how long the app spent in the foreground.
+
+## License
+MIT

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -1,0 +1,44 @@
+const { Constants } = require('expo')
+const { AppState } = require('react-native')
+
+const appStart = new Date()
+
+module.exports = {
+  init: client => {
+    let lastEnteredForeground = appStart
+    let lastState = AppState.currentState
+
+    AppState.addEventListener('change', newState => {
+      if (newState === 'active' && lastState !== 'active') {
+        lastEnteredForeground = new Date()
+      }
+      lastState = newState
+    })
+
+    client.config.beforeSend.unshift(report => {
+      const now = new Date()
+      const inForeground = AppState.currentState === 'active'
+      report.app.inForeground = inForeground
+      report.app.duration = now - appStart
+      if (inForeground) {
+        report.app.durationInForeground = now - lastEnteredForeground
+      }
+    })
+
+    if (!client.app.version && Constants.manifest.version) {
+      client.app.version = Constants.manifest.version
+    }
+
+    if (Constants.platform.android && Constants.platform.android.versionCode) {
+      client.app.versionCode = Constants.platform.android.versionCode
+    }
+
+    if (Constants.platform.ios && Constants.platform.ios.buildNumber) {
+      client.app.bundleVersion = Constants.platform.ios.buildNumber
+    }
+
+    if (Constants.manifest.revisionId) {
+      client.app.codeBundleId = Constants.manifest.revisionId
+    }
+  }
+}

--- a/packages/plugin-expo-app/package-lock.json
+++ b/packages/plugin-expo-app/package-lock.json
@@ -1,0 +1,2494 @@
+{
+	"name": "@bugsnag/plugin-expo-app",
+	"version": "6.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.51"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "7.0.0-beta.51",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/helper-function-name": "7.0.0-beta.51",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"debug": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"dev": true,
+			"requires": {
+				"is-object": "~1.0.1",
+				"merge-descriptors": "~1.0.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+			"dev": true
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
+		},
+		"istanbul-lib-instrument": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
+			"integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/traverse": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"istanbul-lib-coverage": "^2.0.1",
+				"semver": "^5.5.0"
+			}
+		},
+		"jasmine": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+			"integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.6",
+				"jasmine-core": "~3.1.0"
+			}
+		},
+		"jasmine-core": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+			"integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"dev": true
+		},
+		"nyc": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"dev": true,
+			"requires": {
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^2.1.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.5",
+				"istanbul-reports": "^1.4.1",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
+				"yargs": "11.1.0",
+				"yargs-parser": "^8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "^1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"bundled": true,
+					"dev": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true,
+					"dev": true
+				},
+				"atob": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true,
+					"dev": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true,
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"amdefine": ">=0.0.4"
+							}
+						}
+					}
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true,
+					"dev": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"append-transform": "^0.4.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "^1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"handlebars": "^4.0.3"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true,
+					"dev": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "^0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true,
+					"dev": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true,
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true,
+					"dev": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"atob": "^2.1.1",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"camelcase": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"proxyquire": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+			"dev": true,
+			"requires": {
+				"fill-keys": "^1.0.2",
+				"module-not-found-error": "^1.0.0",
+				"resolve": "~1.8.1"
+			}
+		},
+		"resolve": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.5"
+			}
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	}
+}

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bugsnag/plugin-expo-app",
+  "version": "6.0.0",
+  "main": "app.js",
+  "description": "@bugsnag/js plugin to provide information about an Expo app",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "*.js"
+  ],
+  "scripts": {
+    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
+  },
+  "author": "Bugsnag",
+  "license": "MIT",
+  "devDependencies": {
+    "@bugsnag/core": "^6.0.0",
+    "jasmine": "3.1.0",
+    "nyc": "^12.0.2",
+    "proxyquire": "^2.1.0"
+  }
+}

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -1,0 +1,191 @@
+/* global describe, it, expect */
+
+const proxyquire = require('proxyquire').noPreserveCache().noCallThru()
+const Client = require('@bugsnag/core/client')
+const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
+
+describe('plugin: expo device', () => {
+  it('should should use version if defined (all platforms)', done => {
+    const VERSION = '1.0.0'
+    const plugin = proxyquire('../', {
+      'expo': {
+        Constants: {
+          platform: {
+          },
+          manifest: { version: VERSION }
+        }
+      },
+      'react-native': {
+        AppState: {
+          addEventListener: () => {},
+          currentState: 'active'
+        }
+      }
+    })
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'api_key' })
+    c.configure()
+
+    c.use(plugin)
+    c.delivery({
+      sendReport: (config, logger, report) => {
+        const r = JSON.parse(JSON.stringify(report))
+        expect(r).toBeTruthy()
+        expect(r.events[0].app.version).toBe(VERSION)
+        done()
+      }
+    })
+    c.notify(new Error('flip'))
+  })
+
+  it('should should use revisionId if defined (all platforms)', done => {
+    const VERSION = '1.0.0'
+    const REVISION_ID = '1.0.0-r132432'
+    const plugin = proxyquire('../', {
+      'expo': {
+        Constants: {
+          platform: {
+          },
+          manifest: { version: VERSION, revisionId: REVISION_ID }
+        }
+      },
+      'react-native': {
+        AppState: {
+          addEventListener: () => {},
+          currentState: 'active'
+        }
+      }
+    })
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'api_key' })
+    c.configure()
+
+    c.use(plugin)
+    c.delivery({
+      sendReport: (config, logger, report) => {
+        const r = JSON.parse(JSON.stringify(report))
+        expect(r).toBeTruthy()
+        expect(r.events[0].app.codeBundleId).toBe(REVISION_ID)
+        done()
+      }
+    })
+    c.notify(new Error('flip'))
+  })
+
+  it('should should use versionCode if defined (android)', done => {
+    const VERSION_CODE = '1.0'
+    const plugin = proxyquire('../', {
+      'expo': {
+        Constants: {
+          platform: {
+            android: { versionCode: VERSION_CODE }
+          },
+          manifest: { version: '1.0.0' }
+        }
+      },
+      'react-native': {
+        AppState: {
+          addEventListener: () => {},
+          currentState: 'active'
+        }
+      }
+    })
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'api_key' })
+    c.configure()
+
+    c.use(plugin)
+    c.delivery({
+      sendReport: (config, logger, report) => {
+        const r = JSON.parse(JSON.stringify(report))
+        expect(r).toBeTruthy()
+        expect(r.events[0].app.versionCode).toBe(VERSION_CODE)
+        done()
+      }
+    })
+    c.notify(new Error('flip'))
+  })
+
+  it('should should use bundleVersion if defined (ios)', done => {
+    const BUNDLE_VERSION = '1.0'
+    const plugin = proxyquire('../', {
+      'expo': {
+        Constants: {
+          platform: {
+            ios: { buildNumber: BUNDLE_VERSION }
+          },
+          manifest: { version: '1.0.0' }
+        }
+      },
+      'react-native': {
+        AppState: {
+          addEventListener: () => {},
+          currentState: 'active'
+        }
+      }
+    })
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'api_key' })
+    c.configure()
+
+    c.use(plugin)
+    c.delivery({
+      sendReport: (config, logger, report) => {
+        const r = JSON.parse(JSON.stringify(report))
+        expect(r).toBeTruthy()
+        expect(r.events[0].app.bundleVersion).toBe(BUNDLE_VERSION)
+        done()
+      }
+    })
+    c.notify(new Error('flip'))
+  })
+
+  it('detects whether the app is inForeground', done => {
+    const AppState = {
+      addEventListener: (name, fn) => {
+        listener = fn
+      },
+      currentState: 'active'
+    }
+    let listener
+    const plugin = proxyquire('../', {
+      'expo': {
+        Constants: {
+          platform: {},
+          manifest: {}
+        }
+      },
+      'react-native': { AppState }
+    })
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'api_key' })
+    c.configure()
+
+    c.use(plugin)
+    expect(typeof listener).toBe('function')
+    const reports = []
+    c.delivery({
+      sendReport: (config, logger, report) => {
+        const r = JSON.parse(JSON.stringify(report))
+        expect(r).toBeTruthy()
+        reports.push(r)
+        if (reports.length < 3) return
+        expect(reports[0].events[0].app.inForeground).toBe(true)
+        expect(reports[1].events[0].app.inForeground).toBe(false)
+        expect(reports[2].events[0].app.inForeground).toBe(true)
+        done()
+      }
+    })
+    c.notify(new Error('flip'))
+    setTimeout(() => {
+      listener('inactive')
+      AppState.currentState = 'inactive'
+      c.notify(new Error('flop'))
+      setTimeout(() => {
+        listener('active')
+        AppState.currentState = 'active'
+        c.notify(new Error('flooop'))
+      }, 20)
+    }, 20)
+  })
+})


### PR DESCRIPTION
Provides the following payload properties:

- `app.version`
- `app.versionCode` (android)
- `app.buildNumber` (ios)
- `app.codeBundleId`
- `app.duration`
- `app.durationInForeground`
- `app.inForeground`

Unit tests fully cover this file, and I've manually tested on both platforms with standalone applications (you don't get a revisionId, versionCode or buildNumber in development).

![image](https://user-images.githubusercontent.com/609579/54550016-2faeea00-49a3-11e9-9da8-e152cf87c8be.png)
