### PR TITLE
fix(plugin-koa|express|restify): Ensure clientIp and referer are properly collected

### DIFF
--- a/packages/plugin-express/src/request-info.js
+++ b/packages/plugin-express/src/request-info.js
@@ -20,9 +20,12 @@ module.exports = req => {
   request.query = extractObject(req, 'query')
   request.body = extractObject(req, 'body')
 
+  request.clientIp = req.ip || (connection ? connection.remoteAddress : undefined)
+  request.referer = req.headers.referer || req.headers.referrer
+
   if (connection) {
     request.connection = {
-      remoteAddress: connection.remoteAddress || req.ip,
+      remoteAddress: connection.remoteAddress,
       remotePort: connection.remotePort,
       bytesRead: connection.bytesRead,
       bytesWritten: connection.bytesWritten,

--- a/packages/plugin-koa/src/request-info.js
+++ b/packages/plugin-koa/src/request-info.js
@@ -12,6 +12,8 @@ module.exports = ctx => {
     headers: request.headers,
     httpVersion: request.httpVersion,
     query: ctx.request.query,
+    referer: request.headers.referer,
+    clientIp: ctx.ip,
     connection: request.connection ? {
       remoteAddress: request.connection.remoteAddress || request.ip,
       remotePort: request.connection.remotePort,

--- a/packages/plugin-koa/src/request-info.js
+++ b/packages/plugin-koa/src/request-info.js
@@ -12,10 +12,10 @@ module.exports = ctx => {
     headers: request.headers,
     httpVersion: request.httpVersion,
     query: ctx.request.query,
-    referer: request.headers.referer,
-    clientIp: ctx.ip,
+    referer: request.headers.referer || request.headers.referrer,
+    clientIp: ctx.ip || (request.connection ? request.connection.remoteAddress : undefined),
     connection: request.connection ? {
-      remoteAddress: request.connection.remoteAddress || request.ip,
+      remoteAddress: request.connection.remoteAddress,
       remotePort: request.connection.remotePort,
       bytesRead: request.connection.bytesRead,
       bytesWritten: request.connection.bytesWritten,

--- a/packages/plugin-koa/test/koa.test.js
+++ b/packages/plugin-koa/test/koa.test.js
@@ -26,7 +26,7 @@ describe('plugin: koa', () => {
       c.use(plugin)
       const middleware = c.getPlugin('koa')
       const mockCtx = {
-        req: { connection: { address: () => ({ port: 1234 }) } },
+        req: { connection: { address: () => ({ port: 1234 }) }, headers: {} },
         request: { query: {} },
         res: {},
         response: { headerSent: false },

--- a/packages/plugin-restify/src/request-info.js
+++ b/packages/plugin-restify/src/request-info.js
@@ -18,9 +18,12 @@ module.exports = req => {
   request.query = extractObject(req, 'query')
   request.body = extractObject(req, 'body')
 
+  request.clientIp = req.headers['x-forwarded-for'] || (connection ? connection.remoteAddress : undefined)
+  request.referer = req.headers.referer || req.headers.referrer
+
   if (connection) {
     request.connection = {
-      remoteAddress: connection.remoteAddress || req.ip,
+      remoteAddress: connection.remoteAddress,
       remotePort: connection.remotePort,
       bytesRead: connection.bytesRead,
       bytesWritten: connection.bytesWritten,

--- a/test/node/features/express.feature
+++ b/test/node/features/express.feature
@@ -20,6 +20,7 @@ Scenario: a synchronous thrown error in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://express/sync"
   And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: an asynchronous thrown error in a route
   Then I open the URL "http://express/async"

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -20,6 +20,7 @@ Scenario: a synchronous thrown error in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://koa/err"
   And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: an asynchronous thrown error in a route
   Then I open the URL "http://koa/async-err"

--- a/test/node/features/restify.feature
+++ b/test/node/features/restify.feature
@@ -20,6 +20,7 @@ Scenario: a synchronous thrown error in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://restify/sync"
   And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: an asynchronous thrown error in a route
   Then I open the URL "http://restify/async"


### PR DESCRIPTION
`clientIp` and `referer` were not collected from any of the web server plugins. This ensures those properties are collected and passed through to the payload.

In the end to end tests, IP is defined but varies – hence the `not null` check. The `referer` header is never set so we can't test that right now.

Fixes #615.