### PR TITLE
Tests: Double timeouts and add trigger step for full expo tests

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - label:  ':docker: Build expo publisher'
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -16,7 +16,7 @@ steps:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
 
   - label: ':docker: Build expo maze runner image'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       - docker-compose#v2.6.0:
           build: expo-maze-runner
@@ -29,7 +29,7 @@ steps:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
 
   - label:  ':docker: Build expo APK builder'
-    timeout_in_minutes: 20
+    timeout_in_minutes: 40
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -47,7 +47,7 @@ steps:
   - wait
 
   - label:  ':docker: Publish expo app'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -57,7 +57,7 @@ steps:
   - wait
 
   - label:  ':docker: Build expo APK'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
@@ -68,7 +68,7 @@ steps:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
 
   - label: ':docker: Build expo IPA'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     agents:
       queue: "opensource-mac"
     env:
@@ -76,11 +76,11 @@ steps:
     artifact_paths: build/output.ipa
     commands:
       - test/expo/scripts/build-ios.sh
-
+  
   - wait
 
   - label: 'expo Android 9'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -92,9 +92,25 @@ steps:
       APP_LOCATION: "build/output.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'
+  
+  - label: 'expo iOS 12'
+    timeout_in_minutes: 50
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/output.ipa"
+      docker-compose#v2.6.0:
+        run: expo-maze-runner
+        use-aliases: true
+    env:
+      DEVICE_TYPE: "IOS_12"
+      APP_LOCATION: "build/output.ipa"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - block: "Trigger full test suite"
 
   - label: 'expo Android 8'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -108,7 +124,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 7'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -122,7 +138,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 6'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -136,7 +152,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo Android 5'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
@@ -150,7 +166,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo iOS 10'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
@@ -164,7 +180,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo iOS 11'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
@@ -173,20 +189,6 @@ steps:
         use-aliases: true
     env:
       DEVICE_TYPE: "IOS_11"
-      APP_LOCATION: "build/output.ipa"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-
-  - label: 'expo iOS 12'
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/output.ipa"
-      docker-compose#v2.6.0:
-        run: expo-maze-runner
-        use-aliases: true
-    env:
-      DEVICE_TYPE: "IOS_12"
       APP_LOCATION: "build/output.ipa"
     concurrency: 5
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - label: ':docker: Build CI image'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -25,28 +25,28 @@ steps:
     async: true
 
   - label: 'Lint'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: ci
     command: 'npm run test:lint'
 
   - label: 'Unit tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: ci
     command: 'npm run test:unit'
 
   - label: 'Type checks/tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: ci
     command: 'npm run test:types'
 
   - label:  ':docker: Build browser maze runner image'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -56,7 +56,7 @@ steps:
             - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
   - label:  ':docker: Build node maze runner image'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -68,7 +68,7 @@ steps:
   - wait
 
   - label: ':chrome: v43 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -79,7 +79,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':chrome: v61 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -90,7 +90,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v8 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -101,7 +101,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v9 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -112,7 +112,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v10 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -123,7 +123,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v11 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -135,7 +135,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':edge: v14 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -146,7 +146,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':edge: v15 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -157,7 +157,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':safari: v6 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -168,7 +168,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':safari: v10 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -179,7 +179,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':desktop_computer: Opera v12 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -190,7 +190,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':iphone: iOS 10.3 Browser tests'
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -201,7 +201,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':android: Samsung Galaxy S8 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -212,7 +212,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v30 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -223,7 +223,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v56 Browser tests'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       docker-compose#v2.6.0:
         run: browser-maze-runner
@@ -234,7 +234,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':node: Node 4'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -244,7 +244,7 @@ steps:
     command: '-e koa.feature -e koa-1x.feature -e webpack.feature'
 
   - label: ':node: Node 6'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -254,7 +254,7 @@ steps:
     command: '-e koa.feature -e koa-1x.feature'
 
   - label: ':node: Node 8'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -263,7 +263,7 @@ steps:
       NODE_VERSION: "8"
 
   - label: ':node: Node 10'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner
@@ -272,7 +272,7 @@ steps:
       NODE_VERSION: "10"
 
   - label: ':node: Node 12'
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     plugins:
       docker-compose#v2.6.0:
         run: node-maze-runner


### PR DESCRIPTION
Adds longer timeouts for tests.

Additionally adds a trigger in the Expo tests before running the full test set. 
By default the iOS 12 and Android 9 test sets will be run, with the others gated behind a user-input.