### PR TITLE
Add a check for the case when there's no stacktrace at all

### DIFF
--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -74,7 +74,7 @@ module.exports = {
       }
 
       // only attempt to grab some surrounding code if we have a line number
-      if (frame.lineNumber === undefined) return
+      if (frame === undefined || frame.lineNumber === undefined) return
       frame.code = addSurroundingCode(frame.lineNumber)
     })
 


### PR DESCRIPTION
Getting this error message when there's no stack-trace. This PR fixes that issue by first checking if `frame` exists.

<img width="629" alt="Screenshot 2019-06-20 at 10 59 45" src="https://user-images.githubusercontent.com/12616998/59832228-1031af80-934c-11e9-9b5a-990fb4da0e9b.png">