### PR TITLE
V7: Rename autoCaptureSessions -> autoTrackSessions and simplify validation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
 - Migrate lint tooling to ESLint for both .js and .ts source files [#644](https://github.com/bugsnag/bugsnag-js/pull/644)
+- Rename `autoCaptureSessions` -> `autoTrackSessions` and simplify validation logic [#647](https://github.com/bugsnag/bugsnag-js/pull/647)
 
 ## 6.4.3 (2019-10-21)
 

--- a/examples/browser-cdn/app.js
+++ b/examples/browser-cdn/app.js
@@ -23,8 +23,8 @@ var bugsnagClient = bugsnag({
   appVersion: '1.2.3',
 
   // Bugsnag can track the number of “sessions” that happen in your application,
-  // and calculate a crash rate for each release. This defaults to false.
-  autoCaptureSessions: true,
+  // and calculate a crash rate for each release. This defaults to true.
+  autoTrackSessions: true,
 
   // defines the release stage for all events that occur in this app.
   releaseStage: 'development',

--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -80,7 +80,7 @@ module.exports = (opts) => {
 
   bugsnag._logger.debug('Loaded!')
 
-  return bugsnag.config.autoCaptureSessions
+  return bugsnag.config.autoTrackSessions
     ? bugsnag.startSession()
     : bugsnag
 }

--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -10,7 +10,7 @@ declare module "@bugsnag/core" {
     appVersion?: string;
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
-    autoCaptureSessions?: boolean;
+    autoTrackSessions?: boolean;
     notifyReleaseStages?: string[];
     releaseStage?: string;
     maxBreadcrumbs?: number;

--- a/packages/browser/types/test/fixtures/all-options.ts
+++ b/packages/browser/types/test/fixtures/all-options.ts
@@ -6,7 +6,7 @@ bugsnag({
   autoNotify: true,
   beforeSend: [],
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
-  autoCaptureSessions: true,
+  autoTrackSessions: true,
   notifyReleaseStages: [],
   releaseStage: "production",
   maxBreadcrumbs: 20,

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -32,21 +32,19 @@ module.exports.schema = {
       notify: 'https://notify.bugsnag.com',
       sessions: 'https://sessions.bugsnag.com'
     }),
-    message: 'should be an object containing endpoint URLs { notify, sessions }. sessions is optional if autoCaptureSessions=false',
-    validate: (val, obj) =>
+    message: 'should be an object containing endpoint URLs { notify, sessions }',
+    validate: val =>
       // first, ensure it's an object
       (val && typeof val === 'object') &&
       (
-        // endpoints.notify must always be set
-        stringWithLength(val.notify) &&
-        // endpoints.sessions must be set unless session tracking is explicitly off
-        (obj.autoCaptureSessions === false || stringWithLength(val.sessions))
+        // notify and sessions must always be set
+        stringWithLength(val.notify) && stringWithLength(val.sessions)
       ) &&
       // ensure no keys other than notify/session are set on endpoints object
       filter(keys(val), k => !includes(['notify', 'sessions'], k)).length === 0
   },
-  autoCaptureSessions: {
-    defaultValue: (val, opts) => opts.endpoints === undefined || (!!opts.endpoints && !!opts.endpoints.sessions),
+  autoTrackSessions: {
+    defaultValue: val => true,
     message: 'should be true|false',
     validate: val => val === true || val === false
   },

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -8,8 +8,8 @@ export interface Config {
   autoNotify?: boolean;
   appVersion?: string;
   appType?: string;
-  endpoints?: { notify: string; sessions?: string };
-  autoCaptureSessions?: boolean;
+  endpoints?: { notify: string; sessions: string };
+  autoTrackSessions?: boolean;
   notifyReleaseStages?: string[];
   releaseStage?: string;
   maxBreadcrumbs?: number;

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -66,7 +66,7 @@ module.exports = (opts) => {
 
   bugsnag._logger.debug('Loaded!')
 
-  return bugsnag.config.autoCaptureSessions
+  return bugsnag.config.autoTrackSessions
     ? bugsnag.startSession()
     : bugsnag
 }

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -10,7 +10,7 @@ declare module "@bugsnag/core" {
     appVersion?: string;
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
-    autoCaptureSessions?: boolean;
+    autoTrackSessions?: boolean;
     notifyReleaseStages?: string[];
     releaseStage?: string;
     maxBreadcrumbs?: number;

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -6,7 +6,7 @@ bugsnag({
   autoNotify: true,
   beforeSend: [],
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
-  autoCaptureSessions: true,
+  autoTrackSessions: true,
   notifyReleaseStages: [],
   releaseStage: "production",
   maxBreadcrumbs: 20,

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -12,7 +12,7 @@ declare module "@bugsnag/core" {
     appVersion?: string;
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
-    autoCaptureSessions?: boolean;
+    autoTrackSessions?: boolean;
     notifyReleaseStages?: string[];
     releaseStage?: string;
     maxBreadcrumbs?: number;

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -18,11 +18,6 @@ const sessionDelegate = {
       return sessionClient
     }
 
-    if (!sessionClient.config.endpoints.sessions) {
-      sessionClient._logger.warn('Session not sent due to missing endpoints.sessions configuration')
-      return sessionClient
-    }
-
     sessionClient._delivery.sendSession({
       notifier: sessionClient.notifier,
       device: sessionClient.device,

--- a/packages/plugin-browser-session/test/session.test.js
+++ b/packages/plugin-browser-session/test/session.test.js
@@ -84,27 +84,16 @@ describe('plugin: sessions', () => {
     setTimeout(done, 150)
   })
 
-  it('logs a warning when no session endpoint is set', (done) => {
+  it('rejects config when session endpoint is not set', () => {
     const c = new Client(VALID_NOTIFIER)
     c.setOptions({
       apiKey: 'API_KEY',
       releaseStage: 'foo',
       endpoints: { notify: '/foo' },
-      autoCaptureSessions: false
+      autoTrackSessions: false
     })
-    c.configure()
-    c.use(plugin)
-    c.logger({
-      warn: msg => {
-        expect(msg).toMatch(/session not sent/i)
-        done()
-      }
-    })
-    c.delivery(client => ({
-      sendSession: (session, cb) => {
-        expect(true).toBe(false)
-      }
-    }))
-    c.startSession()
+    expect(() => c.configure()).toThrowError(
+      /"endpoints" should be an object containing endpoint URLs { notify, sessions }/
+    )
   })
 })

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -20,7 +20,7 @@ module.exports = {
 
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoCaptureSessions ? client.startSession() : clone(client)
+      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
 
       // attach it to the request
       req.bugsnag = requestClient

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -17,7 +17,7 @@ module.exports = {
     const requestHandler = async (ctx, next) => {
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoCaptureSessions ? client.startSession() : clone(client)
+      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
 
       ctx.bugsnag = requestClient
 
@@ -46,7 +46,7 @@ module.exports = {
     requestHandler.v1 = function * (next) {
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoCaptureSessions ? client.startSession() : clone(client)
+      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
 
       this.bugsnag = requestClient
 

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -70,7 +70,7 @@ const wrapHistoryFn = (client, target, fn, win) => {
     // if throttle plugin is in use, refresh the event sent count
     if (typeof client.refresh === 'function') client.refresh()
     // if the client is operating in auto session-mode, a new route should trigger a new session
-    if (client.config.autoCaptureSessions) client.startSession()
+    if (client.config.autoTrackSessions) client.startSession()
     // Internet Explorer will convert `undefined` to a string when passed, causing an unintended redirect
     // to '/undefined'. therefore we only pass the url if it's not undefined.
     orig.apply(target, [state, title].concat(url !== undefined ? url : []))

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -47,7 +47,7 @@ describe('plugin: navigation breadcrumbs', () => {
     expect(c.breadcrumbs.length).toBe(0)
   })
 
-  it('should start a new session if autoCaptureSessions=true', (done) => {
+  it('should start a new session if autoTrackSessions=true', (done) => {
     const c = new Client(VALID_NOTIFIER)
     c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.configure()
@@ -63,9 +63,9 @@ describe('plugin: navigation breadcrumbs', () => {
     window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
   })
 
-  it('should not a new session if autoCaptureSessions=false', (done) => {
+  it('should not a new session if autoTrackSessions=false', (done) => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoCaptureSessions: false })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoTrackSessions: false })
     c.configure()
     c.sessionDelegate({
       startSession: client => {

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -19,7 +19,7 @@ module.exports = {
 
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoCaptureSessions ? client.startSession() : clone(client)
+      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
 
       // attach it to the request
       req.bugsnag = requestClient

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -37,11 +37,6 @@ const sendSessionSummary = client => sessionCounts => {
     return
   }
 
-  if (!client.config.endpoints.sessions) {
-    client._logger.warn('Session not sent due to missing endpoints.sessions configuration')
-    return
-  }
-
   if (!sessionCounts.length) return
 
   const backoff = new Backoff({ min: 1000, max: 10000 })

--- a/test/browser/features/fixtures/auto_notify/script/a.html
+++ b/test/browser/features/fixtures/auto_notify/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         autoNotify: false
       })
     </script>

--- a/test/browser/features/fixtures/before_send/script/a.html
+++ b/test/browser/features/fixtures/before_send/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         beforeSend: function (report) {
           report.updateMetaData('before_send', 'global', 'works')
         }

--- a/test/browser/features/fixtures/before_send/script/b.html
+++ b/test/browser/features/fixtures/before_send/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         beforeSend: function (report) {
           return false
         }

--- a/test/browser/features/fixtures/before_send/script/c.html
+++ b/test/browser/features/fixtures/before_send/script/c.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         beforeSend: function (report) {
           report.ignore()
         }

--- a/test/browser/features/fixtures/before_send/script/d.html
+++ b/test/browser/features/fixtures/before_send/script/d.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/before_send/script/e.html
+++ b/test/browser/features/fixtures/before_send/script/e.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/before_send/script/f.html
+++ b/test/browser/features/fixtures/before_send/script/f.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/filters/script/a.html
+++ b/test/browser/features/fixtures/filters/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/filters/script/b.html
+++ b/test/browser/features/fixtures/filters/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         filters: [ 'api_key', 'secret' ]
       })
     </script>

--- a/test/browser/features/fixtures/filters/script/c.html
+++ b/test/browser/features/fixtures/filters/script/c.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         filters: [ 'stacktrace', 'secret' ]
       })
     </script>

--- a/test/browser/features/fixtures/filters/script/d.html
+++ b/test/browser/features/fixtures/filters/script/d.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         filters: [ /details\d/ ]
       })
     </script>

--- a/test/browser/features/fixtures/handled/browserify/src/lib/config.js
+++ b/test/browser/features/fixtures/handled/browserify/src/lib/config.js
@@ -3,4 +3,4 @@ var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
 exports.apiKey = API_KEY
-exports.endpoints = { notify: ENDPOINT }
+exports.endpoints = { notify: ENDPOINT, sessions: '/noop' }

--- a/test/browser/features/fixtures/handled/rollup/src/lib/config.js
+++ b/test/browser/features/fixtures/handled/rollup/src/lib/config.js
@@ -3,4 +3,4 @@ var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
 exports.apiKey = API_KEY
-exports.endpoints = { notify: ENDPOINT }
+exports.endpoints = { notify: ENDPOINT, sessions: '/noop' }

--- a/test/browser/features/fixtures/handled/script/a.html
+++ b/test/browser/features/fixtures/handled/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/handled/script/b.html
+++ b/test/browser/features/fixtures/handled/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/handled/script/c.html
+++ b/test/browser/features/fixtures/handled/script/c.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/handled/script/d.html
+++ b/test/browser/features/fixtures/handled/script/d.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/handled/script/e.html
+++ b/test/browser/features/fixtures/handled/script/e.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/handled/typescript/src/lib/config.ts
+++ b/test/browser/features/fixtures/handled/typescript/src/lib/config.ts
@@ -1,4 +1,4 @@
 var ENDPOINT = decodeURIComponent((<Array<string>>window.location.search.match(/ENDPOINT=([^&]+)/))[1])
 var API_KEY = decodeURIComponent((<Array<string>>window.location.search.match(/API_KEY=([^&]+)/))[1])
-const config = { endpoints: { notify: ENDPOINT }, apiKey: API_KEY }
+const config = { endpoints: { notify: ENDPOINT, sessions: '/noop' }, apiKey: API_KEY }
 export default config

--- a/test/browser/features/fixtures/handled/webpack3/src/lib/config.js
+++ b/test/browser/features/fixtures/handled/webpack3/src/lib/config.js
@@ -3,4 +3,4 @@ var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
 exports.apiKey = API_KEY
-exports.endpoints = { notify: ENDPOINT }
+exports.endpoints = { notify: ENDPOINT, sessions: '/noop' }

--- a/test/browser/features/fixtures/handled/webpack4/src/lib/config.js
+++ b/test/browser/features/fixtures/handled/webpack4/src/lib/config.js
@@ -3,4 +3,4 @@ var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
 exports.apiKey = API_KEY
-exports.endpoints = { notify: ENDPOINT }
+exports.endpoints = { notify: ENDPOINT, sessions: '/noop' }

--- a/test/browser/features/fixtures/ip_redaction/script/a.html
+++ b/test/browser/features/fixtures/ip_redaction/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         collectUserIp: false
       })
     </script>

--- a/test/browser/features/fixtures/ip_redaction/script/b.html
+++ b/test/browser/features/fixtures/ip_redaction/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         collectUserIp: false,
         user: { id: 'cjhc3k8wg0000zdojufo6nw6c' }
       })

--- a/test/browser/features/fixtures/navigation/script/a.html
+++ b/test/browser/features/fixtures/navigation/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/plugin_angular/ng/src/app/bugsnag.ts
+++ b/test/browser/features/fixtures/plugin_angular/ng/src/app/bugsnag.ts
@@ -6,7 +6,8 @@ var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)
 const bugsnagClient = bugsnag({
   apiKey: API_KEY,
   endpoints: {
-    notify: ENDPOINT
+    notify: ENDPOINT,
+    sessions: '/noop'
   },
   beforeSend: (report) => {
   }

--- a/test/browser/features/fixtures/plugin_react/webpack4/src/lib/config.js
+++ b/test/browser/features/fixtures/plugin_react/webpack4/src/lib/config.js
@@ -2,4 +2,4 @@ var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
 exports.apiKey = API_KEY
-exports.endpoints = { notify: ENDPOINT }
+exports.endpoints = { notify: ENDPOINT, sessions: '/noop' }

--- a/test/browser/features/fixtures/plugin_vue/webpack4/src/lib/config.js
+++ b/test/browser/features/fixtures/plugin_vue/webpack4/src/lib/config.js
@@ -3,4 +3,4 @@ var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
 exports.apiKey = API_KEY
-exports.endpoints = { notify: ENDPOINT }
+exports.endpoints = { notify: ENDPOINT, sessions: '/noop' }

--- a/test/browser/features/fixtures/release_stage/script/a.html
+++ b/test/browser/features/fixtures/release_stage/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'production'
       })
     </script>

--- a/test/browser/features/fixtures/release_stage/script/b.html
+++ b/test/browser/features/fixtures/release_stage/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'development'
       })
     </script>

--- a/test/browser/features/fixtures/release_stage/script/c.html
+++ b/test/browser/features/fixtures/release_stage/script/c.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'qa',
         notifyReleaseStages: [ 'production', 'staging' ]
       })

--- a/test/browser/features/fixtures/release_stage/script/d.html
+++ b/test/browser/features/fixtures/release_stage/script/d.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'staging',
         notifyReleaseStages: [ 'production', 'staging' ]
       })

--- a/test/browser/features/fixtures/sessions/script/b.html
+++ b/test/browser/features/fixtures/sessions/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         endpoints: {
           notify: ENDPOINT,
           sessions: ENDPOINT

--- a/test/browser/features/fixtures/strict_mode/script/a.html
+++ b/test/browser/features/fixtures/strict_mode/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       window.bugsnagClient = window.bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/a.html
+++ b/test/browser/features/fixtures/unhandled/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/b.html
+++ b/test/browser/features/fixtures/unhandled/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/c.html
+++ b/test/browser/features/fixtures/unhandled/script/c.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/d.html
+++ b/test/browser/features/fixtures/unhandled/script/d.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/e.html
+++ b/test/browser/features/fixtures/unhandled/script/e.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/f.html
+++ b/test/browser/features/fixtures/unhandled/script/f.html
@@ -9,7 +9,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/unhandled/script/g.html
+++ b/test/browser/features/fixtures/unhandled/script/g.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/user_info/script/a.html
+++ b/test/browser/features/fixtures/user_info/script/a.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT },
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
         user: {
           id: 'cjhc01kh00000mcojaw8jqag8',
           name: 'Bug S. Nag'

--- a/test/browser/features/fixtures/user_info/script/b.html
+++ b/test/browser/features/fixtures/user_info/script/b.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
       bugsnagClient.user = {
         id: 'cjhc05e8u0000peojhf4vfd68',

--- a/test/browser/features/fixtures/user_info/script/c.html
+++ b/test/browser/features/fixtures/user_info/script/c.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/user_info/script/d.html
+++ b/test/browser/features/fixtures/user_info/script/d.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/user_info/script/e.html
+++ b/test/browser/features/fixtures/user_info/script/e.html
@@ -8,7 +8,7 @@
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
-        endpoints: { notify: ENDPOINT }
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
     </script>
   </head>

--- a/test/browser/features/sessions.feature
+++ b/test/browser/features/sessions.feature
@@ -6,7 +6,7 @@ Scenario: tracking sessions by default
   Then I wait to receive a request
   And the request is a valid browser payload for the session tracking API
 
-Scenario: autoCaptureSessions=false
+Scenario: autoTrackSessions=false
   When I navigate to the URL "/sessions/script/b.html"
   And I wait for 2 seconds
   Then I should receive no requests

--- a/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
@@ -18,7 +18,7 @@ export default class AppStateBreadcrumbs extends Component {
         client: bugsnag({
           endpoints: endpoints,
           autoNotify: false,
-          autoCaptureSessions: false
+          autoTrackSessions: false
         }),
         errorMessage: "defaultAppStateBreadcrumbsBehaviour"
       }
@@ -31,7 +31,7 @@ export default class AppStateBreadcrumbs extends Component {
         client: bugsnag({
           endpoints: endpoints,
           autoNotify: false,
-          autoCaptureSessions: false,
+          autoTrackSessions: false,
           appStateBreadcrumbsEnabled: false
         }),
         errorMessage: "disabledAppStateBreadcrumbsBehaviour"
@@ -45,7 +45,7 @@ export default class AppStateBreadcrumbs extends Component {
         client: bugsnag({
           endpoints: endpoints,
           autoNotify: false,
-          autoCaptureSessions: false,
+          autoTrackSessions: false,
           autoBreadcrumbs: false
         }),
         errorMessage: "disabledAllAppStateBreadcrumbsBehaviour"
@@ -59,7 +59,7 @@ export default class AppStateBreadcrumbs extends Component {
         client: bugsnag({
           endpoints: endpoints,
           autoNotify: false,
-          autoCaptureSessions: false,
+          autoTrackSessions: false,
           autoBreadcrumbs: false,
           appStateBreadcrumbsEnabled: true
         }),

--- a/test/expo/features/fixtures/test-app/app/bugsnag.js
+++ b/test/expo/features/fixtures/test-app/app/bugsnag.js
@@ -7,7 +7,7 @@ const endpoints = {
 
 const bugsnagClient = bugsnag({
   endpoints: endpoints,
-  autoCaptureSessions: false
+  autoTrackSessions: false
 })
 
 export {

--- a/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
@@ -17,7 +17,7 @@ export default class ConsoleBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false
+        autoTrackSessions: false
       }),
       "defaultConsoleBreadcrumbsBehaviour"
     )
@@ -28,7 +28,7 @@ export default class ConsoleBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         consoleBreadcrumbsEnabled: false
       }),
       "disabledConsoleBreadcrumbsBehaviour"
@@ -40,7 +40,7 @@ export default class ConsoleBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         autoBreadcrumbs: false
       }),
       "disabledAllConsoleBreadcrumbsBehaviour"
@@ -52,7 +52,7 @@ export default class ConsoleBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         autoBreadcrumbs: false,
         consoleBreadcrumbsEnabled: true
       }),

--- a/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
@@ -17,7 +17,7 @@ export default class NetworkBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false
+        autoTrackSessions: false
       }),
       "defaultNetworkBreadcrumbsBehaviour"
     )
@@ -28,7 +28,7 @@ export default class NetworkBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         networkBreadcrumbsEnabled: false
       }),
       "disabledNetworkBreadcrumbsBehaviour"
@@ -40,7 +40,7 @@ export default class NetworkBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         autoBreadcrumbs: false
       }),
       "disabledAllNetworkBreadcrumbsBehaviour"
@@ -52,7 +52,7 @@ export default class NetworkBreadcrumbs extends Component {
       bugsnag({
         endpoints: endpoints,
         autoNotify: false,
-        autoCaptureSessions: false,
+        autoTrackSessions: false,
         autoBreadcrumbs: false,
         networkBreadcrumbsEnabled: true
       }),

--- a/test/expo/features/fixtures/test-app/app/sessions.js
+++ b/test/expo/features/fixtures/test-app/app/sessions.js
@@ -8,7 +8,7 @@ export default class Sessions extends Component {
     bugsnag({
       endpoints: endpoints,
       autoNotify: false,
-      autoCaptureSessions: true
+      autoTrackSessions: true
     })
   }
 

--- a/test/node/features/fixtures/sessions/scenarios/start-session-auto-off.js
+++ b/test/node/features/fixtures/sessions/scenarios/start-session-auto-off.js
@@ -5,7 +5,7 @@ var bugsnagClient = bugsnag({
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
     sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
   },
-  autoCaptureSessions: false,
+  autoTrackSessions: false,
   sessionSummaryInterval: 1000
 })
 

--- a/test/node/features/sessions.feature
+++ b/test/node/features/sessions.feature
@@ -12,7 +12,7 @@ Scenario: calling startSession() manually
   And the payload has a valid sessions array
   And the sessionCount "sessionsStarted" equals 1
 
-Scenario: calling startSession() when autoCaptureSessions=false
+Scenario: calling startSession() when autoTrackSessions=false
   And I run the service "sessions" with the command "node scenarios/start-session-auto-off"
   And I wait to receive a request
   Then the request is valid for the session reporting API version "1" for the "Bugsnag Node" notifier


### PR DESCRIPTION
Per the updated spec, the option to disable sessions is called `autoTrackSessions`. In addition to making that update, a suggestion made here¹ was incorporated to make the session endpoint always required (this only applies when endpoints is set).

Previously the validation of the `autoCaptureSessions` field was dependent on whether a session endpoint was provided, which made the logic unnecessarily complex.

¹https://github.com/bugsnag/bugsnag-js/pull/630/files#r343663933