### PR TITLE
feat(expo): Allow apiKey to be set in app.json rather than in code

### DIFF
--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -22,6 +22,7 @@ module.exports = (opts) => {
 
   // attempt to fetch apiKey from app.json if we didn't get one explicitly passed
   if (!opts.apiKey &&
+    Constants.manifest &&
     Constants.manifest.extra &&
     Constants.manifest.extra.bugsnag &&
     Constants.manifest.extra.bugsnag.apiKey) {

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -1,6 +1,7 @@
 const name = 'Bugsnag Expo'
 const { version } = require('../package.json')
 const url = 'https://github.com/bugsnag/bugsnag-js'
+const { Constants } = require('expo')
 
 const Client = require('@bugsnag/core/client')
 
@@ -14,6 +15,18 @@ const plugins = [
 module.exports = (opts) => {
   // handle very simple use case where user supplies just the api key as a string
   if (typeof opts === 'string') opts = { apiKey: opts }
+
+  // ensure opts is actually an object (at this point it
+  // could be null, undefined, a number, a boolean etc.)
+  opts = { ...opts }
+
+  // attempt to fetch apiKey from app.json if we didn't get one explicitly passed
+  if (!opts.apiKey &&
+    Constants.manifest.extra &&
+    Constants.manifest.extra.bugsnag &&
+    Constants.manifest.extra.bugsnag.apiKey) {
+    opts.apiKey = Constants.manifest.extra.bugsnag.apiKey
+  }
 
   const bugsnag = new Client({ name, version, url })
 


### PR DESCRIPTION
This PR adds support for configuring the `apiKey` using the [`extra`](https://docs.expo.io/versions/v32.0.0/workflow/configuration/#extra) key in `app.json`, for example:

```json
{
  "extra": {
    "bugsnag": {
      "apiKey": "API_KEY"
    }
}
```

There are no unit tests for the standalone notifiers, as they pull together everything and would require an absurd amount of mocking. This one needs manually testing for now.