### PR TITLE
Fix Lerna build issues and flaky iOS browser test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -212,6 +212,7 @@ steps:
         use-aliases: true
     env:
       BROWSER: "iphone_7"
+      HOST: "bs-local.com"
     concurrency: 5
     concurrency_group: 'browserstack'
 

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:12-alpine as browser-feature-builder
+FROM node:lts-alpine as browser-feature-builder
 
 RUN apk add --update bash
 

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:12-alpine
+FROM node:lts-alpine
 
 RUN apk add --update bash
 

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:lts-alpine
 
 RUN apk add --update bash git python
 

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:12-alpine as node-feature-builder
+FROM node:lts-alpine as node-feature-builder
 
 RUN apk add --update bash
 


### PR DESCRIPTION
To avoid issues when new node versions are released this change updates our base docker images to use the `lts-alpine` tag instead of `12-alpine`.  This should give us better stability.

In addition, this adds the `bs-local.com` hostname to the iOS browser test, as there are potential issues with iOS addressing hosts connected to via the BrowserStack tunnel.

Note: Expo is currently failing due to an issue with Turtle CLI/ Jitpack