### PR TITLE
v7: hoist devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2879,6 +2879,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3604,6 +3614,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -3867,6 +3883,33 @@
         "write-json-file": "^2.2.0",
         "write-pkg": "^3.1.0",
         "yargs": "^8.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "levn": {
@@ -4064,6 +4107,12 @@
         }
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-source-map": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
@@ -4172,6 +4221,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "mold-source-map": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
@@ -4259,6 +4314,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -4269,6 +4330,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
     },
     "normalize-package-data": {
@@ -4694,6 +4761,34 @@
         "react-is": "^16.8.1"
       }
     },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5021,12 +5116,28 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -5586,6 +5697,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "timekeeper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
       "dev": true
     },
     "timers-browserify": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
     "eslint-plugin-standard": "^4.0.1",
     "exorcist": "^1.0.1",
     "lerna": "^2.11.0",
+    "ncp": "^2.0.0",
+    "node-fetch": "^2.6.0",
+    "proxyquire": "^2.1.3",
+    "rimraf": "^3.0.0",
+    "timekeeper": "^2.2.0",
     "typescript": "^3.6.4",
     "uglify-js": "^3.4.9"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -189,15 +189,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -247,11 +238,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"iserror": {
 			"version": "0.0.2",
@@ -314,11 +300,6 @@
 				"js-tokens": "^3.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -326,11 +307,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -2147,29 +2123,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-		},
-		"proxyquire": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
-			"integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.5.0"
-			}
-		},
-		"resolve": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
 		},
 		"semver": {
 			"version": "5.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2",
-    "proxyquire": "^2.0.1",
     "typescript": "^2.9.2"
   }
 }

--- a/packages/delivery-expo/package-lock.json
+++ b/packages/delivery-expo/package-lock.json
@@ -177,15 +177,6 @@
 				"uuid-js": "^0.7.5"
 			}
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -235,11 +226,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -297,11 +283,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -310,20 +291,10 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
-		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-		},
-		"node-fetch": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-			"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
 		},
 		"nyc": {
 			"version": "12.0.2",
@@ -2135,29 +2106,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
 		},
 		"semver": {
 			"version": "5.6.0",

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -25,8 +25,6 @@
   },
   "devDependencies": {
     "jasmine": "3.1.0",
-    "node-fetch": "^2.3.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0"
+    "nyc": "^12.0.2"
   }
 }

--- a/packages/expo-cli/package-lock.json
+++ b/packages/expo-cli/package-lock.json
@@ -185,15 +185,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"find-replace": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -251,11 +242,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -330,11 +316,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -343,20 +324,10 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
-		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-		},
-		"ncp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
 		},
 		"nyc": {
 			"version": "12.0.2",
@@ -2169,11 +2140,6 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
 		"prompts": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
@@ -2181,32 +2147,6 @@
 			"requires": {
 				"kleur": "^3.0.2",
 				"sisteransi": "^1.0.0"
-			}
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
-		},
-		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"requires": {
-				"glob": "^7.1.3"
 			}
 		},
 		"semver": {

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -15,10 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "jasmine": "3.1.0",
-    "ncp": "^2.0.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0",
-    "rimraf": "^2.6.3"
+    "nyc": "^12.0.2"
   },
   "dependencies": {
     "command-line-args": "^5.0.2",

--- a/packages/plugin-expo-app/package-lock.json
+++ b/packages/plugin-expo-app/package-lock.json
@@ -101,28 +101,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@bugsnag/core": {
-			"version": "7.0.0-pre-alpha-ben.6",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.0.0-pre-alpha-ben.6.tgz",
-			"integrity": "sha512-NL33soHPbL+8xm/jIMPlIOIzUErEJgelDC3HOqSMNwPpGidE5768H28MUFGTF77TatRkihcZS5MNf4Ymt888Pg==",
-			"requires": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "4.0.0",
-				"error-stack-parser": "^2.0.2",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
-		},
-		"@bugsnag/safe-json-stringify": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-4.0.0.tgz",
-			"integrity": "sha512-eb0yG+PNTdpRXIhfEq4IFi2wBfpE1DjrAlkyehinu9RxE1PKteqJioLmfQjvkG3UviGu/k5pcamYMxNuCAMIoQ=="
-		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -181,14 +159,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"error-stack-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-			"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -205,15 +175,6 @@
 			"integrity": "sha512-O0yL3Ok0YUEWpAqsWjOdgFD/lMfg8PUGH/nq31CZ1s7cuFUlksD42i5YhIRlb0Pa/btK8X9LpfY3eWhx9eTmbg==",
 			"requires": {
 				"ua-parser-js": "^0.7.19"
-			}
-		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -265,16 +226,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-		},
-		"iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -332,11 +283,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -344,11 +290,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.1.1",
@@ -2166,29 +2107,6 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
-		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -2198,19 +2116,6 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"stack-generator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-			"integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
-		"stackframe": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-			"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -22,8 +22,7 @@
   "devDependencies": {
     "@bugsnag/core": "^6.4.1",
     "jasmine": "3.1.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0"
+    "nyc": "^12.0.2"
   },
   "dependencies": {
     "expo-constants": "^6.0.0"

--- a/packages/plugin-expo-device/package-lock.json
+++ b/packages/plugin-expo-device/package-lock.json
@@ -101,28 +101,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@bugsnag/core": {
-			"version": "7.0.0-pre-alpha-ben.6",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.0.0-pre-alpha-ben.6.tgz",
-			"integrity": "sha512-NL33soHPbL+8xm/jIMPlIOIzUErEJgelDC3HOqSMNwPpGidE5768H28MUFGTF77TatRkihcZS5MNf4Ymt888Pg==",
-			"requires": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "4.0.0",
-				"error-stack-parser": "^2.0.2",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
-		},
-		"@bugsnag/safe-json-stringify": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-4.0.0.tgz",
-			"integrity": "sha512-eb0yG+PNTdpRXIhfEq4IFi2wBfpE1DjrAlkyehinu9RxE1PKteqJioLmfQjvkG3UviGu/k5pcamYMxNuCAMIoQ=="
-		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -181,14 +159,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"error-stack-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-			"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -205,15 +175,6 @@
 			"integrity": "sha512-O0yL3Ok0YUEWpAqsWjOdgFD/lMfg8PUGH/nq31CZ1s7cuFUlksD42i5YhIRlb0Pa/btK8X9LpfY3eWhx9eTmbg==",
 			"requires": {
 				"ua-parser-js": "^0.7.19"
-			}
-		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -265,16 +226,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-		},
-		"iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -332,11 +283,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -344,11 +290,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.1.1",
@@ -2166,29 +2107,6 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
-		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -2198,19 +2116,6 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"stack-generator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-			"integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
-		"stackframe": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-			"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -22,8 +22,7 @@
   "devDependencies": {
     "@bugsnag/core": "^6.4.1",
     "jasmine": "3.1.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0"
+    "nyc": "^12.0.2"
   },
   "dependencies": {
     "expo-constants": "^6.0.0"

--- a/packages/plugin-react-native-app-state-breadcrumbs/package-lock.json
+++ b/packages/plugin-react-native-app-state-breadcrumbs/package-lock.json
@@ -169,15 +169,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -227,11 +218,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -289,11 +275,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -301,11 +282,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.1.1",
@@ -2122,29 +2098,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
 		},
 		"semver": {
 			"version": "5.6.0",

--- a/packages/plugin-react-native-app-state-breadcrumbs/package.json
+++ b/packages/plugin-react-native-app-state-breadcrumbs/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@bugsnag/core": "^6.4.1",
     "jasmine": "3.1.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0"
+    "nyc": "^12.0.2"
   }
 }

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package-lock.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package-lock.json
@@ -169,15 +169,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -227,11 +218,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -289,11 +275,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -301,11 +282,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.1.1",
@@ -2122,29 +2098,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
 		},
 		"semver": {
 			"version": "5.6.0",

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@bugsnag/core": "^6.4.1",
     "jasmine": "3.1.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0"
+    "nyc": "^12.0.2"
   }
 }

--- a/packages/plugin-react-native-global-error-handler/package-lock.json
+++ b/packages/plugin-react-native-global-error-handler/package-lock.json
@@ -101,28 +101,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@bugsnag/core": {
-			"version": "7.0.0-pre-alpha-ben.6",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.0.0-pre-alpha-ben.6.tgz",
-			"integrity": "sha512-NL33soHPbL+8xm/jIMPlIOIzUErEJgelDC3HOqSMNwPpGidE5768H28MUFGTF77TatRkihcZS5MNf4Ymt888Pg==",
-			"requires": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "4.0.0",
-				"error-stack-parser": "^2.0.2",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
-		},
-		"@bugsnag/safe-json-stringify": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-4.0.0.tgz",
-			"integrity": "sha512-eb0yG+PNTdpRXIhfEq4IFi2wBfpE1DjrAlkyehinu9RxE1PKteqJioLmfQjvkG3UviGu/k5pcamYMxNuCAMIoQ=="
-		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -179,14 +157,6 @@
 			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 			"requires": {
 				"ms": "^2.1.1"
-			}
-		},
-		"error-stack-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-			"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
-			"requires": {
-				"stackframe": "^1.0.4"
 			}
 		},
 		"escape-string-regexp": {
@@ -248,11 +218,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -2143,19 +2108,6 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"stack-generator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-			"integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
-		"stackframe": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-			"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/packages/plugin-react-native-orientation-breadcrumbs/package-lock.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package-lock.json
@@ -169,15 +169,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -227,11 +218,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -289,11 +275,6 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -301,11 +282,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.1.1",
@@ -2122,29 +2098,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"proxyquire": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.8.1"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
 		},
 		"semver": {
 			"version": "5.7.0",

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@bugsnag/core": "^6.4.1",
     "jasmine": "3.1.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.1.0"
+    "nyc": "^12.0.2"
   }
 }

--- a/packages/plugin-react-native-unhandled-rejection/package-lock.json
+++ b/packages/plugin-react-native-unhandled-rejection/package-lock.json
@@ -101,28 +101,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@bugsnag/core": {
-			"version": "7.0.0-pre-alpha-ben.6",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.0.0-pre-alpha-ben.6.tgz",
-			"integrity": "sha512-NL33soHPbL+8xm/jIMPlIOIzUErEJgelDC3HOqSMNwPpGidE5768H28MUFGTF77TatRkihcZS5MNf4Ymt888Pg==",
-			"requires": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "4.0.0",
-				"error-stack-parser": "^2.0.2",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
-		},
-		"@bugsnag/safe-json-stringify": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-4.0.0.tgz",
-			"integrity": "sha512-eb0yG+PNTdpRXIhfEq4IFi2wBfpE1DjrAlkyehinu9RxE1PKteqJioLmfQjvkG3UviGu/k5pcamYMxNuCAMIoQ=="
-		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -186,14 +164,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"error-stack-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-			"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -253,11 +223,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -2156,19 +2121,6 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"stack-generator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-			"integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
-			"requires": {
-				"stackframe": "^1.0.4"
-			}
-		},
-		"stackframe": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-			"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/packages/plugin-server-session/package-lock.json
+++ b/packages/plugin-server-session/package-lock.json
@@ -174,15 +174,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
-		"fill-keys": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -232,11 +223,6 @@
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.0",
@@ -294,11 +280,6 @@
 				"js-tokens": "^3.0.0"
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -306,11 +287,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"module-not-found-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -2128,29 +2104,6 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
-		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-		},
-		"proxyquire": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
-			"integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
-			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.5.0"
-			}
-		},
-		"resolve": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
-		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -2168,11 +2121,6 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
-		},
-		"timekeeper": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.1.2.tgz",
-			"integrity": "sha512-fc1DDqbiyz5vxRO4xkiATwfWUw1FV7W20+FJYal1SnoIYgNuB4WNxYLtbG3zjUBwOSk3P4u1TgBAZYG/aqBWMw=="
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -25,8 +25,6 @@
   },
   "devDependencies": {
     "jasmine": "^3.1.0",
-    "nyc": "^12.0.2",
-    "proxyquire": "^2.0.1",
-    "timekeeper": "^2.1.2"
+    "nyc": "^12.0.2"
   }
 }


### PR DESCRIPTION
Move common devDependencies to the root of the lerna repo. Moved dependencies have been updated. Note that devDependencies providing "binary" executables have not been hoisted. 

Reference: https://github.com/lerna/lerna/blob/master/README.md#common-devdependencies