### PR TITLE
fix(plugin-koa): Ensure unhandled Koa errors are logged out

### DIFF
--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -33,7 +33,13 @@ module.exports = {
           ctx.bugsnag.notify(createReportFromErr(err, handledState))
         }
         if (!ctx.response.headerSent) ctx.response.status = err.status || 500
-        ctx.app.onerror(err)
+        try {
+          // this function will throw if you give it a non-error, but we still want
+          // to output that, so if it throws, pass it back what it threw (a TypeError)
+          ctx.app.onerror(err)
+        } catch (e) {
+          ctx.app.onerror(e)
+        }
       }
     }
 

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -33,6 +33,7 @@ module.exports = {
           ctx.bugsnag.notify(createReportFromErr(err, handledState))
         }
         if (!ctx.response.headerSent) ctx.response.status = err.status || 500
+        ctx.app.onerror(err)
       }
     }
 

--- a/packages/plugin-koa/test/koa.test.js
+++ b/packages/plugin-koa/test/koa.test.js
@@ -17,4 +17,22 @@ describe('plugin: koa', () => {
     expect(typeof middleware.errorHandler).toBe('function')
     expect(middleware.errorHandler.length).toBe(2)
   })
+
+  describe('requestHandler', () => {
+    it('should call through to app.onerror to ensure the error is logged out', (done) => {
+      const c = new Client(VALID_NOTIFIER)
+      c.setOptions({ apiKey: 'api_key' })
+      c.configure()
+      c.use(plugin)
+      const middleware = c.getPlugin('koa')
+      const mockCtx = {
+        req: { connection: { address: () => ({ port: 1234 }) } },
+        request: { query: {} },
+        res: {},
+        response: { headerSent: false },
+        app: { onerror: () => done() }
+      }
+      middleware.requestHandler(mockCtx)
+    })
+  })
 })


### PR DESCRIPTION
Our plugin adds an `"onerror"` handler to the Koa app, which [stops the default from being called](https://github.com/koajs/koa/blob/a245d18a131341feec4f87659746954e78cae780/lib/application.js#L129).

The default error handler which prints the error is available at `ctx.app.onerror` so by calling through to that after notifying, it exhibits the default behaviour.

Tested manually with `notifyReleaseStages` both allowing and preventing delivery and added a unit test to ensure the original handler is called.

__Output before:__

```
[bugsnag] Report not sent due to releaseStage/notifyReleaseStages configuration
```

__Output after:__

```
[bugsnag] Report not sent due to releaseStage/notifyReleaseStages configuration

  Error: Invalid DSL syntax
      at /Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/app.js:29:29
      at dispatch (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)
      at next (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)
      at /Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-router/lib/router.js:346:16
      at dispatch (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)
      at /Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-router/node_modules/koa-compose/index.js:36:12
      at dispatch (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-router/lib/router.js:351:31)
      at dispatch (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-compose/index.js:42:32)
      at requestHandler (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/dist/bugsnag-koa.js:778:15)
      at dispatch (/Users/bengourley/Development/bugsnag-js/packages/plugin-koa/scratch/node_modules/koa-compose/index.js:42:32)
```

Fixes #602