### PR TITLE
feat(expo): Load @bugsnag/plugin-react by default on Expo notifier

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -48,9 +48,14 @@
   },
   "dependencies": {
     "@bugsnag/core": "^6.0.0",
+    "@bugsnag/plugin-react": "^6.0.0",
     "@bugsnag/plugin-react-native-global-error-handler": "^6.0.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^6.0.0",
     "bugsnag-build-reporter": "^1.0.1",
     "bugsnag-sourcemaps": "^1.1.0"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "expo": "*"
   }
 }

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -1,6 +1,7 @@
 const name = 'Bugsnag Expo'
 const { version } = require('../package.json')
 const url = 'https://github.com/bugsnag/bugsnag-js'
+const React = require('react')
 
 const Client = require('@bugsnag/core/client')
 
@@ -10,6 +11,8 @@ const plugins = [
   require('@bugsnag/plugin-react-native-global-error-handler'),
   require('@bugsnag/plugin-react-native-unhandled-rejection')
 ]
+
+const bugsnagReact = require('@bugsnag/plugin-react')
 
 module.exports = (opts) => {
   // handle very simple use case where user supplies just the api key as a string
@@ -21,6 +24,7 @@ module.exports = (opts) => {
   bugsnag.configure(schema)
 
   plugins.forEach(pl => bugsnag.use(pl))
+  bugsnag.use(bugsnagReact, React)
 
   bugsnag._logger.debug(`Loaded!`)
 


### PR DESCRIPTION
Enable `@bugsnag/plugin-react` on Expo so that the `ErrorBoundary` is available by default.

This adds `react` as a `peerDependency` of `@bugsnag/expo` and while I was there it made sense to add `expo` too.