### PR TITLE
Improve normaliseError() utility in Client class

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -228,6 +228,8 @@ class BugsnagClient {
 }
 
 const normaliseError = (error, opts, logger) => {
+  const synthesizedErrorFramesToSkip = 3
+
   const createAndLogUsageError = reason => {
     const msg = generateNotifyUsageMessage(reason)
     logger.warn(`${LOG_USAGE_ERR_PREFIX} ${msg}`)
@@ -246,7 +248,7 @@ const normaliseError = (error, opts, logger) => {
         _opts = { metaData: { notifier: { notifyArgs: [ error, opts ] } } }
       } else {
         err = new Error(String(error))
-        errorFramesToSkip += 3
+        errorFramesToSkip = synthesizedErrorFramesToSkip
       }
       break
     case 'number':
@@ -262,7 +264,7 @@ const normaliseError = (error, opts, logger) => {
       } else if (error !== null && hasNecessaryFields(error)) {
         err = new Error(error.message || error.errorMessage)
         err.name = error.name || error.errorClass
-        errorFramesToSkip += 3
+        errorFramesToSkip = synthesizedErrorFramesToSkip
       } else {
         err = createAndLogUsageError(error === null ? 'null' : 'unsupported object')
       }

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -161,7 +161,7 @@ class BugsnagClient {
     if (typeof opts !== 'object' || opts === null) opts = {}
 
     // create a report from the error, if it isn't one already
-    const report = BugsnagReport.ensureReport(err, errorFramesToSkip, 1)
+    const report = BugsnagReport.ensureReport(err, errorFramesToSkip, 2)
 
     report.app = { ...{ releaseStage }, ...report.app, ...this.app }
     report.context = report.context || opts.context || this.context || undefined

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -246,7 +246,7 @@ const normaliseError = (error, opts, logger) => {
         _opts = { metaData: { notifier: { notifyArgs: [ error, opts ] } } }
       } else {
         err = new Error(String(error))
-        errorFramesToSkip += 2
+        errorFramesToSkip += 3
       }
       break
     case 'number':
@@ -262,7 +262,7 @@ const normaliseError = (error, opts, logger) => {
       } else if (error !== null && hasNecessaryFields(error)) {
         err = new Error(error.message || error.errorMessage)
         err.name = error.name || error.errorClass
-        errorFramesToSkip += 2
+        errorFramesToSkip += 3
       } else {
         err = createAndLogUsageError(error === null ? 'null' : 'unsupported object')
       }

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -307,6 +307,8 @@ describe('@bugsnag/core/client', () => {
       expect(payloads.length).toBe(1)
       expect(payloads[0].events[0].toJSON().exceptions[0].errorClass).toBe('UnknownThing')
       expect(payloads[0].events[0].toJSON().exceptions[0].message).toBe('found a thing that couldn’t be dealt with')
+      expect(payloads[0].events[0].toJSON().exceptions[0].stacktrace[0].method).not.toMatch(/BugsnagClient/)
+      expect(payloads[0].events[0].toJSON().exceptions[0].stacktrace[0].file).not.toMatch(/core\/client\.js/)
     })
 
     it('leaves a breadcrumb of the error', () => {

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -288,11 +288,9 @@ describe('@bugsnag/core/client', () => {
       client.notify('str1', 'str2')
       client.notify('str1', null)
 
-      payloads
-        .filter((p, i) => i < 3)
-        .map(p => p.events[0].toJSON().exceptions[0].message)
-        .forEach(message => expect(message).toMatch(/^Bugsnag usage error/))
-
+      expect(payloads[0].events[0].toJSON().exceptions[0].message).toBe('Bugsnag usage error. notify() expected error/opts parameters, got nothing')
+      expect(payloads[1].events[0].toJSON().exceptions[0].message).toBe('Bugsnag usage error. notify() expected error/opts parameters, got null')
+      expect(payloads[2].events[0].toJSON().exceptions[0].message).toBe('Bugsnag usage error. notify() expected error/opts parameters, got function')
       expect(payloads[3].events[0].toJSON().exceptions[0].message).toBe('1')
       expect(payloads[4].events[0].toJSON().exceptions[0].message).toBe('errrororor')
       expect(payloads[5].events[0].toJSON().metaData).toEqual({ notifier: { notifyArgs: [ 'str1', 'str2' ] } })

--- a/test/browser/features/fixtures/handled/script/d.html
+++ b/test/browser/features/fixtures/handled/script/d.html
@@ -14,7 +14,12 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify({ name: 'Errr', message: 'make a stacktrace for me' })
+      function a () {
+        bugsnagClient.notify({ name: 'Errr', message: 'make a stacktrace for me' })
+      }
+      function b () { a() }
+      function c () { b() }
+      c()
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/script/d.html
+++ b/test/browser/features/fixtures/handled/script/d.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: API_KEY,
+        endpoint: ENDPOINT
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      bugsnagClient.notify({ name: 'Errr', message: 'make a stacktrace for me' })
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/handled/script/e.html
+++ b/test/browser/features/fixtures/handled/script/e.html
@@ -14,7 +14,12 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify('make a stacktrace for me')
+      function a () {
+        bugsnagClient.notify('make a stacktrace for me')
+      }
+      function b () { a() }
+      function c () { b() }
+      c()
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/script/e.html
+++ b/test/browser/features/fixtures/handled/script/e.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: API_KEY,
+        endpoint: ENDPOINT
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      bugsnagClient.notify('make a stacktrace for me')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -51,3 +51,35 @@ Scenario Outline: calling notify() with Error within Promise catch
     | browserify |
     | rollup     |
     | typescript |
+
+Scenario Outline: calling notify() with an object, getting a generated a stacktrace
+  When I navigate to the URL "/handled/<type>/d.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Errr"
+  And the exception "message" equals "make a stacktrace for me"
+  And the exception "type" equals "browserjs"
+
+  # this ensures that the generated stacktrace doesn't include frames from bugsnag's source
+  And the payload field "events.0.exceptions.0.stacktrace" is an array with 1 elements?
+  And the payload field "events.0.exceptions.0.stacktrace.0.file" ends with "d.html"
+
+  Examples:
+    | type       |
+    | script     |
+
+Scenario Outline: calling notify() with a string, getting a generated stacktrace
+  When I navigate to the URL "/handled/<type>/e.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "make a stacktrace for me"
+  And the exception "type" equals "browserjs"
+
+  # this ensures that the generated stacktrace doesn't include frames from bugsnag's source
+  And the payload field "events.0.exceptions.0.stacktrace" is an array with 1 elements?
+  And the payload field "events.0.exceptions.0.stacktrace.0.file" ends with "e.html"
+
+  Examples:
+    | type       |
+    | script     |

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -52,8 +52,8 @@ Scenario Outline: calling notify() with Error within Promise catch
     | rollup     |
     | typescript |
 
-Scenario Outline: calling notify() with an object, getting a generated a stacktrace
-  When I navigate to the URL "/handled/<type>/d.html"
+Scenario: calling notify() with an object, getting a generated a stacktrace
+  When I navigate to the URL "/handled/script/d.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Errr"
@@ -61,15 +61,11 @@ Scenario Outline: calling notify() with an object, getting a generated a stacktr
   And the exception "type" equals "browserjs"
 
   # this ensures that the generated stacktrace doesn't include frames from bugsnag's source
-  And the payload field "events.0.exceptions.0.stacktrace" is an array with 1 elements?
-  And the payload field "events.0.exceptions.0.stacktrace.0.file" ends with "d.html"
+  And the payload field "events.0.exceptions.0.stacktrace" is an array with 3 elements?
+  And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
 
-  Examples:
-    | type       |
-    | script     |
-
-Scenario Outline: calling notify() with a string, getting a generated stacktrace
-  When I navigate to the URL "/handled/<type>/e.html"
+Scenario: calling notify() with a string, getting a generated stacktrace
+  When I navigate to the URL "/handled/script/e.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
@@ -77,9 +73,5 @@ Scenario Outline: calling notify() with a string, getting a generated stacktrace
   And the exception "type" equals "browserjs"
 
   # this ensures that the generated stacktrace doesn't include frames from bugsnag's source
-  And the payload field "events.0.exceptions.0.stacktrace" is an array with 1 elements?
-  And the payload field "events.0.exceptions.0.stacktrace.0.file" ends with "e.html"
-
-  Examples:
-    | type       |
-    | script     |
+  And the payload field "events.0.exceptions.0.stacktrace" is an array with 3 elements?
+  And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -60,8 +60,7 @@ Scenario: calling notify() with an object, getting a generated a stacktrace
   And the exception "message" equals "make a stacktrace for me"
   And the exception "type" equals "browserjs"
 
-  # this ensures that the generated stacktrace doesn't include frames from bugsnag's source
-  And the payload field "events.0.exceptions.0.stacktrace" is an array with 3 elements?
+  # this ensures the first generated stackframe doesn't come from bugsnag's source
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
 
 Scenario: calling notify() with a string, getting a generated stacktrace
@@ -72,6 +71,5 @@ Scenario: calling notify() with a string, getting a generated stacktrace
   And the exception "message" equals "make a stacktrace for me"
   And the exception "type" equals "browserjs"
 
-  # this ensures that the generated stacktrace doesn't include frames from bugsnag's source
-  And the payload field "events.0.exceptions.0.stacktrace" is an array with 3 elements?
+  # this ensures the first generated stackframe doesn't come from bugsnag's source
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"

--- a/test/node/features/fixtures/handled/scenarios/notify-string.js
+++ b/test/node/features/fixtures/handled/scenarios/notify-string.js
@@ -1,0 +1,10 @@
+var bugsnag = require('@bugsnag/node')
+var bugsnagClient = bugsnag({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  }
+})
+
+bugsnagClient.notify('create an error for me')

--- a/test/node/features/handled_errors.feature
+++ b/test/node/features/handled_errors.feature
@@ -17,7 +17,7 @@ Scenario: calling notify() with an error
   And the "file" of stack frame 0 equals "scenarios/notify.js"
   And the "lineNumber" of stack frame 0 equals 10
 
-Scenario: calling notify() with am error from try/catch
+Scenario: calling notify() with an error from try/catch
   And I run the service "handled" with the command "node scenarios/notify-try-catch"
   And I wait to receive a request
   Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
@@ -67,3 +67,16 @@ Scenario: using intercept to notify a promise rejection
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/intercept-rejection.js"
   And the "lineNumber" of stack frame 0 equals 21
+
+Scenario: calling notify with a string
+  And I run the service "handled" with the command "node scenarios/notify-string"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "severityReason.type" equals "handledException"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "create an error for me"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/notify-string.js"
+  And the "lineNumber" of stack frame 0 equals 10


### PR DESCRIPTION
This PR makes a couple of improvements to the `normaliseError()` function which is used by `notify()` to coerce its arguments into a reasonable error, or generate an error alerting the developer to incorrect usage:

- When https://github.com/bugsnag/bugsnag-js/commit/dd4030b505a5e5f875871de2d05f9537ec00a0af was added it meant every `notify()` call that ended up generating a stacktrace included a frame from this codebase. The `errorFramesToSkip` count has been bump to mitigate that.
- The logic for a missing error argument has been moved so that it is all encapsulated inside this function, and in the process fixed an issue where `null` ended up in the "object" case block (see #400 for original report/potential fix)

## Testing

Unit tests and end-to-end tests added to cover these changes.

## Bundle size discussion time

Since this makes changes to `@bugsnag/core` it stands to affect browser bundle size. Here's the change:

```diff
- 11.68kB
+ 11.64kB
```

Net decrease of `0.04kB`. I think this is 🆒.