### PR TITLE
fix(browser): Stub a .ts file to allow Angular AOT mode to recompile

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "size": "./bin/size",
     "clean": "rm -fr dist && mkdir dist",
-    "bundle-types": "../../bin/bundle-types",
+    "bundle-types": "../../bin/bundle-types && touch dist/types/bugsnag.ts",
     "build": "npm run clean && npm run build:dist && npm run build:dist:min && npm run bundle-types",
     "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
     "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=bugsnag | ../../bin/minify dist/bugsnag.min.js",


### PR DESCRIPTION
In Angular's AOT mode, the first full build would work but an incremental build upon making a change
would fail with an error that it couldn't locale the bugsnag browser types module. By generating an
empty bugsnag.ts file in the browser/dist/types directory, Angular is convinced that it's ok and it
all compiles and runs correctly.

~Additionally this removes the stubbed types on the Bugsnag object – in none of my test permutations were these needed.~ Update: I found that it was required in the end.

Fixes #523

### Testing

Create a new angular app `npx ng new test-ng-app` and integrate [Bugsnag according to the docs](https://docs.bugsnag.com/platforms/javascript/angular/). 

Run it with `ng serve --aot` and once it's running, save one of the source files to trigger a rebuild. Notice this error:

```
ERROR in ./src/app/app.module.ngfactory.js
Module not found: Error: Can't resolve '@bugsnag/browser/dist/types/bugsnag' in '/Users/user/dev/ng-app/src/app'
```

Now switch over to this repository and checkout this branch.

Ensure the dependencies are installed and the standalone modules are built:

```
npm run bootstrap
npm run build
```

Prepare a tarball of the browser notifier:

```
cd packages/browser
npm pack
```

Switch back to the `test-ng-app` directory and install the tarball that was just created `npm install ../../path-to-bugsnag-js/packages/browser/bugsnag-browser-6.2.0.tgz`.

Run the app again with `ng serve --aot` and once it's running, save one of the source files to trigger a rebuild. Notice that the error does not occur.