### PR TITLE
Support various flavours of Angular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - (plugin-inline-script): Ensure inline script content callback doesn't cause error logs when there are no stackframes [#559](https://github.com/bugsnag/bugsnag-js/pull/559) / [#563](https://github.com/bugsnag/bugsnag-js/pull/563)
+- (plugin-angular): Bundle an ES5 and an ES6 version of the plugin to support various Angular build settings [#565](https://github.com/bugsnag/bugsnag-js/pull/559) / [#563](https://github.com/bugsnag/bugsnag-js/pull/565)
 
 ## 6.3.1 (2019-06-17)
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.3.1"
+  "version": "6.3.2-alpha.0"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/browser",
-  "version": "6.3.0",
+  "version": "6.3.2-alpha.0",
   "main": "dist/bugsnag.js",
   "types": "dist/types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for browser JavaScript",
@@ -38,7 +38,7 @@
     "@bugsnag/plugin-browser-session": "^6.3.0",
     "@bugsnag/plugin-client-ip": "^6.3.0",
     "@bugsnag/plugin-console-breadcrumbs": "^6.3.0",
-    "@bugsnag/plugin-inline-script-content": "^6.3.0",
+    "@bugsnag/plugin-inline-script-content": "^6.3.2-alpha.0",
     "@bugsnag/plugin-interaction-breadcrumbs": "^6.3.0",
     "@bugsnag/plugin-navigation-breadcrumbs": "^6.3.0",
     "@bugsnag/plugin-network-breadcrumbs": "^6.3.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/js",
-  "version": "6.3.1",
+  "version": "6.3.2-alpha.0",
   "main": "node/notifier.js",
   "browser": "browser/notifier.js",
   "types": "types.d.ts",
@@ -33,7 +33,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/browser": "^6.3.0",
+    "@bugsnag/browser": "^6.3.2-alpha.0",
     "@bugsnag/node": "^6.3.1"
   },
   "devDependencies": {

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -2,9 +2,13 @@
   "name": "@bugsnag/plugin-angular",
   "version": "6.3.1",
   "description": "Angular integration for bugsnag-js",
-  "main": "dist/index.js",
-  "browser": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/es5/index.js",
+  "browser": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
+  "es2015": "dist/esm/index.js",
+  "esm5": "dist/es5/index.js",
+  "types": "dist/esm/index.d.ts",
+  "typings": "dist/esm/index.d.ts",
   "homepage": "https://www.bugsnag.com/",
   "repository": {
     "type": "git",
@@ -19,8 +23,9 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "lint": "tslint -p .",
-    "build": "npm run clean && npm run build:dist",
-    "build:dist": "ngc -p .",
+    "build": "npm run clean && npm run build:es2015 && npm run build:esm5",
+    "build:es2015": "ngc -p tsconfig.json",
+    "build:esm5": "ngc -p tsconfig.esm5.json",
     "test": "npm run lint",
     "postversion": "npm run build"
   },

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/plugin-angular",
-  "version": "6.3.1",
+  "version": "6.3.2-alpha.0",
   "description": "Angular integration for bugsnag-js",
   "main": "dist/es5/index.js",
   "browser": "dist/es5/index.js",
@@ -36,7 +36,7 @@
     "@angular/compiler": "^7.2.15",
     "@angular/compiler-cli": "^7.2.15",
     "@angular/core": "^7.2.15",
-    "@bugsnag/js": "^6.3.1",
+    "@bugsnag/js": "^6.3.2-alpha.0",
     "rxjs": "^5.5.8",
     "tslint": "^5.9.1",
     "typescript": "^3.2.4",

--- a/packages/plugin-angular/tsconfig.esm5.json
+++ b/packages/plugin-angular/tsconfig.esm5.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES5",
+    "outDir": "./dist/es5",
+  }
+}

--- a/packages/plugin-angular/tsconfig.json
+++ b/packages/plugin-angular/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "files": [ "./src/index.ts" ],
   "compilerOptions": {
-    "module": "ES6",
-    "target": "ES6",
+    "module": "ES2015",
+    "target": "ES2015",
     "lib": [ "ES5", "ES6", "DOM" ],
     "allowJs": false,
     "declaration": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "outDir": "./dist",
+    "outDir": "./dist/esm",
     "rootDir": "./src",
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/plugin-inline-script-content",
-  "version": "6.3.0",
+  "version": "6.3.2-alpha.0",
   "main": "inline-script-content.js",
   "description": "@bugsnag/js plugin to attach inline script content to error reports",
   "homepage": "https://www.bugsnag.com/",


### PR DESCRIPTION
This PR aims to solve a few different problems

- plugin not working with Angular v8 / `enableIvy: true` #556
- plugin not having interop with native ES classes #545 / #505
- plugin not honouring `target: "es5"` (outputting native classes) #552

The solution is to build two different outputs – one for `es5` and one for `es6` – following the guidance in this [Angular Package Format](https://goo.gl/jB3GVv) document.

I'll cut a prerelease for people to try out before landing this PR.