### PR TITLE
feat(core): Detect JS runtime to correctly populate exception.type in Expo/RN

### DIFF
--- a/packages/core/lib/js-runtime.js
+++ b/packages/core/lib/js-runtime.js
@@ -1,0 +1,5 @@
+module.exports = process.env.IS_BROWSER
+  ? 'browserjs'
+  : ((typeof navigator !== 'undefined' && navigator.product === 'ReactNative')
+    ? (typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs')
+    : 'nodejs')

--- a/packages/core/report.js
+++ b/packages/core/report.js
@@ -2,6 +2,7 @@ const ErrorStackParser = require('./lib/error-stack-parser')
 const StackGenerator = require('stack-generator')
 const hasStack = require('./lib/has-stack')
 const { reduce, filter } = require('./lib/es-utils')
+const jsRuntime = require('./lib/js-runtime')
 
 class BugsnagReport {
   constructor (errorClass, errorMessage, stacktrace = [], handledState = defaultHandledState()) {
@@ -105,7 +106,7 @@ class BugsnagReport {
           errorClass: this.errorClass,
           message: this.errorMessage,
           stacktrace: this.stacktrace,
-          type: process.env.IS_BROWSER ? 'browserjs' : 'nodejs'
+          type: jsRuntime
         }
       ],
       severity: this.severity,


### PR DESCRIPTION
This PR adds logic to detect the stacktrace type that should be included in the payload.

Since this code runs in all environments it stands to affect browser bundle size, so I'm going to show my workings out here.

This is the implementation I arrived at. It may look concerning to have all of that logic in the browser – hang with me:

```js
if (process.env.IS_BROWSER) {
  module.exports = 'browserjs'
} else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
  module.exports = typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs'
} else {
  module.exports = 'nodejs'
}
```

_Aside, referencing `global` causes browserify to wrap the module in a function closure which passes in that variable explicitly. This is why I check for `navigator`'s existence in the global scope (`typeof navigator === 'undefined'`) rather than checking `if (global.navigator)` like I normally would. Same for `global.Expo`._

The browser build replaces `process.env.IS_BROWSER` with the static string `"yes"`, which means that it becomes the following:

```js
if ("yes") {
  module.exports = 'browserjs'
} else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
  module.exports = typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs'
} else {
  module.exports = 'nodejs'
}
```

The `browser-pack-flat` transform gets rid of the `module.exports` assignment:

```js
// js-runtime.js
var _$jsRuntime_12 = {};
if ("yes") {
  _$jsRuntime_12 = 'browserjs';
} else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
  _$jsRuntime_12 = typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs';
} else {
  _$jsRuntime_12 = 'nodejs';
}

// report.js
exceptions: [{
  errorClass: this.errorClass,
  message: this.errorMessage,
  stacktrace: this.stacktrace,
  type: _$jsRuntime_12
}],
```

Which means the uglify optimisation removes all of the following dead/uncreachable code:


```js
// since "yes" is always truthy, the else blocks can all be optimised away
// and the contents of the if block can just be output as statement

var _$jsRuntime_12 = {};
/* if ("yes") { */
     _$jsRuntime_12 = 'browserjs'
/* } else if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') { */
/*   module.exports = typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs' */
/* } else { */
/*   module.exports = 'nodejs' */
/* } */
```

This extra assignment to empty object before assigning to `'browserjs'` was the last thing to eliminate. By converting the if/else block to a nested ternary (ew!) we can avoid the extra assignment:

```js
module.exports = process.env.IS_BROWSER
  ? 'browserjs'
  : ((typeof navigator !== 'undefined' && navigator.product === 'ReactNative')
    ? (typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs')
    : 'nodejs')
```

Which optimises everything away to this in the minified bundle (scroll all the way along to see relevant bit):

```js
// report.toJSON() function:
t.toJSON=function(){return{payloadVersion:"4",exceptions:[{errorClass:this.errorClass,message:this.errorMessage,stacktrace:this.stacktrace,type:"browserjs"}]
```

### tl;dr

The browser bundle size __before__ this PR is `11.71kB`.
The browser bundle size __after__ this PR is: `11.71kB`.

### Testing

There are already end to end tests for browser/node. I manually tested Expo.