### PR TITLE
Improve logging and available information when error reports are not sent

### DIFF
--- a/packages/browser/types/test/types.test.js
+++ b/packages/browser/types/test/types.test.js
@@ -51,9 +51,9 @@ bugsnag({
     const program = `
 import { Bugsnag } from "../../..";
 let bugsnagInstance: Bugsnag.Client | undefined = undefined;
-export function notify(error: Bugsnag.NotifiableError, opts?: Bugsnag.INotifyOpts): boolean {
+export function notify(error: Bugsnag.NotifiableError, opts?: Bugsnag.INotifyOpts): void {
   if (bugsnagInstance === undefined) {
-    return false
+    return
   }
   return bugsnagInstance.notify(error, opts)
 }

--- a/packages/browser/types/test/types.test.js
+++ b/packages/browser/types/test/types.test.js
@@ -106,4 +106,22 @@ console.log(bugsnagClient.getPlugin('foo') === 10)
     ])
     expect(stdout.toString()).toBe('')
   })
+
+  it('should work with the notify() callback', () => {
+    const program = `
+import bugsnag from "../../..";
+const bugsnagClient = bugsnag('api_key');
+bugsnagClient.notify(new Error('123'), {
+  beforeSend: (report) => { return false }
+}, (err, report) => {
+  console.log(report.originalError)
+})
+`.trim()
+    writeFileSync(`${__dirname}/fixtures/app.ts`, program)
+    const { stdout } = spawnSync('./node_modules/.bin/tsc', [
+      '--strict',
+      `${__dirname}/fixtures/app.ts`
+    ])
+    expect(stdout.toString()).toBe('')
+  })
 })

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -192,7 +192,7 @@ class BugsnagClient {
     // exit early if the reports should not be sent on the current releaseStage
     if (isArray(this.config.notifyReleaseStages) && !includes(this.config.notifyReleaseStages, releaseStage)) {
       this._logger.warn(`Report not sent due to releaseStage/notifyReleaseStages configuration`)
-      return false
+      return cb(null, report)
     }
 
     const originalSeverity = report.severity
@@ -208,7 +208,7 @@ class BugsnagClient {
 
       if (preventSend) {
         this._logger.debug(`Report not sent due to beforeSend callback`)
-        return false
+        return cb(null, report)
       }
 
       // only leave a crumb for the error if actually got sent

--- a/packages/core/lib/report-from-error.js
+++ b/packages/core/lib/report-from-error.js
@@ -9,7 +9,8 @@ module.exports = (maybeError, handledState) => {
     actualError.name,
     actualError.message,
     Report.getStacktrace(actualError),
-    handledState
+    handledState,
+    maybeError
   )
   if (maybeError !== actualError) report.updateMetaData('error', 'non-error value', String(maybeError))
   return report

--- a/packages/core/report.js
+++ b/packages/core/report.js
@@ -4,7 +4,7 @@ const hasStack = require('./lib/has-stack')
 const { reduce, filter } = require('./lib/es-utils')
 
 class BugsnagReport {
-  constructor (errorClass, errorMessage, stacktrace = [], handledState = defaultHandledState()) {
+  constructor (errorClass, errorMessage, stacktrace = [], handledState = defaultHandledState(), originalError) {
     // duck-typing ftw >_<
     this.__isBugsnagReport = true
 
@@ -37,6 +37,7 @@ class BugsnagReport {
     }, [])
     this.user = undefined
     this.session = undefined
+    this.originalError = originalError
   }
 
   ignore () {
@@ -164,9 +165,9 @@ BugsnagReport.ensureReport = function (reportOrError, errorFramesToSkip = 0, gen
   if (reportOrError.__isBugsnagReport) return reportOrError
   try {
     const stacktrace = BugsnagReport.getStacktrace(reportOrError, errorFramesToSkip, 1 + generatedFramesToSkip)
-    return new BugsnagReport(reportOrError.name, reportOrError.message, stacktrace)
+    return new BugsnagReport(reportOrError.name, reportOrError.message, stacktrace, undefined, reportOrError)
   } catch (e) {
-    return new BugsnagReport(reportOrError.name, reportOrError.message, [])
+    return new BugsnagReport(reportOrError.name, reportOrError.message, [], undefined, reportOrError)
   }
 }
 

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -400,6 +400,23 @@ describe('@bugsnag/core/client', () => {
         done()
       })
     })
+
+    it('should attach the original error to the report object', done => {
+      const client = new Client(VALID_NOTIFIER)
+      client.setOptions({ apiKey: 'API_KEY', beforeSend: () => false })
+      client.configure()
+      client.delivery({
+        sendSession: () => {},
+        sendReport: (logger, config, report, cb) => cb(null)
+      })
+      const orig = new Error('111')
+      client.notify(orig, {}, (err, report) => {
+        expect(err).toBe(null)
+        expect(report).toBeTruthy()
+        expect(report.originalError).toBe(orig)
+        done()
+      })
+    })
   })
 
   describe('leaveBreadcrumb()', () => {

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -177,8 +177,7 @@ describe('@bugsnag/core/client', () => {
       client.setOptions({ apiKey: 'API_KEY_YEAH', notifyReleaseStages: [] })
       client.configure()
 
-      const sent = client.notify(new Error('oh em eff gee'))
-      expect(sent).toBe(false)
+      client.notify(new Error('oh em eff gee'))
 
       // give the event loop a tick to see if the reports get send
       process.nextTick(() => done())
@@ -194,8 +193,7 @@ describe('@bugsnag/core/client', () => {
       client.setOptions({ apiKey: 'API_KEY_YEAH', releaseStage: 'staging', notifyReleaseStages: [ 'production' ] })
       client.configure()
 
-      const sent = client.notify(new Error('oh em eff gee'))
-      expect(sent).toBe(false)
+      client.notify(new Error('oh em eff gee'))
 
       // give the event loop a tick to see if the reports get send
       process.nextTick(() => done())
@@ -212,8 +210,7 @@ describe('@bugsnag/core/client', () => {
       client.configure()
       client.app.releaseStage = 'staging'
 
-      const sent = client.notify(new Error('oh em eff gee'))
-      expect(sent).toBe(false)
+      client.notify(new Error('oh em eff gee'))
 
       // give the event loop a tick to see if the reports get send
       process.nextTick(() => done())
@@ -336,6 +333,71 @@ describe('@bugsnag/core/client', () => {
         }
       })
       expect(client.metaData.foo['3']).toBe(undefined)
+    })
+
+    it('should call the callback (success)', done => {
+      const client = new Client(VALID_NOTIFIER)
+      client.setOptions({ apiKey: 'API_KEY' })
+      client.configure()
+      client.delivery({
+        sendSession: () => {},
+        sendReport: (logger, config, report, cb) => cb(null)
+      })
+      client.notify(new Error('111'), {}, (err, report) => {
+        expect(err).toBe(null)
+        expect(report).toBeTruthy()
+        expect(report.errorMessage).toBe('111')
+        done()
+      })
+    })
+
+    it('should call the callback (err)', done => {
+      const client = new Client(VALID_NOTIFIER)
+      client.setOptions({ apiKey: 'API_KEY' })
+      client.configure()
+      client.delivery({
+        sendSession: () => {},
+        sendReport: (logger, config, report, cb) => cb(new Error('flerp'))
+      })
+      client.notify(new Error('111'), {}, (err, report) => {
+        expect(err).toBeTruthy()
+        expect(err.message).toBe('flerp')
+        expect(report).toBeTruthy()
+        expect(report.errorMessage).toBe('111')
+        done()
+      })
+    })
+
+    it('should call the callback even if the report doesn’t send (notifyReleaseStages)', done => {
+      const client = new Client(VALID_NOTIFIER)
+      client.setOptions({ apiKey: 'API_KEY', notifyReleaseStages: [ 'production' ], releaseStage: 'development' })
+      client.configure()
+      client.delivery({
+        sendSession: () => {},
+        sendReport: (logger, config, report, cb) => cb(null)
+      })
+      client.notify(new Error('111'), {}, (err, report) => {
+        expect(err).toBe(null)
+        expect(report).toBeTruthy()
+        expect(report.errorMessage).toBe('111')
+        done()
+      })
+    })
+
+    it('should call the callback even if the report doesn’t send (beforeSend)', done => {
+      const client = new Client(VALID_NOTIFIER)
+      client.setOptions({ apiKey: 'API_KEY', beforeSend: () => false })
+      client.configure()
+      client.delivery({
+        sendSession: () => {},
+        sendReport: (logger, config, report, cb) => cb(null)
+      })
+      client.notify(new Error('111'), {}, (err, report) => {
+        expect(err).toBe(null)
+        expect(report).toBeTruthy()
+        expect(report.errorMessage).toBe('111')
+        done()
+      })
     })
   })
 

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -22,7 +22,7 @@ declare class Client {
   public delivery(delivery: common.IDelivery): Client;
   public logger(logger: common.ILogger): Client;
   public sessionDelegate(sessionDelegate: common.ISessionDelegate): Client;
-  public notify(error: common.NotifiableError, opts?: common.INotifyOpts): boolean;
+  public notify(error: common.NotifiableError, opts?: common.INotifyOpts, cb?: (err: any) => void): void;
   public leaveBreadcrumb(name: string, metaData?: any, type?: string, timestamp?: string): Client;
   public startSession(): Client;
 }

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -22,7 +22,11 @@ declare class Client {
   public delivery(delivery: common.IDelivery): Client;
   public logger(logger: common.ILogger): Client;
   public sessionDelegate(sessionDelegate: common.ISessionDelegate): Client;
-  public notify(error: common.NotifiableError, opts?: common.INotifyOpts, cb?: (err: any) => void): void;
+  public notify(
+    error: common.NotifiableError,
+    opts?: common.INotifyOpts,
+    cb?: (err: any, report: Report) => void,
+  ): void;
   public leaveBreadcrumb(name: string, metaData?: any, type?: string, timestamp?: string): Client;
   public startSession(): Client;
 }

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -20,7 +20,7 @@ export interface IConfig {
   [key: string]: any;
 }
 
-export type BeforeSend = (report: Report, cb?: (err: null | Error) => void) => void | Promise<void>;
+export type BeforeSend = (report: Report, cb?: (err: null | Error) => void) => void | Promise<void> | boolean;
 
 export interface IPlugin {
   name?: string;

--- a/packages/core/types/report.d.ts
+++ b/packages/core/types/report.d.ts
@@ -33,7 +33,14 @@ declare class Report {
     url: string;
   };
 
-  constructor(errorClass: string, errorMessage: string, stacktrace?: any[], handledState?: IHandledState);
+  constructor(
+    errorClass: string,
+    errorMessage: string,
+    stacktrace?: any[],
+    handledState?: IHandledState,
+    originalError?: any,
+  );
+
   public isIgnored(): boolean;
   public ignore(): void;
   public updateMetaData(section: string, value: object): Report;

--- a/packages/core/types/report.d.ts
+++ b/packages/core/types/report.d.ts
@@ -32,6 +32,7 @@ declare class Report {
   public request: {
     url: string;
   };
+  public originalError: any;
 
   constructor(
     errorClass: string,

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   onUncaughtException: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Reported an uncaught exception${getContext(report)}, the process will now terminate…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${(err && err.stack) ? err.stack : err}`)
       process.exit(1)
     },
     message: 'should be a function',
@@ -38,7 +38,7 @@ module.exports = {
   },
   onUnhandledRejection: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Reported an unhandled rejection${getContext(report)}…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Unhandled rejection${getContext(report)}…\n${(err && err.stack) ? err.stack : err}`)
     },
     message: 'should be a function',
     validate: value => typeof value === 'function'

--- a/packages/plugin-angular/src/index.ts
+++ b/packages/plugin-angular/src/index.ts
@@ -21,6 +21,7 @@ export class BugsnagErrorHandler extends ErrorHandler {
       error.message,
       this.bugsnagClient.BugsnagReport.getStacktrace(error),
       handledState,
+      error,
     );
 
     if (error.ngDebugContext) {

--- a/packages/plugin-react/src/index.js
+++ b/packages/plugin-react/src/index.js
@@ -15,7 +15,7 @@ module.exports = {
         const { beforeSend } = this.props
         const BugsnagReport = client.BugsnagReport
         const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
-        const report = new BugsnagReport(error.name, error.message, BugsnagReport.getStacktrace(error), handledState)
+        const report = new BugsnagReport(error.name, error.message, BugsnagReport.getStacktrace(error), handledState, error)
         if (info && info.componentStack) info.componentStack = formatComponentStack(info.componentStack)
         report.updateMetaData('react', info)
         client.notify(report, { beforeSend })

--- a/packages/plugin-vue/src/index.js
+++ b/packages/plugin-vue/src/index.js
@@ -6,7 +6,7 @@ module.exports = {
 
     const handler = (err, vm, info) => {
       const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
-      const report = new client.BugsnagReport(err.name, err.message, client.BugsnagReport.getStacktrace(err), handledState)
+      const report = new client.BugsnagReport(err.name, err.message, client.BugsnagReport.getStacktrace(err), handledState, err)
 
       report.updateMetaData('vue', {
         errorInfo: info,

--- a/packages/plugin-window-onerror/onerror.js
+++ b/packages/plugin-window-onerror/onerror.js
@@ -27,7 +27,8 @@ module.exports = {
               error.name,
               error.message,
               decorateStack(client.BugsnagReport.getStacktrace(error), url, lineNo, charNo),
-              handledState
+              handledState,
+              error
             )
           } else {
             // otherwise, for non error values that were thrown, stringify it for
@@ -36,7 +37,8 @@ module.exports = {
               'window.onerror',
               String(error),
               decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo),
-              handledState
+              handledState,
+              error
             )
             // include the raw input as metadata
             report.updateMetaData('window onerror', { error })
@@ -63,7 +65,8 @@ module.exports = {
             name,
             message,
             client.BugsnagReport.getStacktrace(new Error(), 1).slice(1),
-            handledState
+            handledState,
+            messageOrEvent
           )
           // include the raw input as metadata – it might contain more info than we extracted
           report.updateMetaData('window onerror', { event: messageOrEvent, extraParameters: url })
@@ -74,7 +77,8 @@ module.exports = {
             'window.onerror',
             String(messageOrEvent),
             decorateStack(client.BugsnagReport.getStacktrace(error, 1), url, lineNo, charNo),
-            handledState
+            handledState,
+            messageOrEvent
           )
           // include the raw input as metadata – it might contain more info than we extracted
           report.updateMetaData('window onerror', { event: messageOrEvent })

--- a/packages/plugin-window-unhandled-rejection/unhandled-rejection.js
+++ b/packages/plugin-window-unhandled-rejection/unhandled-rejection.js
@@ -29,7 +29,7 @@ exports.init = (client, win = window) => {
     let report
     if (error && hasStack(error)) {
       // if it quacks like an Error…
-      report = new client.BugsnagReport(error.name, error.message, ErrorStackParser.parse(error), handledState)
+      report = new client.BugsnagReport(error.name, error.message, ErrorStackParser.parse(error), handledState, error)
       if (isBluebird) {
         report.stacktrace = reduce(report.stacktrace, fixBluebirdStacktrace(error), [])
       }
@@ -40,7 +40,8 @@ exports.init = (client, win = window) => {
         error && error.name ? error.name : 'UnhandledRejection',
         error && error.message ? error.message : msg,
         [],
-        handledState
+        handledState,
+        error
       )
       // stuff the rejection reason into metaData, it could be useful
       report.updateMetaData('promise', 'rejection reason', serializableReason(error))


### PR DESCRIPTION
This PR contains a few small improvements for the following situations:

- `releaseStage` is not in the list of `notifyReleaseStages`, therefore reports are not send
- a `beforeSend` callback prevents a report from being sent

### The problem

As described in #449, Bugsnag shouldn't silently consume the errors if it's not going to send them anywhere, they should be logged out.

### Unhandled errors

In both of these cases, when the error is __unhandled__ the following log message would be written and the `notify(err, opts, cb)` callback would not run:

```
[bugsnag] Report not sent due to releaseStage/notifyReleaseStages configuration
```

By ensuring that the `notify(err, opts, cb)` callback is called, in Node this means the defautlt `onUncaughtException` (and `onUnhandledRejection`) now correctly get called so the error is printed and the process exits (using the example from #449):

```
[bugsnag] Report not sent due to releaseStage/notifyReleaseStages configuration
[bugsnag] Uncaught exception, the process will now terminate…
/Users/bengourley/scratch/bad.js:2
  bad: 123;
          ^

SyntaxError: Unexpected token ;
    at new Script (vm.js:74:7)
    at createScript (vm.js:246:10)
    at Object.runInThisContext (vm.js:298:10)
    at Module._compile (internal/modules/cjs/loader.js:670:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
```

Unit tests were added to ensure the behaviour was correct for various permutations.

### Handled errors

The situation for handled errors is a little different. We can't assume that a log is desirable, but we can provide the means for users to log it themselves.

I added a property `originalError` to the `Report` class which contains whatever the raw thing was that the report was created from. This also resolves #420, meaning that users who want to do something such as 

- log out the stack
- inspect the error

can do so with the following:

```js
// it's available in beforeSend, however if the beforeSend callback was
// added after one which can return false, this one won't be run
bugsnagClient.notify(new Error, {
  beforeSend: report => console.log(report.originalError)
})

// so it's also in the notify callback which runs after the last
// beforeSend, even if one returned false
bugsnagClient.notify(new Error, { /* opts */ }, (err, report) => {
  console.log(report.originalError)
})
```

## Tests

Added unit tests to ensure the `client.notify(err, opts, cb)` callback was always called. The end-to-end tests aren't set up to make assertions about the the process's output, so I manually tested that the expected content was seen when `releaseStage` was not in `notifyReleaseStages` and when a `beforeSend` prevented a report from sending.

## Bundle size discussion time

Since this makes changes to `@bugsnag/core` it stands to affect browser bundle size. Here's the change:

```diff
- 11.68kB
+ 11.69kB
```

Net increase of `0.01kB`. I think this is 🆗.