### PR TITLE
ci: Add danger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .DS_Store
 maze_output
 *.ngsummary.json
+.size

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "12"
+before_script:
+  - mkdir .size
+  - npx lerna bootstrap --ignore @bugsnag/expo
+  - npx lerna run build --scope @bugsnag/browser
+  - cat packages/browser/dist/bugsnag.min.js | wc -c > .size/after-minified
+  - cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .size/after-gzipped
+  - git checkout $TRAVIS_BRANCH
+  - npm ci
+  - npx lerna bootstrap --ignore @bugsnag/expo
+  - npx lerna run build --scope @bugsnag/browser
+  - cat packages/browser/dist/bugsnag.min.js | wc -c > .size/before-minified
+  - cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .size/before-gzipped
+  - git checkout -
+script:
+  - npx danger ci

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,33 @@
+/* global markdown */
+
+const { readFileSync } = require('fs')
+
+const before = {
+  minified: parseInt(readFileSync(`${__dirname}/.size/before-minified`, 'utf8').trim()),
+  gzipped: parseInt(readFileSync(`${__dirname}/.size/before-gzipped`, 'utf8').trim())
+}
+
+const after = {
+  minified: parseInt(readFileSync(`${__dirname}/.size/after-minified`, 'utf8').trim()),
+  gzipped: parseInt(readFileSync(`${__dirname}/.size/after-gzipped`, 'utf8').trim())
+}
+
+const formatKbs = (n) => (n / 1000).toFixed(2)
+
+const diffMinSize = before.minified - after.minified
+const diffZipSize = before.gzipped - after.gzipped
+const showDiff = n => {
+  if (n > 0) return `⚠️ +${n} bytes ⬆️`
+  if (n < 0) return `-${n} bytes ⬇️`
+  return 'No change'
+}
+
+markdown(`
+### \`@bugsnag/browser\` bundle size diff
+
+|        | Minified                      | Minfied + Gzipped            |
+|--------|-------------------------------|------------------------------|
+| Before | ${formatKbs(before.minified)} | ${formatKbs(before.gzipped)} |
+| After  | ${formatKbs(after.minified)}  | ${formatKbs(after.gzipped)}  |
+| ±      | ${showDiff(diffMinSize)}      | ${showDiff(diffZipSize)}     |
+`)


### PR DESCRIPTION
Add Danger JS to make browser bundle size diff automatically visible on PRs.
Runs on Travis CI and comments on PRs with the diff versus the target branch.