### PR TITLE
fix(plugin-navigation-breadcrumbs): Don't call startSession() if autoCaptureSessions=false

### DIFF
--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -69,8 +69,8 @@ const wrapHistoryFn = (client, target, fn, win) => {
     client.leaveBreadcrumb(`History ${fn}`, stateChangeToMetaData(win, state, title, url), 'navigation')
     // if throttle plugin is in use, refresh the event sent count
     if (typeof client.refresh === 'function') client.refresh()
-    // if the client is operating in session-mode, a new route should trigger a new session
-    if (client.session) client.startSession()
+    // if the client is operating in auto session-mode, a new route should trigger a new session
+    if (client.config.autoCaptureSessions) client.startSession()
     // Internet Explorer will convert `undefined` to a string when passed, causing an unintended redirect
     // to '/undefined'. therefore we only pass the url if it's not undefined.
     orig.apply(target, [ state, title ].concat(url !== undefined ? url : []))

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -47,6 +47,40 @@ describe('plugin: navigation breadcrumbs', () => {
     expect(c.breadcrumbs.length).toBe(0)
   })
 
+  it('should start a new session if autoCaptureSessions=true', (done) => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
+    c.configure()
+    c.sessionDelegate({
+      startSession: client => {
+        done()
+      }
+    })
+    const { winHandlers, docHandlers, window } = getMockWindow()
+    c.use(plugin, window)
+    winHandlers['load'].forEach((h) => h.call(window))
+    docHandlers['DOMContentLoaded'].forEach((h) => h.call(window.document))
+    window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
+  })
+
+  it('should not a new session if autoCaptureSessions=false', (done) => {
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoCaptureSessions: false })
+    c.configure()
+    c.sessionDelegate({
+      startSession: client => {
+        expect('shouldn’t get here').toBe(false)
+        done()
+      }
+    })
+    const { winHandlers, docHandlers, window } = getMockWindow()
+    c.use(plugin, window)
+    winHandlers['load'].forEach((h) => h.call(window))
+    docHandlers['DOMContentLoaded'].forEach((h) => h.call(window.document))
+    window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
+    setTimeout(() => done(), 1)
+  })
+
   it('should be enabled when autoBreadcrumbs=false and navigationBreadcrumbsEnabled=true', () => {
     const c = new Client(VALID_NOTIFIER)
     c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, navigationBreadcrumbsEnabled: true })


### PR DESCRIPTION
Fixes #488.