### PR TITLE
Update expected value in Samsung S8 browser tests

### DIFF
--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -257,7 +257,7 @@ android_s8:
     errorMessage: 'foo is not defined'
   unhandled_syntax:
     errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token !"
+    errorMessage: "Unexpected token '!'"
     lineNumber: 17
     columnNumber: 13
     file: '/unhandled/script/a.html'


### PR DESCRIPTION
The default browser on the S8 device we use on BrowserStack has changed and this value in the list of expected results was no longer correct.

It caused failures like [this](https://buildkite.com/bugsnag/at-bugsnag-js/builds/1000#56f40a0a-3263-447b-a2b2-4c09de4da314/94-384).

@Cawllec looked in to seeing if we could pin the browser to what was previously being used but nothing was forthcoming so we decided the best thing to do was just update the expected value.