### PR TITLE
Write configuration into writablemap for RN Android layer

### DIFF
--- a/packages/react-native/android/src/androidTest/java/com/bugsnag/reactnative/ConfigSerializerTest.java
+++ b/packages/react-native/android/src/androidTest/java/com/bugsnag/reactnative/ConfigSerializerTest.java
@@ -1,0 +1,48 @@
+package com.bugsnag.reactnative;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.android.Configuration;
+
+import android.support.test.InstrumentationRegistry;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.soloader.SoLoader;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ConfigSerializerTest {
+
+    private ConfigSerializer configSerializer = new ConfigSerializer();
+
+    @Test
+    public void testConfigSerialisation() throws IOException {
+        SoLoader.init(InstrumentationRegistry.getContext(), 0);
+        Configuration config = new Configuration("api-key");
+        config.setBuildUUID("123");
+        config.setAppVersion("2.0");
+        config.setReleaseStage("prod");
+
+        WritableMap map = configSerializer.serialize(config);
+        assertNotNull(map);
+        assertEquals(9, map.toHashMap().size());
+        assertEquals("api-key", map.getString("apiKey"));
+        assertEquals("2.0", map.getString("appVersion"));
+        assertEquals("123", map.getString("buildUuid"));
+        assertNotNull(map.getString("releaseStage"));
+        assertTrue(map.getBoolean("sendThreads"));
+        assertTrue(map.getBoolean("autoCaptureSessions"));
+        assertFalse(map.getBoolean("detectAnrs"));
+        assertFalse(map.getBoolean("detectNdkCrashes"));
+
+        ReadableMap endpoints = map.getMap("endpoints");
+        assertEquals("https://notify.bugsnag.com", endpoints.getString("notify"));
+        assertEquals("https://sessions.bugsnag.com", endpoints.getString("sessions"));
+    }
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
     static String bugsnagAndroidVersion;
 
     private final BreadcrumbDeserializer breadcrumbDeserializer = new BreadcrumbDeserializer();
+    private final ConfigSerializer configSerializer = new ConfigSerializer();
 
     public BugsnagReactNative(@Nonnull ReactApplicationContext reactContext) {
         super(reactContext);
@@ -95,8 +97,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
     @ReactMethod(isBlockingSynchronousMethod = true)
     public WritableMap getConfig() {
         Configuration config = Bugsnag.getClient().getConfig();
-        // TODO serialise as a readablemap
-        return null;
+        return configSerializer.serialize(config);
     }
 
     /**

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
@@ -1,0 +1,27 @@
+package com.bugsnag.reactnative;
+
+import com.bugsnag.android.Configuration;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+public class ConfigSerializer implements WritableMapSerializer<Configuration> {
+
+    @Override
+    public WritableMap serialize(Configuration config) {
+        WritableMap map = new WritableNativeMap();
+        WritableMap endpoints = new WritableNativeMap();
+        endpoints.putString("notify", config.getEndpoint());
+        endpoints.putString("sessions", config.getSessionEndpoint());
+        map.putMap("endpoints", endpoints);
+        map.putString("apiKey", config.getApiKey());
+        map.putString("appVersion", config.getAppVersion());
+        map.putString("buildUuid", config.getBuildUUID());
+        map.putString("releaseStage", config.getReleaseStage());
+        map.putBoolean("sendThreads", config.getSendThreads());
+        map.putBoolean("autoCaptureSessions", config.getAutoCaptureSessions());
+        map.putBoolean("detectAnrs", config.getDetectAnrs());
+        map.putBoolean("detectNdkCrashes", config.getDetectNdkCrashes());
+        return map;
+    }
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/WritableMapSerializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/WritableMapSerializer.java
@@ -1,0 +1,7 @@
+package com.bugsnag.reactnative;
+
+import com.facebook.react.bridge.WritableMap;
+
+interface WritableMapSerializer<T> {
+    WritableMap serialize(T obj);
+}


### PR DESCRIPTION
Serialises fields from the `Configuration` class into a `WritableMap` which will be accessible from JS.

This also adds a `WritableMapSerializer` interface that can be implemented by any other type wishing to be serialised.