### PR TITLE
Load config from package manifests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --scope '@bugsnag/node' --scope '@bugsnag/browser' --scope '@bugsnag/expo' && lerna run build --ignore '@bugsnag/node' --ignore '@bugsnag/browser' --ignore '@bugsnag/expo'",
     "test:lint": "eslint . && eslint --no-eslintrc -c .eslintrc.ts.js --ext .ts .",
-    "test:unit": "lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",
+    "test:unit": "lerna run test",
     "test:types": "lerna run test:types",
     "test:test-container-registry-login": "$(aws ecr get-login --profile=opensource --no-include-email)",
     "test:build-browser-container": "docker-compose up --build minimal-packager && docker-compose build --pull browser-maze-runner",

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -61,3 +61,7 @@ export type NotifiableError = Error
   | any;
 
 export { BugsnagStatic }
+
+export interface Configuration {
+  load: () => object;
+}

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -31,23 +31,20 @@ const plugins = [
 
 const bugsnagReact = require('@bugsnag/plugin-react')
 
-module.exports.default = module.exports
+const Configuration = {
+  load: () => {
+    if (Constants.manifest && Constants.manifest.extra) {
+      return { ...Constants.manifest.extra.bugsnag }
+    }
+  }
+}
 
 const Bugsnag = {
   _client: null,
   createClient: (opts) => {
     // handle very simple use case where user supplies just the api key as a string
     if (typeof opts === 'string') opts = { apiKey: opts }
-    if (!opts) opts = {}
-
-    // attempt to fetch apiKey from app.json if we didn't get one explicitly passed
-    if (!opts.apiKey &&
-      Constants.manifest &&
-      Constants.manifest.extra &&
-      Constants.manifest.extra.bugsnag &&
-      Constants.manifest.extra.bugsnag.apiKey) {
-      opts.apiKey = Constants.manifest.extra.bugsnag.apiKey
-    }
+    if (!opts) opts = Configuration.load()
 
     const bugsnag = new Client(opts, schema, { name, version, url })
 
@@ -99,6 +96,8 @@ module.exports.Client = Client
 module.exports.Event = Event
 module.exports.Session = Session
 module.exports.Breadcrumb = Breadcrumb
+
+module.exports.Configuration = Configuration
 
 // Export a "default" property for compatibility with ESM imports
 module.exports.default = Bugsnag

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -1,6 +1,7 @@
 import { Client, Breadcrumb, Event, Session, AbstractTypes } from "@bugsnag/core";
 
 declare const Bugsnag: AbstractTypes.BugsnagStatic;
+declare const Configuration: AbstractTypes.Configuration;
 
 export default Bugsnag;
-export { Client, Breadcrumb, Event, Session, AbstractTypes };
+export { Client, Breadcrumb, Event, Session, AbstractTypes, Configuration };

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,7 +20,8 @@
     "bundle-types": "../../bin/bundle-types",
     "build": "npm run clean && npm run build:dist && npm run bundle-types",
     "build:dist": "../../bin/bundle src/notifier.js --node --exclude=iserror,stack-generator,error-stack-parser,pump,byline --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
-    "postversion": "npm run build"
+    "postversion": "npm run build",
+    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/node/src/config-loader.js
+++ b/packages/node/src/config-loader.js
@@ -1,0 +1,28 @@
+const { readFileSync } = require('fs')
+const { join, resolve, sep } = require('path')
+
+const getAllContainingPaths = (p) => {
+  const parts = p.split(sep)
+  if (parts.length < 3) return [p]
+  return [p].concat(getAllContainingPaths(parts.slice(0, -1).join(sep)))
+}
+
+const LOOKUP_PATHS = []
+  .concat(process.mainModule ? process.mainModule.paths.map(p => resolve(p, '..')) : [])
+  .concat(getAllContainingPaths(process.cwd()))
+  .reduce((accum, p) => accum.indexOf(p) !== -1 ? accum : accum.concat(p), [])
+
+const findPackageConfig = () => {
+  return LOOKUP_PATHS.reduce((accum, p) => {
+    if (accum) return accum
+    const pkg = readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    if (!pkg) return accum
+    const { bugsnag } = JSON.parse(pkg)
+    if (bugsnag && typeof bugsnag === 'object') return bugsnag
+    return accum
+  }, null)
+}
+
+module.exports = () => ({
+  ...findPackageConfig()
+})

--- a/packages/node/src/test/config-loader.test.js
+++ b/packages/node/src/test/config-loader.test.js
@@ -1,0 +1,22 @@
+const { describe, it, expect } = global
+
+// const loadConfig = require('../config-loader')
+const { execSync } = require('child_process')
+
+describe('config loader', () => {
+  describe('loadConfig()', () => {
+    it('works with process cwd', () => {
+      const str = execSync('node app.js', { cwd: `${__dirname}/fixtures/config-loader`, encoding: 'utf8' })
+      const config = JSON.parse(str)
+      expect(config.apiKey).toBe('123')
+      expect(config.releaseStage).toBe('jim')
+    })
+
+    it('works with app entrypoint', () => {
+      const str = execSync('node alt/entrypoint.js', { cwd: `${__dirname}/fixtures/config-loader`, encoding: 'utf8' })
+      const config = JSON.parse(str)
+      expect(config.apiKey).toBe('123')
+      expect(config.releaseStage).toBe('jim')
+    })
+  })
+})

--- a/packages/node/src/test/fixtures/config-loader/alt/entrypoint.js
+++ b/packages/node/src/test/fixtures/config-loader/alt/entrypoint.js
@@ -1,0 +1,2 @@
+const loadConfig = require('../../../../config-loader')
+console.log(JSON.stringify(loadConfig()))

--- a/packages/node/src/test/fixtures/config-loader/app.js
+++ b/packages/node/src/test/fixtures/config-loader/app.js
@@ -1,0 +1,2 @@
+const loadConfig = require('../../../config-loader')
+console.log(JSON.stringify(loadConfig()))

--- a/packages/node/src/test/fixtures/config-loader/package.json
+++ b/packages/node/src/test/fixtures/config-loader/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "Bugsnag config loader test",
+  "version": "0.0.1",
+  "bugsnag": {
+    "apiKey": "123",
+    "releaseStage": "jim"
+  }
+}

--- a/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
-import { endpoints } from './bugsnag'
+import { buildConfiguration } from './bugsnag'
 import Bugsnag from '@bugsnag/expo'
 
 export default class AppStateBreadcrumbs extends Component {
@@ -13,55 +13,47 @@ export default class AppStateBreadcrumbs extends Component {
   }
 
   defaultAppStateBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
     this.setState(() => (
       {
-        client: Bugsnag.createClient({
-          endpoints: endpoints,
-          autoDetectErrors: false,
-          autoTrackSessions: false
-        }),
+        client: Bugsnag.createClient(config),
         errorMessage: "defaultAppStateBreadcrumbsBehaviour"
       }
     ))
   }
 
   disabledAppStateBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = []
     this.setState(() => (
       {
-        client: Bugsnag.createClient({
-          endpoints: endpoints,
-          autoDetectErrors: false,
-          autoTrackSessions: false,
-          enabledBreadcrumbTypes: []
-        }),
+        client: Bugsnag.createClient(config),
         errorMessage: "disabledAppStateBreadcrumbsBehaviour"
       }
     ))
   }
 
   disabledAllAppStateBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = []
     this.setState(() => (
       {
-        client: Bugsnag.createClient({
-          endpoints: endpoints,
-          autoDetectErrors: false,
-          autoTrackSessions: false,
-          enabledBreadcrumbTypes: []
-        }),
+        client: Bugsnag.createClient(config),
         errorMessage: "disabledAllAppStateBreadcrumbsBehaviour"
       }
     ))
   }
 
   overrideAppStateBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = ['state']
     this.setState(() => (
       {
-        client: Bugsnag.createClient({
-          endpoints: endpoints,
-          autoDetectErrors: false,
-          autoTrackSessions: false,
-          enabledBreadcrumbTypes: ['state']
-        }),
+        client: Bugsnag.createClient(config),
         errorMessage: "overrideAppStateBreadcrumbsBehaviour"
       }
     ))

--- a/test/expo/features/fixtures/test-app/app/bugsnag.js
+++ b/test/expo/features/fixtures/test-app/app/bugsnag.js
@@ -1,16 +1,21 @@
-import Bugsnag from '@bugsnag/expo'
+import Bugsnag, { Configuration } from '@bugsnag/expo'
 
 const endpoints = {
   notify: 'http://bs-local.com:9339',
   sessions: 'http://bs-local.com:9339'
 }
 
-const bugsnagClient = Bugsnag.createClient({
-  endpoints: endpoints,
-  autoTrackSessions: false
-})
+function buildConfiguration() {
+  var config = Configuration.load()
+  config.endpoints = endpoints
+  config.autoTrackSessions = false
+  return config
+}
+
+const bugsnagClient = Bugsnag.createClient(buildConfiguration())
 
 export {
   endpoints,
-  bugsnagClient
+  bugsnagClient,
+  buildConfiguration
 }

--- a/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
@@ -1,52 +1,44 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
-import { endpoints } from './bugsnag'
+import { buildConfiguration } from './bugsnag'
 import Bugsnag from '@bugsnag/expo'
 
 export default class ConsoleBreadcrumbs extends Component {
   defaultConsoleBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
     this.triggerConsoleBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false
-      }),
+      Bugsnag.createClient(config),
       "defaultConsoleBreadcrumbsBehaviour"
     )
   }
 
   disabledConsoleBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = []
     this.triggerConsoleBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false,
-        enabledBreadcrumbTypes: []
-      }),
+      Bugsnag.createClient(config),
       "disabledConsoleBreadcrumbsBehaviour"
     )
   }
 
   disabledAllConsoleBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = null
     this.triggerConsoleBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false,
-        enabledBreadcrumbTypes: null
-      }),
+      Bugsnag.createClient(config),
       "disabledAllConsoleBreadcrumbsBehaviour"
     )
   }
 
   overrideConsoleBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = ['log']
     this.triggerConsoleBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false,
-        enabledBreadcrumbTypes: ["log"]
-      }),
+      Bugsnag.createClient(config),
       "overrideConsoleBreadcrumbsBehaviour"
     )
   }

--- a/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
-import { endpoints } from './bugsnag'
+import { buildConfiguration } from './bugsnag'
 import Bugsnag from '@bugsnag/expo'
 
 export default class NetworkBreadcrumbs extends Component {
@@ -13,49 +13,40 @@ export default class NetworkBreadcrumbs extends Component {
   }
 
   defaultNetworkBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
     this.triggerNetworkBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false
-      }),
+      Bugsnag.createClient(config),
       "defaultNetworkBreadcrumbsBehaviour"
     )
   }
 
   disabledNetworkBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = []
     this.triggerNetworkBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false,
-        enabledBreadcrumbTypes: []
-      }),
+      Bugsnag.createClient(config),
       "disabledNetworkBreadcrumbsBehaviour"
     )
   }
 
   disabledAllNetworkBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = null
     this.triggerNetworkBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false,
-        enabledBreadcrumbTypes: null
-      }),
+      Bugsnag.createClient(config),
       "disabledAllNetworkBreadcrumbsBehaviour"
     )
   }
 
   overrideNetworkBreadcrumbsBehaviour = () => {
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.enabledBreadcrumbTypes = ["request"]
     this.triggerNetworkBreadcrumbsError(
-      Bugsnag.createClient({
-        endpoints: endpoints,
-        autoDetectErrors: false,
-        autoTrackSessions: false,
-        autoBreadcrumbs: false,
-        enabledBreadcrumbTypes: ["request"]
-      }),
+      Bugsnag.createClient(config),
       "overrideNetworkBreadcrumbsBehaviour"
     )
   }

--- a/test/expo/features/fixtures/test-app/app/sessions.js
+++ b/test/expo/features/fixtures/test-app/app/sessions.js
@@ -1,15 +1,14 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
-import { endpoints, bugsnagClient } from './bugsnag'
+import { bugsnagClient, buildConfiguration } from './bugsnag'
 import Bugsnag from '@bugsnag/expo'
 
 export default class Sessions extends Component {
   autoSession = () => {
-    Bugsnag.createClient({
-      endpoints: endpoints,
-      autoDetectErrors: false,
-      autoTrackSessions: true
-    })
+    let config = buildConfiguration()
+    config.autoDetectErrors = false
+    config.autoTrackSessions = true
+    Bugsnag.createClient(config)
   }
 
   manualSession = () => {

--- a/test/node/features/config_file.feature
+++ b/test/node/features/config_file.feature
@@ -1,0 +1,19 @@
+Feature: Loading config from a file
+
+Background:
+  Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+  And I store the endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
+  And I store the endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+
+Scenario: loading config from package.json
+  And I run the service "config-file" with the command "node scenarios/app"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "app.releaseStage" equals "staging"
+  And the event "app.type" equals "worker"
+  And the event "app.version" equals "1.0.0"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "nope"
+  And the exception "type" equals "nodejs"
+  And the event "metaData.serviceCredentials.host" equals "authentication.xyz"
+  And the event "metaData.serviceCredentials.accessToken" equals "[REDACTED]"

--- a/test/node/features/fixtures/config-file/Dockerfile
+++ b/test/node/features/fixtures/config-file/Dockerfile
@@ -1,0 +1,11 @@
+ARG NODE_VERSION=8
+FROM node:$NODE_VERSION-alpine
+
+WORKDIR /app
+
+COPY package* ./
+RUN npm install
+
+COPY . ./
+
+RUN npm install --no-package-lock --no-save bugsnag-node*.tgz

--- a/test/node/features/fixtures/config-file/package-lock.json
+++ b/test/node/features/fixtures/config-file/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "bugsnag-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/test/node/features/fixtures/config-file/package.json
+++ b/test/node/features/fixtures/config-file/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bugsnag-test",
+  "bugsnag": {
+    "enabledReleaseStages": ["production", "staging"],
+    "appType": "worker",
+    "appVersion": "1.0.0",
+    "maxBreadcrumbs": 5,
+    "redactedKeys": ["accessToken"],
+    "metadata": {
+      "serviceCredentials": {
+        "host": "authentication.xyz",
+        "accessToken": "c2VjcmV0IGtleQo="
+      }
+    }
+  }
+}

--- a/test/node/features/fixtures/config-file/scenarios/app.js
+++ b/test/node/features/fixtures/config-file/scenarios/app.js
@@ -1,0 +1,13 @@
+var fs = require('fs')
+var Bugsnag = require('@bugsnag/node')
+
+var conf = Bugsnag.Configuration.load()
+conf.apiKey = process.env.BUGSNAG_API_KEY,
+conf.endpoints = {
+  notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+  sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+}
+conf.releaseStage = 'staging'
+
+Bugsnag.init(conf)
+Bugsnag.notify(new Error('nope'))

--- a/test/node/features/fixtures/docker-compose.yml
+++ b/test/node/features/fixtures/docker-compose.yml
@@ -193,6 +193,21 @@ services:
       - BUGSNAG_SESSIONS_ENDPOINT
     restart: "no"
 
+  config-file:
+    build:
+      context: config-file
+      args:
+        - NODE_VERSION
+    networks:
+      default:
+        aliases:
+          - config-file
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_SESSIONS_ENDPOINT
+    restart: "no"
+
 networks:
   default:
     name: ${NETWORK_NAME:-js-maze-runner}


### PR DESCRIPTION
- on Node this loads config from the `bugsnag` key in `package.json`
- on Expo this loads config from the `extra.bugsnag` key in `app.json`

If an error happens when the config is loaded on Node the following kind of message is output:

```
Error: Could not load Bugsnag configuration from package.json due to the following error:
 │
 └  Error: ENOENT: no such file or directory, open '/Users/bengourley/Development/bugsnag-js/packages/node/scratch/config-loading/package.json'
      at Object.openSync (fs.js:447:3)
      at readFileSync (fs.js:349:35)
      at /Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:1623:15
      at Array.reduce (<anonymous>)
      at findPackageConfig (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:1621:23)
      at _$configLoader_27 (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:1635:28)
      at Object.load (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:2531:14)
      at Object.createClient (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:2544:37)
      at Object.init (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:2574:31)
      at Object.<anonymous> (/Users/bengourley/Development/bugsnag-js/packages/node/scratch/config-loading/app.js:3:9)

    at Object.load (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:2533:13)
    at Object.createClient (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:2544:37)
    at Object.init (/Users/bengourley/Development/bugsnag-js/packages/node/dist/bugsnag.js:2574:31)
    at Object.<anonymous> (/Users/bengourley/Development/bugsnag-js/packages/node/scratch/config-loading/app.js:3:9)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11
```