### PR TITLE
fix(core): Omit stacktrace in error breadcrumbs

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -216,8 +216,7 @@ class BugsnagClient {
         this.leaveBreadcrumb(report.errorClass, {
           errorClass: report.errorClass,
           errorMessage: report.errorMessage,
-          severity: report.severity,
-          stacktrace: report.stacktrace
+          severity: report.severity
         }, 'error')
       }
 

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -321,6 +321,7 @@ describe('@bugsnag/core/client', () => {
       expect(client.breadcrumbs.length).toBe(1)
       expect(client.breadcrumbs[0].type).toBe('error')
       expect(client.breadcrumbs[0].name).toBe('Error')
+      expect(client.breadcrumbs[0].metaData.stacktrace).toBe(undefined)
       // the error shouldn't appear as a breadcrumb for itself
       expect(payloads[0].events[0].breadcrumbs.length).toBe(0)
     })


### PR DESCRIPTION
This change originally happened in PR #360 (02a4434), but it was undone when a refactor to `notify()` which started before that change (async beforeSend functions #368 (eead5c6)) was eventually landed.