### PR TITLE
Add node-12 tests to CI pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -237,3 +237,11 @@ steps:
         use-aliases: true
     env:
       NODE_VERSION: "10"
+
+  - label: ':node: Node 12'
+    plugins:
+      docker-compose#v2.6.0:
+        run: node-maze-runner
+        use-aliases: true
+    env:
+      NODE_VERSION: "12"


### PR DESCRIPTION
As Node 12 will be an LTS version this adds a Node 12 e2e tests step to the CI pipeline.

Now with a CI-able branch name!