### PR TITLE
fix(plugin-inline-script-content): Ensure event handlers added before Bugsnag can be removed

### DIFF
--- a/packages/plugin-inline-script-content/test/inline-script-content.test.js
+++ b/packages/plugin-inline-script-content/test/inline-script-content.test.js
@@ -190,4 +190,45 @@ Lorem ipsum dolor sit amet.
     expect(payloads[0].events[0].stacktrace).toEqual([])
     expect(spy).toHaveBeenCalledTimes(0)
   })
+
+  it('calls removeEventListener with wrapped and unwrapped callback', () => {
+    const scriptContent = `console.log("unwrapped")`
+    const document = {
+      scripts: [ { innerHTML: scriptContent } ],
+      currentScript: { innerHTML: scriptContent },
+      documentElement: {
+        outerHTML: `<p>
+Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet.
+</p>
+<script>${scriptContent}
+</script>
+<p>more content</p>`
+      }
+    }
+    function Window () {}
+    Window.prototype = {
+      addEventListener: function () {},
+      removeEventListener: function () {}
+    }
+    const window = {
+      location: { href: 'https://app.bugsnag.com/errors' }
+    }
+
+    Object.setPrototypeOf(window, Window.prototype)
+    window.Window = Window
+
+    function myfun () {}
+    window.addEventListener('click', myfun)
+
+    const spy = spyOn(Window.prototype, 'removeEventListener')
+    const client = new Client(VALID_NOTIFIER)
+    client.setOptions({ apiKey: 'API_KEY_YEAH' })
+    client.configure()
+    client.use(plugin, document, window)
+
+    window.removeEventListener('click', myfun)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
Fixes a bug where an event handler added before Bugsnag is initialised cannot be removed.

The following snippet will continue to log clicks after the `removeEventListener` function is called:

```js
function click (e) {
  console.log('click event', e)
}
window.addEventListener('click', logClick)
var bugsnagClient = bugsnag('API_KEY')
window.removeEventListener('click', logClick)
```

With this fix it is now removed correctly.

#### Details

The inline script tracking code wraps `addEventListener()` callbacks in a function that tracks where it came from. Since `removeEventListener()` takes a reference to the function that should be removed, passing it the wrapped function means it is not the same reference as the original function that was added.

The solution is to do [as Bugsnag v3 did](https://github.com/bugsnag/bugsnag-js/blob/9cee10eca1a1bf6d66b89c31e5b42a5b186a74ad/src/bugsnag.js#L1337-L1338) and call `removeEventListener()` with both the wrapped and un-wrapped function.

##### Aside

In debugging this, I also noticed `addEventListener()` was being wrapped multiple times. It turned out that this is because all of the entries in the list of event target classes share the same object prototype upon which the original `addEventListener()` is defined. The check is updated to only wrap it if the object being inspected defines its own `addEventListener` function, rather than it being in the prototype chain.