### PR TITLE
Update metadata in android layer

### DIFF
--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java
@@ -7,6 +7,7 @@ import com.bugsnag.android.Callback;
 import com.bugsnag.android.Client;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.InternalHooks;
+import com.bugsnag.android.MetaData;
 import com.bugsnag.android.Report;
 
 import android.content.Context;
@@ -104,7 +105,8 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void updateMetaData(ReadableMap update) {
-        // TODO update metadata
+        MetaData metaData = new MetaData(update.toHashMap());
+        Bugsnag.getClient().setMetaData(metaData);
     }
 
     /**


### PR DESCRIPTION
Updates the native metadata when the JS layer posts an update to the metadata. This overwrites the previously existing native metadata.