### PR TITLE
Populate bugsnag-android version in a writeable map for RN

### DIFF
--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,11 +28,7 @@ import javax.annotation.Nonnull;
 
 public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
-    // TODO populate this (read directly from JS)
-    public static ReadableMap versions;
-
-    static String bugsnagJsVersion; // TODO need to set this value
-    static String bugsnagAndroidVersion;
+    public static WritableMap versions;
 
     private final BreadcrumbDeserializer breadcrumbDeserializer = new BreadcrumbDeserializer();
 
@@ -82,9 +79,26 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
         // TODO set these as config up front if possible
         client.setIgnoreClasses("com.facebook.react.common.JavascriptException");
-        bugsnagAndroidVersion = client.getClass().getPackage().getSpecificationVersion();
         // TODO set codeBundleId here
         Log.d("BugsnagReactNative", "Initialised bugsnag-react-native");
+    }
+
+    private static void configureBugsnagAndroidVersion(Client client) {
+        versions = new WritableNativeMap();
+        String androidVersion = getPackageVersion(client.getClass());
+        String rnVersion = getPackageVersion(BugsnagReactNative.class);
+
+        if (androidVersion != null) {
+            versions.putString("bugsnag-android", androidVersion);
+        }
+        if (rnVersion != null) {
+            versions.putString("bugsnag-react-native", rnVersion);
+        }
+    }
+
+    private static String getPackageVersion(Class clz) {
+        Package pkg = clz.getPackage();
+        return pkg != null ? pkg.getSpecificationVersion() : null;
     }
 
     @Override
@@ -94,6 +108,7 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
 
     @ReactMethod(isBlockingSynchronousMethod = true)
     public WritableMap getConfig() {
+        configureBugsnagAndroidVersion(Bugsnag.getClient());
         Configuration config = Bugsnag.getClient().getConfig();
         // TODO serialise as a readablemap
         return null;


### PR DESCRIPTION
Populates the bugsnag-android version in a `WriteableMap` which is accessible from JS.

Note that originally we intended to include the version for BugsnagReactNative too - however, as we don't actually version that, I have skipped that part of the implementation.