### PR TITLE
feat(node): Support loading config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --scope '@bugsnag/node' --scope '@bugsnag/browser' --scope '@bugsnag/expo' && lerna run build --ignore '@bugsnag/node' --ignore '@bugsnag/browser' --ignore '@bugsnag/expo'",
     "test:lint": "standard",
-    "test:unit": "lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",
+    "test:unit": "lerna run test",
     "test:types": "lerna run test:types",
     "test:test-container-registry-login": "$(aws ecr get-login --profile=opensource --no-include-email)",
     "test:build-browser-container": "docker-compose build --pull browser-maze-runner",

--- a/packages/js/types.d.ts
+++ b/packages/js/types.d.ts
@@ -1,5 +1,6 @@
 import { Bugsnag } from '@bugsnag/browser';
 import bugsnag from '@bugsnag/browser';
 import bugsnagNode from '@bugsnag/node';
+export { loadConfig } from '@bugsnag/node';
 export { Bugsnag };
 export default bugsnag;

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "bundle-types": "../../bin/bundle-types",
+    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'",
     "build": "npm run clean && npm run build:dist && npm run bundle-types",
     "build:dist": "../../bin/bundle src/notifier.js --node --exclude=iserror,stack-generator,error-stack-parser,pump,byline --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
     "postversion": "npm run build"
@@ -36,7 +37,7 @@
     "@bugsnag/plugin-node-unhandled-rejection": "^6.3.0",
     "@bugsnag/plugin-server-session": "^6.3.0",
     "@bugsnag/plugin-strip-project-root": "^6.3.0",
-    "jasmine": "^3.1.0",
+    "jasmine": "3.1.0",
     "nyc": "^12.0.2"
   },
   "dependencies": {

--- a/packages/node/src/config-loader.js
+++ b/packages/node/src/config-loader.js
@@ -1,15 +1,16 @@
 const { readFileSync } = require('fs')
-const { join, dirname } = require('path')
+const { join, resolve, sep } = require('path')
+
+const getAllContainingPaths = (p) => {
+  const parts = p.split(sep)
+  if (parts.length < 3) return [ p ]
+  return [ p ].concat(getAllContainingPaths(parts.slice(0, -1).join(sep)))
+}
 
 const LOOKUP_PATHS = []
-  .concat(
-    // current directory of the process
-    process.cwd()
-  )
-  .concat(
-    // directory of the app's entrypoint
-    process.mainModule ? dirname(process.mainModule.filename) : []
-  )
+  .concat(process.mainModule ? process.mainModule.paths.map(p => resolve(p, '..')) : [])
+  .concat(getAllContainingPaths(process.cwd()))
+  .reduce((accum, p) => accum.includes(p) ? accum : accum.concat(p), [])
 
 const findPackageConfig = () => {
   return LOOKUP_PATHS.reduce((accum, p) => {

--- a/packages/node/src/config-loader.js
+++ b/packages/node/src/config-loader.js
@@ -10,7 +10,7 @@ const getAllContainingPaths = (p) => {
 const LOOKUP_PATHS = []
   .concat(process.mainModule ? process.mainModule.paths.map(p => resolve(p, '..')) : [])
   .concat(getAllContainingPaths(process.cwd()))
-  .reduce((accum, p) => accum.includes(p) ? accum : accum.concat(p), [])
+  .reduce((accum, p) => accum.indexOf(p) !== -1 ? accum : accum.concat(p), [])
 
 const findPackageConfig = () => {
   return LOOKUP_PATHS.reduce((accum, p) => {

--- a/packages/node/src/config-loader.js
+++ b/packages/node/src/config-loader.js
@@ -1,0 +1,31 @@
+const { readFileSync } = require('fs')
+const { join, dirname } = require('path')
+
+const LOOKUP_PATHS = []
+  .concat(
+    // current directory of the process
+    process.cwd()
+  )
+  .concat(
+    // directory of the app's entrypoint
+    process.mainModule ? dirname(process.mainModule.filename) : []
+  )
+
+const findPackageConfig = () => {
+  return LOOKUP_PATHS.reduce((accum, p) => {
+    if (accum) return accum
+    try {
+      const pkg = readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+      if (!pkg) return accum
+      const { bugsnag } = JSON.parse(pkg)
+      if (bugsnag && typeof bugsnag === 'object') return bugsnag
+      return accum
+    } catch (e) {
+      return accum
+    }
+  }, null)
+}
+
+module.exports = () => ({
+  ...findPackageConfig()
+})

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -56,4 +56,6 @@ module.exports = (opts, userPlugins = []) => {
   return bugsnag
 }
 
+module.exports.loadConfig = require('./config-loader')
+
 module.exports['default'] = module.exports

--- a/packages/node/src/test/config-loader.test.js
+++ b/packages/node/src/test/config-loader.test.js
@@ -1,0 +1,22 @@
+const { describe, it, expect } = global
+
+// const loadConfig = require('../config-loader')
+const { execSync } = require('child_process')
+
+describe('config loader', () => {
+  describe('loadConfig()', () => {
+    it('works with process cwd', () => {
+      const str = execSync(`node app.js`, { cwd: `${__dirname}/fixtures/config-loader`, encoding: 'utf8' })
+      const config = JSON.parse(str)
+      expect(config.apiKey).toBe('123')
+      expect(config.releaseStage).toBe('jim')
+    })
+
+    it('works with app entrypoint', () => {
+      const str = execSync(`node alt/entrypoint.js`, { cwd: `${__dirname}/fixtures/config-loader`, encoding: 'utf8' })
+      const config = JSON.parse(str)
+      expect(config.apiKey).toBe('123')
+      expect(config.releaseStage).toBe('jim')
+    })
+  })
+})

--- a/packages/node/src/test/fixtures/config-loader/alt/entrypoint.js
+++ b/packages/node/src/test/fixtures/config-loader/alt/entrypoint.js
@@ -1,0 +1,2 @@
+const loadConfig = require('../../../../config-loader')
+console.log(JSON.stringify(loadConfig()))

--- a/packages/node/src/test/fixtures/config-loader/app.js
+++ b/packages/node/src/test/fixtures/config-loader/app.js
@@ -1,0 +1,2 @@
+const loadConfig = require('../../../config-loader')
+console.log(JSON.stringify(loadConfig()))

--- a/packages/node/src/test/fixtures/config-loader/package.json
+++ b/packages/node/src/test/fixtures/config-loader/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "Bugsnag config loader test",
+  "version": "0.0.1",
+  "bugsnag": {
+    "apiKey": "123",
+    "releaseStage": "jim"
+  }
+}

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -36,6 +36,9 @@ declare module "@bugsnag/core" {
 // two ways to call the exported function: apiKey or config object
 declare function bugsnag(apiKeyOrOpts: string | BugsnagCore.IConfig): BugsnagCore.Client;
 
+declare function loadConfig(): { [key: string]: any };
+
 // commonjs/requirejs export
 export default bugsnag;
+export { loadConfig };
 export { BugsnagCore as Bugsnag }


### PR DESCRIPTION
This supports configuring Bugsnag via `package.json` in Node.

Any primitive values, including maps/arrays of primitive values can be configured under the `bugsnag` key in `package.json`, e.g.:

```json
{
  "name": "MyApp",
  "version": "1.2",
  "bugsnag": {
    "apiKey": "API_KEY",
    "notifyReleaseStages": [ "staging", "production" ],
    "sendCode": false
  }
}
```

It looks first in the current working directory of the running application, then in the directory of the application's entrypoint. __Question:__ should we keep looking further up file paths if we don't find one?