### PR TITLE
fix(plugin-koa): Better handling of ctx.throw() errors

### DIFF
--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -29,8 +29,10 @@ module.exports = {
       try {
         await next()
       } catch (err) {
-        ctx.bugsnag.notify(createReportFromErr(err, handledState))
-        if (!ctx.response.headerSent) ctx.response.status = 500
+        if (err.status === undefined || err.status >= 500) {
+          ctx.bugsnag.notify(createReportFromErr(err, handledState))
+        }
+        if (!ctx.response.headerSent) ctx.response.status = err.status || 500
       }
     }
 
@@ -49,8 +51,10 @@ module.exports = {
       try {
         yield next
       } catch (err) {
-        this.bugsnag.notify(createReportFromErr(err, handledState))
-        if (!this.headerSent) this.status = 500
+        if (err.status === undefined || err.status >= 500) {
+          this.bugsnag.notify(createReportFromErr(err, handledState))
+        }
+        if (!this.headerSent) this.status = err.status || 500
       }
     }
 

--- a/test/node/features/fixtures/koa-1x/scenarios/app.js
+++ b/test/node/features/fixtures/koa-1x/scenarios/app.js
@@ -43,6 +43,8 @@ app.use(function * (next) {
     throw new Error('noooop')
   } else if (this.path === '/ctx-throw') {
     this.throw(500, 'thrown')
+  } else if (this.path === '/ctx-throw-400') {
+    this.throw(400, 'thrown')
   } else if (this.path === '/throw-non-error') {
     throw 'error' // eslint-disable-line
   } else {

--- a/test/node/features/fixtures/koa/scenarios/app.js
+++ b/test/node/features/fixtures/koa/scenarios/app.js
@@ -45,6 +45,8 @@ app.use(async (ctx, next) => {
     await erroneous()
   } else if (ctx.path === '/ctx-throw') {
     ctx.throw(500, 'thrown')
+  } else if (ctx.path === '/ctx-throw-400') {
+    ctx.throw(400, 'thrown')
   } else if (ctx.path === '/throw-non-error') {
     throw 'error' // eslint-disable-line
   } else {

--- a/test/node/features/koa-1x.feature
+++ b/test/node/features/koa-1x.feature
@@ -57,3 +57,8 @@ Scenario: throwing non-Error error
   And the exception "message" matches "^Handled a non-error\."
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-koa/dist/bugsnag-koa.js"
+
+Scenario: A non-5XX error created with with ctx.throw()
+  Then I open the URL "http://koa-1x/ctx-throw-400"
+  And I wait for 1 second
+  Then I should receive no requests

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -69,3 +69,8 @@ Scenario: throwing non-Error error
   And the exception "message" matches "^Handled a non-error\."
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "node_modules/@bugsnag/plugin-koa/dist/bugsnag-koa.js"
+
+Scenario: A non-5XX error created with with ctx.throw()
+  Then I open the URL "http://koa/ctx-throw-400"
+  And I wait for 1 second
+  Then I should receive no requests


### PR DESCRIPTION
3XX and 4XX errors generated with `ctx.throw()` are no longer reported to Bugsnag. The status code for such errors was previously not honoured by the error handler and a 500 was always sent. This has been corrected.

Fixes #471.

### Testing

Added maze tests for the error reports themselves, but to verify the correct status code I used the example app to manually test, as this isn't something you can make assertions about in maze.