### PR TITLE
fix(plugin-inline-script-content): Ensure line numbers are correct when error is at line 1/2/3

### DIFF
--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -45,9 +45,9 @@ module.exports = {
       const htmlLines = [ '<!-- DOC START -->' ].concat(html.split('\n'))
       const zeroBasedLine = lineNumber - 1
       const start = Math.max(zeroBasedLine - 3, 0)
-      const end = Math.min(zeroBasedLine + 3, htmlLines.length - 1)
+      const end = Math.min(zeroBasedLine + 3, htmlLines.length)
       return reduce(htmlLines.slice(start, end), (accum, line, i) => {
-        accum[i + lineNumber - 3] = line.length <= MAX_LINE_LENGTH ? line : line.substr(0, MAX_LINE_LENGTH)
+        accum[start + 1 + i] = line.length <= MAX_LINE_LENGTH ? line : line.substr(0, MAX_LINE_LENGTH)
         return accum
       }, {})
     }


### PR DESCRIPTION
A bug with the logic adding the surrounding code to the stackframe meant that errors near the start of the document (line 1, 2 or 3) would result in negative-indexed surrounding code, e.g.:

```js
  code: {
    '0': '  Error.apply(this, args)',
    '-2': '<!-- DOC START -->',
    '-1': '<script>function BadThing() {'
  }
```

This change fixes the logic so that the line numbers are correct and never go below 1.