### PR TITLE
Fix connecting from behind a proxy with `agent`

### DIFF
--- a/packages/delivery-node/request.js
+++ b/packages/delivery-node/request.js
@@ -18,7 +18,8 @@ module.exports = ({ url, headers, body, agent }, cb) => {
     hostname: parsedUrl.hostname,
     port: parsedUrl.port,
     path: parsedUrl.path,
-    headers
+    headers,
+    agent
   })
   req.on('error', onError)
   req.on('response', res => {


### PR DESCRIPTION
When trying to get bugsnag working behind our corporate firewall, I had
problems using the instructions about hooking in `https-proxy-agent`, and
the agent configuration was not obeyed.  When I went digging into the code
I realized the config option was never actually passed to the `https.request()`
call within the `deliver()` function. This fixes that.

Also it seems that [this integration test](https://github.com/bugsnag/bugsnag-js/blob/3569eccf0822948d2fae9df94a04b52d198b9054/test/node/features/proxy.feature)
is not testing what its supposed to, but I'm not familiar enough with the Maze Runner
tests to be able to fix it myself (plus it seems from CONTRIBUTING.md that I can't run it
anyway).