### PR TITLE
fix(plugin-angular): Ensure exported JS from Node notifier matches the shape of the .d.ts export

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.1"
+  "version": "6.4.2-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.4.2-alpha.0"
+  "version": "6.4.2-alpha.1"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/browser",
-  "version": "6.4.1",
+  "version": "6.4.2-alpha.0",
   "main": "dist/bugsnag.js",
   "types": "dist/types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for browser JavaScript",

--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -85,10 +85,8 @@ module.exports = (opts) => {
     : bugsnag
 }
 
-// Stub this value because this is what the type interface looks like
-// (types/bugsnag.d.ts). This is only an issue in Angular's development
-// mode as its TS/DI thingy attempts to use this value at runtime.
-// In most other situations, TS only uses the types at compile time.
+// Angular's DI system needs this interface to match what is exposed
+// in the type definition file (types/bugsnag.d.ts)
 module.exports.Bugsnag = {
   Client,
   Report,

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/js",
-  "version": "6.4.2-alpha.0",
+  "version": "6.4.2-alpha.1",
   "main": "node/notifier.js",
   "browser": "browser/notifier.js",
   "types": "types.d.ts",
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/browser": "^6.4.2-alpha.0",
-    "@bugsnag/node": "^6.4.2-alpha.0"
+    "@bugsnag/node": "^6.4.2-alpha.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/js",
-  "version": "6.4.1",
+  "version": "6.4.2-alpha.0",
   "main": "node/notifier.js",
   "browser": "browser/notifier.js",
   "types": "types.d.ts",
@@ -33,8 +33,8 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/browser": "^6.4.1",
-    "@bugsnag/node": "^6.4.1"
+    "@bugsnag/browser": "^6.4.2-alpha.0",
+    "@bugsnag/node": "^6.4.2-alpha.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/node",
-  "version": "6.4.2-alpha.0",
+  "version": "6.4.2-alpha.1",
   "main": "dist/bugsnag.js",
   "types": "dist/types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for Node.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/node",
-  "version": "6.4.1",
+  "version": "6.4.2-alpha.0",
   "main": "dist/bugsnag.js",
   "types": "dist/types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for Node.js",

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -3,6 +3,9 @@ const version = '__VERSION__'
 const url = 'https://github.com/bugsnag/bugsnag-js'
 
 const Client = require('@bugsnag/core/client')
+const Report = require('@bugsnag/core/report')
+const Session = require('@bugsnag/core/session')
+const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
 const delivery = require('@bugsnag/delivery-node')
 

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -56,4 +56,14 @@ module.exports = (opts, userPlugins = []) => {
   return bugsnag
 }
 
+// Angular's DI system needs this interface to match what is exposed
+// in the type definition file (types/bugsnag.d.ts)
+module.exports.Bugsnag = {
+  Client,
+  Report,
+  Session,
+  Breadcrumb
+}
+
+// Export a "default" property for compatibility with ESM imports
 module.exports['default'] = module.exports

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/plugin-angular",
-  "version": "6.4.2-alpha.0",
+  "version": "6.4.2-alpha.1",
   "description": "Angular integration for bugsnag-js",
   "main": "dist/es5/index.js",
   "browser": "dist/es5/index.js",
@@ -36,7 +36,7 @@
     "@angular/compiler": "^7.2.15",
     "@angular/compiler-cli": "^7.2.15",
     "@angular/core": "^7.2.15",
-    "@bugsnag/js": "^6.4.2-alpha.0",
+    "@bugsnag/js": "^6.4.2-alpha.1",
     "rxjs": "^5.5.8",
     "tslint": "^5.9.1",
     "typescript": "^3.2.4",

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/plugin-angular",
-  "version": "6.4.1",
+  "version": "6.4.2-alpha.0",
   "description": "Angular integration for bugsnag-js",
   "main": "dist/es5/index.js",
   "browser": "dist/es5/index.js",
@@ -36,7 +36,7 @@
     "@angular/compiler": "^7.2.15",
     "@angular/compiler-cli": "^7.2.15",
     "@angular/core": "^7.2.15",
-    "@bugsnag/js": "^6.4.1",
+    "@bugsnag/js": "^6.4.2-alpha.0",
     "rxjs": "^5.5.8",
     "tslint": "^5.9.1",
     "typescript": "^3.2.4",


### PR DESCRIPTION
Angular uses this type information at runtime for DI. The browser notifier had it, but the node
notifier was missing it, so this wasn't working when trying to do SSR with Angular.

Updated the comment in the browser notifier to be more clear.

Fixes #604.