### PR TITLE
Prevent error when running inline script plugin on empty stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (plugin-inline-script): Ensure inline script content callback doesn't cause error logs when there are no stackframes [#559](https://github.com/bugsnag/bugsnag-js/pull/559) / [#563](https://github.com/bugsnag/bugsnag-js/pull/563)
+
 ## 6.3.1 (2019-06-17)
 
 ### Fixed

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -74,7 +74,7 @@ module.exports = {
       }
 
       // only attempt to grab some surrounding code if we have a line number
-      if (frame === undefined || frame.lineNumber === undefined) return
+      if (!frame || frame.lineNumber === undefined) return
       frame.code = addSurroundingCode(frame.lineNumber)
     })
 

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -74,7 +74,7 @@ module.exports = {
       }
 
       // only attempt to grab some surrounding code if we have a line number
-      if (!frame || frame.lineNumber === undefined) return
+      if (!frame || !frame.lineNumber) return
       frame.code = addSurroundingCode(frame.lineNumber)
     })
 

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -74,7 +74,7 @@ module.exports = {
       }
 
       // only attempt to grab some surrounding code if we have a line number
-      if (frame.lineNumber === undefined) return
+      if (frame === undefined || frame.lineNumber === undefined) return
       frame.code = addSurroundingCode(frame.lineNumber)
     })
 

--- a/packages/plugin-inline-script-content/test/inline-script-content.test.js
+++ b/packages/plugin-inline-script-content/test/inline-script-content.test.js
@@ -1,4 +1,4 @@
-const { describe, it, expect } = global
+const { describe, it, expect, spyOn } = global
 
 const plugin = require('../')
 
@@ -156,5 +156,38 @@ Lorem ipsum dolor sit amet.
       expect(surroundingCode[line].length > 200).toBe(false)
     })
     expect(payloads[0].events[0].metaData.script).toBeDefined()
+  })
+
+  it('works when the stacktrace is empty', () => {
+    const scriptContent = `console.log("EMPTY")`
+    const document = {
+      scripts: [ { innerHTML: scriptContent } ],
+      currentScript: { innerHTML: scriptContent },
+      documentElement: {
+        outerHTML: `<p>
+Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet.
+</p>
+<script>${scriptContent}
+</script>
+<p>more content</p>`
+      }
+    }
+    const window = { location: { href: 'https://app.bugsnag.com/errors' } }
+
+    const client = new Client(VALID_NOTIFIER)
+    const payloads = []
+    client.setOptions({ apiKey: 'API_KEY_YEAH' })
+    client.configure()
+    client.use(plugin, document, window)
+
+    expect(client.config.beforeSend.length).toBe(1)
+    client.delivery(client => ({ sendReport: (payload) => payloads.push(payload) }))
+    const spy = spyOn(client._logger, 'error')
+    client.notify(new Report('EmptyStacktrace', 'Has nothing in it', []))
+    expect(payloads.length).toEqual(1)
+    expect(payloads[0].events[0].stacktrace).toEqual([])
+    expect(spy).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
In the case of an error without a stacktrace, the `beforeSend` implemented by `@bugsnag/plugin-inline-script-content` would throw an error (see #559).

Since the logic that runs the list of `beforeSend` callbacks tolerates errors, the effect of this was pretty minimal – just some undesirable error logs output.

The fix supplied by @andvla (thanks 🙏) was tweaked so that we won't attempt to look for `.lineNumber` on any falsey value for `stacktrace[0]`.