### PR TITLE
Tests: Update CI to make iOS build less flakey

### DIFF
--- a/test/expo/scripts/build-android-locally.sh
+++ b/test/expo/scripts/build-android-locally.sh
@@ -1,6 +1,8 @@
 set -e
 
 export EXPO_RELEASE_CHANNEL=local
-docker-compose up --build expo-publisher
-docker-compose up --build expo-android-builder
+docker-compose build expo-publisher
+docker-compose run expo-publisher
+docker-compose build expo-android-builder
+docker-compose run expo-android-builder
 docker-compose build expo-maze-runner

--- a/test/expo/scripts/build-ios-locally.sh
+++ b/test/expo/scripts/build-ios-locally.sh
@@ -2,10 +2,11 @@
 
 set -e
 
-docker-compose up --build expo-publisher
+docker-compose build expo-publisher
+docker-compose run expo-publisher
 
 cd test/expo/features/fixtures/test-app && \
-npm i turtle-cli bunyan --no-save --no-package-lock && \
+npm i turtle-cli@0.11.1 bunyan --no-save --no-package-lock && \
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/xdl/build/detach/IosNSBundle.js && \
 node_modules/.bin/turtle build:ios \
   -c test/expo/features/fixtures/test-app/app.json \

--- a/test/expo/scripts/build-ios.sh
+++ b/test/expo/scripts/build-ios.sh
@@ -5,7 +5,7 @@ set -e
 # Lets make sure the build folder was cleared out correctly
 rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH/build/*
 cd test/expo/features/fixtures/test-app
-npm i turtle-cli bunyan
+npm i turtle-cli@0.11.1 bunyan
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/xdl/build/detach/IosNSBundle.js
 node_modules/.bin/turtle build:ios \
   -c ./app.json \


### PR DESCRIPTION
- Fixes Turtle-ci version against 0.11.1 - A known to be working version
- Separates out run and build docker steps in local build scripts to ensure fast failures when publishing and building the test fixture