### PR TITLE
Add tests for @bugsnag/plugin-react-native-session

### DIFF
--- a/packages/plugin-react-native-session/test/session.test.js
+++ b/packages/plugin-react-native-session/test/session.test.js
@@ -1,7 +1,32 @@
-const { describe, it, expect } = global
+const { describe, it, expect, spyOn } = global
+
+const plugin = require('../')
+const Client = require('@bugsnag/core/client')
+const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: react native session', () => {
-  it('should', () => {
-    expect(true).toBe(true)
+  it('adds missing methods and forwards calls to native client', () => {
+    const NativeClient = {
+      startSession: () => {},
+      stopSession: () => {},
+      resumeSession: () => {}
+    }
+
+    const startSpy = spyOn(NativeClient, 'startSession')
+    const stopSpy = spyOn(NativeClient, 'stopSession')
+    const resumeSpy = spyOn(NativeClient, 'resumeSession')
+
+    const c = new Client(VALID_NOTIFIER)
+    c.setOptions({ apiKey: 'api_key' })
+    c.configure()
+    c.use(plugin, NativeClient)
+    expect(typeof c.stopSession).toBe('function')
+    expect(typeof c.resumeSession).toBe('function')
+    c.startSession()
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    c.stopSession()
+    expect(stopSpy).toHaveBeenCalledTimes(1)
+    c.resumeSession()
+    expect(resumeSpy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Asserts that stop and resume methods are momkeypatched and that calls are forwarded on the native client.