### PR TITLE
Fix angular build with correct resolving referenced modules

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
+  "browser": {
+    "dist/types/bugsnag": "./dist/bugsnag.js"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -18,7 +21,7 @@
   "scripts": {
     "size": "./bin/size",
     "clean": "rm -fr dist && mkdir dist",
-    "bundle-types": "../../bin/bundle-types && touch dist/types/bugsnag.ts",
+    "bundle-types": "../../bin/bundle-types",
     "build": "npm run clean && npm run build:dist && npm run build:dist:min && npm run bundle-types",
     "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
     "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=bugsnag | ../../bin/minify dist/bugsnag.min.js",


### PR DESCRIPTION
Instead of creating stub file provide valid browser alias.
Initial issue https://github.com/bugsnag/bugsnag-js/issues/523
Updated issue https://github.com/bugsnag/bugsnag-js/issues/631
