### PR TITLE
Add notify's 3rd argument type

### DIFF
--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -22,7 +22,7 @@ declare class Client {
   public delivery(delivery: common.IDelivery): Client;
   public logger(logger: common.ILogger): Client;
   public sessionDelegate(sessionDelegate: common.ISessionDelegate): Client;
-  public notify(error: common.NotifiableError, opts?: common.INotifyOpts): boolean;
+  public notify(error: common.NotifiableError, opts?: common.INotifyOpts, callback?: (...args: any[]) => void): boolean;
   public leaveBreadcrumb(name: string, metaData?: any, type?: string, timestamp?: string): Client;
   public startSession(): Client;
 }


### PR DESCRIPTION
# Issue 
- Typescript is unaware of 3rd argument 

# Goal 
- Add 3rd argument to typescript definition

# Code 
- https://github.com/bugsnag/bugsnag-js/blob/next/packages/core/client.js#L150

```
notify (error, opts = {}, cb = () => {}) {
```