### PR TITLE
feat(expo): Support "endpoint" option for builds/source maps

### DIFF
--- a/packages/expo/hooks/lib/report-build.js
+++ b/packages/expo/hooks/lib/report-build.js
@@ -1,10 +1,10 @@
 const reportBuild = require('bugsnag-build-reporter')
 
-module.exports = async (apiKey, manifest, projectRoot) => {
+module.exports = async (apiKey, manifest, projectRoot, endpoint) => {
   const { revisionId, version } = manifest
   await reportBuild({
     apiKey,
     appVersion: version,
     metadata: { [`bundle@${new Date().toISOString()}`]: revisionId }
-  }, { path: projectRoot })
+  }, { path: projectRoot, endpoint })
 }

--- a/packages/expo/hooks/lib/upload-source-maps.js
+++ b/packages/expo/hooks/lib/upload-source-maps.js
@@ -14,7 +14,8 @@ module.exports = async (
   androidManifest,
   androidBundle,
   androidSourceMap,
-  projectRoot
+  projectRoot,
+  endpoint
 ) => {
   const dir = await makeTmpDir()
 
@@ -30,26 +31,29 @@ module.exports = async (
   await writeFileAsync(androidSourceMapPath, androidSourceMap, 'utf-8')
   await writeFileAsync(androidBundlePath, androidBundle, 'utf-8')
 
+  const opts = { apiKey }
+  if (endpoint) opts.endpoint = endpoint
+
   // android
   console.log(`Uploading Android source map`)
   await upload({
-    apiKey,
     appVersion: androidManifest.version,
     minifiedUrl: '*/cached-bundle-experience-*',
     minifiedFile: androidBundlePath,
     codeBundleId: androidManifest.revisionId,
-    sourceMap: androidSourceMapPath
+    sourceMap: androidSourceMapPath,
+    ...opts
   })
 
   // ios
   console.log(`Uploading iOS source map`)
   await upload({
-    apiKey,
     appVersion: iosManifest.version,
     minifiedUrl: iosManifest.bundleUrl,
     minifiedFile: iosBundlePath,
     codeBundleId: iosManifest.revisionId,
-    sourceMap: iosSourceMapPath
+    sourceMap: iosSourceMapPath,
+    ...opts
   })
 }
 

--- a/packages/expo/hooks/post-publish.js
+++ b/packages/expo/hooks/post-publish.js
@@ -23,10 +23,14 @@ module.exports = async ({
         '@bugsnag/expo postPublish hook requires your Bugsnag API key'
       )
     }
-    if (!config || config.reportBuild !== false) {
-      await reportBuild(apiKey, iosManifest, projectRoot)
+
+    const buildReporterConfig = (config && config.buildReporter) ? config.buildReporter : {}
+    if (buildReporterConfig.disabled !== true) {
+      await reportBuild(apiKey, iosManifest, projectRoot, buildReporterConfig.endpoint)
     }
-    if (!config || config.uploadSourcemaps !== false) {
+
+    const sourceMapConfig = (config && config.sourceMapUploader) ? config.sourceMapUploader : {}
+    if (sourceMapConfig.disabled !== true) {
       await uploadSourcemaps(
         apiKey,
         iosManifest,
@@ -35,7 +39,8 @@ module.exports = async ({
         androidManifest,
         androidBundle,
         androidSourceMap,
-        projectRoot
+        projectRoot,
+        sourceMapConfig.endpoint
       )
     }
   } catch (e) {


### PR DESCRIPTION
This change adds support for configuring endpoints on the source map upload and build reporter within the Expo post-publish hook.

Previously On-premise users would not have been able to configure the post-publish hook to speak to their endpoints.

Configuration in `app.json` should be set as follows:

```json
    "hooks": {
      "postPublish": [
        {
          "file": "@bugsnag/expo/hooks/post-publish.js",
          "config": {
            "sourceMapUploader": { "endpoint": "https://upload-server.onprem.com" },
            "buildReporter": { "endpoint": "https://build-reporter.onprem.com" }
          }
        }
      ]
    }
```

A docs PR will be made once this change is approved.

Tested against a local bugsnag instance.