### PR TITLE
Expo ci fix turtle

### DIFF
--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -27,3 +27,4 @@ CMD EXPO_ANDROID_KEYSTORE_PASSWORD=password \
     --keystore-alias password \
     --output /app/test/expo/features/fixtures/build/output.apk \
     --release-channel $EXPO_RELEASE_CHANNEL
+    --type apk

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -14,7 +14,7 @@ WORKDIR /app/test/expo/features/fixtures/test-app
 RUN mkdir -p /app/test/expo/features/fixures/build
 
 RUN yarn global add gulp-cli node-gyp
-RUN yarn add bunyan turtle-cli
+RUN yarn add bunyan turtle-cli@0.7.2
 
 RUN node_modules/.bin/turtle setup:android
 

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -26,5 +26,5 @@ CMD EXPO_ANDROID_KEYSTORE_PASSWORD=password \
     --keystore-path fakekeys.jks \
     --keystore-alias password \
     --output /app/test/expo/features/fixtures/build/output.apk \
-    --release-channel $EXPO_RELEASE_CHANNEL
+    --release-channel $EXPO_RELEASE_CHANNEL \
     --type apk

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -14,7 +14,7 @@ WORKDIR /app/test/expo/features/fixtures/test-app
 RUN mkdir -p /app/test/expo/features/fixures/build
 
 RUN yarn global add gulp-cli node-gyp
-RUN yarn add bunyan turtle-cli@0.7.2
+RUN yarn add bunyan turtle-cli@0.8.6
 
 RUN node_modules/.bin/turtle setup:android
 

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --update bash git
+RUN apk add --update bash git python
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes the CI failures with the cached version of Turtle (0.8.5) and fixes the version to avoid issues in the future.