### PR TITLE
feat(plugin-navigation-breadcrumbs): Compile away _restore test function in production bundle

### DIFF
--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -75,7 +75,9 @@ const wrapHistoryFn = (client, target, fn, win) => {
     // to '/undefined'. therefore we only pass the url if it's not undefined.
     orig.apply(target, [ state, title ].concat(url !== undefined ? url : []))
   }
-  target[fn]._restore = () => { target[fn] = orig }
+  if (process.env.NODE_ENV !== 'production') {
+    target[fn]._restore = () => { target[fn] = orig }
+  }
 }
 
 const getCurrentState = (win) => {


### PR DESCRIPTION
I can't – no matter how hard I try – replicate #399. However in looking at it I realised that line of code can be compiled away in the minified bundle anyway. It's the definition of a `_restore` function which only serves a function in running this code multiple times in the same process for tests.

So, this fixes #399. Or rather, makes it impossible for that code path to be following in production.

This small changes sees a decrease in bundle size of `0.01kb`:

```diff
- 11.69kB
+ 11.68kB
```