### PR TITLE
V7: rename notifyReleaseStages option

### DIFF
--- a/examples/browser-cdn/app.js
+++ b/examples/browser-cdn/app.js
@@ -30,7 +30,7 @@ var bugsnagClient = bugsnag({
   releaseStage: 'development',
 
   //  defines which release stages bugsnag should report. e.g. ignore staging errors.
-  notifyReleaseStages: [ 'development', 'production' ],
+  enabledReleaseStages: [ 'development', 'production' ],
 
   // one of the most powerful tools in our library, beforeSend lets you evaluate,
   // modify, add and remove data before sending the error to bugsnag. The actions

--- a/examples/plain-node/app.js
+++ b/examples/plain-node/app.js
@@ -7,10 +7,10 @@ var bugsnagClient = bugsnag({
   apiKey: process.env.BUGSNAG_API_KEY,
   // setting the appVersion is useful to track when errors are introduced/fixed
   appVersion: '1.2.3',
-  // using a combination of releaseStage/notifyReleaseStages you can ensure you
+  // using a combination of releaseStage/enabledReleaseStages you can ensure you
   // only get reports from the environments you care about
   releaseStage: 'production',
-  notifyReleaseStages: [ 'staging', 'production' ],
+  enabledReleaseStages: [ 'staging', 'production' ],
   // you can set global metaData when you initialise Bugsnag
   metaData: {}
 })

--- a/examples/typescript/src/app.ts
+++ b/examples/typescript/src/app.ts
@@ -9,10 +9,10 @@ const bugsnagClient = bugsnag({
   apiKey: apiKey,
   // setting the appVersion is useful to track when errors are introduced/fixed
   appVersion: '1.2.3',
-  // using a combination of releaseStage/notifyReleaseStages you can ensure you
+  // using a combination of releaseStage/enabledReleaseStages you can ensure you
   // only get reports from the environments you care about
   releaseStage: 'production',
-  notifyReleaseStages: [ 'staging', 'production' ],
+  enabledReleaseStages: [ 'staging', 'production' ],
   // you can set global metaData when you initialise Bugsnag
   metaData: {}
 })

--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -12,7 +12,7 @@ declare module "@bugsnag/core" {
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
     autoTrackSessions?: boolean;
-    notifyReleaseStages?: string[];
+    enabledReleaseStages?: string[];
     releaseStage?: string;
     maxBreadcrumbs?: number;
     user?: object | null;

--- a/packages/browser/types/test/fixtures/all-options.ts
+++ b/packages/browser/types/test/fixtures/all-options.ts
@@ -8,7 +8,7 @@ bugsnag({
   beforeSend: [],
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
   autoTrackSessions: true,
-  notifyReleaseStages: [],
+  enabledReleaseStages: [],
   releaseStage: "production",
   maxBreadcrumbs: 20,
   autoBreadcrumbs: true,

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -2,7 +2,7 @@ const config = require('./config')
 const BugsnagEvent = require('./event')
 const BugsnagBreadcrumb = require('./breadcrumb')
 const BugsnagSession = require('./session')
-const { map, includes, isArray } = require('./lib/es-utils')
+const { map, includes } = require('./lib/es-utils')
 const inferReleaseStage = require('./lib/infer-release-stage')
 const isError = require('./lib/iserror')
 const some = require('./lib/async-some')
@@ -183,8 +183,8 @@ class BugsnagClient {
     }
 
     // exit early if events should not be sent on the current releaseStage
-    if (isArray(this.config.notifyReleaseStages) && !includes(this.config.notifyReleaseStages, releaseStage)) {
-      this._logger.warn('Event not sent due to releaseStage/notifyReleaseStages configuration')
+    if (this.config.enabledReleaseStages.length > 0 && !includes(this.config.enabledReleaseStages, releaseStage)) {
+      this._logger.warn('Event not sent due to releaseStage/enabledReleaseStages configuration')
       return cb(null, event)
     }
 

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -53,10 +53,10 @@ module.exports.schema = {
     message: 'should be true|false',
     validate: val => val === true || val === false
   },
-  notifyReleaseStages: {
-    defaultValue: () => null,
+  enabledReleaseStages: {
+    defaultValue: () => [],
     message: 'should be an array of strings',
-    validate: value => value === null || (isArray(value) && filter(value, f => typeof f === 'string').length === value.length)
+    validate: value => isArray(value) && filter(value, f => typeof f === 'string').length === value.length
   },
   releaseStage: {
     defaultValue: () => 'production',

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -167,14 +167,14 @@ describe('@bugsnag/core/client', () => {
       process.nextTick(() => done())
     })
 
-    it('supports preventing send with notifyReleaseStages', done => {
+    it('supports preventing send with enabledReleaseStages', done => {
       const client = new Client(VALID_NOTIFIER)
       client.delivery(client => ({
         sendEvent: (payload) => {
           fail('sendEvent() should not be called')
         }
       }))
-      client.setOptions({ apiKey: 'API_KEY_YEAH', notifyReleaseStages: [] })
+      client.setOptions({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['qa'] })
       client.configure()
 
       client.notify(new Error('oh em eff gee'))
@@ -190,7 +190,7 @@ describe('@bugsnag/core/client', () => {
           fail('sendEvent() should not be called')
         }
       }))
-      client.setOptions({ apiKey: 'API_KEY_YEAH', releaseStage: 'staging', notifyReleaseStages: ['production'] })
+      client.setOptions({ apiKey: 'API_KEY_YEAH', releaseStage: 'staging', enabledReleaseStages: ['production'] })
       client.configure()
 
       client.notify(new Error('oh em eff gee'))
@@ -206,7 +206,7 @@ describe('@bugsnag/core/client', () => {
           fail('sendEvent() should not be called')
         }
       }))
-      client.setOptions({ apiKey: 'API_KEY_YEAH', notifyReleaseStages: ['production'] })
+      client.setOptions({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['production'] })
       client.configure()
       client.app.releaseStage = 'staging'
 
@@ -224,7 +224,7 @@ describe('@bugsnag/core/client', () => {
           done()
         }
       }))
-      client.setOptions({ apiKey: 'API_KEY_YEAH', notifyReleaseStages: ['staging'] })
+      client.setOptions({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['staging'] })
       client.configure()
       client.app.releaseStage = 'staging'
       client.notify(new Error('oh em eff gee'))
@@ -238,7 +238,7 @@ describe('@bugsnag/core/client', () => {
           done()
         }
       }))
-      client.setOptions({ apiKey: 'API_KEY_YEAH', notifyReleaseStages: ['staging'], releaseStage: 'staging' })
+      client.setOptions({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['staging'], releaseStage: 'staging' })
       client.configure()
       client.notify(new Error('oh em eff gee'))
     })
@@ -251,7 +251,7 @@ describe('@bugsnag/core/client', () => {
           done()
         }
       }))
-      client.setOptions({ apiKey: 'API_KEY_YEAH', notifyReleaseStages: ['testing'], releaseStage: 'staging' })
+      client.setOptions({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['testing'], releaseStage: 'staging' })
       client.configure()
       client.app.releaseStage = 'testing'
       client.notify(new Error('oh em eff gee'))
@@ -373,9 +373,9 @@ describe('@bugsnag/core/client', () => {
       })
     })
 
-    it('should call the callback even if the event doesn’t send (notifyReleaseStages)', done => {
+    it('should call the callback even if the event doesn’t send (enabledReleaseStages)', done => {
       const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY', notifyReleaseStages: ['production'], releaseStage: 'development' })
+      client.setOptions({ apiKey: 'API_KEY', enabledReleaseStages: ['production'], releaseStage: 'development' })
       client.configure()
       client.delivery(client => ({
         sendSession: () => {},

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -11,7 +11,7 @@ export interface Config {
   appType?: string;
   endpoints?: { notify: string; sessions: string };
   autoTrackSessions?: boolean;
-  notifyReleaseStages?: string[];
+  enabledReleaseStages?: string[];
   releaseStage?: string;
   maxBreadcrumbs?: number;
   user?: object | null;

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -12,7 +12,7 @@ declare module "@bugsnag/core" {
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
     autoTrackSessions?: boolean;
-    notifyReleaseStages?: string[];
+    enabledReleaseStages?: string[];
     releaseStage?: string;
     maxBreadcrumbs?: number;
     user?: object | null;

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -8,7 +8,7 @@ bugsnag({
   beforeSend: [],
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
   autoTrackSessions: true,
-  notifyReleaseStages: [],
+  enabledReleaseStages: ['zzz'],
   releaseStage: "production",
   maxBreadcrumbs: 20,
   autoBreadcrumbs: true,

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -14,7 +14,7 @@ declare module "@bugsnag/core" {
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
     autoTrackSessions?: boolean;
-    notifyReleaseStages?: string[];
+    enabledReleaseStages?: string[];
     releaseStage?: string;
     maxBreadcrumbs?: number;
     user?: object | null;

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -1,4 +1,4 @@
-const { isArray, includes } = require('@bugsnag/core/lib/es-utils')
+const { includes } = require('@bugsnag/core/lib/es-utils')
 const inferReleaseStage = require('@bugsnag/core/lib/infer-release-stage')
 
 module.exports = {
@@ -13,8 +13,8 @@ const sessionDelegate = {
     const releaseStage = inferReleaseStage(sessionClient)
 
     // exit early if the current releaseStage is not enabled
-    if (isArray(sessionClient.config.notifyReleaseStages) && !includes(sessionClient.config.notifyReleaseStages, releaseStage)) {
-      sessionClient._logger.warn('Session not sent due to releaseStage/notifyReleaseStages configuration')
+    if (sessionClient.config.enabledReleaseStages.length > 0 && !includes(sessionClient.config.enabledReleaseStages, releaseStage)) {
+      sessionClient._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
       return sessionClient
     }
 

--- a/packages/plugin-browser-session/test/session.test.js
+++ b/packages/plugin-browser-session/test/session.test.js
@@ -70,9 +70,9 @@ describe('plugin: sessions', () => {
     c.startSession()
   })
 
-  it('doesn’t send when releaseStage is not in notifyReleaseStages', (done) => {
+  it('doesn’t send when releaseStage is not in enabledReleaseStages', (done) => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'API_KEY', releaseStage: 'foo', notifyReleaseStages: ['baz'] })
+    c.setOptions({ apiKey: 'API_KEY', releaseStage: 'foo', enabledReleaseStages: ['baz'] })
     c.configure()
     c.use(plugin)
     c.delivery(client => ({

--- a/packages/plugin-intercept/test/intercept.test.js
+++ b/packages/plugin-intercept/test/intercept.test.js
@@ -114,7 +114,7 @@ describe('plugin: intercept', () => {
     c.setOptions({
       apiKey: 'api_key'
     })
-    c.configure({})
+    c.configure()
     c.use(plugin)
     const intercept = c.getPlugin('intercept')
     fs.readFile('does not exist', intercept(data => {

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -1,4 +1,4 @@
-const { isArray, includes } = require('@bugsnag/core/lib/es-utils')
+const { includes } = require('@bugsnag/core/lib/es-utils')
 const inferReleaseStage = require('@bugsnag/core/lib/infer-release-stage')
 const { intRange } = require('@bugsnag/core/lib/validators')
 const clone = require('@bugsnag/core/lib/clone-client')
@@ -32,8 +32,8 @@ const sendSessionSummary = client => sessionCounts => {
   const releaseStage = inferReleaseStage(client)
 
   // exit early if the current releaseStage is not enabled
-  if (isArray(client.config.notifyReleaseStages) && !includes(client.config.notifyReleaseStages, releaseStage)) {
-    client._logger.warn('Session not sent due to releaseStage/notifyReleaseStages configuration')
+  if (client.config.enabledReleaseStages.length > 0 && !includes(client.config.enabledReleaseStages, releaseStage)) {
+    client._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
     return
   }
 

--- a/packages/plugin-server-session/test/session.test.js
+++ b/packages/plugin-server-session/test/session.test.js
@@ -38,7 +38,7 @@ describe('plugin: server sessions', () => {
     c.startSession()
   })
 
-  it('should not send the session when releaseStage is not in notifyReleaseStages', done => {
+  it('should not send the session when releaseStage is not in enabledReleaseStages', done => {
     class TrackerMock extends Emitter {
       start () {
         this.emit('summary', [
@@ -60,14 +60,14 @@ describe('plugin: server sessions', () => {
         debug: () => {},
         info: () => {},
         warn: (msg) => {
-          expect(msg).toBe('Session not sent due to releaseStage/notifyReleaseStages configuration')
+          expect(msg).toBe('Session not sent due to releaseStage/enabledReleaseStages configuration')
           setTimeout(done, 150)
         },
         error: () => {}
       },
       endpoints: { notify: 'bloo', sessions: 'blah' },
       releaseStage: 'qa',
-      notifyReleaseStages: ['production']
+      enabledReleaseStages: ['production']
     })
     c.delivery(client => ({
       sendEvent: () => {},
@@ -99,7 +99,7 @@ describe('plugin: server sessions', () => {
     c.setOptions({
       apiKey: 'aaaa-aaaa-aaaa-aaaa',
       endpoints: { notify: 'bloo', sessions: 'blah' },
-      notifyReleaseStages: null,
+      enabledReleaseStages: ['qa'],
       releaseStage: 'qa',
       appType: 'server',
       appVersion: '1.2.3'

--- a/test/browser/features/fixtures/release_stage/script/c.html
+++ b/test/browser/features/fixtures/release_stage/script/c.html
@@ -10,7 +10,7 @@
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'qa',
-        notifyReleaseStages: [ 'production', 'staging' ]
+        enabledReleaseStages: [ 'production', 'staging' ]
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/release_stage/script/d.html
+++ b/test/browser/features/fixtures/release_stage/script/d.html
@@ -10,7 +10,7 @@
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'staging',
-        notifyReleaseStages: [ 'production', 'staging' ]
+        enabledReleaseStages: [ 'production', 'staging' ]
       })
     </script>
   </head>

--- a/test/browser/features/release_stage.feature
+++ b/test/browser/features/release_stage.feature
@@ -1,5 +1,5 @@
 @release_stage
-Feature: Configuring releaseStage and notifyReleaseStages
+Feature: Configuring releaseStage and enabledReleaseStages
 
 Scenario: setting releaseStage=production
   When I navigate to the URL "/release_stage/script/a.html"
@@ -13,12 +13,12 @@ Scenario: setting releaseStage=development
   And the request is a valid browser payload for the error reporting API
   And the event "app.releaseStage" equals "development"
 
-Scenario: setting releaseStage=qa notifyReleaseStages=[production,staging]
+Scenario: setting releaseStage=qa enabledReleaseStages=[production,staging]
   When I navigate to the URL "/release_stage/script/c.html"
   And I wait for 2 seconds
   Then I should receive no requests
 
-Scenario: setting releaseStage=staging notifyReleaseStages=[production,staging]
+Scenario: setting releaseStage=staging enabledReleaseStages=[production,staging]
   When I navigate to the URL "/release_stage/script/d.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API


### PR DESCRIPTION
Updated the naming of the notifyReleaseStages option to be enabledReleaseStages to denote the fact that it reflects sessions as well as error reporting. Additionally tweaked the behaviour to match the new spec:

 - An empty list should be interpreted as all `releaseStages` being enabled
 - The default value should be an empty list (instead of `null`)