### PR TITLE
fix(plugin-angular): Target ES6 so that built classes are native 

### DIFF
--- a/packages/plugin-angular/package-lock.json
+++ b/packages/plugin-angular/package-lock.json
@@ -1,320 +1,289 @@
 {
 	"name": "@bugsnag/plugin-angular",
-	"version": "6.0.0",
+	"version": "6.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@angular-devkit/build-optimizer": {
-			"version": "0.3.2",
-			"resolved": "http://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.3.2.tgz",
-			"integrity": "sha512-U0BCZtThq5rUfY08shHXpxe8ZhSsiYB/cJjUvAWRTs/ORrs8pbngS6xwseQws8d/vHoVrtqGD9GU9h8AmFRERQ==",
+		"@angular-devkit/architect": {
+			"version": "0.13.9",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.13.9.tgz",
+			"integrity": "sha512-EAFtCs9dsGhpMRC45PoYsrkiExpWz9Ax15qXfzwdDRacz5DmdOVt+QpkLW1beUOwiyj/bhFyj23eaONK2RTn/w==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"source-map": "^0.5.6",
-				"typescript": "~2.6.2",
-				"webpack-sources": "^1.0.1"
+				"@angular-devkit/core": "7.3.9",
+				"rxjs": "6.3.3"
 			},
 			"dependencies": {
-				"typescript": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-					"integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
-					"dev": true
+				"rxjs": {
+					"version": "6.3.3",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
 				}
 			}
 		},
 		"@angular-devkit/core": {
-			"version": "0.3.2",
-			"resolved": "http://registry.npmjs.org/@angular-devkit/core/-/core-0.3.2.tgz",
-			"integrity": "sha512-zABk/iP7YX5SVbmK4e+IX7j2d0D37MQJQiKgWdV3JzfvVJhNJzddiirtT980pIafoq+KyvTgVwXtc+vnux0oeQ==",
+			"version": "7.3.9",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-7.3.9.tgz",
+			"integrity": "sha512-SaxD+nKFW3iCBKsxNR7+66J30EexW/y7tm8m5AvUH+GwSAgIj0ZYmRUzFEPggcaLVA4WnE/YWqIXZMJW5dT7gw==",
 			"dev": true,
 			"requires": {
-				"ajv": "~5.5.1",
-				"chokidar": "^1.7.0",
-				"rxjs": "^5.5.6",
-				"source-map": "^0.5.6"
+				"ajv": "6.9.1",
+				"chokidar": "2.0.4",
+				"fast-json-stable-stringify": "2.0.0",
+				"rxjs": "6.3.3",
+				"source-map": "0.7.3"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+				"rxjs": {
+					"version": "6.3.3",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"tslib": "^1.9.0"
 					}
 				}
 			}
 		},
 		"@angular-devkit/schematics": {
-			"version": "0.3.2",
-			"resolved": "http://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.3.2.tgz",
-			"integrity": "sha512-B6zZoqvHaTJy+vVdA6EtlxnCdGMa5elCa4j9lQLC3JI8DLvMXUWkCIPVbPzJ/GSRR9nsKWpvYMYaJyfBDUqfhw==",
+			"version": "7.3.9",
+			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-7.3.9.tgz",
+			"integrity": "sha512-xzROGCYp7aQbeJ3V6YC0MND7wKEAdWqmm/GaCufEk0dDS8ZGe0sQhcM2oBRa2nQqGQNeThFIH51kx+FayrJP0w==",
 			"dev": true,
 			"requires": {
-				"@ngtools/json-schema": "^1.1.0",
-				"rxjs": "^5.5.6"
+				"@angular-devkit/core": "7.3.9",
+				"rxjs": "6.3.3"
+			},
+			"dependencies": {
+				"rxjs": {
+					"version": "6.3.3",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				}
 			}
 		},
 		"@angular/cli": {
-			"version": "1.7.4",
-			"resolved": "http://registry.npmjs.org/@angular/cli/-/cli-1.7.4.tgz",
-			"integrity": "sha512-URdb1QtnQf+Ievy93wjq7gE81s25BkWUwJFPey+YkphBA3G1lbCAQPiEh2pntBwaIKavgEuCw+Sf2YZdgTVhDA==",
+			"version": "7.3.9",
+			"resolved": "https://registry.npmjs.org/@angular/cli/-/cli-7.3.9.tgz",
+			"integrity": "sha512-7oJj7CKDlFUbQav1x1CV4xKKcbt0pnxY4unKcm7Q1tVXhu8bU2bc3cDA0aJnbofcYb6TJcd/C2qHgCt78q7edA==",
 			"dev": true,
 			"requires": {
-				"@angular-devkit/build-optimizer": "0.3.2",
-				"@angular-devkit/core": "0.3.2",
-				"@angular-devkit/schematics": "0.3.2",
-				"@ngtools/json-schema": "1.2.0",
-				"@ngtools/webpack": "1.10.2",
-				"@schematics/angular": "0.3.2",
-				"@schematics/package-update": "0.3.2",
-				"ajv": "^6.1.1",
-				"autoprefixer": "^7.2.3",
-				"cache-loader": "^1.2.0",
-				"chalk": "~2.2.0",
-				"circular-dependency-plugin": "^4.2.1",
-				"clean-css": "^4.1.11",
-				"common-tags": "^1.3.1",
-				"copy-webpack-plugin": "~4.4.1",
-				"core-object": "^3.1.0",
-				"denodeify": "^1.2.1",
-				"ember-cli-string-utils": "^1.0.0",
-				"extract-text-webpack-plugin": "^3.0.2",
-				"file-loader": "^1.1.5",
-				"fs-extra": "^4.0.0",
-				"glob": "^7.0.3",
-				"html-webpack-plugin": "^2.29.0",
-				"istanbul-instrumenter-loader": "^3.0.0",
-				"karma-source-map-support": "^1.2.0",
-				"less": "^2.7.2",
-				"less-loader": "^4.0.5",
-				"license-webpack-plugin": "^1.0.0",
-				"loader-utils": "1.1.0",
-				"lodash": "^4.11.1",
-				"memory-fs": "^0.4.1",
-				"minimatch": "^3.0.4",
-				"node-modules-path": "^1.0.0",
-				"node-sass": "^4.7.2",
-				"nopt": "^4.0.1",
-				"opn": "~5.1.0",
-				"portfinder": "~1.0.12",
-				"postcss": "^6.0.16",
-				"postcss-import": "^11.0.0",
-				"postcss-loader": "^2.0.10",
-				"postcss-url": "^7.1.2",
-				"raw-loader": "^0.5.1",
-				"resolve": "^1.1.7",
-				"rxjs": "^5.5.6",
-				"sass-loader": "^6.0.6",
-				"semver": "^5.1.0",
-				"silent-error": "^1.0.0",
-				"source-map-support": "^0.4.1",
-				"style-loader": "^0.19.1",
-				"stylus": "^0.54.5",
-				"stylus-loader": "^3.0.1",
-				"uglifyjs-webpack-plugin": "^1.1.8",
-				"url-loader": "^0.6.2",
-				"webpack": "~3.11.0",
-				"webpack-dev-middleware": "~1.12.0",
-				"webpack-dev-server": "~2.11.0",
-				"webpack-merge": "^4.1.0",
-				"webpack-sources": "^1.0.0",
-				"webpack-subresource-integrity": "^1.0.1"
+				"@angular-devkit/architect": "0.13.9",
+				"@angular-devkit/core": "7.3.9",
+				"@angular-devkit/schematics": "7.3.9",
+				"@schematics/angular": "7.3.9",
+				"@schematics/update": "0.13.9",
+				"@yarnpkg/lockfile": "1.1.0",
+				"ini": "1.3.5",
+				"inquirer": "6.2.1",
+				"npm-package-arg": "6.1.0",
+				"open": "6.0.0",
+				"pacote": "9.4.0",
+				"semver": "5.6.0",
+				"symbol-observable": "1.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"dev": true
+				},
+				"symbol-observable": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+					"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+					"dev": true
+				}
 			}
 		},
 		"@angular/compiler": {
-			"version": "4.4.7",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.4.7.tgz",
-			"integrity": "sha512-aiRh86RqHMTgJ7xckQWzG2UTnq23+WuDVhYh/QL19R43areZLglqgtKSkfezg9aatO5CGzxDA3qL5WGhccQ5EQ==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-7.2.15.tgz",
+			"integrity": "sha512-5yb4NcLk8GuXkYf7Dcor4XkGueYp4dgihzDmMjYDUrV0NPhubKlr+SwGtLOtzgRBWJ1I2bO0S3zwa0q0OgIPOw==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.7.1"
+				"tslib": "^1.9.0"
 			}
 		},
 		"@angular/compiler-cli": {
-			"version": "4.4.7",
-			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.4.7.tgz",
-			"integrity": "sha512-vzphs9galtMV29CW+ihp6v0HwSQrjAFqs04swqt9o0jEJET6/mPi1EFjJRNZiFn6ghh6lxUPr3vThy7CrSNxHg==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-7.2.15.tgz",
+			"integrity": "sha512-+AsfyKawmj/sa+m4Pz8VSRFbCfx/3IOjAuuEjhopbyr154YpPDSu8NTbcwzq3yfbVcPwK4/4exmbQzpsndaCTg==",
 			"dev": true,
 			"requires": {
-				"@angular/tsc-wrapped": "4.4.7",
+				"canonical-path": "1.0.0",
+				"chokidar": "^2.1.1",
+				"convert-source-map": "^1.5.1",
+				"dependency-graph": "^0.7.2",
+				"magic-string": "^0.25.0",
 				"minimist": "^1.2.0",
-				"reflect-metadata": "^0.1.2"
+				"reflect-metadata": "^0.1.2",
+				"shelljs": "^0.8.1",
+				"source-map": "^0.6.1",
+				"tslib": "^1.9.0",
+				"yargs": "9.0.1"
 			},
 			"dependencies": {
+				"chokidar": {
+					"version": "2.1.6",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+					"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+					"dev": true,
+					"requires": {
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.1",
+						"braces": "^2.3.2",
+						"fsevents": "^1.2.7",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.3",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^3.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.2.1",
+						"upath": "^1.1.1"
+					}
+				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
 		"@angular/core": {
-			"version": "4.4.7",
-			"resolved": "https://registry.npmjs.org/@angular/core/-/core-4.4.7.tgz",
-			"integrity": "sha512-Jxs6gNTl5KjXflg5vi5rlnokq1johFccN94qSOgDv+Mg1iuGF2i9p7EHkw3Y8jBCVaSLw1qgHE+wMb6KTlJDLA==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-7.2.15.tgz",
+			"integrity": "sha512-XsuYm0jEU/mOqwDOk2utThv8J9kESkAerfuCHClE9rB2TtHUOGCfekF7lJWqjjypu6/J9ygoPFo7hdAE058ZGg==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.7.1"
-			}
-		},
-		"@angular/tsc-wrapped": {
-			"version": "4.4.7",
-			"resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.4.7.tgz",
-			"integrity": "sha512-R9w7sTU+HSTMPOa4NgvPL753qB6aqnPc1AVh2rwSl5FOpLS/AeeyzIhRnBsVXGrZrTcBQVLp/Cxg1oUSXE2k4Q==",
-			"dev": true,
-			"requires": {
-				"tsickle": "^0.21.0"
-			}
-		},
-		"@ngtools/json-schema": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ngtools/json-schema/-/json-schema-1.2.0.tgz",
-			"integrity": "sha512-pMh+HDc6mOjUO3agRfB1tInimo7hf67u+0Cska2bfXFe6oU7rSMnr5PLVtiZVgwMoBHpx/6XjBymvcnWPo2Uzg==",
-			"dev": true
-		},
-		"@ngtools/webpack": {
-			"version": "1.10.2",
-			"resolved": "http://registry.npmjs.org/@ngtools/webpack/-/webpack-1.10.2.tgz",
-			"integrity": "sha512-3u2zg2rarG3qNLSukBClGADWuq/iNn5SQtlSeAbfKzwBeyLGbF0gN1z1tVx1Bcr8YwFzR6NdRePQmJGcoqq1fg==",
-			"dev": true,
-			"requires": {
-				"chalk": "~2.2.0",
-				"enhanced-resolve": "^3.1.0",
-				"loader-utils": "^1.0.2",
-				"magic-string": "^0.22.3",
-				"semver": "^5.3.0",
-				"source-map": "^0.5.6",
-				"tree-kill": "^1.0.0",
-				"webpack-sources": "^1.1.0"
+				"tslib": "^1.9.0"
 			}
 		},
 		"@schematics/angular": {
-			"version": "0.3.2",
-			"resolved": "http://registry.npmjs.org/@schematics/angular/-/angular-0.3.2.tgz",
-			"integrity": "sha512-Elrk0BA951s0ScFZU0AWrpUeJBYVR52DZ1QTIO5R0AhwEd1PW4olI8szPLGQlVW5Sd6H0FA/fyFLIvn2r9v6Rw==",
+			"version": "7.3.9",
+			"resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-7.3.9.tgz",
+			"integrity": "sha512-B3lytFtFeYNLfWdlrIzvy3ulFRccD2/zkoL0734J+DAGfUz7vbysJ50RwYL46sQUcKdZdvb48ktfu1S8yooP6Q==",
 			"dev": true,
 			"requires": {
-				"typescript": "~2.6.2"
+				"@angular-devkit/core": "7.3.9",
+				"@angular-devkit/schematics": "7.3.9",
+				"typescript": "3.2.4"
 			},
 			"dependencies": {
 				"typescript": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-					"integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+					"version": "3.2.4",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+					"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
 					"dev": true
 				}
 			}
 		},
-		"@schematics/package-update": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@schematics/package-update/-/package-update-0.3.2.tgz",
-			"integrity": "sha512-7aVP4994Hu8vRdTTohXkfGWEwLhrdNP3EZnWyBootm5zshWqlQojUGweZe5zwewsKcixeVOiy2YtW+aI4aGSLA==",
+		"@schematics/update": {
+			"version": "0.13.9",
+			"resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.13.9.tgz",
+			"integrity": "sha512-4MQcaKFxhMzZyE//+DknDh3h3duy3avg2oxSHxdwXlCZ8Q92+4lpegjJcSRiqlEwO4qeJ5XnrjrvzfIiaIZOmA==",
 			"dev": true,
 			"requires": {
-				"rxjs": "^5.5.6",
-				"semver": "^5.3.0",
-				"semver-intersect": "^1.1.2"
-			}
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
-		},
-		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-			"dev": true,
-			"requires": {
-				"mime-types": "~2.1.18",
-				"negotiator": "0.6.1"
-			}
-		},
-		"acorn": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-			"dev": true
-		},
-		"acorn-dynamic-import": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"dev": true,
-			"requires": {
-				"acorn": "^4.0.3"
+				"@angular-devkit/core": "7.3.9",
+				"@angular-devkit/schematics": "7.3.9",
+				"@yarnpkg/lockfile": "1.1.0",
+				"ini": "1.3.5",
+				"pacote": "9.4.0",
+				"rxjs": "6.3.3",
+				"semver": "5.6.0",
+				"semver-intersect": "1.4.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+				"rxjs": {
+					"version": "6.3.3",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
 					"dev": true
 				}
+			}
+		},
+		"@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true
+		},
+		"JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			}
+		},
+		"agent-base": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"dev": true,
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
+		"agentkeepalive": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+			"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+			"dev": true,
+			"requires": {
+				"humanize-ms": "^1.2.1"
 			}
 		},
 		"ajv": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-			"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+			"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
-			},
-			"dependencies": {
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
-				}
 			}
 		},
-		"ajv-keywords": {
+		"ansi-escapes": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-			"dev": true
-		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
-			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
-			}
-		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
-		},
-		"ansi-html": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -333,13 +302,13 @@
 			}
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"aproba": {
@@ -347,17 +316,6 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -369,13 +327,10 @@
 			}
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -389,115 +344,11 @@
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
-		"array-find-index": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
-		},
-		"array-flatten": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
-			"dev": true
-		},
-		"array-includes": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
-			}
-		},
-		"array-union": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
-			"requires": {
-				"array-uniq": "^1.0.1"
-			}
-		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
-		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
-		},
-		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true,
-			"optional": true
-		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"assert": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true,
-			"requires": {
-				"util": "0.10.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
-				},
-				"util": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.1"
-					}
-				}
-			}
-		},
-		"assert-plus": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-			"dev": true,
-			"optional": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -505,68 +356,17 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
-		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.10"
-			}
-		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
-		},
-		"async-foreach": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-			"dev": true,
-			"optional": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true,
-			"optional": true
 		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
-		},
-		"autoprefixer": {
-			"version": "7.2.6",
-			"resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-			"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^2.11.3",
-				"caniuse-lite": "^1.0.30000805",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^6.0.17",
-				"postcss-value-parser": "^3.2.3"
-			}
-		},
-		"aws-sign2": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-			"dev": true,
-			"optional": true
-		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true,
-			"optional": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -605,89 +405,6 @@
 					"dev": true
 				}
 			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
-			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -747,132 +464,20 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
-		},
-		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-			"dev": true
-		},
-		"batch": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-			"dev": true
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
-		"big.js": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-			"dev": true
 		},
 		"binary-extensions": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
-		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"inherits": "~2.0.0"
-			}
 		},
 		"bluebird": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
 			"dev": true
-		},
-		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-			"dev": true
-		},
-		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-			"dev": true,
-			"requires": {
-				"bytes": "3.0.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
-				"iconv-lite": "0.4.19",
-				"on-finished": "~2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
-				}
-			}
-		},
-		"bonjour": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-			"dev": true,
-			"requires": {
-				"array-flatten": "^2.1.0",
-				"deep-equal": "^1.0.1",
-				"dns-equal": "^1.0.0",
-				"dns-txt": "^2.0.2",
-				"multicast-dns": "^6.0.1",
-				"multicast-dns-service-types": "^1.1.0"
-			}
-		},
-		"boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
-		},
-		"boom": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"hoek": "2.x.x"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -885,112 +490,32 @@
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
-			}
-		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
-		},
-		"browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
-			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"browserify-cipher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
-			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
-			}
-		},
-		"browserify-des": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"browserify-rsa": {
-			"version": "4.0.1",
-			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
-			}
-		},
-		"browserify-sign": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
-			}
-		},
-		"browserify-zlib": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
-			"requires": {
-				"pako": "~1.0.5"
-			}
-		},
-		"browserslist": {
-			"version": "2.11.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-			"dev": true,
-			"requires": {
-				"caniuse-lite": "^1.0.30000792",
-				"electron-to-chromium": "^1.3.30"
-			}
-		},
-		"buffer": {
-			"version": "4.9.1",
-			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-			"dev": true,
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"buffer-from": {
@@ -999,54 +524,37 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"buffer-indexof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
-			"dev": true
-		},
-		"buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
-		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
-		"builtin-status-codes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
-		},
-		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+		"builtins": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 			"dev": true
 		},
 		"cacache": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.1",
-				"chownr": "^1.0.1",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.1.11",
-				"lru-cache": "^4.1.1",
-				"mississippi": "^2.0.0",
+				"bluebird": "^3.5.3",
+				"chownr": "^1.1.1",
+				"figgy-pudding": "^3.5.1",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"lru-cache": "^5.1.1",
+				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^2.6.2",
-				"ssri": "^5.2.4",
-				"unique-filename": "^1.1.0",
+				"ssri": "^6.0.1",
+				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
 			}
 		},
@@ -1065,125 +573,62 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
-			}
-		},
-		"cache-loader": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cache-loader/-/cache-loader-1.2.2.tgz",
-			"integrity": "sha512-rsGh4SIYyB9glU+d0OcHwiXHXBoUgDhHZaQ1KAbiXqfz1CDPxtTboh1gPbJ0q2qdO8a9lfcjgC5CJ2Ms32y5bw==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.1.0",
-				"mkdirp": "^0.5.1",
-				"neo-async": "^2.5.0",
-				"schema-utils": "^0.4.2"
-			}
-		},
-		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true,
-			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
 			}
 		},
 		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 			"dev": true
 		},
-		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"dev": true,
-			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
-			}
-		},
-		"caniuse-lite": {
-			"version": "1.0.30000885",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
-			"integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
+		"canonical-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+			"integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
 			"dev": true
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true,
-			"optional": true
-		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
-			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
-			}
 		},
 		"chalk": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.2.tgz",
-			"integrity": "sha512-LvixLAQ4MYhbf7hgL4o5PeK32gJKvVzDRiSNIApDofQvyhl8adgG2lJVXn4+ekQoK7HL9RF8lqxwerpe0x2pCw==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.1.0",
+				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^4.0.0"
+				"supports-color": "^5.3.0"
 			}
 		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
+		},
 		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^1.3.0",
+				"anymatch": "^2.0.0",
 				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.2.2",
+				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.1",
 				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
+				"is-glob": "^4.0.0",
+				"lodash.debounce": "^4.0.8",
+				"normalize-path": "^2.1.1",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.5"
 			}
 		},
 		"chownr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-			"dev": true
-		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"circular-dependency-plugin": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-4.4.0.tgz",
-			"integrity": "sha512-yEFtUNUYT4jBykEX5ZOHw+5goA3glGZr9wAXIQqoyakjz5H5TeUmScnWRc52douAhb9eYzK3s7V6bXfNnjFdzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 			"dev": true
 		},
 		"class-utils": {
@@ -1206,31 +651,23 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
-		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"source-map": "~0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
+				"restore-cursor": "^2.0.0"
 			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -1241,48 +678,29 @@
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1",
 				"wrap-ansi": "^2.0.0"
-			}
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-			"dev": true
-		},
-		"clone-deep": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
-			"dev": true,
-			"requires": {
-				"for-own": "^1.0.0",
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.0",
-				"shallow-clone": "^1.0.0"
 			},
 			"dependencies": {
-				"for-own": {
+				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"for-in": "^1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
 				}
 			}
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -1315,63 +733,17 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
 			"dev": true
 		},
-		"common-tags": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
-			"dev": true
-		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
-		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
-		},
-		"compressible": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
-			"integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
-			"dev": true,
-			"requires": {
-				"mime-db": ">= 1.34.0 < 2"
-			}
-		},
-		"compression": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.5",
-				"bytes": "3.0.0",
-				"compressible": "~2.0.14",
-				"debug": "2.6.9",
-				"on-headers": "~1.0.1",
-				"safe-buffer": "5.1.2",
-				"vary": "~1.1.2"
-			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1391,46 +763,6 @@
 				"typedarray": "^0.0.6"
 			}
 		},
-		"connect-history-api-fallback": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
-			"dev": true
-		},
-		"console-browserify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
-			"requires": {
-				"date-now": "^0.1.4"
-			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true,
-			"optional": true
-		},
-		"constants-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
-		},
-		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-			"dev": true
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
-		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1439,18 +771,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
-		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-			"dev": true
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -1472,238 +792,45 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"copy-webpack-plugin": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.4.3.tgz",
-			"integrity": "sha512-v4THQ24Tks2NkyOvZuFDgZVfDD9YaA9rwYLZTrWg2GHIA8lrH5DboEyeoorh5Skki+PUbgSmnsCwhMWqYrQZrA==",
-			"dev": true,
-			"requires": {
-				"cacache": "^10.0.1",
-				"find-cache-dir": "^1.0.0",
-				"globby": "^7.1.1",
-				"is-glob": "^4.0.0",
-				"loader-utils": "^1.1.0",
-				"minimatch": "^3.0.4",
-				"p-limit": "^1.0.0",
-				"serialize-javascript": "^1.4.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				}
-			}
-		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
-		},
-		"core-object": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/core-object/-/core-object-3.1.5.tgz",
-			"integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.0"
-			}
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
-		"cosmiconfig": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-			"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-			"dev": true,
-			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"parse-json": "^4.0.0",
-				"require-from-string": "^2.0.1"
-			},
-			"dependencies": {
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				}
-			}
-		},
-		"create-ecdh": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
-			}
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
 		"cross-spawn": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			}
-		},
-		"cryptiles": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"boom": "2.x.x"
-			}
-		},
-		"crypto-browserify": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
-			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
-			}
-		},
-		"css-parse": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
-			"integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
-			"dev": true
-		},
-		"css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"dev": true,
-			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
-				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
-			}
-		},
-		"css-what": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-			"dev": true
-		},
-		"cuint": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-			"integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
-			"dev": true
-		},
-		"currently-unhandled": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
-			"requires": {
-				"array-find-index": "^1.0.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
 			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-			"dev": true
-		},
-		"d": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"dev": true,
-			"requires": {
-				"es5-ext": "^0.10.9"
-			}
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"date-now": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
 			"dev": true
 		},
 		"debug": {
@@ -1726,21 +853,6 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
-		},
-		"deep-equal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-			"dev": true
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
 		},
 		"define-property": {
 			"version": "2.0.2",
@@ -1780,113 +892,13 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
-		"del": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-			"dev": true,
-			"requires": {
-				"globby": "^6.1.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"p-map": "^1.1.1",
-				"pify": "^3.0.0",
-				"rimraf": "^2.2.8"
-			},
-			"dependencies": {
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"dev": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
-					}
-				}
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true,
-			"optional": true
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true,
-			"optional": true
-		},
-		"denodeify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-			"integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
-			"dev": true
-		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
-		"des.js": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
-		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
-			"requires": {
-				"repeating": "^2.0.0"
-			}
-		},
-		"detect-node": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+		"dependency-graph": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.7.2.tgz",
+			"integrity": "sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ==",
 			"dev": true
 		},
 		"diff": {
@@ -1895,122 +907,10 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
-		"diffie-hellman": {
-			"version": "5.0.3",
-			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
-			}
-		},
-		"dir-glob": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"path-type": "^3.0.0"
-			}
-		},
-		"dns-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
-			"dev": true
-		},
-		"dns-packet": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
-			"dev": true,
-			"requires": {
-				"ip": "^1.1.0",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"dns-txt": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-			"dev": true,
-			"requires": {
-				"buffer-indexof": "^1.0.0"
-			}
-		},
-		"dom-converter": {
-			"version": "0.1.4",
-			"resolved": "http://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
-			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
-			"dev": true,
-			"requires": {
-				"utila": "~0.3"
-			},
-			"dependencies": {
-				"utila": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-					"dev": true
-				}
-			}
-		},
-		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-			"dev": true,
-			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
-				}
-			}
-		},
-		"domain-browser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-			"dev": true
-		},
-		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-			"dev": true
-		},
-		"domhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-			"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-			"dev": true,
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"dev": true,
-			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
 		"duplexify": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -2019,67 +919,14 @@
 				"stream-shift": "^1.0.0"
 			}
 		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
-		},
-		"ejs": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
-			"dev": true
-		},
-		"electron-to-chromium": {
-			"version": "1.3.67",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.67.tgz",
-			"integrity": "sha512-h3zEBLdHvsKfaXv1SHAtykJyNtwYFEKkrWGSFyW1BzGgPQ4ykAzD5Hd8C5MZGTAEhkCKmtyIwYUrapsI0xfKww==",
-			"dev": true
-		},
-		"elliptic": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"iconv-lite": "~0.4.13"
 			}
-		},
-		"ember-cli-string-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
-			"integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
-			"dev": true
-		},
-		"emojis-list": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -2090,32 +937,11 @@
 				"once": "^1.4.0"
 			}
 		},
-		"enhanced-resolve": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"object-assign": "^4.0.1",
-				"tapable": "^0.2.7"
-			}
-		},
-		"entities": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+		"err-code": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
 			"dev": true
-		},
-		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
-			"requires": {
-				"prr": "~1.0.1"
-			}
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -2126,106 +952,20 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
-		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-			"dev": true,
-			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"dev": true,
-			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
-			}
-		},
-		"es5-ext": {
-			"version": "0.10.46",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-			"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
-			"dev": true,
-			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-map": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-set": "~0.1.5",
-				"es6-symbol": "~3.1.1",
-				"event-emitter": "~0.3.5"
-			}
-		},
-		"es6-set": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
-			}
-		},
-		"es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
-		"es6-weak-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+		"es6-promise": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
 			"dev": true
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -2233,37 +973,10 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
-		"escope": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"dev": true,
-			"requires": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			}
-		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
-			"requires": {
-				"estraverse": "^4.1.0"
-			}
-		},
-		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
 			"dev": true
 		},
 		"esutils": {
@@ -2271,53 +984,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
-		},
-		"event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
-		"eventemitter3": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
-			"dev": true
-		},
-		"events": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-			"dev": true
-		},
-		"eventsource": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-			"dev": true,
-			"requires": {
-				"original": ">=0.0.5"
-			}
-		},
-		"evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"execa": {
 			"version": "0.7.0",
@@ -2334,101 +1000,48 @@
 				"strip-eof": "^1.0.0"
 			},
 			"dependencies": {
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
 				}
 			}
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
-			"requires": {
-				"fill-range": "^2.1.0"
-			}
-		},
-		"express": {
-			"version": "4.16.3",
-			"resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
-			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.5",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.18.2",
-				"content-disposition": "0.5.2",
-				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.3",
-				"qs": "6.5.1",
-				"range-parser": "~1.2.0",
-				"safe-buffer": "5.1.1",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
-				"array-flatten": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-					"dev": true
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
 				},
-				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
 				}
 			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true,
-			"optional": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -2451,61 +1064,86 @@
 				}
 			}
 		},
-		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+		"external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
 			}
 		},
-		"extract-text-webpack-plugin": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
-			"integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"async": "^2.4.1",
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.3.0",
-				"webpack-sources": "^1.0.1"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"is-descriptor": "^1.0.0"
 					}
 				},
-				"schema-utils": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"ajv": "^5.0.0"
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				}
 			}
 		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true,
-			"optional": true
-		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
@@ -2514,68 +1152,42 @@
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 			"dev": true
 		},
-		"faye-websocket": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-			"dev": true,
-			"requires": {
-				"websocket-driver": ">=0.5.1"
-			}
-		},
-		"file-loader": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
-			"integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.0.2",
-				"schema-utils": "^0.4.5"
-			}
-		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+		"figgy-pudding": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
 		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
 		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
-			}
-		},
-		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
-				"unpipe": "~1.0.0"
-			}
-		},
-		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
-			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"find-up": {
@@ -2588,73 +1200,19 @@
 			}
 		},
 		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
-			}
-		},
-		"follow-redirects": {
-			"version": "1.5.8",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
-			"integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
-			"dev": true,
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
-			}
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true,
-			"optional": true
-		},
-		"form-data": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.5",
-				"mime-types": "^2.1.12"
-			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
 			"dev": true
 		},
 		"fragment-cache": {
@@ -2666,12 +1224,6 @@
 				"map-cache": "^0.2.2"
 			}
 		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
-		},
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -2682,15 +1234,13 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
-		"fs-extra": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+		"fs-minipass": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"minipass": "^2.2.1"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -2712,14 +1262,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2741,7 +1291,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2767,7 +1317,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2797,16 +1347,16 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2855,7 +1405,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2875,12 +1425,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -2945,17 +1495,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2973,35 +1523,35 @@
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -3018,13 +1568,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3101,12 +1651,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -3136,16 +1686,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3163,7 +1713,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3216,17 +1766,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -3237,12 +1787,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -3252,58 +1802,18 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				}
 			}
 		},
-		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			}
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+		"genfun": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
 			"dev": true
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			}
-		},
-		"gaze": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"globule": "^1.0.0"
-			}
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
@@ -3311,42 +1821,20 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
-		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				}
-			}
 		},
 		"glob": {
 			"version": "7.1.3",
@@ -3362,108 +1850,32 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
 		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
-			}
-		},
-		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
-		},
-		"globby": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-			"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-			"dev": true,
-			"requires": {
-				"array-union": "^1.0.1",
-				"dir-glob": "^2.0.0",
-				"glob": "^7.1.2",
-				"ignore": "^3.3.5",
-				"pify": "^3.0.0",
-				"slash": "^1.0.0"
-			}
-		},
-		"globule": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
-				"minimatch": "~3.0.2"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
-		},
-		"handle-thing": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-			"dev": true
-		},
-		"har-schema": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-			"dev": true,
-			"optional": true
-		},
-		"har-validator": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"ajv": "^4.9.1",
-				"har-schema": "^1.0.5"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"is-extglob": "^2.1.0"
 					}
 				}
 			}
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
 		},
 		"has-ansi": {
 			"version": "2.0.0",
@@ -3475,17 +1887,10 @@
 			}
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true,
-			"optional": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -3496,14 +1901,6 @@
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"has-values": {
@@ -3516,26 +1913,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -3547,270 +1924,83 @@
 				}
 			}
 		},
-		"hash-base": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"hash.js": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hawk": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"boom": "2.x.x",
-				"cryptiles": "2.x.x",
-				"hoek": "2.x.x",
-				"sntp": "1.x.x"
-			}
-		},
-		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"hoek": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-			"dev": true,
-			"optional": true
-		},
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
-		"hpack.js": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"obuf": "^1.0.0",
-				"readable-stream": "^2.0.1",
-				"wbuf": "^1.1.0"
-			}
-		},
-		"html-entities": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+		"http-cache-semantics": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 			"dev": true
 		},
-		"html-minifier": {
-			"version": "3.5.20",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-			"integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+		"http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 			"dev": true,
 			"requires": {
-				"camel-case": "3.0.x",
-				"clean-css": "4.2.x",
-				"commander": "2.17.x",
-				"he": "1.1.x",
-				"param-case": "2.1.x",
-				"relateurl": "0.2.x",
-				"uglify-js": "3.4.x"
-			}
-		},
-		"html-webpack-plugin": {
-			"version": "2.30.1",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
-			"integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.4.7",
-				"html-minifier": "^3.2.3",
-				"loader-utils": "^0.2.16",
-				"lodash": "^4.17.3",
-				"pretty-error": "^2.0.2",
-				"toposort": "^1.0.0"
+				"agent-base": "4",
+				"debug": "3.1.0"
 			},
 			"dependencies": {
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"dev": true,
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				}
-			}
-		},
-		"htmlparser2": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-			"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-			"dev": true,
-			"requires": {
-				"domelementtype": "1",
-				"domhandler": "2.1",
-				"domutils": "1.1",
-				"readable-stream": "1.0"
-			},
-			"dependencies": {
-				"domutils": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"dev": true,
-					"requires": {
-						"domelementtype": "1"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"http-deceiver": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
-			"dev": true
-		},
-		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
-			}
-		},
-		"http-parser-js": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
-			"dev": true
-		},
-		"http-proxy": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
-			"dev": true,
-			"requires": {
-				"eventemitter3": "^3.0.0",
-				"follow-redirects": "^1.0.0",
-				"requires-port": "^1.0.0"
-			}
-		},
-		"http-proxy-middleware": {
-			"version": "0.17.4",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
-			"dev": true,
-			"requires": {
-				"http-proxy": "^1.16.2",
-				"is-glob": "^3.1.0",
-				"lodash": "^4.17.2",
-				"micromatch": "^2.3.11"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
+				"debug": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.0"
+						"ms": "2.0.0"
 					}
 				}
 			}
 		},
-		"http-signature": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+		"https-proxy-agent": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"assert-plus": "^0.2.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"agent-base": "^4.1.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
 			}
 		},
-		"https-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
+		"humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+			"dev": true,
+			"requires": {
+				"ms": "^2.0.0"
+			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
-		},
-		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-			"dev": true
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -3818,73 +2008,19 @@
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
 		},
-		"ignore": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-			"dev": true
-		},
-		"image-size": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-			"integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
-			"dev": true,
-			"optional": true
-		},
-		"import-cwd": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
-			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+		"ignore-walk": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 			"dev": true,
 			"requires": {
-				"import-from": "^2.1.0"
-			}
-		},
-		"import-from": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^3.0.0"
-			}
-		},
-		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"dev": true,
-			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"minimatch": "^3.0.4"
 			}
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
-		},
-		"in-publish": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
-			"dev": true,
-			"optional": true
-		},
-		"indent-string": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
-			"requires": {
-				"repeating": "^2.0.0"
-			}
-		},
-		"indexof": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
 			"dev": true
 		},
 		"inflight": {
@@ -3903,29 +2039,64 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
-		"internal-ip": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
+		},
+		"inquirer": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+			"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
 			"dev": true,
 			"requires": {
-				"meow": "^3.3.0"
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.0",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.10",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.1.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.0.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"rxjs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+					"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"interpret": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
-		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
 		},
 		"invert-kv": {
 			"version": "1.0.0",
@@ -3939,12 +2110,6 @@
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
 			"dev": true
 		},
-		"ipaddr.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-			"dev": true
-		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -3952,6 +2117,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-arrayish": {
@@ -3975,21 +2151,6 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "^1.0.0"
-			}
-		},
-		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-			"dev": true
-		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -3997,13 +2158,18 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
-		},
-		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -4024,27 +2190,6 @@
 				}
 			}
 		},
-		"is-directory": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
-		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4052,69 +2197,44 @@
 			"dev": true
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
-		},
 		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
-			}
-		},
-		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-			"dev": true
-		},
-		"is-path-in-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-			"dev": true,
-			"requires": {
-				"is-path-inside": "^1.0.0"
-			}
-		},
-		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"dev": true,
-			"requires": {
-				"path-is-inside": "^1.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-plain-object": {
@@ -4124,60 +2244,18 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
-		},
-		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.1"
-			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
-		},
-		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true,
-			"optional": true
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
 			"dev": true
 		},
 		"is-windows": {
@@ -4205,83 +2283,10 @@
 			"dev": true
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
-			"requires": {
-				"isarray": "1.0.0"
-			}
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true,
-			"optional": true
-		},
-		"istanbul-instrumenter-loader": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz",
-			"integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
-			"dev": true,
-			"requires": {
-				"convert-source-map": "^1.5.0",
-				"istanbul-lib-instrument": "^1.7.3",
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.3.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"schema-utils": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-					"dev": true,
-					"requires": {
-						"ajv": "^5.0.0"
-					}
-				}
-			}
-		},
-		"istanbul-lib-coverage": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-			"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
-		},
-		"istanbul-lib-instrument": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
-			"dev": true,
-			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"semver": "^5.3.0"
-			}
-		},
-		"js-base64": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-			"integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
-			"dev": true,
-			"optional": true
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -4299,157 +2304,28 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
-			"optional": true
-		},
-		"jsesc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-			"dev": true
-		},
-		"json-loader": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-			"dev": true
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true,
-			"optional": true
-		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true,
-			"optional": true
-		},
-		"json3": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-			"dev": true
-		},
-		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
-		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true,
-			"optional": true
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"karma-source-map-support": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.3.0.tgz",
-			"integrity": "sha512-HcPqdAusNez/ywa+biN4EphGz62MmQyPggUsDfsHqa7tSe4jdsxgvTKuDfIazjL+IOxpVWyT7Pr4dhAV+sxX5Q==",
-			"dev": true,
-			"requires": {
-				"source-map-support": "^0.5.5"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.9",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				}
-			}
-		},
-		"killable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
-			"integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+		"jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5"
-			}
-		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
 		},
 		"lcid": {
@@ -4461,78 +2337,16 @@
 				"invert-kv": "^1.0.0"
 			}
 		},
-		"less": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
-			"integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
-			"dev": true,
-			"requires": {
-				"errno": "^0.1.1",
-				"graceful-fs": "^4.1.2",
-				"image-size": "~0.5.0",
-				"mime": "^1.2.11",
-				"mkdirp": "^0.5.0",
-				"promise": "^7.1.1",
-				"request": "2.81.0",
-				"source-map": "^0.5.3"
-			}
-		},
-		"less-loader": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/less-loader/-/less-loader-4.1.0.tgz",
-			"integrity": "sha512-KNTsgCE9tMOM70+ddxp9yyt9iHqgmSs0yTZc5XH5Wo+g80RWRIYNqE58QJKm/yMud5wZEvz50ugRDuzVIkyahg==",
-			"dev": true,
-			"requires": {
-				"clone": "^2.1.1",
-				"loader-utils": "^1.1.0",
-				"pify": "^3.0.0"
-			}
-		},
-		"license-webpack-plugin": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-1.4.0.tgz",
-			"integrity": "sha512-iwuNFMWbXS76WiQXJBTs8/7Tby4NQnY8AIkBMuJG5El79UT8zWrJQMfpW+KRXt4Y2Bs5uk+Myg/MO7ROSF8jzA==",
-			"dev": true,
-			"requires": {
-				"ejs": "^2.5.7"
-			}
-		},
 		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
 				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
-			}
-		},
-		"loader-runner": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
-			"dev": true
-		},
-		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"dev": true,
-			"requires": {
-				"big.js": "^3.1.3",
-				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
@@ -4551,113 +2365,71 @@
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true,
-			"optional": true
-		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
-		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
-		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
-			"dev": true,
-			"optional": true
-		},
-		"lodash.tail": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-			"dev": true
-		},
-		"loglevel": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
-			"dev": true
-		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"loud-rejection": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
-			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
-			}
-		},
-		"lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
-		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^3.0.2"
 			}
 		},
 		"magic-string": {
-			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+			"integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
 			"dev": true,
 			"requires": {
-				"vlq": "^0.2.2"
+				"sourcemap-codec": "^1.4.4"
 			}
 		},
-		"make-dir": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+		"make-fetch-happen": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
+			"integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"agentkeepalive": "^3.4.1",
+				"cacache": "^11.0.1",
+				"http-cache-semantics": "^3.8.1",
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1",
+				"lru-cache": "^4.1.2",
+				"mississippi": "^3.0.0",
+				"node-fetch-npm": "^2.0.2",
+				"promise-retry": "^1.1.1",
+				"socks-proxy-agent": "^4.0.0",
+				"ssri": "^6.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
-		},
-		"map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 			"dev": true
 		},
 		"map-visit": {
@@ -4669,28 +2441,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
-		},
-		"md5.js": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"dev": true
-		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -4700,122 +2450,31 @@
 				"mimic-fn": "^1.0.0"
 			}
 		},
-		"memory-fs": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
-			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
-			}
-		},
-		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"dev": true,
-			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
-			}
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
-		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
-			}
-		},
-		"miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
-			}
-		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true
-		},
-		"mime-db": {
-			"version": "1.36.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.20",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-			"dev": true,
-			"requires": {
-				"mime-db": "~1.36.0"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
-		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
 			"dev": true
 		},
 		"minimatch": {
@@ -4833,10 +2492,29 @@
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
+		"minipass": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			}
+		},
+		"minizlib": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+			"dev": true,
+			"requires": {
+				"minipass": "^2.2.1"
+			}
+		},
 		"mississippi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
@@ -4845,7 +2523,7 @@
 				"flush-write-stream": "^1.0.0",
 				"from2": "^2.1.0",
 				"parallel-transform": "^1.1.0",
-				"pump": "^2.0.1",
+				"pump": "^3.0.0",
 				"pumpify": "^1.3.3",
 				"stream-each": "^1.1.0",
 				"through2": "^2.0.0"
@@ -4869,24 +2547,6 @@
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
-				}
-			}
-		},
-		"mixin-object": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"dependencies": {
-				"for-in": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-					"dev": true
 				}
 			}
 		},
@@ -4919,26 +2579,16 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"multicast-dns": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
-			"dev": true,
-			"requires": {
-				"dns-packet": "^1.3.1",
-				"thunky": "^1.0.2"
-			}
-		},
-		"multicast-dns-service-types": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-			"integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true,
 			"optional": true
 		},
@@ -4959,473 +2609,40 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
 			}
 		},
-		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-			"dev": true
-		},
-		"neo-async": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
-			"integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==",
-			"dev": true
-		},
-		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-			"dev": true
-		},
-		"no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+		"node-fetch-npm": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
 			"dev": true,
 			"requires": {
-				"lower-case": "^1.1.1"
-			}
-		},
-		"node-forge": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
-			"dev": true
-		},
-		"node-gyp": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"fstream": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^2.0.0",
-				"which": "1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-					"dev": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"har-schema": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-					"dev": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ajv": "^5.3.0",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"http-signature": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
-					}
-				},
-				"nopt": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1"
-					}
-				},
-				"oauth-sign": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-					"dev": true,
-					"optional": true
-				},
-				"performance-now": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-					"dev": true,
-					"optional": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true,
-					"optional": true
-				},
-				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true,
-					"optional": true
-				},
-				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					}
-				}
-			}
-		},
-		"node-libs-browser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-			"dev": true,
-			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
-				"https-browserify": "^1.0.0",
-				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.0",
-				"process": "^0.11.10",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.3.3",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.7.2",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
-				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.10.3",
-				"vm-browserify": "0.0.4"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
-		},
-		"node-modules-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.1.tgz",
-			"integrity": "sha1-QAlrCM560OoUaAhjr0ScfHWl0cg=",
-			"dev": true
-		},
-		"node-sass": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
-			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"async-foreach": "^0.1.3",
-				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
-				"gaze": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
-				"node-gyp": "^3.8.0",
-				"npmlog": "^4.0.0",
-				"request": "2.87.0",
-				"sass-graph": "^2.2.4",
-				"stdout-stream": "^1.4.0",
-				"true-case-path": "^1.0.2"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-					"dev": true,
-					"optional": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"form-data": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"har-schema": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-					"dev": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ajv": "^5.1.0",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"http-signature": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
-					}
-				},
-				"performance-now": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-					"dev": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true,
-					"optional": true
-				},
-				"request": {
-					"version": "2.87.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-					"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.6.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.1",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.1",
-						"har-validator": "~5.0.3",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.17",
-						"oauth-sign": "~0.8.2",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.1",
-						"safe-buffer": "^5.1.1",
-						"tough-cookie": "~2.3.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.1.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"nopt": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
+				"encoding": "^0.1.11",
+				"json-parse-better-errors": "^1.0.0",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+					"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
 			}
 		},
 		"normalize-path": {
@@ -5437,11 +2654,76 @@
 				"remove-trailing-separator": "^1.0.1"
 			}
 		},
-		"normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+		"npm-bundled": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 			"dev": true
+		},
+		"npm-package-arg": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+			"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.6.0",
+				"osenv": "^0.1.5",
+				"semver": "^5.5.0",
+				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"npm-packlist": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+			"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+			"dev": true,
+			"requires": {
+				"ignore-walk": "^3.0.1",
+				"npm-bundled": "^1.0.1"
+			}
+		},
+		"npm-pick-manifest": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
+			"integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+			"dev": true,
+			"requires": {
+				"figgy-pudding": "^3.5.1",
+				"npm-package-arg": "^6.0.0",
+				"semver": "^5.4.1"
+			}
+		},
+		"npm-registry-fetch": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
+			"integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.3.4",
+				"bluebird": "^3.5.1",
+				"figgy-pudding": "^3.4.1",
+				"lru-cache": "^4.1.3",
+				"make-fetch-happen": "^4.0.1",
+				"npm-package-arg": "^6.1.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
+			}
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -5452,51 +2734,10 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
-		"nth-check": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"dev": true,
-			"requires": {
-				"boolbase": "~1.0.0"
-			}
-		},
-		"num2fraction": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
-		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
-		},
-		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true,
-			"optional": true
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
 		"object-copy": {
@@ -5518,14 +2759,17 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
 				}
 			}
-		},
-		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -5534,24 +2778,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -5561,36 +2787,7 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
-		},
-		"obuf": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-			"dev": true
-		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
-		"on-headers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
@@ -5601,29 +2798,23 @@
 				"wrappy": "1"
 			}
 		},
-		"opn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-			"integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
+		"open": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-6.0.0.tgz",
+			"integrity": "sha512-/yb5mVZBz7mHLySMiSj2DcLtMBbFPJk5JBKEkHVZFxZAPzeg3L026O0T+lbdz1B2nyDnkClRSwRQJdeVUIF7zw==",
 			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
-		},
-		"original": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-			"dev": true,
-			"requires": {
-				"url-parse": "^1.4.3"
-			}
-		},
-		"os-browserify": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
@@ -5632,12 +2823,14 @@
 			"dev": true
 		},
 		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"lcid": "^1.0.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -5680,23 +2873,54 @@
 				"p-limit": "^1.1.0"
 			}
 		},
-		"p-map": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-			"dev": true
-		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
-		"pako": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-			"dev": true
+		"pacote": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.4.0.tgz",
+			"integrity": "sha512-WQ1KL/phGMkedYEQx9ODsjj7xvwLSpdFJJdEXrLyw5SILMxcTNt5DTxT2Z93fXuLFYJBlZJdnwdalrQdB/rX5w==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.5.3",
+				"cacache": "^11.3.2",
+				"figgy-pudding": "^3.5.1",
+				"get-stream": "^4.1.0",
+				"glob": "^7.1.3",
+				"lru-cache": "^5.1.1",
+				"make-fetch-happen": "^4.0.1",
+				"minimatch": "^3.0.4",
+				"minipass": "^2.3.5",
+				"mississippi": "^3.0.0",
+				"mkdirp": "^0.5.1",
+				"normalize-package-data": "^2.4.0",
+				"npm-package-arg": "^6.1.0",
+				"npm-packlist": "^1.1.12",
+				"npm-pick-manifest": "^2.2.3",
+				"npm-registry-fetch": "^3.8.0",
+				"osenv": "^0.1.5",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^1.1.1",
+				"protoduck": "^5.0.1",
+				"rimraf": "^2.6.2",
+				"safe-buffer": "^5.1.2",
+				"semver": "^5.6.0",
+				"ssri": "^6.0.1",
+				"tar": "^4.4.8",
+				"unique-filename": "^1.1.1",
+				"which": "^1.3.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
+			}
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -5709,40 +2933,6 @@
 				"readable-stream": "^2.1.5"
 			}
 		},
-		"param-case": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-			"dev": true,
-			"requires": {
-				"no-case": "^2.2.0"
-			}
-		},
-		"parse-asn1": {
-			"version": "5.1.1",
-			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
-			"dev": true,
-			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
-			}
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
 		"parse-json": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -5752,22 +2942,10 @@
 				"error-ex": "^1.2.0"
 			}
 		},
-		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-			"dev": true
-		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
-		},
-		"path-browserify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
 			"dev": true
 		},
 		"path-dirname": {
@@ -5788,12 +2966,6 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
-		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -5806,214 +2978,25 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-			"dev": true
-		},
 		"path-type": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "^2.0.0"
 			}
-		},
-		"pbkdf2": {
-			"version": "3.0.16",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
-			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
-			"dev": true,
-			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"performance-now": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-			"dev": true,
-			"optional": true
 		},
 		"pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 			"dev": true
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
-			"requires": {
-				"pinkie": "^2.0.0"
-			}
-		},
-		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
-			"requires": {
-				"find-up": "^2.1.0"
-			}
-		},
-		"portfinder": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
-			"integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
-			"dev": true,
-			"requires": {
-				"async": "^1.5.2",
-				"debug": "^2.2.0",
-				"mkdirp": "0.5.x"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
-				}
-			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
-		},
-		"postcss": {
-			"version": "6.0.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-			"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"source-map": "^0.6.1",
-				"supports-color": "^5.4.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"postcss-import": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.1.0.tgz",
-			"integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
-			"dev": true,
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-value-parser": "^3.2.3",
-				"read-cache": "^1.0.0",
-				"resolve": "^1.1.7"
-			}
-		},
-		"postcss-load-config": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
-			"dev": true,
-			"requires": {
-				"cosmiconfig": "^4.0.0",
-				"import-cwd": "^2.0.0"
-			}
-		},
-		"postcss-loader": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
-			"integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.1.0",
-				"postcss": "^6.0.0",
-				"postcss-load-config": "^2.0.0",
-				"schema-utils": "^0.4.0"
-			}
-		},
-		"postcss-url": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-7.3.2.tgz",
-			"integrity": "sha512-QMV5mA+pCYZQcUEPQkmor9vcPQ2MT+Ipuu8qdi1gVxbNiIiErEGft+eny1ak19qALoBkccS5AHaCaCDzh7b9MA==",
-			"dev": true,
-			"requires": {
-				"mime": "^1.4.1",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.0",
-				"postcss": "^6.0.1",
-				"xxhashjs": "^0.2.1"
-			}
-		},
-		"postcss-value-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
-			"dev": true
-		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
-		},
-		"pretty-error": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
-			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-			"dev": true,
-			"requires": {
-				"renderkid": "^2.0.1",
-				"utila": "~0.4"
-			}
-		},
-		"process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
 			"dev": true
 		},
 		"process-nextick-args": {
@@ -6022,37 +3005,30 @@
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true
 		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"asap": "~2.0.3"
-			}
-		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
 		},
-		"proxy-addr": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+		"promise-retry": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
 			"dev": true,
 			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.8.0"
+				"err-code": "^1.0.0",
+				"retry": "^0.10.0"
 			}
 		},
-		"prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+		"protoduck": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+			"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+			"dev": true,
+			"requires": {
+				"genfun": "^5.0.0"
+			}
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -6060,30 +3036,10 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
-		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-			"dev": true,
-			"optional": true
-		},
-		"public-encrypt": {
-			"version": "4.0.2",
-			"resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
-			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1"
-			}
-		},
 		"pump": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
@@ -6099,6 +3055,18 @@
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
 				"pump": "^2.0.0"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
 			}
 		},
 		"punycode": {
@@ -6107,201 +3075,25 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"qs": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-			"dev": true,
-			"optional": true
-		},
-		"querystring": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
-		},
-		"querystring-es3": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
-		},
-		"querystringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
-			"dev": true
-		},
-		"randomatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
-			}
-		},
-		"randombytes": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"randomfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
-			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-			"dev": true
-		},
-		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-			"dev": true,
-			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-					"dev": true
-				},
-				"http-errors": {
-					"version": "1.6.2",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"dev": true,
-					"requires": {
-						"depd": "1.1.1",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.3",
-						"statuses": ">= 1.3.1 < 2"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-					"dev": true
-				}
-			}
-		},
-		"raw-loader": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-			"integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-			"dev": true
-		},
-		"read-cache": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
-			"dev": true,
-			"requires": {
-				"pify": "^2.3.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
-			}
-		},
 		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
+				"load-json-file": "^2.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
+				"path-type": "^2.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				}
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
 			}
 		},
 		"readable-stream": {
@@ -6320,47 +3112,30 @@
 			}
 		},
 		"readdirp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
 			}
 		},
-		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"resolve": "^1.1.6"
 			}
 		},
 		"reflect-metadata": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
-			"integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
 			"dev": true
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
-			}
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -6372,38 +3147,11 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"relateurl": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
-			"dev": true
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
-		},
-		"renderkid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
-			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
-			"dev": true,
-			"requires": {
-				"css-select": "^1.1.0",
-				"dom-converter": "~0.1",
-				"htmlparser2": "~3.3.0",
-				"strip-ansi": "^3.0.0",
-				"utila": "~0.3"
-			},
-			"dependencies": {
-				"utila": {
-					"version": "0.3.3",
-					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-					"dev": true
-				}
-			}
 		},
 		"repeat-element": {
 			"version": "1.1.3",
@@ -6417,68 +3165,16 @@
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
-		},
-		"request": {
-			"version": "2.81.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"aws-sign2": "~0.6.0",
-				"aws4": "^1.2.1",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.0",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.1.1",
-				"har-validator": "~4.2.1",
-				"hawk": "~3.1.3",
-				"http-signature": "~1.1.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.7",
-				"oauth-sign": "~0.8.1",
-				"performance-now": "^0.2.0",
-				"qs": "~6.4.0",
-				"safe-buffer": "^5.0.1",
-				"stringstream": "~0.0.4",
-				"tough-cookie": "~2.3.0",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.0.0"
-			}
-		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
-		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
 			"dev": true
 		},
 		"resolve": {
@@ -6490,26 +3186,21 @@
 				"path-parse": "^1.0.5"
 			}
 		},
-		"resolve-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^3.0.0"
-			}
-		},
-		"resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-			"dev": true
-		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
 		},
 		"ret": {
 			"version": "0.1.15",
@@ -6517,32 +3208,28 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
-			"requires": {
-				"align-text": "^0.1.1"
-			}
+		"retry": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"run-queue": {
@@ -6582,88 +3269,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
-			"optional": true
-		},
-		"sass-graph": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"glob": "^7.0.0",
-				"lodash": "^4.0.0",
-				"scss-tokenizer": "^0.2.3",
-				"yargs": "^7.0.0"
-			}
-		},
-		"sass-loader": {
-			"version": "6.0.7",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
-			"integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
-			"dev": true,
-			"requires": {
-				"clone-deep": "^2.0.1",
-				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
-				"neo-async": "^2.5.0",
-				"pify": "^3.0.0"
-			}
-		},
-		"sax": {
-			"version": "0.5.8",
-			"resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-			"integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
 			"dev": true
-		},
-		"schema-utils": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0"
-			}
-		},
-		"scss-tokenizer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"js-base64": "^2.1.8",
-				"source-map": "^0.4.2"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
-		},
-		"select-hose": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
-			"dev": true
-		},
-		"selfsigned": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
-			"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
-			"dev": true,
-			"requires": {
-				"node-forge": "0.7.5"
-			}
 		},
 		"semver": {
 			"version": "5.5.1",
@@ -6680,78 +3286,10 @@
 				"semver": "^5.0.0"
 			}
 		},
-		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
-			},
-			"dependencies": {
-				"mime": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-					"dev": true
-				}
-			}
-		},
-		"serialize-javascript": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
-			"dev": true
-		},
-		"serve-index": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.4",
-				"batch": "0.6.1",
-				"debug": "2.6.9",
-				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
-			}
-		},
-		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"dev": true,
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
-			}
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
 			"dev": true
 		},
 		"set-value": {
@@ -6777,47 +3315,6 @@
 				}
 			}
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"dev": true
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"shallow-clone": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-			"dev": true,
-			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^5.0.0",
-				"mixin-object": "^2.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
-				}
-			}
-		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -6833,25 +3330,27 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shelljs": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
-		"silent-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
-			"integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-			"dev": true,
-			"requires": {
-				"debug": "^2.2.0"
-			}
-		},
-		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+		"smart-buffer": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
 			"dev": true
 		},
 		"snapdragon": {
@@ -6887,6 +3386,12 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -6938,18 +3443,6 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
@@ -6960,63 +3453,43 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
-			}
-		},
-		"sntp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"hoek": "2.x.x"
-			}
-		},
-		"sockjs": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
-			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
-			"dev": true,
-			"requires": {
-				"faye-websocket": "^0.10.0",
-				"uuid": "^3.0.1"
-			}
-		},
-		"sockjs-client": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
-			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
-			"dev": true,
-			"requires": {
-				"debug": "^2.6.6",
-				"eventsource": "0.1.6",
-				"faye-websocket": "~0.11.0",
-				"inherits": "^2.0.1",
-				"json3": "^3.3.2",
-				"url-parse": "^1.1.8"
 			},
 			"dependencies": {
-				"faye-websocket": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"websocket-driver": ">=0.5.1"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
 		},
-		"source-list-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-			"dev": true
+		"socks": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+			"integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+			"dev": true,
+			"requires": {
+				"ip": "^1.1.5",
+				"smart-buffer": "4.0.2"
+			}
+		},
+		"socks-proxy-agent": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "~4.2.1",
+				"socks": "~2.3.2"
+			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
 			"dev": true
 		},
 		"source-map-resolve": {
@@ -7032,25 +3505,22 @@
 				"urix": "^0.1.0"
 			}
 		},
-		"source-map-support": {
-			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
-			"requires": {
-				"source-map": "^0.5.6"
-			}
-		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
+		"sourcemap-codec": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+			"integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+			"dev": true
+		},
 		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -7058,9 +3528,9 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
@@ -7074,39 +3544,10 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
 			"dev": true
-		},
-		"spdy": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-			"dev": true,
-			"requires": {
-				"debug": "^2.6.8",
-				"handle-thing": "^1.2.5",
-				"http-deceiver": "^1.2.7",
-				"safe-buffer": "^5.0.1",
-				"select-hose": "^2.0.0",
-				"spdy-transport": "^2.0.18"
-			}
-		},
-		"spdy-transport": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
-			"dev": true,
-			"requires": {
-				"debug": "^2.6.8",
-				"detect-node": "^2.0.3",
-				"hpack.js": "^2.1.6",
-				"obuf": "^1.1.1",
-				"readable-stream": "^2.2.9",
-				"safe-buffer": "^5.0.1",
-				"wbuf": "^1.7.2"
-			}
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -7123,40 +3564,13 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"sshpk": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
 		"ssri": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.1"
+				"figgy-pudding": "^3.5.1"
 			}
 		},
 		"static-extend": {
@@ -7180,32 +3594,6 @@
 				}
 			}
 		},
-		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-			"dev": true
-		},
-		"stdout-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
-		},
-		"stream-browserify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
-			}
-		},
 		"stream-each": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -7216,19 +3604,6 @@
 				"stream-shift": "^1.0.0"
 			}
 		},
-		"stream-http": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-			"dev": true,
-			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.6",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
@@ -7236,14 +3611,30 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string_decoder": {
@@ -7255,13 +3646,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"stringstream": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-			"dev": true,
-			"optional": true
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -7272,13 +3656,10 @@
 			}
 		},
 		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
-			"requires": {
-				"is-utf8": "^0.2.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -7286,105 +3667,13 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
-		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "^4.0.1"
-			}
-		},
-		"style-loader": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
-			"integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.0.2",
-				"schema-utils": "^0.3.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"schema-utils": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-					"dev": true,
-					"requires": {
-						"ajv": "^5.0.0"
-					}
-				}
-			}
-		},
-		"stylus": {
-			"version": "0.54.5",
-			"resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
-			"integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
-			"dev": true,
-			"requires": {
-				"css-parse": "1.7.x",
-				"debug": "*",
-				"glob": "7.0.x",
-				"mkdirp": "0.5.x",
-				"sax": "0.5.x",
-				"source-map": "0.1.x"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.0.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-					"integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.2",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"source-map": {
-					"version": "0.1.43",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
-		},
-		"stylus-loader": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.2.tgz",
-			"integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.0.2",
-				"lodash.clonedeep": "^4.5.0",
-				"when": "~3.6.x"
-			}
-		},
 		"supports-color": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^2.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"symbol-observable": {
@@ -7393,66 +3682,45 @@
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
 			"dev": true
 		},
-		"tapable": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-			"dev": true
-		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.2",
-				"inherits": "2"
+				"chownr": "^1.1.1",
+				"fs-minipass": "^1.2.5",
+				"minipass": "^2.3.4",
+				"minizlib": "^1.1.1",
+				"mkdirp": "^0.5.0",
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.2"
 			}
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
 		"through2": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.1.5",
+				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
 		},
-		"thunky": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
-			"dev": true
-		},
-		"time-stamp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.1.0.tgz",
-			"integrity": "sha512-lJbq6KsFhZJtN3fPUVje1tq/hHsJOKUUcUj/MGCiQR6qWBDcyi5kxL9J7/RnaEChCn0+L/DUN2WvemDrkk4i3Q==",
-			"dev": true
-		},
-		"timers-browserify": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "^1.0.4"
+				"os-tmpdir": "~1.0.2"
 			}
-		},
-		"to-arraybuffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -7461,6 +3729,17 @@
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"to-regex": {
@@ -7483,90 +3762,6 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				}
-			}
-		},
-		"toposort": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
-			"dev": true
-		},
-		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"tree-kill": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-			"integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
-			"dev": true
-		},
-		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
-		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
-		"true-case-path": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"glob": "^7.1.2"
-			}
-		},
-		"tsickle": {
-			"version": "0.21.6",
-			"resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
-			"integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"source-map": "^0.5.6",
-				"source-map-support": "^0.4.2"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"tslib": {
@@ -7632,39 +3827,6 @@
 				"tslib": "^1.8.1"
 			}
 		},
-		"tty-browserify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
-			"optional": true
-		},
-		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-			"dev": true,
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
-			}
-		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -7672,75 +3834,10 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-			"integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
 			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-			"dev": true,
-			"requires": {
-				"commander": "~2.17.1",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
-			"optional": true
-		},
-		"uglifyjs-webpack-plugin": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-			"dev": true,
-			"requires": {
-				"cacache": "^10.0.4",
-				"find-cache-dir": "^1.0.0",
-				"schema-utils": "^0.4.5",
-				"serialize-javascript": "^1.4.0",
-				"source-map": "^0.6.1",
-				"uglify-es": "^3.3.4",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"dev": true,
-					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
-					}
-				}
-			}
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -7778,34 +3875,22 @@
 			}
 		},
 		"unique-filename": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
 		},
 		"unique-slug": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
-		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -7844,25 +3929,13 @@
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
 					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
-			"dev": true
-		},
-		"upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
 			"dev": true
 		},
 		"uri-js": {
@@ -7880,105 +3953,16 @@
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true
 		},
-		"url": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
-			"requires": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
-				}
-			}
-		},
-		"url-loader": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
-			"integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.0.2",
-				"mime": "^1.4.1",
-				"schema-utils": "^0.3.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"schema-utils": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-					"dev": true,
-					"requires": {
-						"ajv": "^5.0.0"
-					}
-				}
-			}
-		},
-		"url-parse": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
-			"dev": true,
-			"requires": {
-				"querystringify": "^2.0.0",
-				"requires-port": "^1.0.0"
-			}
-		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-			"dev": true,
-			"requires": {
-				"inherits": "2.0.3"
-			}
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
-		"utila": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
-			"dev": true
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -7991,1234 +3975,14 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"vlq": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-			"dev": true
-		},
-		"vm-browserify": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+		"validate-npm-package-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 			"dev": true,
 			"requires": {
-				"indexof": "0.0.1"
+				"builtins": "^1.0.3"
 			}
-		},
-		"watchpack": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-			"dev": true,
-			"requires": {
-				"chokidar": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
-			},
-			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"chokidar": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-					"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.0",
-						"braces": "^2.3.0",
-						"fsevents": "^1.2.2",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.1",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"lodash.debounce": "^4.0.8",
-						"normalize-path": "^2.1.1",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.0.0",
-						"upath": "^1.0.5"
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
-			}
-		},
-		"wbuf": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-			"dev": true,
-			"requires": {
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"webpack": {
-			"version": "3.11.0",
-			"resolved": "http://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
-			"integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^2.0.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"async": "^2.1.2",
-				"enhanced-resolve": "^3.4.0",
-				"escope": "^3.6.0",
-				"interpret": "^1.0.0",
-				"json-loader": "^0.5.4",
-				"json5": "^0.5.1",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"mkdirp": "~0.5.0",
-				"node-libs-browser": "^2.0.0",
-				"source-map": "^0.5.3",
-				"supports-color": "^4.2.1",
-				"tapable": "^0.2.7",
-				"uglifyjs-webpack-plugin": "^0.4.6",
-				"watchpack": "^1.4.0",
-				"webpack-sources": "^1.0.1",
-				"yargs": "^8.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-					"dev": true
-				},
-				"cliui": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"dev": true,
-					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
-						"wordwrap": "0.0.2"
-					}
-				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
-					}
-				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
-					"requires": {
-						"pify": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				},
-				"uglify-js": {
-					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"dev": true,
-					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
-					},
-					"dependencies": {
-						"yargs": {
-							"version": "3.10.0",
-							"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-							"dev": true,
-							"requires": {
-								"camelcase": "^1.0.2",
-								"cliui": "^2.1.0",
-								"decamelize": "^1.0.0",
-								"window-size": "0.1.0"
-							}
-						}
-					}
-				},
-				"uglifyjs-webpack-plugin": {
-					"version": "0.4.6",
-					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-					"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-					"dev": true,
-					"requires": {
-						"source-map": "^0.5.6",
-						"uglify-js": "^2.8.29",
-						"webpack-sources": "^1.0.1"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-							"dev": true
-						},
-						"cliui": {
-							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-							"dev": true,
-							"requires": {
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wrap-ansi": "^2.0.0"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-									"dev": true,
-									"requires": {
-										"code-point-at": "^1.0.0",
-										"is-fullwidth-code-point": "^1.0.0",
-										"strip-ansi": "^3.0.0"
-									}
-								}
-							}
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-							"dev": true
-						}
-					}
-				}
-			}
-		},
-		"webpack-core": {
-			"version": "0.6.9",
-			"resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
-			"integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
-			"dev": true,
-			"requires": {
-				"source-list-map": "~0.1.7",
-				"source-map": "~0.4.1"
-			},
-			"dependencies": {
-				"source-list-map": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
-					"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
-		},
-		"webpack-dev-middleware": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-			"dev": true,
-			"requires": {
-				"memory-fs": "~0.4.1",
-				"mime": "^1.5.0",
-				"path-is-absolute": "^1.0.0",
-				"range-parser": "^1.0.3",
-				"time-stamp": "^2.0.0"
-			}
-		},
-		"webpack-dev-server": {
-			"version": "2.11.3",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
-			"integrity": "sha512-Qz22YEFhWx+M2vvJ+rQppRv39JA0h5NNbOOdODApdX6iZ52Diz7vTPXjF7kJlfn+Uc24Qr48I3SZ9yncQwRycg==",
-			"dev": true,
-			"requires": {
-				"ansi-html": "0.0.7",
-				"array-includes": "^3.0.3",
-				"bonjour": "^3.5.0",
-				"chokidar": "^2.0.0",
-				"compression": "^1.5.2",
-				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
-				"del": "^3.0.0",
-				"express": "^4.16.2",
-				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.17.4",
-				"import-local": "^1.0.0",
-				"internal-ip": "1.2.0",
-				"ip": "^1.1.5",
-				"killable": "^1.0.0",
-				"loglevel": "^1.4.1",
-				"opn": "^5.1.0",
-				"portfinder": "^1.0.9",
-				"selfsigned": "^1.9.1",
-				"serve-index": "^1.7.2",
-				"sockjs": "0.3.19",
-				"sockjs-client": "1.1.5",
-				"spdy": "^3.4.1",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^5.1.0",
-				"webpack-dev-middleware": "1.12.2",
-				"yargs": "6.6.0"
-			},
-			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
-					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					}
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
-				},
-				"chokidar": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-					"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-					"dev": true,
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.0",
-						"braces": "^2.3.0",
-						"fsevents": "^1.2.2",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.1",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"lodash.debounce": "^4.0.8",
-						"normalize-path": "^2.1.1",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.0.0",
-						"upath": "^1.0.5"
-					}
-				},
-				"debug": {
-					"version": "3.2.5",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-							"dev": true
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^0.1.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "^3.0.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "^1.1.5"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
-					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "^1.0.0"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "^0.1.0"
-							}
-						}
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "^6.0.0"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0"
-					}
-				}
-			}
-		},
-		"webpack-merge": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.4.tgz",
-			"integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.5"
-			}
-		},
-		"webpack-sources": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.2.0.tgz",
-			"integrity": "sha512-9BZwxR85dNsjWz3blyxdOhTgtnQvv3OEs5xofI0wPYTwu5kaWxS08UuD1oI7WLBLpRO+ylf0ofnXLXWmGb2WMw==",
-			"dev": true,
-			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"webpack-subresource-integrity": {
-			"version": "1.0.4",
-			"resolved": "http://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-1.0.4.tgz",
-			"integrity": "sha1-j6yKfo61n8ahZ2ioXJ2U7n+dDts=",
-			"dev": true,
-			"requires": {
-				"webpack-core": "^0.6.8"
-			}
-		},
-		"websocket-driver": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-			"dev": true,
-			"requires": {
-				"http-parser-js": ">=0.4.0",
-				"websocket-extensions": ">=0.1.1"
-			}
-		},
-		"websocket-extensions": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-			"dev": true
-		},
-		"when": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
-			"integrity": "sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=",
-			"dev": true
 		},
 		"which": {
 			"version": "1.3.1",
@@ -9230,41 +3994,10 @@
 			}
 		},
 		"which-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
-		},
-		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true
-		},
-		"wordwrap": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-			"dev": true
-		},
-		"worker-farm": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-			"dev": true,
-			"requires": {
-				"errno": "~0.1.7"
-			}
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
@@ -9274,6 +4007,28 @@
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -9288,15 +4043,6 @@
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 			"dev": true
 		},
-		"xxhashjs": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-			"integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
-			"dev": true,
-			"requires": {
-				"cuint": "^0.2.2"
-			}
-		},
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -9304,66 +4050,47 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 			"dev": true
 		},
 		"yargs": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"camelcase": "^3.0.0",
+				"camelcase": "^4.1.0",
 				"cliui": "^3.2.0",
 				"decamelize": "^1.1.1",
 				"get-caller-file": "^1.0.1",
-				"os-locale": "^1.4.0",
-				"read-pkg-up": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"read-pkg-up": "^2.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
-				"string-width": "^1.0.2",
-				"which-module": "^1.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
 				"y18n": "^3.2.1",
-				"yargs-parser": "^5.0.0"
+				"yargs-parser": "^7.0.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true,
-					"optional": true
-				},
 				"y18n": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"camelcase": "^3.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true,
-					"optional": true
-				}
+				"camelcase": "^4.1.0"
 			}
 		},
 		"zone.js": {

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -27,14 +27,14 @@
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@angular/cli": "^1.7.4",
-    "@angular/compiler": "^4.4.7",
-    "@angular/compiler-cli": "^4.4.7",
-    "@angular/core": "^4.4.7",
+    "@angular/cli": "^7.3.9",
+    "@angular/compiler": "^7.2.15",
+    "@angular/compiler-cli": "^7.2.15",
+    "@angular/core": "^7.2.15",
     "@bugsnag/js": "^6.2.0",
     "rxjs": "^5.5.8",
     "tslint": "^5.9.1",
-    "typescript": "2.3.4",
+    "typescript": "^3.2.4",
     "zone.js": "^0.8.26"
   }
 }

--- a/packages/plugin-angular/tsconfig.json
+++ b/packages/plugin-angular/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [ "./src/index.ts" ],
   "compilerOptions": {
     "module": "ES6",
+    "target": "ES6",
     "lib": [ "ES5", "ES6", "DOM" ],
     "allowJs": false,
     "declaration": true,


### PR DESCRIPTION
Polyfilled classes are not compatible with native classes so this updates the plugin-angular build target to be ES6, meaning native classes are output.

Fixes #505 and #482.

### Testing

Create a new angular app `npx ng new test-ng-app` and integrate [Bugsnag according to the docs](https://docs.bugsnag.com/platforms/javascript/angular/). 

Set `"target": "es6",` in the `tsconfig.json`, run the app with `ng serve` see that at runtime the notifer crashes with this error:

```
TypeError: Class constructor ErrorHandler cannot be invoked without 'new'
```

Now switch over to this repository and checkout this branch.

Ensure the dependencies are installed and the standalone modules are built:

```
npm run bootstrap
npm run build
```

Prepare a tarball of the angular plugin:

```
cd packages/plugin-angular
npm pack
```

Switch back to the `test-ng-app` directory and install the tarball that was just created `npm install ../../path-to-bugsnag-js/packages/browser/bugsnag-angular-6.2.0.tgz`.

Run the app again with `ng serve` and see that the previous error does not occur.