### PR TITLE
Buildkite: Add CI timeouts

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label:  ':docker: Build expo publisher'
+    timeout_in_minutes: 20
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -15,6 +16,7 @@ steps:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
 
   - label: ':docker: Build expo maze runner image'
+    timeout_in_minutes: 5
     plugins:
       - docker-compose#v2.6.0:
           build: expo-maze-runner
@@ -27,6 +29,7 @@ steps:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
 
   - label:  ':docker: Build expo APK builder'
+    timeout_in_minutes: 20
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -44,6 +47,7 @@ steps:
   - wait
 
   - label:  ':docker: Publish expo app'
+    timeout_in_minutes: 10
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -53,6 +57,7 @@ steps:
   - wait
 
   - label:  ':docker: Build expo APK'
+    timeout_in_minutes: 10
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
@@ -63,6 +68,7 @@ steps:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
 
   - label: ':docker: Build expo IPA'
+    timeout_in_minutes: 10
     agents:
       queue: "opensource-mac"
     env:
@@ -74,6 +80,7 @@ steps:
   - wait
 
   - label: 'expo Android 9'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -87,6 +94,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 8'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -100,6 +108,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 7'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -113,6 +122,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 6'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -126,6 +136,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 5'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -139,6 +150,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo iOS 10'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
@@ -152,6 +164,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo iOS 11'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
@@ -165,6 +178,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo iOS 12'
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: ':docker: Build CI image'
+    timeout_in_minutes: 10
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -24,24 +25,28 @@ steps:
     async: true
 
   - label: 'Lint'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: ci
     command: 'npm run test:lint'
 
   - label: 'Unit tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: ci
     command: 'npm run test:unit'
 
   - label: 'Type checks/tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: ci
     command: 'npm run test:types'
 
   - label:  ':docker: Build browser maze runner image'
+    timeout_in_minutes: 10
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -51,6 +56,7 @@ steps:
             - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
   - label:  ':docker: Build node maze runner image'
+    timeout_in_minutes: 10
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -62,6 +68,7 @@ steps:
   - wait
 
   - label: ':chrome: v43 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -72,6 +79,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':chrome: v61 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -82,6 +90,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v8 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -92,6 +101,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v9 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -102,6 +112,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v10 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -112,6 +123,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v11 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -123,6 +135,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':edge: v14 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -133,6 +146,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':edge: v15 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -143,6 +157,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':safari: v6 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -153,6 +168,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':safari: v10 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -163,6 +179,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':desktop_computer: Opera v12 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -173,6 +190,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':iphone: iOS 10.3 Browser tests'
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -183,6 +201,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':android: Samsung Galaxy S8 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -193,6 +212,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v30 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -203,6 +223,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v56 Browser tests'
+    timeout_in_minutes: 5
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -213,6 +234,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':node: Node 4'
+    timeout_in_minutes: 15
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -222,6 +244,7 @@ steps:
     command: '-e koa.feature -e koa-1x.feature -e webpack.feature'
 
   - label: ':node: Node 6'
+    timeout_in_minutes: 15
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -231,6 +254,7 @@ steps:
     command: '-e koa.feature -e koa-1x.feature'
 
   - label: ':node: Node 8'
+    timeout_in_minutes: 15
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -239,6 +263,7 @@ steps:
       NODE_VERSION: "8"
 
   - label: ':node: Node 10'
+    timeout_in_minutes: 15
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -247,6 +272,7 @@ steps:
       NODE_VERSION: "10"
 
   - label: ':node: Node 12'
+    timeout_in_minutes: 15
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner


### PR DESCRIPTION
Adds timeouts to all jobs.

Currently timeouts are estimated based on actual time taken multiplied by a factor of 2-5 depending on importance of task.