### PR TITLE
feat(expo): Enable console/network breadcrumbs on Expo

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -48,6 +48,8 @@
   },
   "dependencies": {
     "@bugsnag/core": "^6.0.0",
+    "@bugsnag/plugin-console-breadcrumbs": "^6.0.0",
+    "@bugsnag/plugin-network-breadcrumbs": "^6.0.0",
     "@bugsnag/plugin-react-native-global-error-handler": "^6.0.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^6.0.0",
     "bugsnag-build-reporter": "^1.0.1",

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
@@ -49,7 +49,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', '/')
@@ -73,7 +73,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, undefined, window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', '/')
@@ -88,7 +88,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', '/this-does-not-exist')
@@ -111,7 +111,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
 
@@ -134,7 +134,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, undefined, window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', client.config.endpoints.notify)
@@ -149,7 +149,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, undefined, window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', client.config.endpoints.sessions)
@@ -163,7 +163,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     window.fetch('/', {}, false, 200).then(() => {
       expect(client.breadcrumbs.length).toBe(1)
@@ -185,7 +185,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     window.fetch('/does-not-exist', {}, false, 404).then(() => {
       expect(client.breadcrumbs.length).toBe(1)
@@ -207,7 +207,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     window.fetch('https://another-domain.xyz/foo/bar', {}, true).catch(() => {
       expect(client.breadcrumbs.length).toBe(1)
@@ -228,7 +228,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', '/')
@@ -243,7 +243,7 @@ describe('plugin: network breadcrumbs', () => {
     const client = new Client(VALID_NOTIFIER)
     client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, networkBreadcrumbsEnabled: true })
     client.configure()
-    client.use(plugin, window)
+    client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
     request.open('GET', '/')


### PR DESCRIPTION
Enabled the following existing plugins by default on Expo:

- `@bugsnag/plugin-console-breadcrumbs`
- `@bugsnag/plugin-network-breadcrumbs`

The console crumbs went on just fine, but the network crumbs required some tweaks as follows.

#### Duplicate breadcrumbs for `fetch()` calls
RN uses [`whatwg-fetch`](https://github.com/github/fetch/) as a polyfill, which uses [`XMLHttpRequest`](https://github.com/github/fetch/blob/3674c98df696d45573750aa7873814887d25689a/fetch.js#L449) under the hood. Because our plugin monkeypatches both fetch and xhr APIs this resulted in duplicate breadcrumbs for each network request.

Thankfully the polyfill identifies itself as such with [`polyfill = true`](https://github.com/github/fetch/blob/3674c98df696d45573750aa7873814887d25689a/fetch.js#L509) so I was able to make a change that uses the value of this property to decide whether to monkeypatch `fetch()` or not.

#### Tracking internal Expo logging calls

It turns out that Expo uses the xhr primitives to send logs to its backend:

```
  Object {
    "metaData": Object {
      "request": "POST http://192.168.3.42:19000/logs",
      "status": 200,
    },
    "name": "XMLHttpRequest succeeded",
    "timestamp": "2019-03-19T10:39:05.715Z",
    "type": "request",
  }
```

The network breadcrumbs plugin aready had a mechanism to ignore certain urls (so that we don't track the requests to `notify|sessions.bugsnag.com`) so I refactored to be extendable. When initialising the plugin on Expo we pass in a list of ignored urls, which include the expo log url.