### PR TITLE
fix(plugin-inline-script-content): Tolerate errors when trying to call existing installed handler

### DIFF
--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -21,7 +21,7 @@ module.exports = {
         html = getHtml()
         DOMContentLoaded = true
       }
-      if (typeof prev === 'function') prev.apply(this, arguments)
+      try { prev.apply(this, arguments) } catch (e) {}
     }
 
     var _lastScript = null


### PR DESCRIPTION
We checked it was a function, but sometimes we get "Permission denied" if we call it, so this
change wraps the call in a try/catch instead.

Fixes #608