### PR TITLE
Fix representation of simple object errors (currently "[object Object]")

### DIFF
--- a/packages/core/lib/report-from-error.js
+++ b/packages/core/lib/report-from-error.js
@@ -12,6 +12,6 @@ module.exports = (maybeError, handledState) => {
     handledState,
     maybeError
   )
-  if (maybeError !== actualError) report.updateMetaData('error', 'non-error value', String(maybeError))
+  if (maybeError !== actualError) report.updateMetaData('error', 'non-error value', JSON.stringify(maybeError))
   return report
 }

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   onUncaughtException: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${(err && err.stack) ? err.stack : JSON.stringify(err)}`)
       process.exit(1)
     },
     message: 'should be a function',
@@ -38,7 +38,7 @@ module.exports = {
   },
   onUnhandledRejection: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Unhandled rejection${getContext(report)}…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Unhandled rejection${getContext(report)}…\n${(err && err.stack) ? err.stack : JSON.stringify(err)}`)
     },
     message: 'should be a function',
     validate: value => typeof value === 'function'


### PR DESCRIPTION
### Description
If a library throws a simple object as an error, it is just displayed as "[object Object]", which is not very helpful for troubleshooting. This fix changes the behavior so that errors are converted to a JSON string if they are not of type Error.    


### Example
| Location | Current behaviour | Expected behaviour |
|-----------|---------------------|----------------------------------|
| Console | ![image](https://user-images.githubusercontent.com/23224757/61782822-08f83880-ae07-11e9-883b-b17625a2514a.png) | ![image](https://user-images.githubusercontent.com/23224757/61782805-01389400-ae07-11e9-98fe-7261d70e2559.png)
| Online | ![image](https://user-images.githubusercontent.com/23224757/61782792-f8e05900-ae06-11e9-838d-b4bcca66b329.png) | ![image](https://user-images.githubusercontent.com/23224757/61782890-2d541500-ae07-11e9-83d7-302408e3b291.png)