### PR TITLE
Add android native module prototype

### DIFF
--- a/examples/reactnative/App.js
+++ b/examples/reactnative/App.js
@@ -12,7 +12,7 @@ import { NativeModules } from 'react-native';
 
 // setup bugsnag client to capture errors automatically
 import bugsnag from '@bugsnag/react-native';
-const client = bugsnag('api-key');
+const bugsnagClient = bugsnag('api-key');
 
 function triggerException() {
   bogusFunction(); // eslint-disable-line no-undef
@@ -57,7 +57,7 @@ export default class App extends Component {
                 try { // execute crashy code
                   triggerHandledException();
                 } catch (error) {
-                  client.notify(error);
+                  bugsnagClient.notify(error);
                 }
               }} />
             <Text style={styles.info}>
@@ -70,8 +70,8 @@ export default class App extends Component {
                 try { // execute crashy code
                   throw new Error("Error with user");
                 } catch (error) {
-                  client.setUser("user-5fab67", "John Smith", "john@example.com");
-                  client.notify(error);
+                  bugsnagClient.setUser("user-5fab67", "John Smith", "john@example.com");
+                  bugsnagClient.notify(error);
                 }
               }} />
             <Text style={styles.info}>
@@ -82,14 +82,14 @@ export default class App extends Component {
               title="Leave breadcrumbs"
               onPress={() => {
                 // log a breadcrumb, which will be attached to the error report
-                client.leaveBreadcrumb('About to execute crashy code', {
+                bugsnagClient.leaveBreadcrumb('About to execute crashy code', {
                   type: 'user'
                 });
 
                 try { // execute crashy code
                   throw new Error("Error with breadcrumbs");
                 } catch (error) {
-                  client.notify(error);
+                  bugsnagClient.notify(error);
                 }
               }} />
             <Text style={styles.info}>

--- a/examples/reactnative/App.js
+++ b/examples/reactnative/App.js
@@ -8,11 +8,11 @@
 
 import React, { Component } from 'react';
 import { View, Text, Button, ScrollView, StyleSheet, Platform } from 'react-native';
-import { Client } from 'bugsnag-react-native';
 import { NativeModules } from 'react-native';
 
 // setup bugsnag client to capture errors automatically
-const bugsnag = new Client();
+import bugsnag from '@bugsnag/react-native';
+const client = bugsnag('api-key');
 
 function triggerException() {
   bogusFunction(); // eslint-disable-line no-undef
@@ -57,7 +57,7 @@ export default class App extends Component {
                 try { // execute crashy code
                   triggerHandledException();
                 } catch (error) {
-                  bugsnag.notify(error);
+                  client.notify(error);
                 }
               }} />
             <Text style={styles.info}>
@@ -70,8 +70,8 @@ export default class App extends Component {
                 try { // execute crashy code
                   throw new Error("Error with user");
                 } catch (error) {
-                  bugsnag.setUser("user-5fab67", "John Smith", "john@example.com");
-                  bugsnag.notify(error);
+                  client.setUser("user-5fab67", "John Smith", "john@example.com");
+                  client.notify(error);
                 }
               }} />
             <Text style={styles.info}>
@@ -82,14 +82,14 @@ export default class App extends Component {
               title="Leave breadcrumbs"
               onPress={() => {
                 // log a breadcrumb, which will be attached to the error report
-                bugsnag.leaveBreadcrumb('About to execute crashy code', {
+                client.leaveBreadcrumb('About to execute crashy code', {
                   type: 'user'
                 });
 
                 try { // execute crashy code
                   throw new Error("Error with breadcrumbs");
                 } catch (error) {
-                  bugsnag.notify(error);
+                  client.notify(error);
                 }
               }} />
             <Text style={styles.info}>

--- a/examples/reactnative/android/app/src/main/java/com/reactnative/MainApplication.java
+++ b/examples/reactnative/android/app/src/main/java/com/reactnative/MainApplication.java
@@ -2,8 +2,9 @@ package com.reactnative;
 
 import android.app.Application;
 
+import com.bugsnag.reactnative.BugsnagPackage;
 import com.facebook.react.ReactApplication;
-import com.bugsnag.BugsnagReactNative;
+import com.bugsnag.reactnative.BugsnagReactNative;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -22,9 +23,9 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
+      return Arrays.asList(
           new MainReactPackage(),
-            BugsnagReactNative.getPackage(),
+            new BugsnagPackage(),
             new CrashyPackage()
       );
     }

--- a/examples/reactnative/android/build.gradle
+++ b/examples/reactnative/android/build.gradle
@@ -22,12 +22,11 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
-        google()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        jcenter()
+        google()
     }
 }

--- a/examples/reactnative/android/settings.gradle
+++ b/examples/reactnative/android/settings.gradle
@@ -1,5 +1,5 @@
 rootProject.name = 'reactnative'
 include ':bugsnag-react-native'
-project(':bugsnag-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/bugsnag-react-native/android')
+project(':bugsnag-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/@bugsnag/react-native/android')
 
 include ':app'

--- a/packages/react-native/.gitignore
+++ b/packages/react-native/.gitignore
@@ -1,5 +1,6 @@
 # Android/IntelliJ
 #
+.npmrc
 build/
 .idea
 .gradle

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -47,16 +47,12 @@ dependencies {
 
 allprojects {
     repositories {
-        google()
-        mavenLocal()
-        mavenCentral()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-
-        maven { url 'https://maven.google.com' }
+        jcenter()
+        google()
     }
 }
 

--- a/packages/react-native/android/src/androidTest/java/com/bugsnag/reactnative/SanityTest.java
+++ b/packages/react-native/android/src/androidTest/java/com/bugsnag/reactnative/SanityTest.java
@@ -1,4 +1,4 @@
-package com.bugsnag.android;
+package com.bugsnag.reactnative;
 
 import static org.junit.Assert.assertEquals;
 

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android;
+
+public class InternalHooks {
+
+    /**
+     * Configures the bugsnag client by hooking into package-visible APIs within bugsnag-android
+     */
+    public static void configureClient(Client client) {
+        client.getConfig().addBeforeSendSession(new BeforeSendSession() {
+            @Override
+            public void beforeSendSession(SessionTrackingPayload payload) {
+                RuntimeVersions.addRuntimeVersions(payload.getDevice());
+            }
+        });
+
+        client.getConfig().beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                RuntimeVersions.addRuntimeVersions(report.getError().getDeviceData());
+                return true;
+            }
+        });
+    }
+
+    /**
+     * Logs a warning using bugsnag-android's logger, as this already handles whether the user
+     * has disabled logging or not.
+     */
+    public static void logWarning(String msg) {
+        Logger.warn(msg);
+    }
+
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/RuntimeVersions.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/RuntimeVersions.java
@@ -1,0 +1,59 @@
+package com.bugsnag.android;
+
+import com.facebook.react.modules.systeminfo.ReactNativeVersion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class RuntimeVersions {
+
+    /**
+     * Adds information about the react native version to a device dictionary
+     *
+     * @param device the device dictionary
+     */
+    static void addRuntimeVersions(Map<String, Object> device) {
+        @SuppressWarnings("unchecked") // ignore type erasure when casting Map
+        Map<String, Object> runtimeVersions = (Map<String, Object>) device.get("runtimeVersions");
+
+        if (runtimeVersions == null) {
+            runtimeVersions = new HashMap<>();
+            device.put("runtimeVersions", runtimeVersions);
+        }
+        runtimeVersions.put("reactNative", findReactNativeVersion());
+    }
+
+    // see https://github.com/facebook/react-native/blob/6df2edeb2a33d529e4b13a5b6767f300d08aeb0a/scripts/bump-oss-version.js
+    private static String findReactNativeVersion() {
+        StringBuilder sb = new StringBuilder();
+
+        String major = getStringSafe("major", ReactNativeVersion.VERSION);
+        if (major != null) {
+            sb.append(major);
+            sb.append(".");
+        }
+
+        String minor = getStringSafe("minor", ReactNativeVersion.VERSION);
+        if (minor != null) {
+            sb.append(minor);
+            sb.append(".");
+        }
+
+        String patch = getStringSafe("patch", ReactNativeVersion.VERSION);
+        if (patch != null) {
+            sb.append(patch);
+        }
+
+        String prerelease = getStringSafe("prerelease", ReactNativeVersion.VERSION);
+        if (prerelease != null) {
+            sb.append("-");
+            sb.append(prerelease);
+        }
+        return sb.toString();
+    }
+
+    private static String getStringSafe(String key, Map<String, Object> map) {
+        Object obj = map.get(key);
+        return (obj != null) ? obj.toString() : null;
+    }
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BreadcrumbDeserializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BreadcrumbDeserializer.java
@@ -1,0 +1,15 @@
+package com.bugsnag.reactnative;
+
+import com.bugsnag.android.Breadcrumb;
+
+import com.facebook.react.bridge.ReadableMap;
+
+class BreadcrumbDeserializer implements ReadableMapDeserializer<Breadcrumb> {
+
+    @Override
+    public Breadcrumb deserialize(ReadableMap map) {
+        // TODO deserialize the breadcrumb here
+        return null;
+    }
+
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagPackage.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagPackage.java
@@ -1,20 +1,14 @@
 package com.bugsnag.reactnative;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class BugsnagPackage implements ReactPackage {
-
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
 
     @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
     @Override
@@ -24,6 +18,6 @@ public class BugsnagPackage implements ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new BugsnagReactNative(reactContext));
+        return Collections.<NativeModule>singletonList(new BugsnagReactNative(reactContext));
     }
 }

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
@@ -112,7 +112,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void updateContext(String context) {
-        // TODO update context
+        Bugsnag.getClient().setContext(context);
     }
 
     /**
@@ -120,7 +120,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     void updateUser(String id, String name, String email) {
-        // TODO update user
+        Bugsnag.getClient().setUser(id, name, email);
     }
 
     /**

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -92,9 +93,10 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    public void getConfig(Promise promise) {
+    public WritableMap getConfig() {
         Configuration config = Bugsnag.getClient().getConfig();
         // TODO serialise as a readablemap
+        return null;
     }
 
     /**

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
@@ -1,103 +1,193 @@
 package com.bugsnag.reactnative;
 
+import com.bugsnag.android.Breadcrumb;
 import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.BugsnagException;
+import com.bugsnag.android.Callback;
 import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
+import com.bugsnag.android.InternalHooks;
+import com.bugsnag.android.Report;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.Log;
 
-import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 
-import java.util.logging.Logger;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
 
 public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
-    private ReactContext reactContext;
-    private String libraryVersion;
-    private String bugsnagAndroidVersion;
-    static final Logger logger = Logger.getLogger("bugsnag-react-native");
+    // TODO populate this (read directly from JS)
+    public static ReadableMap versions;
 
-    public static ReactPackage getPackage() {
-        return new BugsnagPackage();
-    }
+    static String bugsnagJsVersion; // TODO need to set this value
+    static String bugsnagAndroidVersion;
 
-    public BugsnagReactNative(ReactApplicationContext reactContext) {
+    private final BreadcrumbDeserializer breadcrumbDeserializer = new BreadcrumbDeserializer();
+
+    public BugsnagReactNative(@Nonnull ReactApplicationContext reactContext) {
         super(reactContext);
-        this.reactContext = reactContext;
     }
 
-    // @Override
-    // public Map<String, Object> getConstants() {
-    //   HashMap<String, Object> constants = new HashMap<>();
-    //   Client client = getClient();
-    //   if (client != null) {
-    //     Configuration config = client.getConfig();
-    //     String key = config.getApiKey();
-    //     constants.put("apiKey", key);
-    //   }
-    //   // TODO: if bugsnag has not been started, it would be nice to read the manifest
-    //   // and get the default api key. This is how it works on iOS.
-    //   return constants;
-    // }
-    //
-    // // @Override
-    // public boolean hasConstants() {
-    //   return true;
-    // }
-    //
+    /**
+     * Instantiates a bugsnag client using the API key in the AndroidManifest.xml
+     *
+     * @param context the application context
+     * @return the bugsnag client
+     */
+    public static Client start(Context context) {
+        Client client = Bugsnag.init(context);
+        configureClient(client);
+        return client;
+    }
+
+    /**
+     * Instantiates a bugsnag client with a given API key.
+     *
+     * @param context the application context
+     * @param apiKey  the api key for your project
+     * @return the bugsnag client
+     */
+    public static Client startWithApiKey(Context context, String apiKey) {
+        Client client = Bugsnag.init(context, apiKey);
+        configureClient(client);
+        return client;
+    }
+
+    /**
+     * Instantiates a bugsnag client with a given configuration object.
+     *
+     * @param context the application context
+     * @param config  configuration for how bugsnag should behave
+     * @return the bugsnag client
+     */
+    public static Client startWithConfiguration(Context context, Configuration config) {
+        Client client = Bugsnag.init(context, config);
+        configureClient(client);
+        return client;
+    }
+
+    private static void configureClient(Client client) {
+        InternalHooks.configureClient(client);
+
+        // TODO set these as config up front if possible
+        client.setIgnoreClasses("com.facebook.react.common.JavascriptException");
+        bugsnagAndroidVersion = client.getClass().getPackage().getSpecificationVersion();
+        // TODO set codeBundleId here
+        Log.d("BugsnagReactNative", "Initialised bugsnag-react-native");
+    }
+
     @Override
     public String getName() {
         return "BugsnagReactNative";
     }
 
-    /** Start a new session. */
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public void getConfig(Promise promise) {
+        Configuration config = Bugsnag.getClient().getConfig();
+        // TODO serialise as a readablemap
+    }
+
+    /**
+     * Updates the native metadata using metadata from the JS layer
+     */
+    @ReactMethod
+    public void updateMetaData(ReadableMap update) {
+        // TODO update metadata
+    }
+
+    /**
+     * Updates the native context using the context from the JS layer
+     */
+    @ReactMethod
+    public void updateContext(String context) {
+        // TODO update context
+    }
+
+    /**
+     * Updates the native user using the user from the JS layer
+     */
+    @ReactMethod
+    void updateUser(String id, String name, String email) {
+        // TODO update user
+    }
+
+    /**
+     * Deliver the report using the native delivery mechanism
+     */
+    @ReactMethod
+    public void dispatch(ReadableMap payload, Promise promise) {
+        // TODO deserialize stacktrace etc here
+        BugsnagException exc = new BugsnagException("", "", new StackTraceElement[]{});
+
+        Bugsnag.getClient().notify(exc, new Callback() {
+            @Override
+            public void beforeNotify(@NonNull Report report) {
+                // TODO modify payload here
+            }
+        });
+        promise.resolve(true);
+    }
+
+    /**
+     * Retrieves breadcrumbs, app info, and device info from the native layer.
+     */
+    @ReactMethod
+    public void getPayloadInfo(Promise promise) {
+        Client client = Bugsnag.getClient();
+        Map<String, Object> info = new HashMap<>();
+        info.put("app", client.getAppData());
+        info.put("device", client.getDeviceData());
+        info.put("breadcrumbs", client.getBreadcrumbs());
+        promise.resolve(info);
+    }
+
+    /**
+     * Adds a breadcrumb from the JS layer to the native layer.
+     */
+    @ReactMethod
+    public void leaveBreadcrumb(ReadableMap map) {
+        Breadcrumb breadcrumb = breadcrumbDeserializer.deserialize(map);
+
+        if (breadcrumb != null) {
+            Bugsnag.getClient().leaveBreadcrumb(breadcrumb.getName(),
+                    breadcrumb.getType(), breadcrumb.getMetadata());
+        } else {
+            // TODO log a warning
+        }
+    }
+
+    /**
+     * Start a new session in the native layer.
+     */
     @ReactMethod
     public void startSession() {
-        Bugsnag.startSession();
+        Bugsnag.getClient().startSession();
     }
 
-    /** Stop the current session. */
+    /**
+     * Stop the current session in the native layer, if one has been started.
+     */
     @ReactMethod
     public void stopSession() {
-        Bugsnag.stopSession();
+        Bugsnag.getClient().stopSession();
     }
 
-    /** Resume the previously started session or start a new one if none available. */
+    /**
+     * Resume the previously started session or start a new one if none available.
+     */
     @ReactMethod
-    public void resumeSession() {
-        Bugsnag.resumeSession();
+    public void resumeSession(Promise promise) {
+        promise.resolve(Bugsnag.getClient().resumeSession());
     }
-
-    /** Leaves a breadcrumb. */
-    @ReactMethod
-    public void leaveBreadcrumb(ReadableMap options) {
-      // Bugsnag.leaveBreadcrumb(
-      //     options.getString("name"),
-      //     parseBreadcrumbType(options.getString("type")),
-      //     readStringMap(options.getMap("metadata")));
-    }
-
-    /** Deliver the report. */
-    @ReactMethod
-    public void deliver(ReadableMap payload, Promise promise) {
-        // TODO: deliver payload immediately, caching upon failure
-        promise.resolve(null);
-    }
-
-    /** Breadcrumbs, app info, and device info available in the native layer. */
-    @ReactMethod
-    public void nativePayloadInfo(Promise promise) {
-        promise.resolve("");
-    }
-
-    /** Update configuration based on props set on the JavaScript layer client. */
-    @ReactMethod
-    public void updateClientProperty(ReadableMap options) {}
 
 }

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/DiagnosticsCallback.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/DiagnosticsCallback.java
@@ -1,0 +1,123 @@
+package com.bugsnag.reactnative;
+
+import com.bugsnag.android.Callback;
+import com.bugsnag.android.MetaData;
+import com.bugsnag.android.Report;
+import com.bugsnag.android.Severity;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Attaches report diagnostics before delivery
+ */
+@Deprecated // copied from previous implementation for reference
+class DiagnosticsCallback implements Callback {
+
+    static final String NOTIFIER_NAME = "Bugsnag for React Native";
+    static final String NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-react-native";
+
+    private final Severity severity;
+    private final String context;
+    private final String groupingHash;
+    private final Map<String, Object> metadata;
+    private final String libraryVersion;
+    private final String bugsnagAndroidVersion;
+
+    DiagnosticsCallback(String libraryVersion,
+                        String bugsnagAndroidVersion,
+                        ReadableMap payload) {
+        this.libraryVersion = libraryVersion;
+        this.bugsnagAndroidVersion = bugsnagAndroidVersion;
+        severity = parseSeverity(payload.getString("severity"));
+        metadata = readObjectMap(payload.getMap("metadata"));
+
+        if (payload.hasKey("context")) {
+            context = payload.getString("context");
+        } else {
+            context = null;
+        }
+
+        if (payload.hasKey("groupingHash")) {
+            groupingHash = payload.getString("groupingHash");
+        } else {
+            groupingHash = null;
+        }
+    }
+
+    Severity parseSeverity(String value) {
+        switch (value) {
+            case "error":
+                return Severity.ERROR;
+            case "info":
+                return Severity.INFO;
+            case "warning":
+            default:
+                return Severity.WARNING;
+        }
+    }
+
+    /**
+     * Convert a typed map from JS into a Map
+     */
+    Map<String, Object> readObjectMap(ReadableMap map) {
+        Map<String, Object> output = new HashMap<>();
+        ReadableMapKeySetIterator iterator = map.keySetIterator();
+
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            ReadableMap pair = map.getMap(key);
+            switch (pair.getString("type")) {
+                case "boolean":
+                    output.put(key, pair.getBoolean("value"));
+                    break;
+                case "number":
+                    output.put(key, pair.getDouble("value"));
+                    break;
+                case "string":
+                    output.put(key, pair.getString("value"));
+                    break;
+                case "map":
+                    output.put(key, readObjectMap(pair.getMap("value")));
+                    break;
+                default:
+                    break;
+            }
+        }
+        return output;
+    }
+
+    @Override
+    public void beforeNotify(Report report) {
+        report.getNotifier().setName(NOTIFIER_NAME);
+        report.getNotifier().setURL(NOTIFIER_URL);
+        report.getNotifier().setVersion(String.format("%s (Android %s)",
+                libraryVersion,
+                bugsnagAndroidVersion));
+
+        if (groupingHash != null && groupingHash.length() > 0) {
+            report.getError().setGroupingHash(groupingHash);
+        }
+        if (context != null && context.length() > 0) {
+            report.getError().setContext(context);
+        }
+        if (metadata != null) {
+            MetaData reportMetadata = report.getError().getMetaData();
+            for (String tab : metadata.keySet()) {
+                Object value = metadata.get(tab);
+
+                if (value instanceof Map) {
+                    @SuppressWarnings("unchecked") // ignore type erasure when casting Map
+                            Map<String, Object> values = (Map<String, Object>) value;
+
+                    for (String key : values.keySet()) {
+                        reportMetadata.addToTab(tab, key, values.get(key));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/JavaScriptException.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/JavaScriptException.java
@@ -1,0 +1,78 @@
+package com.bugsnag.reactnative;
+
+import com.bugsnag.android.InternalHooks;
+import com.bugsnag.android.JsonStream;
+
+import java.io.IOException;
+
+/**
+ * Creates a streamable exception with a JavaScript stacktrace
+ */
+@Deprecated // copied from previous implementation for reference
+class JavaScriptException extends Exception implements JsonStream.Streamable {
+
+    private static final String EXCEPTION_TYPE = "browserjs";
+    private static final long serialVersionUID = 1175784680140218622L;
+
+    private final String name;
+    private final String rawStacktrace;
+
+    JavaScriptException(String name, String message, String rawStacktrace) {
+        super(message);
+        this.name = name;
+        this.rawStacktrace = rawStacktrace;
+    }
+
+    @Override
+    public void toStream(JsonStream writer) throws IOException {
+        writer.beginObject();
+        writer.name("errorClass").value(name);
+        writer.name("message").value(getLocalizedMessage());
+        writer.name("type").value(EXCEPTION_TYPE);
+
+        writer.name("stacktrace");
+        writer.beginArray();
+        for (String rawFrame : rawStacktrace.split("\\n")) {
+            writer.beginObject();
+            String[] methodComponents = rawFrame.split("@", 2);
+            String fragment = methodComponents[0];
+            if (methodComponents.length == 2) {
+                writer.name("method").value(methodComponents[0]);
+                fragment = methodComponents[1];
+            }
+
+            int columnIndex = fragment.lastIndexOf(":");
+            if (columnIndex != -1) {
+                String columnString = fragment.substring(columnIndex + 1);
+                try {
+                    int columnNumber = Integer.parseInt(columnString);
+                    writer.name("columnNumber").value(columnNumber);
+                } catch (NumberFormatException exc) {
+                    InternalHooks.logWarning(String.format(
+                            "Failed to parse column: '%s'",
+                            columnString));
+                }
+                fragment = fragment.substring(0, columnIndex);
+            }
+
+            int lineNumberIndex = fragment.lastIndexOf(":");
+            if (lineNumberIndex != -1) {
+                String lineNumberString = fragment.substring(lineNumberIndex + 1);
+                try {
+                    int lineNumber = Integer.parseInt(lineNumberString);
+                    writer.name("lineNumber").value(lineNumber);
+                } catch (NumberFormatException exc) {
+                    InternalHooks.logWarning(String.format(
+                            "Failed to parse lineNumber: '%s'",
+                            lineNumberString));
+                }
+                fragment = fragment.substring(0, lineNumberIndex);
+            }
+
+            writer.name("file").value(fragment);
+            writer.endObject();
+        }
+        writer.endArray();
+        writer.endObject();
+    }
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/MessageEvent.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/MessageEvent.java
@@ -1,0 +1,12 @@
+package com.bugsnag.reactnative;
+
+final class MessageEvent {
+
+    final String type;
+    final Object value;
+
+    MessageEvent(String type, Object value) {
+        this.type = type;
+        this.value = value;
+    }
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ReadableMapDeserializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ReadableMapDeserializer.java
@@ -1,0 +1,7 @@
+package com.bugsnag.reactnative;
+
+import com.facebook.react.bridge.ReadableMap;
+
+interface ReadableMapDeserializer<T> {
+    T deserialize(ReadableMap map);
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -26,7 +26,9 @@
   "files": [
     "src",
     "dist",
-    "android",
+    "android/build.gradle",
+    "android/proguard-rules.pro",
+    "android/src/main",
     "ios/BugsnagReactNative.{h,m,xcodeproj}",
     "ios/BSGConvert.{h,m}",
     "ios/vendor/bugsnag-cocoa/Source/**/*.{h,m,mm,cpp,c}",


### PR DESCRIPTION
Adds a prototype of the Android native module for React Native, by implementing the methods specified in #561 

## Changeset

- Updated example app to use new `@bugsnag/react-native` package and native instructions
- Altered repository order in build.gradle to ensure node_modules are accessed first, as this picks up a more recent version of the RN AAR than the one published on bintray
- Copy existing classes from bugsnag-react-native implementation as a reference point for the new implementation, deprecating the ones which will be removed
- Altered `npm pack` whitelist to exclude the gradlew
- Created methods specified in JS interface