### PR TITLE
V7: Breadcrumb refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Rename `autoCaptureSessions` -> `autoTrackSessions` and simplify validation logic [#647](https://github.com/bugsnag/bugsnag-js/pull/647)
 - Rename `report` to `event` [#646](https://github.com/bugsnag/bugsnag-js/pull/646)
 - Rename `notifyReleaseStages` -> `enabledReleaseStages` [#649](https://github.com/bugsnag/bugsnag-js/pull/649)
+- Remove individual breadcrumb flags in favour of `enabledBreadcrumbTypes`, rename `breadcrumb.{ name -> message, metaData -> metadata }`, and update `leaveBreadcrumb()` type signature to be more explicit [#650](https://github.com/bugsnag/bugsnag-js/pull/649)
 
 ## 6.4.3 (2019-10-21)
 

--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -5,9 +5,9 @@ declare module "@bugsnag/core" {
   interface Config {
     apiKey: string;
     beforeSend?: BugsnagCore.BeforeSend | BugsnagCore.BeforeSend[];
-    autoBreadcrumbs?: boolean;
     autoDetectErrors?: boolean;
     autoDetectUnhandledRejections?: boolean;
+    enabledBreadcrumbTypes?: BugsnagCore.BreadcrumbType[] | null;
     appVersion?: string;
     appType?: string;
     endpoints?: { notify: string; sessions?: string };
@@ -23,10 +23,6 @@ declare module "@bugsnag/core" {
     [key: string]: any;
     // options for all bundled browser plugins
     maxEvents?: number;
-    consoleBreadcrumbsEnabled?: boolean;
-    networkBreadcrumbsEnabled?: boolean;
-    navigationBreadcrumbsEnabled?: boolean;
-    interactionBreadcrumbsEnabled?: boolean;
     collectUserIp?: boolean;
   }
 }

--- a/packages/browser/types/test/fixtures/all-options.ts
+++ b/packages/browser/types/test/fixtures/all-options.ts
@@ -11,15 +11,11 @@ bugsnag({
   enabledReleaseStages: [],
   releaseStage: "production",
   maxBreadcrumbs: 20,
-  autoBreadcrumbs: true,
+  enabledBreadcrumbTypes: ['manual','log','request'],
   user: null,
   metaData: null,
   logger: undefined,
   filters: ["foo",/bar/],
   collectUserIp: true,
-  consoleBreadcrumbsEnabled: undefined,
-  interactionBreadcrumbsEnabled: undefined,
-  navigationBreadcrumbsEnabled: undefined,
-  networkBreadcrumbsEnabled: undefined,
   maxEvents: 10
 })

--- a/packages/browser/types/test/fixtures/breadcrumb-types.ts
+++ b/packages/browser/types/test/fixtures/breadcrumb-types.ts
@@ -4,8 +4,8 @@ const bugsnagClient = bugsnag({
   beforeSend: (event) => {
     event.breadcrumbs.map(breadcrumb => {
       console.log(breadcrumb.type)
-      console.log(breadcrumb.name)
-      console.log(breadcrumb.metaData)
+      console.log(breadcrumb.message)
+      console.log(breadcrumb.metadata)
       console.log(breadcrumb.timestamp)
     })
   }

--- a/packages/core/breadcrumb.js
+++ b/packages/core/breadcrumb.js
@@ -1,19 +1,19 @@
 const { isoDate } = require('./lib/es-utils')
 
 class BugsnagBreadcrumb {
-  constructor (name = '[anonymous]', metaData = {}, type = 'manual', timestamp = isoDate()) {
+  constructor (message, metadata, type, timestamp = isoDate()) {
     this.type = type
-    this.name = name
-    this.metaData = metaData
+    this.message = message
+    this.metadata = metadata
     this.timestamp = timestamp
   }
 
   toJSON () {
     return {
       type: this.type,
-      name: this.name,
+      name: this.message,
       timestamp: this.timestamp,
-      metaData: this.metaData
+      metaData: this.metadata
     }
   }
 }

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -124,19 +124,19 @@ class BugsnagClient {
     return this._sessionDelegate.startSession(this)
   }
 
-  leaveBreadcrumb (name, metaData, type, timestamp) {
+  leaveBreadcrumb (message, metadata, type) {
     if (!this._configured) throw new Error('client not configured')
 
     // coerce bad values so that the defaults get set
-    name = name || undefined
-    type = typeof type === 'string' ? type : undefined
-    timestamp = typeof timestamp === 'string' ? timestamp : undefined
-    metaData = typeof metaData === 'object' && metaData !== null ? metaData : undefined
+    message = typeof message === 'string' ? message : ''
+    type = typeof type === 'string' ? type : 'manual'
+    metadata = typeof metadata === 'object' && metadata !== null ? metadata : {}
 
-    // if no name and no metaData, usefulness of this crumb is questionable at best so discard
-    if (typeof name !== 'string' && !metaData) return
+    // if no message, discard
+    if (!message) return
 
-    const crumb = new BugsnagBreadcrumb(name, metaData, type, timestamp)
+    const crumb = new BugsnagBreadcrumb(message, metadata, type)
+
     // check the breadcrumb is the list of enabled types
     if (!this.config.enabledBreadcrumbTypes || !includes(this.config.enabledBreadcrumbTypes, crumb.type)) return
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -135,10 +135,10 @@ class BugsnagClient {
     // if no message, discard
     if (!message) return
 
-    const crumb = new BugsnagBreadcrumb(message, metadata, type)
-
     // check the breadcrumb is the list of enabled types
-    if (!this.config.enabledBreadcrumbTypes || !includes(this.config.enabledBreadcrumbTypes, crumb.type)) return
+    if (!this.config.enabledBreadcrumbTypes || !includes(this.config.enabledBreadcrumbTypes, type)) return
+
+    const crumb = new BugsnagBreadcrumb(message, metadata, type)
 
     // push the valid crumb onto the queue and maintain the length
     this.breadcrumbs.push(crumb)

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -137,6 +137,8 @@ class BugsnagClient {
     if (typeof name !== 'string' && !metaData) return
 
     const crumb = new BugsnagBreadcrumb(name, metaData, type, timestamp)
+    // check the breadcrumb is the list of enabled types
+    if (!this.config.enabledBreadcrumbTypes || !includes(this.config.enabledBreadcrumbTypes, crumb.type)) return
 
     // push the valid crumb onto the queue and maintain the length
     this.breadcrumbs.push(crumb)
@@ -205,13 +207,11 @@ class BugsnagClient {
       }
 
       // only leave a crumb for the error if actually got sent
-      if (this.config.autoBreadcrumbs) {
-        this.leaveBreadcrumb(event.errorClass, {
-          errorClass: event.errorClass,
-          errorMessage: event.errorMessage,
-          severity: event.severity
-        }, 'error')
-      }
+      BugsnagClient.prototype.leaveBreadcrumb.call(this, event.errorClass, {
+        errorClass: event.errorClass,
+        errorMessage: event.errorMessage,
+        severity: event.severity
+      }, 'error')
 
       if (originalSeverity !== event.severity) {
         event._handledState.severityReason = { type: 'userCallbackSetSeverity' }

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -1,6 +1,8 @@
 const { filter, reduce, keys, isArray, includes } = require('./lib/es-utils')
 const { intRange, stringWithLength } = require('./lib/validators')
 
+const BREADCRUMB_TYPES = ['navigation', 'request', 'process', 'log', 'user', 'state', 'error', 'manual']
+
 module.exports.schema = {
   apiKey: {
     defaultValue: () => null,
@@ -68,10 +70,13 @@ module.exports.schema = {
     message: 'should be a number ≤40',
     validate: value => intRange(0, 40)(value)
   },
-  autoBreadcrumbs: {
-    defaultValue: () => true,
-    message: 'should be true|false',
-    validate: (value) => typeof value === 'boolean'
+  enabledBreadcrumbTypes: {
+    defaultValue: () => BREADCRUMB_TYPES,
+    message: `should be null or a list of available breadcrumb types (${BREADCRUMB_TYPES.join(',')})`,
+    validate: value => value === null || (isArray(value) && reduce(BREADCRUMB_TYPES, (accum, maybeType) => {
+      if (accum === false) return accum
+      return includes(BREADCRUMB_TYPES, maybeType)
+    }, true))
   },
   user: {
     defaultValue: () => null,

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -73,7 +73,7 @@ module.exports.schema = {
   enabledBreadcrumbTypes: {
     defaultValue: () => BREADCRUMB_TYPES,
     message: `should be null or a list of available breadcrumb types (${BREADCRUMB_TYPES.join(',')})`,
-    validate: value => value === null || (isArray(value) && reduce(BREADCRUMB_TYPES, (accum, maybeType) => {
+    validate: value => value === null || (isArray(value) && reduce(value, (accum, maybeType) => {
       if (accum === false) return accum
       return includes(BREADCRUMB_TYPES, maybeType)
     }, true))

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -321,8 +321,8 @@ describe('@bugsnag/core/client', () => {
       client.notify(new Error('foobar'))
       expect(client.breadcrumbs.length).toBe(1)
       expect(client.breadcrumbs[0].type).toBe('error')
-      expect(client.breadcrumbs[0].name).toBe('Error')
-      expect(client.breadcrumbs[0].metaData.stacktrace).toBe(undefined)
+      expect(client.breadcrumbs[0].message).toBe('Error')
+      expect(client.breadcrumbs[0].metadata.stacktrace).toBe(undefined)
       // the error shouldn't appear as a breadcrumb for itself
       expect(payloads[0].events[0].breadcrumbs.length).toBe(0)
     })
@@ -431,8 +431,8 @@ describe('@bugsnag/core/client', () => {
       client.leaveBreadcrumb('french stick')
       expect(client.breadcrumbs.length).toBe(1)
       expect(client.breadcrumbs[0].type).toBe('manual')
-      expect(client.breadcrumbs[0].name).toBe('french stick')
-      expect(client.breadcrumbs[0].metaData).toEqual({})
+      expect(client.breadcrumbs[0].message).toBe('french stick')
+      expect(client.breadcrumbs[0].metadata).toEqual({})
     })
 
     it('caps the length of breadcrumbs at the configured limit', () => {
@@ -447,14 +447,14 @@ describe('@bugsnag/core/client', () => {
       expect(client.breadcrumbs.length).toBe(3)
       client.leaveBreadcrumb('seedy farmhouse')
       expect(client.breadcrumbs.length).toBe(3)
-      expect(client.breadcrumbs.map(b => b.name)).toEqual([
+      expect(client.breadcrumbs.map(b => b.message)).toEqual([
         'medium sliced white hovis',
         'pumperninkel',
         'seedy farmhouse'
       ])
     })
 
-    it('doesn’t add the breadcrumb if it didn’t contain anything useful', () => {
+    it('doesn’t add the breadcrumb if it didn’t contain a message', () => {
       const client = new Client(VALID_NOTIFIER)
       client.setOptions({ apiKey: 'API_KEY_YEAH' })
       client.configure()
@@ -462,12 +462,7 @@ describe('@bugsnag/core/client', () => {
       client.leaveBreadcrumb(null, { data: 'is useful' })
       client.leaveBreadcrumb(null, {}, null)
       client.leaveBreadcrumb(null, { t: 10 }, null, 4)
-      expect(client.breadcrumbs.length).toBe(3)
-      expect(client.breadcrumbs[0].type).toBe('manual')
-      expect(client.breadcrumbs[0].name).toBe('[anonymous]')
-      expect(client.breadcrumbs[0].metaData).toEqual({ data: 'is useful' })
-      expect(client.breadcrumbs[1].type).toBe('manual')
-      expect(typeof client.breadcrumbs[2].timestamp).toBe('string')
+      expect(client.breadcrumbs.length).toBe(0)
     })
 
     it('allows maxBreadcrumbs to be set to 0', () => {

--- a/packages/core/test/config.test.js
+++ b/packages/core/test/config.test.js
@@ -64,4 +64,11 @@ describe('@bugsnag/core/config', () => {
       })
     })
   })
+
+  describe('enabledBreadcrumbTypes', () => {
+    it('fails when a supplied value is not a valid breadcrumb type', () => {
+      const enabledBreadcrumbTypesValidator = config.schema.enabledBreadcrumbTypes.validate
+      expect(enabledBreadcrumbTypesValidator(['UNKNOWN_BREADCRUMB_TYPE'])).toBe(false)
+    })
+  })
 })

--- a/packages/core/types/breadcrumb.d.ts
+++ b/packages/core/types/breadcrumb.d.ts
@@ -1,9 +1,8 @@
 declare class Breadcrumb {
-  public name: string;
-  public metaData: object;
+  public message: string;
+  public metadata: object;
   public type: string;
   public timestamp: string;
-  constructor(name: string, metaData?: object, type?: string, timestamp?: string);
 }
 
 export default Breadcrumb;

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -27,7 +27,7 @@ declare class Client {
     opts?: common.NotifyOpts,
     cb?: (err: any, event: Event) => void,
   ): void;
-  public leaveBreadcrumb(name: string, metaData?: any, type?: string, timestamp?: string): Client;
+  public leaveBreadcrumb(message: string, metadata?: { [key: string]: common.BreadcrumbMetadataValue }, type?: string): Client;
   public startSession(): Client;
 }
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -108,3 +108,8 @@ export type NotifiableError = Error
   | { errorClass: string; errorMessage: string }
   | { name: string; message: string }
   | any;
+
+type Primitive = boolean | string | number | undefined | null;
+export type BreadcrumbMetadataValue = Primitive | Array<Primitive>;
+
+export type BreadcrumbType = "error" | "log" | "manual" | "navigation" | "process" | "request" | "state" | "user";

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -4,7 +4,7 @@ import Event from "./event";
 export interface Config {
   apiKey: string;
   beforeSend?: BeforeSend | BeforeSend[];
-  autoBreadcrumbs?: boolean;
+  enabledBreadcrumbTypes?: BreadcrumbType[];
   autoDetectErrors?: boolean;
   autoDetectUnhandledRejections?: boolean;
   appVersion?: string;

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -5,7 +5,7 @@ declare module "@bugsnag/core" {
   interface Config {
     apiKey?: string;
     beforeSend?: BugsnagCore.BeforeSend | BugsnagCore.BeforeSend[];
-    autoBreadcrumbs?: boolean;
+    enabledBreadcrumbTypes?: BugsnagCore.BreadcrumbType[];
     autoDetectErrors?: boolean;
     autoDetectUnhandledRejections?: boolean;
     appVersion?: string;
@@ -21,13 +21,6 @@ declare module "@bugsnag/core" {
     filters?: Array<string | RegExp>;
     // catch-all for any missing options
     [key: string]: any;
-    // options for all bundled expo plugins
-    appStateBreadcrumbsEnabled?: boolean;
-    consoleBreadcrumbsEnabled?: boolean;
-    networkBreadcrumbsEnabled?: boolean;
-    navigationBreadcrumbsEnabled?: boolean;
-    connectivityBreadcrumbsEnabled?: boolean;
-    orientationBreadcrumbsEnabled?: boolean;
   }
 }
 

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -11,15 +11,11 @@ bugsnag({
   enabledReleaseStages: ['zzz'],
   releaseStage: "production",
   maxBreadcrumbs: 20,
-  autoBreadcrumbs: true,
+  enabledBreadcrumbTypes: ['manual','log','request'],
   user: null,
   metaData: null,
   logger: undefined,
   filters: ["foo",/bar/],
   collectUserIp: true,
-  consoleBreadcrumbsEnabled: undefined,
-  interactionBreadcrumbsEnabled: undefined,
-  navigationBreadcrumbsEnabled: undefined,
-  networkBreadcrumbsEnabled: undefined,
   maxEvents: 10
 })

--- a/packages/expo/types/test/fixtures/breadcrumb-types.ts
+++ b/packages/expo/types/test/fixtures/breadcrumb-types.ts
@@ -4,8 +4,8 @@ const bugsnagClient = bugsnag({
   beforeSend: (event) => {
     event.breadcrumbs.map(breadcrumb => {
       console.log(breadcrumb.type)
-      console.log(breadcrumb.name)
-      console.log(breadcrumb.metaData)
+      console.log(breadcrumb.message)
+      console.log(breadcrumb.metadata)
       console.log(breadcrumb.timestamp)
     })
   }

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -12,8 +12,8 @@ const delivery = require('@bugsnag/delivery-node')
 // extend the base config schema with some node-specific options
 const schema = { ...require('@bugsnag/core/config').schema, ...require('./config') }
 
-// remove autoBreadcrumbs from the config schema
-delete schema.autoBreadcrumbs
+// remove enabledBreadcrumbTypes from the config schema
+delete schema.enabledBreadcrumbTypes
 
 const pluginSurroundingCode = require('@bugsnag/plugin-node-surrounding-code')
 const pluginInProject = require('@bugsnag/plugin-node-in-project')

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -7,7 +7,6 @@ declare module "@bugsnag/core" {
   interface Config {
     apiKey: string;
     beforeSend?: BugsnagCore.BeforeSend | BugsnagCore.BeforeSend[];
-    // autoBreadcrumbs?: boolean; // this option is disabled in node, see below
     autoDetectErrors?: boolean;
     autoDetectUnhandledRejections?: boolean;
     appVersion?: string;
@@ -30,7 +29,8 @@ declare module "@bugsnag/core" {
     agent?: any;
     projectRoot?: string;
     sendCode?: boolean;
-    autoBreadcrumbs?: void;
+    // breadcrumbs are disabled in Node
+    enabledBreadcrumbTypes?: void;
   }
 }
 

--- a/packages/plugin-console-breadcrumbs/README.md
+++ b/packages/plugin-console-breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-console-breadcrumbs
 
-This plugin adds the ability to record console method calls as breadcrumbs by monkey patching them. It defines a configuration option `consoleBreadcrumbsEnabled` which can be used to disable the functionality. It is included in the browser notifier.
+This plugin adds the ability to record console method calls as breadcrumbs by monkey patching them. It is included in the browser notifier.
 
 **Note:** enabling this plugin means that the line/col origin of console logs appear to come from within Bugsnag's code, so it is not recommended for use in dev environments.
 

--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -1,4 +1,4 @@
-const { map, reduce, filter } = require('@bugsnag/core/lib/es-utils')
+const { map, reduce, filter, includes } = require('@bugsnag/core/lib/es-utils')
 
 /*
  * Leaves breadcrumbs when console log methods are called
@@ -6,9 +6,7 @@ const { map, reduce, filter } = require('@bugsnag/core/lib/es-utils')
 exports.init = (client) => {
   const isDev = /^dev(elopment)?$/.test(client.config.releaseStage)
 
-  const explicitlyDisabled = client.config.consoleBreadcrumbsEnabled === false
-  const implicitlyDisabled = (client.config.autoBreadcrumbs === false || isDev) && client.config.consoleBreadcrumbsEnabled !== true
-  if (explicitlyDisabled || implicitlyDisabled) return
+  if (!client.config.enabledBreadcrumbTypes || !includes(client.config.enabledBreadcrumbTypes, 'log') || isDev) return
 
   map(CONSOLE_LOG_METHODS, method => {
     const original = console[method]
@@ -34,14 +32,6 @@ exports.init = (client) => {
     }
     console[method]._restore = () => { console[method] = original }
   })
-}
-
-exports.configSchema = {
-  consoleBreadcrumbsEnabled: {
-    defaultValue: () => undefined,
-    validate: (value) => value === true || value === false || value === undefined,
-    message: 'should be true|false'
-  }
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
@@ -24,10 +24,10 @@ describe('plugin: console breadcrumbs', () => {
       }
     })
     expect(c.breadcrumbs.length).toBe(3)
-    expect(c.breadcrumbs[0].metaData['[0]']).toBe('check 1, 2')
-    expect(c.breadcrumbs[1].metaData['[0]']).toBe('null')
-    expect(c.breadcrumbs[2].metaData['[0]']).toBe('{"foo":[1,2,3,"four"]}')
-    expect(c.breadcrumbs[2].metaData['[1]']).toBe('{"pets":{"cat":"scratcher","dog":"pupper","rabbit":"sniffer"}}')
+    expect(c.breadcrumbs[0].metadata['[0]']).toBe('check 1, 2')
+    expect(c.breadcrumbs[1].metadata['[0]']).toBe('null')
+    expect(c.breadcrumbs[2].metadata['[0]']).toBe('{"foo":[1,2,3,"four"]}')
+    expect(c.breadcrumbs[2].metadata['[1]']).toBe('{"pets":{"cat":"scratcher","dog":"pupper","rabbit":"sniffer"}}')
     // undo the global side effects of wrapping console.* for the rest of the tests
     plugin.destroy()
   })
@@ -39,8 +39,8 @@ describe('plugin: console breadcrumbs', () => {
     c.use(plugin)
     expect(() => console.log(Object.create(null))).not.toThrow()
     expect(c.breadcrumbs.length).toBe(1)
-    expect(c.breadcrumbs[0].name).toBe('Console output')
-    expect(c.breadcrumbs[0].metaData['[0]']).toBe('[Unknown value]')
+    expect(c.breadcrumbs[0].message).toBe('Console output')
+    expect(c.breadcrumbs[0].metadata['[0]']).toBe('[Unknown value]')
     plugin.destroy()
   })
 

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
@@ -44,9 +44,9 @@ describe('plugin: console breadcrumbs', () => {
     plugin.destroy()
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     c.configure()
     c.use(plugin)
     console.log(123)
@@ -54,9 +54,9 @@ describe('plugin: console breadcrumbs', () => {
     plugin.destroy()
   })
 
-  it('should be enabled when autoBreadcrumbs=false, consoleBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["log"]', () => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, consoleBreadcrumbsEnabled: true })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['log'] })
     c.configure()
     c.use(plugin)
     console.log(123)
@@ -71,16 +71,6 @@ describe('plugin: console breadcrumbs', () => {
     c.use(plugin)
     console.log(123)
     expect(c.breadcrumbs.length).toBe(0)
-    plugin.destroy()
-  })
-
-  it('can be enabled when releaseStage=development', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'development', consoleBreadcrumbsEnabled: true })
-    c.configure()
-    c.use(plugin)
-    console.log(123)
-    expect(c.breadcrumbs.length).toBe(1)
     plugin.destroy()
   })
 })

--- a/packages/plugin-interaction-breadcrumbs/README.md
+++ b/packages/plugin-interaction-breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-interaction-breadcrumbs
 
-This plugin adds the ability to record click events as breadcrumbs by listening to events on the `window`, with the selector and text of the target element (if available) added to the breadcrumb as metadata. It defines a configuration option `interactionBreadcrumbsEnabled` which can be used to disable the functionality. It is included in the browser notifier.
+This plugin adds the ability to record click events as breadcrumbs by listening to events on the `window`, with the selector and text of the target element (if available) added to the breadcrumb as metadata. It is included in the browser notifier.
 
 ## License
 MIT

--- a/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
+++ b/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
@@ -1,3 +1,5 @@
+const { includes } = require('@bugsnag/core/lib/es-utils')
+
 /*
  * Leaves breadcrumbs when the user interacts with the DOM
  */
@@ -5,9 +7,7 @@ module.exports = {
   init: (client, win = window) => {
     if (!('addEventListener' in win)) return
 
-    const explicitlyDisabled = client.config.interactionBreadcrumbsEnabled === false
-    const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.interactionBreadcrumbsEnabled !== true
-    if (explicitlyDisabled || implicitlyDisabled) return
+    if (!client.config.enabledBreadcrumbTypes || !includes(client.config.enabledBreadcrumbTypes, 'user')) return
 
     win.addEventListener('click', (event) => {
       let targetText, targetSelector
@@ -21,13 +21,6 @@ module.exports = {
       }
       client.leaveBreadcrumb('UI click', { targetText, targetSelector }, 'user')
     }, true)
-  },
-  configSchema: {
-    interactionBreadcrumbsEnabled: {
-      defaultValue: () => undefined,
-      validate: (value) => value === true || value === false || value === undefined,
-      message: 'should be true|false'
-    }
   }
 }
 

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
@@ -16,9 +16,9 @@ describe('plugin: interaction breadcrumbs', () => {
     expect(c.breadcrumbs.length).toBe(1)
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     c.configure()
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
@@ -26,9 +26,9 @@ describe('plugin: interaction breadcrumbs', () => {
     expect(c.breadcrumbs.length).toBe(0)
   })
 
-  it('should be enabled when autoBreadcrumbs=false and interactionBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["user"]', () => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, interactionBreadcrumbsEnabled: true })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['user'] })
     c.configure()
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)

--- a/packages/plugin-navigation-breadcrumbs/README.md
+++ b/packages/plugin-navigation-breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-navigation-breadcrumbs
 
-This plugin adds the ability to record browser navigation as breadcrumbs by listening to events on the `window` and monkey-patching `pushState`/`replaceState` history methods. It defines a configuration option `navigationBreadcrumbsEnabled` which can be used to disable the functionality. It is included in the browser notifier.
+This plugin adds the ability to record browser navigation as breadcrumbs by listening to events on the `window` and monkey-patching `pushState`/`replaceState` history methods. It is included in the browser notifier.
 
 ## License
 MIT

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -1,12 +1,12 @@
+const { includes } = require('@bugsnag/core/lib/es-utils')
+
 /*
  * Leaves breadcrumbs when navigation methods are called or events are emitted
  */
 exports.init = (client, win = window) => {
   if (!('addEventListener' in win)) return
 
-  const explicitlyDisabled = client.config.navigationBreadcrumbsEnabled === false
-  const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.navigationBreadcrumbsEnabled !== true
-  if (explicitlyDisabled || implicitlyDisabled) return
+  if (!client.config.enabledBreadcrumbTypes || !includes(client.config.enabledBreadcrumbTypes, 'navigation')) return
 
   // returns a function that will drop a breadcrumb with a given name
   const drop = name => () => client.leaveBreadcrumb(name, {}, 'navigation')
@@ -33,14 +33,6 @@ exports.init = (client, win = window) => {
   if (win.history.pushState) wrapHistoryFn(client, win.history, 'pushState', win)
 
   client.leaveBreadcrumb('Bugsnag loaded', {}, 'navigation')
-}
-
-exports.configSchema = {
-  navigationBreadcrumbsEnabled: {
-    defaultValue: () => undefined,
-    validate: (value) => value === true || value === false || value === undefined,
-    message: 'should be true|false'
-  }
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -23,11 +23,11 @@ describe('plugin: navigation breadcrumbs', () => {
 
     // first ensure that the pushState command works to change the url of the page
     window.history.replaceState(state, 'bar', 'network-breadcrumb-test.html')
-    expect(c.breadcrumbs[c.breadcrumbs.length - 1].metaData.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
+    expect(c.breadcrumbs[c.breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
 
     window.history.replaceState(state, 'bar')
     // then ensure that it works with `undefined` as the url parameter (IE11-specific issue)
-    expect(c.breadcrumbs[c.breadcrumbs.length - 1].metaData.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
+    expect(c.breadcrumbs[c.breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
 
     expect(c.breadcrumbs.length).toBe(6)
 

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -34,9 +34,9 @@ describe('plugin: navigation breadcrumbs', () => {
     done()
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     c.configure()
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
@@ -81,9 +81,9 @@ describe('plugin: navigation breadcrumbs', () => {
     setTimeout(() => done(), 1)
   })
 
-  it('should be enabled when autoBreadcrumbs=false and navigationBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledReleaseStages=["navigation"]', () => {
     const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, navigationBreadcrumbsEnabled: true })
+    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledReleaseStages: ['navigation'] })
     c.configure()
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)

--- a/packages/plugin-network-breadcrumbs/README.md
+++ b/packages/plugin-network-breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-network-breadcrumbs
 
-This plugin adds the ability to record browser requests as breadcrumbs by monkey-patching `window.XMLHttpRequest` and `window.fetch`, including HTTP status codes where available. It defines a configuration option `networkBreadcrumbsEnabled` which can be used to disable the functionality. It is included in the browser notifier.
+This plugin adds the ability to record browser requests as breadcrumbs by monkey-patching `window.XMLHttpRequest` and `window.fetch`, including HTTP status codes where available. It is included in the browser notifier.
 
 ## License
 MIT

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -22,23 +22,13 @@ const defaultIgnoredUrls = () => [
  */
 exports.name = 'networkBreadcrumbs'
 exports.init = (_client, _getIgnoredUrls = defaultIgnoredUrls, _win = window) => {
-  const explicitlyDisabled = _client.config.networkBreadcrumbsEnabled === false
-  const implicitlyDisabled = _client.config.autoBreadcrumbs === false && _client.config.networkBreadcrumbsEnabled !== true
-  if (explicitlyDisabled || implicitlyDisabled) return
+  if (!_client.config.enabledBreadcrumbTypes || !includes(_client.config.enabledBreadcrumbTypes, 'request')) return
 
   client = _client
   win = _win
   getIgnoredUrls = _getIgnoredUrls
   monkeyPatchXMLHttpRequest()
   monkeyPatchFetch()
-}
-
-exports.configSchema = {
-  networkBreadcrumbsEnabled: {
-    defaultValue: () => undefined,
-    validate: (value) => value === true || value === false || value === undefined,
-    message: 'should be true|false'
-  }
 }
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
@@ -59,8 +59,8 @@ describe('plugin: network breadcrumbs', () => {
     expect(client.breadcrumbs.length).toBe(1)
     expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
       type: 'request',
-      name: 'XMLHttpRequest succeeded',
-      metaData: {
+      message: 'XMLHttpRequest succeeded',
+      metadata: {
         status: 200,
         request: 'GET /'
       }
@@ -97,8 +97,8 @@ describe('plugin: network breadcrumbs', () => {
     expect(client.breadcrumbs.length).toBe(1)
     expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
       type: 'request',
-      name: 'XMLHttpRequest failed',
-      metaData: {
+      message: 'XMLHttpRequest failed',
+      metadata: {
         status: 404,
         request: 'GET /this-does-not-exist'
       }
@@ -121,8 +121,8 @@ describe('plugin: network breadcrumbs', () => {
     expect(client.breadcrumbs.length).toBe(1)
     expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
       type: 'request',
-      name: 'XMLHttpRequest error',
-      metaData: {
+      message: 'XMLHttpRequest error',
+      metadata: {
         request: 'GET https://another-domain.xyz/'
       }
     }))
@@ -169,8 +169,8 @@ describe('plugin: network breadcrumbs', () => {
       expect(client.breadcrumbs.length).toBe(1)
       expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
-        name: 'fetch() succeeded',
-        metaData: {
+        message: 'fetch() succeeded',
+        metadata: {
           status: 200,
           request: 'GET /'
         }
@@ -191,8 +191,8 @@ describe('plugin: network breadcrumbs', () => {
       expect(client.breadcrumbs.length).toBe(1)
       expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
-        name: 'fetch() failed',
-        metaData: {
+        message: 'fetch() failed',
+        metadata: {
           status: 404,
           request: 'GET /does-not-exist'
         }
@@ -213,8 +213,8 @@ describe('plugin: network breadcrumbs', () => {
       expect(client.breadcrumbs.length).toBe(1)
       expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
-        name: 'fetch() error',
-        metaData: {
+        message: 'fetch() error',
+        metadata: {
           request: 'GET https://another-domain.xyz/foo/bar'
         }
       }))

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
@@ -222,11 +222,11 @@ describe('plugin: network breadcrumbs', () => {
     })
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     const window = { XMLHttpRequest }
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.configure()
     client.use(plugin, () => [], window)
 
@@ -237,11 +237,11 @@ describe('plugin: network breadcrumbs', () => {
     expect(client.breadcrumbs.length).toBe(0)
   })
 
-  it('should be enabled when autoBreadcrumbs=false and networkBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["request"]', () => {
     const window = { XMLHttpRequest }
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, networkBreadcrumbsEnabled: true })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['request'] })
     client.configure()
     client.use(plugin, () => [], window)
 

--- a/packages/plugin-react-native-app-state-breadcrumbs/README.md
+++ b/packages/plugin-react-native-app-state-breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-react-native-app-state-breadcrumbs
 
-This plugin adds the ability to record changes in network state. It defines a configuration option `appStateBreadcrumbsEnabled` which can be used to disable the functionality. It is included in the Expo notifier.
+This plugin adds the ability to record changes in network state. It is included in the Expo notifier.
 
 ## License
 MIT

--- a/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
@@ -2,19 +2,10 @@ const { AppState } = require('react-native')
 
 module.exports = {
   init: client => {
-    const explicitlyDisabled = client.config.appStateBreadcrumbsEnabled === false
-    const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.appStateBreadcrumbsEnabled !== true
-    if (explicitlyDisabled || implicitlyDisabled) return
+    if (!client.config.enabledBreadcrumbTypes || !client.config.enabledBreadcrumbTypes.includes('state')) return
 
     AppState.addEventListener('change', state => {
       client.leaveBreadcrumb('App state changed', { state }, 'state')
     })
-  },
-  configSchema: {
-    appStateBreadcrumbsEnabled: {
-      defaultValue: () => undefined,
-      validate: (value) => value === true || value === false || value === undefined,
-      message: 'should be true|false'
-    }
   }
 }

--- a/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
@@ -28,14 +28,14 @@ describe('plugin: react native app state breadcrumbs', () => {
     _cb('background')
     expect(client.breadcrumbs.length).toBe(1)
     expect(client.breadcrumbs[0].type).toBe('state')
-    expect(client.breadcrumbs[0].name).toBe('App state changed')
-    expect(client.breadcrumbs[0].metaData).toEqual({ state: 'background' })
+    expect(client.breadcrumbs[0].message).toBe('App state changed')
+    expect(client.breadcrumbs[0].metadata).toEqual({ state: 'background' })
 
     _cb('active')
     expect(client.breadcrumbs.length).toBe(2)
     expect(client.breadcrumbs[1].type).toBe('state')
-    expect(client.breadcrumbs[1].name).toBe('App state changed')
-    expect(client.breadcrumbs[1].metaData).toEqual({ state: 'active' })
+    expect(client.breadcrumbs[1].message).toBe('App state changed')
+    expect(client.breadcrumbs[1].metadata).toEqual({ state: 'active' })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {

--- a/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
@@ -38,7 +38,7 @@ describe('plugin: react native app state breadcrumbs', () => {
     expect(client.breadcrumbs[1].metaData).toEqual({ state: 'active' })
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=null', () => {
     let _cb
     const AppState = {
       addEventListener: (type, fn) => {
@@ -50,14 +50,14 @@ describe('plugin: react native app state breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
     client.configure()
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
   })
 
-  it('should not be enabled when appStateBreadcrumbsEnabled=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     let _cb
     const AppState = {
       addEventListener: (type, fn) => {
@@ -69,14 +69,14 @@ describe('plugin: react native app state breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', appStateBreadcrumbsEnabled: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.configure()
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
   })
 
-  it('should be enabled when autoBreadcrumbs=false and appStateBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["state"]', () => {
     let _cb
     const AppState = {
       addEventListener: (type, fn) => {
@@ -88,7 +88,7 @@ describe('plugin: react native app state breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, appStateBreadcrumbsEnabled: true })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
     client.configure()
     client.use(plugin)
 

--- a/packages/plugin-react-native-connectivity-breadcrumbs/README.md
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-react-native-connectivity-breadcrumbs
 
-This plugin adds the ability to record changes in network state. It defines a configuration option `connectivityBreadcrumbsEnabled` which can be used to disable the functionality. It is included in the Expo notifier.
+This plugin adds the ability to record changes in network state. It is included in the Expo notifier.
 
 ## License
 MIT

--- a/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
@@ -2,9 +2,7 @@ const { NetInfo } = require('react-native')
 
 module.exports = {
   init: client => {
-    const explicitlyDisabled = client.config.connectivityBreadcrumbsEnabled === false
-    const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.connectivityBreadcrumbsEnabled !== true
-    if (explicitlyDisabled || implicitlyDisabled) return
+    if (!client.config.enabledBreadcrumbTypes || !client.config.enabledBreadcrumbTypes.includes('state')) return
 
     NetInfo.addEventListener('connectionChange', ({ type, effectiveType }) => {
       client.leaveBreadcrumb(
@@ -16,12 +14,5 @@ module.exports = {
         'state'
       )
     })
-  },
-  configSchema: {
-    connectivityBreadcrumbsEnabled: {
-      defaultValue: () => undefined,
-      validate: (value) => value === true || value === false || value === undefined,
-      message: 'should be true|false'
-    }
   }
 }

--- a/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
@@ -38,7 +38,7 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     expect(client.breadcrumbs[1].metaData).toEqual({ type: 'none', effectiveType: 'unknown' })
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=null', () => {
     let _cb
     const NetInfo = {
       addEventListener: (type, fn) => {
@@ -50,14 +50,14 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
     client.configure()
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
   })
 
-  it('should not be enabled when connectivityBreadcrumbsEnabled=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     let _cb
     const NetInfo = {
       addEventListener: (type, fn) => {
@@ -69,14 +69,14 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', connectivityBreadcrumbsEnabled: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.configure()
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
   })
 
-  it('should be enabled when autoBreadcrumbs=false and connectivityBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["state"]', () => {
     let _cb
     const NetInfo = {
       addEventListener: (type, fn) => {
@@ -88,7 +88,7 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, connectivityBreadcrumbsEnabled: true })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
     client.configure()
     client.use(plugin)
 

--- a/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
@@ -28,14 +28,14 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     _cb({ type: 'wifi', effectiveType: '3g' })
     expect(client.breadcrumbs.length).toBe(1)
     expect(client.breadcrumbs[0].type).toBe('state')
-    expect(client.breadcrumbs[0].name).toBe('Connectivity changed')
-    expect(client.breadcrumbs[0].metaData).toEqual({ type: 'wifi', effectiveType: '3g' })
+    expect(client.breadcrumbs[0].message).toBe('Connectivity changed')
+    expect(client.breadcrumbs[0].metadata).toEqual({ type: 'wifi', effectiveType: '3g' })
 
     _cb({ type: 'none', effectiveType: 'unknown' })
     expect(client.breadcrumbs.length).toBe(2)
     expect(client.breadcrumbs[1].type).toBe('state')
-    expect(client.breadcrumbs[1].name).toBe('Connectivity changed')
-    expect(client.breadcrumbs[1].metaData).toEqual({ type: 'none', effectiveType: 'unknown' })
+    expect(client.breadcrumbs[1].message).toBe('Connectivity changed')
+    expect(client.breadcrumbs[1].metadata).toEqual({ type: 'none', effectiveType: 'unknown' })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {

--- a/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
@@ -2,9 +2,7 @@ const { Dimensions } = require('react-native')
 
 module.exports = {
   init: client => {
-    const explicitlyDisabled = client.config.orientationBreadcrumbsEnabled === false
-    const implicitlyDisabled = client.config.autoBreadcrumbs === false && client.config.orientationBreadcrumbsEnabled !== true
-    if (explicitlyDisabled || implicitlyDisabled) return
+    if (!client.config.enabledBreadcrumbTypes || !client.config.enabledBreadcrumbTypes.includes('state')) return
 
     let lastOrientation
 
@@ -34,12 +32,5 @@ module.exports = {
 
     lastOrientation = getCurrentOrientation()
     Dimensions.addEventListener('change', updateOrientation)
-  },
-  configSchema: {
-    orientationBreadcrumbsEnabled: {
-      defaultValue: () => undefined,
-      validate: (value) => value === true || value === false || value === undefined,
-      message: 'should be true|false'
-    }
   }
 }

--- a/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
@@ -33,8 +33,8 @@ describe('plugin: react native orientation breadcrumbs', () => {
     currentDimensions = { height: 200, width: 100 }
     _cb()
     expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0].name).toBe('Orientation changed')
-    expect(client.breadcrumbs[0].metaData).toEqual({ from: 'landscape', to: 'portrait' })
+    expect(client.breadcrumbs[0].message).toBe('Orientation changed')
+    expect(client.breadcrumbs[0].metadata).toEqual({ from: 'landscape', to: 'portrait' })
 
     currentDimensions = { height: 200, width: 100 }
     _cb()
@@ -43,8 +43,8 @@ describe('plugin: react native orientation breadcrumbs', () => {
     currentDimensions = { height: 100, width: 200 }
     _cb()
     expect(client.breadcrumbs.length).toBe(2)
-    expect(client.breadcrumbs[1].name).toBe('Orientation changed')
-    expect(client.breadcrumbs[1].metaData).toEqual({ from: 'portrait', to: 'landscape' })
+    expect(client.breadcrumbs[1].message).toBe('Orientation changed')
+    expect(client.breadcrumbs[1].metadata).toEqual({ from: 'portrait', to: 'landscape' })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {

--- a/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
@@ -47,7 +47,7 @@ describe('plugin: react native orientation breadcrumbs', () => {
     expect(client.breadcrumbs[1].metaData).toEqual({ from: 'portrait', to: 'landscape' })
   })
 
-  it('should not be enabled when autoBreadcrumbs=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=null', () => {
     let _cb
     const Dimensions = {
       addEventListener: (type, fn) => {
@@ -59,14 +59,14 @@ describe('plugin: react native orientation breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
     client.configure()
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
   })
 
-  it('should not be enabled when orientationBreadcrumbsEnabled=false', () => {
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     let _cb
     const Dimensions = {
       addEventListener: (type, fn) => {
@@ -78,14 +78,14 @@ describe('plugin: react native orientation breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', orientationBreadcrumbsEnabled: false })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.configure()
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
   })
 
-  it('should be enabled when autoBreadcrumbs=false and orientationBreadcrumbsEnabled=true', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["state"]', () => {
     let _cb
     const Dimensions = {
       addEventListener: (type, fn) => {
@@ -98,7 +98,7 @@ describe('plugin: react native orientation breadcrumbs', () => {
     })
 
     const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoBreadcrumbs: false, orientationBreadcrumbsEnabled: true })
+    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
     client.configure()
     client.use(plugin)
 

--- a/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
@@ -32,7 +32,7 @@ export default class AppStateBreadcrumbs extends Component {
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false,
-          appStateBreadcrumbsEnabled: false
+          enabledBreadcrumbTypes: ['log']
         }),
         errorMessage: "disabledAppStateBreadcrumbsBehaviour"
       }
@@ -46,7 +46,7 @@ export default class AppStateBreadcrumbs extends Component {
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false,
-          autoBreadcrumbs: false
+          enabledBreadcrumbTypes: []
         }),
         errorMessage: "disabledAllAppStateBreadcrumbsBehaviour"
       }
@@ -60,8 +60,7 @@ export default class AppStateBreadcrumbs extends Component {
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false,
-          autoBreadcrumbs: false,
-          appStateBreadcrumbsEnabled: true
+          enabledBreadcrumbTypes: ['state']
         }),
         errorMessage: "overrideAppStateBreadcrumbsBehaviour"
       }

--- a/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
@@ -29,7 +29,7 @@ export default class ConsoleBreadcrumbs extends Component {
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
-        consoleBreadcrumbsEnabled: false
+        enabledBreadcrumbTypes: ['request']
       }),
       "disabledConsoleBreadcrumbsBehaviour"
     )
@@ -41,7 +41,7 @@ export default class ConsoleBreadcrumbs extends Component {
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
-        autoBreadcrumbs: false
+        enabledBreadcrumbTypes: []
       }),
       "disabledAllConsoleBreadcrumbsBehaviour"
     )
@@ -53,8 +53,7 @@ export default class ConsoleBreadcrumbs extends Component {
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
-        autoBreadcrumbs: false,
-        consoleBreadcrumbsEnabled: true
+        enabledBreadcrumbTypes: ['log']
       }),
       "overrideConsoleBreadcrumbsBehaviour"
     )

--- a/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
@@ -29,7 +29,7 @@ export default class NetworkBreadcrumbs extends Component {
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
-        networkBreadcrumbsEnabled: false
+        enabledBreadcrumbTypes: ['state']
       }),
       "disabledNetworkBreadcrumbsBehaviour"
     )
@@ -41,7 +41,7 @@ export default class NetworkBreadcrumbs extends Component {
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
-        autoBreadcrumbs: false
+        enabledBreadcrumbTypes: []
       }),
       "disabledAllNetworkBreadcrumbsBehaviour"
     )
@@ -53,8 +53,7 @@ export default class NetworkBreadcrumbs extends Component {
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
-        autoBreadcrumbs: false,
-        networkBreadcrumbsEnabled: true
+        enabledBreadcrumbTypes: ['request']
       }),
       "overrideNetworkBreadcrumbsBehaviour"
     )


### PR DESCRIPTION
- Remove individual breadcrumb flags in favour of `enabledBreadcrumbTypes` option
  The `*BreadcrumbsEnabled` plugin-specfic options have been removed and breadcrumbs are now controlled by generic list in `enabledBreadcrumbTypes`.
- Rename `breadcrumb.{ name -> message, metaData -> metadata }`
  These fields have been renamed. Note that `metaData` -> `metadata` will happen elsewhere in the codebase too but I limited the scope to just breadcrumbs for this PR
- Update `leaveBreadcrumb()` type signature to be more explicit
  The `metadata` object is only allowed to be one level deep in breadcrumbs so the type signature now enforces that