### PR TITLE
Add mobile packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Use the following plugins and guides to integrate Bugsnag with various framework
 | Express | [@bugsnag/plugin-express](packages/plugin-express)  | [Express docs](https://docs.bugsnag.com/platforms/javascript/express) |
 | Restify | [@bugsnag/plugin-restify](packages/plugin-restify)  | [Restify docs](https://docs.bugsnag.com/platforms/javascript/restify) |
 
+### Mobile
+
+| Framework  | Bugsnag plugin | Documentation |
+| ---------- | -------------- | --------------|
+| Expo | [@bugsnag/expo](packages/expo)  | [Expo docs](https://docs.bugsnag.com/platforms/react-native/expo/) |
+| React Native | See the [bugsnag-react-native](https://github.com/bugsnag/bugsnag-react-native) notifier | |
+
 ## Support
 
 * Check out the [FAQ](https://docs.bugsnag.com/platforms/javascript/faq) and [configuration options](https://docs.bugsnag.com/platforms/javascript/configuration-options)

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Use the following plugins and guides to integrate Bugsnag with various framework
 
 ### Mobile
 
-| Framework  | Bugsnag plugin | Documentation |
+| Framework  | Bugsnag notifier | Documentation |
 | ---------- | -------------- | --------------|
 | Expo | [@bugsnag/expo](packages/expo)  | [Expo docs](https://docs.bugsnag.com/platforms/react-native/expo/) |
-| React Native | See the [bugsnag-react-native](https://github.com/bugsnag/bugsnag-react-native) notifier | |
+| React Native | [bugsnag-react-native](https://github.com/bugsnag/bugsnag-react-native) (lives in a separate repo) | [Docs](https://docs.bugsnag.com/platforms/react-native/react-native/) |
 
 ## Support
 


### PR DESCRIPTION
Proposal for adding a mobile section to the bugsnag-js README now we've added expo to this repo.