### PR TITLE
V7: Simplify client configuration and store config privately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove individual breadcrumb flags in favour of `enabledBreadcrumbTypes`, rename `breadcrumb.{ name -> message, metaData -> metadata }`, and update `leaveBreadcrumb()` type signature to be more explicit [#650](https://github.com/bugsnag/bugsnag-js/pull/650)
 - Rename `beforeSend` -> `onError`, remove `event.ignore()` and refactor callback logic [#654](https://github.com/bugsnag/bugsnag-js/pull/654)
 - Update signature of `notify(err, opts?, cb?)` -> `notify(err, onError?, cb?)` for a canonical way to update events [#655](https://github.com/bugsnag/bugsnag-js/pull/655)
+- Simplify client configuration, and store resulting config privately [#656](https://github.com/bugsnag/bugsnag-js/pull/656)
 
 ## 6.4.3 (2019-10-21)
 

--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -33,28 +33,13 @@ module.exports = (opts) => {
   // handle very simple use case where user supplies just the api key as a string
   if (typeof opts === 'string') opts = { apiKey: opts }
 
-  // support renamed/deprecated options
-
-  let warningMessage = ''
-
-  if (opts.endpoints && opts.endpoints.notify && !opts.endpoints.sessions) {
-    warningMessage += 'notify endpoint is set but sessions endpoint is not. No sessions will be sent.'
-  }
-
-  const bugsnag = new Client({ name, version, url })
-
-  bugsnag.setOptions(opts)
+  // configure a client with user supplied options
+  const bugsnag = new Client(opts, schema, { name, version, url })
 
   // set delivery based on browser capability (IE 8+9 have an XDomainRequest object)
   bugsnag.delivery(window.XDomainRequest ? dXDomainRequest : dXMLHttpRequest)
 
-  // configure with user supplied options
-  // errors can be thrown here that prevent the lib from being in a useable state
-  bugsnag.configure(schema)
-
-  if (warningMessage) bugsnag._logger.warn(warningMessage)
-
-  // always-on browser-specific plugins
+  // add browser-specific plugins
   bugsnag.use(pluginDevice)
   bugsnag.use(pluginContext)
   bugsnag.use(pluginRequest)
@@ -74,7 +59,7 @@ module.exports = (opts) => {
 
   bugsnag._logger.debug('Loaded!')
 
-  return bugsnag.config.autoTrackSessions
+  return bugsnag._config.autoTrackSessions
     ? bugsnag.startSession()
     : bugsnag
 }

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -1,9 +1,8 @@
 module.exports = (client) => {
-  const clone = new client.BugsnagClient(client.notifier)
-  clone.configure({})
+  const clone = new client.BugsnagClient({}, {}, client._notifier)
 
   // changes to these properties should be reflected in the original client
-  clone.config = client.config
+  clone._config = client._config
   clone.app = client.app
   clone.context = client.context
   clone.device = client.device

--- a/packages/core/lib/infer-release-stage.js
+++ b/packages/core/lib/infer-release-stage.js
@@ -1,4 +1,4 @@
 module.exports = client =>
   client.app && typeof client.app.releaseStage === 'string'
     ? client.app.releaseStage
-    : client.config.releaseStage
+    : client._config.releaseStage

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -7,7 +7,6 @@ declare class Client {
   public app: object;
   public device: object;
   public context: string | void;
-  public config: common.Config;
   public user: object;
   public metaData: object;
 
@@ -17,8 +16,6 @@ declare class Client {
 
   public use(plugin: common.Plugin, ...args: any[]): Client;
   public getPlugin(name: string): any;
-  public setOptions(opts: common.Config): Client;
-  public configure(schema?: common.ConfigSchema): Client;
   public delivery(delivery: common.Delivery): Client;
   public logger(logger: common.Logger): Client;
   public sessionDelegate(sessionDelegate: common.SessionDelegate): Client;

--- a/packages/delivery-expo/delivery.js
+++ b/packages/delivery-expo/delivery.js
@@ -37,16 +37,16 @@ module.exports = (client, fetch = global.fetch) => {
 
   return {
     sendEvent: (event, cb = () => {}) => {
-      const url = client.config.endpoints.notify
+      const url = client._config.endpoints.notify
 
       let body, opts
       try {
-        body = payload.event(event, client.config.filters)
+        body = payload.event(event, client._config.filters)
         opts = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Bugsnag-Api-Key': event.apiKey || client.config.apiKey,
+            'Bugsnag-Api-Key': event.apiKey || client._config.apiKey,
             'Bugsnag-Payload-Version': '4',
             'Bugsnag-Sent-At': isoDate()
           },
@@ -67,16 +67,16 @@ module.exports = (client, fetch = global.fetch) => {
     },
 
     sendSession: (session, cb = () => {}) => {
-      const url = client.config.endpoints.sessions
+      const url = client._config.endpoints.sessions
 
       let body, opts
       try {
-        body = payload.session(session, client.config.filters)
+        body = payload.session(session, client._config.filters)
         opts = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Bugsnag-Api-Key': client.config.apiKey,
+            'Bugsnag-Api-Key': client._config.apiKey,
             'Bugsnag-Payload-Version': '1',
             'Bugsnag-Sent-At': isoDate()
           },

--- a/packages/delivery-expo/test/delivery.test.js
+++ b/packages/delivery-expo/test/delivery.test.js
@@ -68,7 +68,7 @@ describe('delivery: expo', () => {
         endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` },
         filters: []
       }
-      delivery({ config, _logger: noopLogger }, fetch).sendEvent(payload, (err) => {
+      delivery({ _config: config, _logger: noopLogger }, fetch).sendEvent(payload, (err) => {
         expect(err).toBe(null)
         expect(requests.length).toBe(1)
         expect(requests[0].method).toBe('POST')
@@ -102,7 +102,7 @@ describe('delivery: expo', () => {
         endpoints: { notify: 'blah', sessions: `http://0.0.0.0:${server.address().port}/sessions/` },
         filters: []
       }
-      delivery({ config, _logger: noopLogger }, fetch).sendSession(payload, (err) => {
+      delivery({ _config: config, _logger: noopLogger }, fetch).sendSession(payload, (err) => {
         expect(err).toBe(null)
         expect(requests.length).toBe(1)
         expect(requests[0].method).toBe('POST')
@@ -140,7 +140,7 @@ describe('delivery: expo', () => {
     }
     let didLog = false
     const log = () => { didLog = true }
-    delivery({ config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
+    delivery({ _config: config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
       expect(didLog).toBe(true)
       expect(err).toBeTruthy()
       expect(err.code).toBe('ECONNREFUSED')
@@ -174,7 +174,7 @@ describe('delivery: expo', () => {
       }
       let didLog = false
       const log = () => { didLog = true }
-      delivery({ config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
+      delivery({ _config: config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
         expect(didLog).toBe(true)
         expect(spiedEnqueue).not.toHaveBeenCalled()
         expect(err).toBeTruthy()
@@ -206,7 +206,7 @@ describe('delivery: expo', () => {
     }
     let didLog = false
     const log = () => { didLog = true }
-    delivery({ config, _logger: { error: log, info: () => {} } }, fetch).sendSession(payload, (err) => {
+    delivery({ _config: config, _logger: { error: log, info: () => {} } }, fetch).sendSession(payload, (err) => {
       expect(didLog).toBe(true)
       expect(err).toBeTruthy()
       expect(err.code).toBe('ECONNREFUSED')
@@ -242,7 +242,7 @@ describe('delivery: expo', () => {
       }
       let didLog = false
       const log = () => { didLog = true }
-      delivery({ config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
+      delivery({ _config: config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
         expect(err.code).toBe('ECONNRESET')
@@ -280,7 +280,7 @@ describe('delivery: expo', () => {
       }
       let didLog = false
       const log = () => { didLog = true }
-      delivery({ config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
+      delivery({ _config: config, _logger: { error: log, info: () => {} } }, fetch).sendEvent(payload, (err) => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
         expect(spiedEnqueue).toHaveBeenCalled()
@@ -308,7 +308,7 @@ describe('delivery: expo', () => {
       endpoints: { notify: 'https://some-address.com' },
       filters: []
     }
-    delivery({ config, _logger: noopLogger }, fetch).sendEvent(payload, (err) => {
+    delivery({ _config: config, _logger: noopLogger }, fetch).sendEvent(payload, (err) => {
       expect(err).not.toBeTruthy()
       expect(spiedEnqueue).toHaveBeenCalled()
       done()
@@ -395,7 +395,7 @@ describe('delivery: expo', () => {
       n++
       if (n === 2) done()
     }
-    const d = delivery({ config, _logger: noopLogger }, fetch)
+    const d = delivery({ _config: config, _logger: noopLogger }, fetch)
     d.sendEvent(payload, (err) => {
       expect(err).not.toBeTruthy()
       expect(spiedEnqueue).toHaveBeenCalledTimes(1)

--- a/packages/delivery-node/delivery.js
+++ b/packages/delivery-node/delivery.js
@@ -11,15 +11,15 @@ module.exports = (client) => ({
 
     try {
       request({
-        url: client.config.endpoints.notify,
+        url: client._config.endpoints.notify,
         headers: {
           'Content-Type': 'application/json',
-          'Bugsnag-Api-Key': event.apiKey || client.config.apiKey,
+          'Bugsnag-Api-Key': event.apiKey || client._config.apiKey,
           'Bugsnag-Payload-Version': '4',
           'Bugsnag-Sent-At': isoDate()
         },
-        body: payload.event(event, client.config.filters),
-        agent: client.config.agent
+        body: payload.event(event, client._config.filters),
+        agent: client._config.agent
       }, (err, body) => _cb(err))
     } catch (e) {
       _cb(e)
@@ -33,15 +33,15 @@ module.exports = (client) => ({
 
     try {
       request({
-        url: client.config.endpoints.sessions,
+        url: client._config.endpoints.sessions,
         headers: {
           'Content-Type': 'application/json',
-          'Bugsnag-Api-Key': client.config.apiKey,
+          'Bugsnag-Api-Key': client._config.apiKey,
           'Bugsnag-Payload-Version': '1',
           'Bugsnag-Sent-At': isoDate()
         },
-        body: payload.session(session, client.config.filters),
-        agent: client.config.agent
+        body: payload.session(session, client._config.filters),
+        agent: client._config.agent
       }, err => _cb(err))
     } catch (e) {
       _cb(e)

--- a/packages/delivery-node/test/delivery.test.js
+++ b/packages/delivery-node/test/delivery.test.js
@@ -36,7 +36,7 @@ describe('delivery:node', () => {
         endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` },
         filters: []
       }
-      delivery({ _logger: {}, config }).sendEvent(payload, (err) => {
+      delivery({ _logger: {}, _config: config }).sendEvent(payload, (err) => {
         expect(err).toBe(null)
         expect(requests.length).toBe(1)
         expect(requests[0].method).toBe('POST')
@@ -64,7 +64,7 @@ describe('delivery:node', () => {
         endpoints: { notify: 'blah', sessions: `http://0.0.0.0:${server.address().port}/sessions/` },
         filters: []
       }
-      delivery({ _logger: {}, config }).sendSession(payload, (err) => {
+      delivery({ _logger: {}, _config: config }).sendSession(payload, (err) => {
         expect(err).toBe(null)
         expect(requests.length).toBe(1)
         expect(requests[0].method).toBe('POST')
@@ -90,7 +90,7 @@ describe('delivery:node', () => {
     }
     let didLog = false
     const log = () => { didLog = true }
-    delivery({ config, _logger: { error: log } }).sendEvent(payload, (err) => {
+    delivery({ _config: config, _logger: { error: log } }).sendEvent(payload, (err) => {
       expect(didLog).toBe(true)
       expect(err).toBeTruthy()
       expect(err.code).toBe('ECONNREFUSED')
@@ -113,7 +113,7 @@ describe('delivery:node', () => {
       }
       let didLog = false
       const log = () => { didLog = true }
-      delivery({ config, _logger: { error: log } }).sendEvent(payload, (err) => {
+      delivery({ _config: config, _logger: { error: log } }).sendEvent(payload, (err) => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
         expect(err.code).toBe('ECONNRESET')
@@ -138,7 +138,7 @@ describe('delivery:node', () => {
       }
       let didLog = false
       const log = () => { didLog = true }
-      delivery({ config, _logger: { error: log } }).sendEvent(payload, (err) => {
+      delivery({ _config: config, _logger: { error: log } }).sendEvent(payload, (err) => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
         done()

--- a/packages/delivery-x-domain-request/delivery.js
+++ b/packages/delivery-x-domain-request/delivery.js
@@ -3,7 +3,7 @@ const { isoDate } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = (client, win = window) => ({
   sendEvent: (event, cb = () => {}) => {
-    const url = getApiUrl(client.config, 'notify', '4', win)
+    const url = getApiUrl(client._config, 'notify', '4', win)
     const req = new win.XDomainRequest()
     req.onload = function () {
       cb(null)
@@ -11,7 +11,7 @@ module.exports = (client, win = window) => ({
     req.open('POST', url)
     setTimeout(() => {
       try {
-        req.send(payload.event(event, client.config.filters))
+        req.send(payload.event(event, client._config.filters))
       } catch (e) {
         client._logger.error(e)
         cb(e)
@@ -19,7 +19,7 @@ module.exports = (client, win = window) => ({
     }, 0)
   },
   sendSession: (session, cb = () => {}) => {
-    const url = getApiUrl(client.config, 'sessions', '1', win)
+    const url = getApiUrl(client._config, 'sessions', '1', win)
     const req = new win.XDomainRequest()
     req.onload = function () {
       cb(null)
@@ -27,7 +27,7 @@ module.exports = (client, win = window) => ({
     req.open('POST', url)
     setTimeout(() => {
       try {
-        req.send(payload.session(session, client.config.filters))
+        req.send(payload.session(session, client._config.filters))
       } catch (e) {
         this._logger.error(e)
         cb(e)

--- a/packages/delivery-x-domain-request/test/delivery.test.js
+++ b/packages/delivery-x-domain-request/test/delivery.test.js
@@ -30,7 +30,7 @@ describe('delivery:XDomainRequest', () => {
       endpoints: { notify: '/echo/' },
       filters: []
     }
-    delivery({ logger: {}, config }, window).sendEvent(payload, (err) => {
+    delivery({ logger: {}, _config: config }, window).sendEvent(payload, (err) => {
       expect(err).toBe(null)
       expect(requests.length).toBe(1)
       expect(requests[0].method).toBe('POST')
@@ -69,7 +69,7 @@ describe('delivery:XDomainRequest', () => {
       endpoints: { notify: '/echo/', sessions: '/sessions/' },
       filters: []
     }
-    delivery({ logger: {}, config }, window).sendSession(payload, (err) => {
+    delivery({ logger: {}, _config: config }, window).sendSession(payload, (err) => {
       expect(err).toBe(null)
       expect(requests.length).toBe(1)
       expect(requests[0].method).toBe('POST')

--- a/packages/delivery-xml-http-request/delivery.js
+++ b/packages/delivery-xml-http-request/delivery.js
@@ -4,34 +4,34 @@ const { isoDate } = require('@bugsnag/core/lib/es-utils')
 module.exports = (client, win = window) => ({
   sendEvent: (event, cb = () => {}) => {
     try {
-      const url = client.config.endpoints.notify
+      const url = client._config.endpoints.notify
       const req = new win.XMLHttpRequest()
       req.onreadystatechange = function () {
         if (req.readyState === win.XMLHttpRequest.DONE) cb(null)
       }
       req.open('POST', url)
       req.setRequestHeader('Content-Type', 'application/json')
-      req.setRequestHeader('Bugsnag-Api-Key', event.apiKey || client.config.apiKey)
+      req.setRequestHeader('Bugsnag-Api-Key', event.apiKey || client._config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '4')
       req.setRequestHeader('Bugsnag-Sent-At', isoDate())
-      req.send(payload.event(event, client.config.filters))
+      req.send(payload.event(event, client._config.filters))
     } catch (e) {
       client._logger.error(e)
     }
   },
   sendSession: (session, cb = () => {}) => {
     try {
-      const url = client.config.endpoints.sessions
+      const url = client._config.endpoints.sessions
       const req = new win.XMLHttpRequest()
       req.onreadystatechange = function () {
         if (req.readyState === win.XMLHttpRequest.DONE) cb(null)
       }
       req.open('POST', url)
       req.setRequestHeader('Content-Type', 'application/json')
-      req.setRequestHeader('Bugsnag-Api-Key', client.config.apiKey)
+      req.setRequestHeader('Bugsnag-Api-Key', client._config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '1')
       req.setRequestHeader('Bugsnag-Sent-At', isoDate())
-      req.send(payload.session(session, client.config.filters))
+      req.send(payload.session(session, client._config.filters))
     } catch (e) {
       client._logger.error(e)
     }

--- a/packages/delivery-xml-http-request/test/delivery.test.js
+++ b/packages/delivery-xml-http-request/test/delivery.test.js
@@ -35,7 +35,7 @@ describe('delivery:XMLHttpRequest', () => {
       endpoints: { notify: '/echo/' },
       filters: []
     }
-    delivery({ logger: {}, config }, { XMLHttpRequest }).sendEvent(payload, (err) => {
+    delivery({ logger: {}, _config: config }, { XMLHttpRequest }).sendEvent(payload, (err) => {
       expect(err).toBe(null)
       expect(requests.length).toBe(1)
       expect(requests[0].method).toBe('POST')
@@ -81,7 +81,7 @@ describe('delivery:XMLHttpRequest', () => {
       endpoints: { notify: '/', sessions: '/echo/' },
       filters: []
     }
-    delivery({ config, logger: {} }, { XMLHttpRequest }).sendSession(payload, (err) => {
+    delivery({ _config: config, logger: {} }, { XMLHttpRequest }).sendSession(payload, (err) => {
       expect(err).toBe(null)
       expect(requests.length).toBe(1)
       expect(requests[0].method).toBe('POST')

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -43,18 +43,16 @@ module.exports = (opts) => {
     opts.apiKey = Constants.manifest.extra.bugsnag.apiKey
   }
 
-  const bugsnag = new Client({ name, version, url })
+  const bugsnag = new Client(opts, schema, { name, version, url })
 
   bugsnag.delivery(delivery)
-  bugsnag.setOptions(opts)
-  bugsnag.configure(schema)
 
   plugins.forEach(pl => {
     switch (pl.name) {
       case 'networkBreadcrumbs':
         bugsnag.use(pl, () => [
-          bugsnag.config.endpoints.notify,
-          bugsnag.config.endpoints.sessions,
+          bugsnag._config.endpoints.notify,
+          bugsnag._config.endpoints.sessions,
           Constants.manifest.logUrl
         ])
         break
@@ -66,7 +64,7 @@ module.exports = (opts) => {
 
   bugsnag._logger.debug('Loaded!')
 
-  return bugsnag.config.autoTrackSessions
+  return bugsnag._config.autoTrackSessions
     ? bugsnag.startSession()
     : bugsnag
 }

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -41,11 +41,9 @@ module.exports = (opts, userPlugins = []) => {
   // handle very simple use case where user supplies just the api key as a string
   if (typeof opts === 'string') opts = { apiKey: opts }
 
-  const bugsnag = new Client({ name, version, url })
+  const bugsnag = new Client(opts, schema, { name, version, url })
 
   bugsnag.delivery(delivery)
-  bugsnag.setOptions(opts)
-  bugsnag.configure(schema)
 
   plugins.forEach(pl => bugsnag.use(pl))
 

--- a/packages/plugin-browser-context/context.js
+++ b/packages/plugin-browser-context/context.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   init: (client, win = window) => {
-    client.config.onError.unshift(event => {
+    client._config.onError.unshift(event => {
       if (event.context) return
       event.context = win.location.pathname
     })

--- a/packages/plugin-browser-context/test/context.test.js
+++ b/packages/plugin-browser-context/test/context.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 const window = {
   location: {
@@ -13,10 +12,8 @@ const window = {
 
 describe('plugin: context', () => {
   it('sets client.context (and event.context) to window.location.pathname', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, window)
 
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
@@ -27,10 +24,8 @@ describe('plugin: context', () => {
   })
 
   it('sets doesn’t overwrite an existing context', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, window)
 
     client.context = 'something else'

--- a/packages/plugin-browser-device/device.js
+++ b/packages/plugin-browser-device/device.js
@@ -14,7 +14,7 @@ module.exports = {
     client.device = { ...device, ...client.device }
 
     // add time just as the event is sent
-    client.config.onError.unshift((event) => {
+    client._config.onError.unshift((event) => {
       event.device = { ...event.device, time: isoDate() }
     })
   }

--- a/packages/plugin-browser-device/test/device.test.js
+++ b/packages/plugin-browser-device/test/device.test.js
@@ -3,19 +3,16 @@ const { describe, it, expect } = global
 const plugin = require('../device')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 const navigator = { locale: 'en_GB', userAgent: 'testing browser 1.2.3' }
 
 describe('plugin: device', () => {
   it('should add an onError callback which captures device information', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, navigator)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
 
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Error('noooo'))

--- a/packages/plugin-browser-request/request.js
+++ b/packages/plugin-browser-request/request.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
   init: (client, win = window) => {
-    client.config.onError.unshift(event => {
+    client._config.onError.unshift(event => {
       if (event.request && event.request.url) return
       event.request = { ...event.request, url: win.location.href }
     })

--- a/packages/plugin-browser-request/test/request.test.js
+++ b/packages/plugin-browser-request/test/request.test.js
@@ -3,16 +3,13 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 const window = { location: { href: 'http://xyz.abc/foo/bar.html' } }
 
 describe('plugin: request', () => {
   it('sets event.request to window.location.href', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, window)
 
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
@@ -23,10 +20,8 @@ describe('plugin: request', () => {
   })
 
   it('sets doesn’t overwrite an existing request', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, window)
 
     client.request = { url: 'foobar' }

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -13,13 +13,13 @@ const sessionDelegate = {
     const releaseStage = inferReleaseStage(sessionClient)
 
     // exit early if the current releaseStage is not enabled
-    if (sessionClient.config.enabledReleaseStages.length > 0 && !includes(sessionClient.config.enabledReleaseStages, releaseStage)) {
+    if (sessionClient._config.enabledReleaseStages.length > 0 && !includes(sessionClient._config.enabledReleaseStages, releaseStage)) {
       sessionClient._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
       return sessionClient
     }
 
     sessionClient._delivery.sendSession({
-      notifier: sessionClient.notifier,
+      notifier: sessionClient._notifier,
       device: sessionClient.device,
       app: { ...{ releaseStage }, ...sessionClient.app },
       sessions: [

--- a/packages/plugin-browser-session/test/session.test.js
+++ b/packages/plugin-browser-session/test/session.test.js
@@ -7,9 +7,7 @@ const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: sessions', () => {
   it('notifies the session endpoint', (done) => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'API_KEY' })
-    c.configure()
+    const c = new Client({ apiKey: 'API_KEY' }, undefined, VALID_NOTIFIER)
     c.use(plugin)
     c.delivery(client => ({
       sendSession: (session, cb) => {
@@ -26,9 +24,7 @@ describe('plugin: sessions', () => {
   })
 
   it('tracks handled/unhandled error counts and sends them in error payloads', (done) => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'API_KEY' })
-    c.configure()
+    const c = new Client({ apiKey: 'API_KEY' })
     let i = 0
     c.use(plugin)
     c.delivery(client => ({
@@ -56,9 +52,7 @@ describe('plugin: sessions', () => {
   })
 
   it('correctly infers releaseStage', (done) => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'API_KEY', releaseStage: 'foo' })
-    c.configure()
+    const c = new Client({ apiKey: 'API_KEY', releaseStage: 'foo' })
     c.use(plugin)
     c.delivery(client => ({
       sendSession: (session, cb) => {
@@ -71,9 +65,7 @@ describe('plugin: sessions', () => {
   })
 
   it('doesn’t send when releaseStage is not in enabledReleaseStages', (done) => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'API_KEY', releaseStage: 'foo', enabledReleaseStages: ['baz'] })
-    c.configure()
+    const c = new Client({ apiKey: 'API_KEY', releaseStage: 'foo', enabledReleaseStages: ['baz'] })
     c.use(plugin)
     c.delivery(client => ({
       sendSession: (session, cb) => {
@@ -85,14 +77,15 @@ describe('plugin: sessions', () => {
   })
 
   it('rejects config when session endpoint is not set', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({
-      apiKey: 'API_KEY',
-      releaseStage: 'foo',
-      endpoints: { notify: '/foo' },
-      autoTrackSessions: false
-    })
-    expect(() => c.configure()).toThrowError(
+    expect(() => {
+      const c = new Client({
+        apiKey: 'API_KEY',
+        releaseStage: 'foo',
+        endpoints: { notify: '/foo' },
+        autoTrackSessions: false
+      })
+      expect(c).toBe(c)
+    }).toThrowError(
       /"endpoints" should be an object containing endpoint URLs { notify, sessions }/
     )
   })

--- a/packages/plugin-client-ip/client-ip.js
+++ b/packages/plugin-client-ip/client-ip.js
@@ -3,9 +3,9 @@
  */
 module.exports = {
   init: (client) => {
-    if (client.config.collectUserIp) return
+    if (client._config.collectUserIp) return
 
-    client.config.onError.push(event => {
+    client._config.onError.push(event => {
       // If user.id is explicitly undefined, it will be missing from the payload. It needs
       // removing so that the following line replaces it
       if (event.user && typeof event.user.id === 'undefined') delete event.user.id

--- a/packages/plugin-client-ip/test/client-ip.test.js
+++ b/packages/plugin-client-ip/test/client-ip.test.js
@@ -3,14 +3,11 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: ip', () => {
   it('does nothing when collectUserIp=true', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin)
 
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
@@ -21,10 +18,8 @@ describe('plugin: ip', () => {
   })
 
   it('doesn’t overwrite an existing user id', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
-    client.configure()
     client.use(plugin)
 
     client.user = { id: 'foobar' }
@@ -38,10 +33,8 @@ describe('plugin: ip', () => {
   })
 
   it('overwrites a user id if it is explicitly `undefined`', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
-    client.configure()
     client.use(plugin)
 
     client.user = { id: undefined }
@@ -55,10 +48,8 @@ describe('plugin: ip', () => {
   })
 
   it('redacts user IP if none is provided', () => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH', collectUserIp: false })
-    client.configure()
     client.use(plugin)
 
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))

--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -4,9 +4,9 @@ const { map, reduce, filter, includes } = require('@bugsnag/core/lib/es-utils')
  * Leaves breadcrumbs when console log methods are called
  */
 exports.init = (client) => {
-  const isDev = /^dev(elopment)?$/.test(client.config.releaseStage)
+  const isDev = /^dev(elopment)?$/.test(client._config.releaseStage)
 
-  if (!client.config.enabledBreadcrumbTypes || !includes(client.config.enabledBreadcrumbTypes, 'log') || isDev) return
+  if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'log') || isDev) return
 
   map(CONSOLE_LOG_METHODS, method => {
     const original = console[method]

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
@@ -3,13 +3,10 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: console breadcrumbs', () => {
   it('should leave a breadcrumb when console.log() is called', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.use(plugin)
     console.log('check 1, 2')
     // make sure it's null-safe
@@ -33,9 +30,7 @@ describe('plugin: console breadcrumbs', () => {
   })
 
   it('should not throw when an object without toString is logged', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.use(plugin)
     expect(() => console.log(Object.create(null))).not.toThrow()
     expect(c.breadcrumbs.length).toBe(1)
@@ -45,9 +40,7 @@ describe('plugin: console breadcrumbs', () => {
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     c.use(plugin)
     console.log(123)
     expect(c.breadcrumbs.length).toBe(0)
@@ -55,9 +48,7 @@ describe('plugin: console breadcrumbs', () => {
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["log"]', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['log'] })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['log'] })
     c.use(plugin)
     console.log(123)
     expect(c.breadcrumbs.length).toBe(1)
@@ -65,9 +56,7 @@ describe('plugin: console breadcrumbs', () => {
   })
 
   it('should be not enabled by default when releaseStage=development', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'development' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'development' })
     c.use(plugin)
     console.log(123)
     expect(c.breadcrumbs.length).toBe(0)

--- a/packages/plugin-contextualize/contextualize.js
+++ b/packages/plugin-contextualize/contextualize.js
@@ -21,7 +21,7 @@ module.exports = {
         })
         client.notify(event, onError, (e, event) => {
           if (e) client._logger.error('Failed to send event to Bugsnag')
-          client.config.onUncaughtException(err, event, client._logger)
+          client._config.onUncaughtException(err, event, client._logger)
         })
       })
       process.nextTick(() => dom.run(fn))

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -25,7 +25,7 @@ module.exports = {
       }
     }
 
-    client.config.onError.unshift(event => {
+    client._config.onError.unshift(event => {
       const now = new Date()
       const inForeground = AppState.currentState === 'active'
       event.app.inForeground = inForeground

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -2,7 +2,6 @@
 
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru()
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: expo device', () => {
   it('should should use version if defined (all platforms)', done => {
@@ -22,9 +21,7 @@ describe('plugin: expo device', () => {
         }
       }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
 
     c.use(plugin)
     c.delivery(client => ({
@@ -56,9 +53,7 @@ describe('plugin: expo device', () => {
         }
       }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
 
     c.use(plugin)
     c.delivery(client => ({
@@ -91,9 +86,7 @@ describe('plugin: expo device', () => {
         }
       }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
 
     c.use(plugin)
     c.delivery(client => ({
@@ -126,9 +119,7 @@ describe('plugin: expo device', () => {
         }
       }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
 
     c.use(plugin)
     c.delivery(client => ({
@@ -159,9 +150,7 @@ describe('plugin: expo device', () => {
       },
       'react-native': { AppState }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
 
     c.use(plugin)
     expect(typeof listener).toBe('function')

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -37,7 +37,7 @@ module.exports = {
       }
     }
 
-    client.config.onError.unshift(event => {
+    client._config.onError.unshift(event => {
       event.device = {
         ...event.device,
         time: isoDate(),

--- a/packages/plugin-expo-device/test/device.test.js
+++ b/packages/plugin-expo-device/test/device.test.js
@@ -2,7 +2,6 @@
 
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru()
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: expo device', () => {
   it('should extract the expected properties from expo/react native (android)', done => {
@@ -31,9 +30,7 @@ describe('plugin: expo device', () => {
       },
       'react-native/package.json': { version: REACT_NATIVE_VERSION }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     const before = (new Date()).toISOString()
     c.delivery(client => ({
       sendEvent: (payload) => {
@@ -84,9 +81,7 @@ describe('plugin: expo device', () => {
       },
       'react-native/package.json': { version: REACT_NATIVE_VERSION }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     const before = (new Date()).toISOString()
     c.delivery(client => ({
       sendEvent: (payload) => {
@@ -157,9 +152,7 @@ describe('plugin: expo device', () => {
       },
       'react-native/package.json': { version: REACT_NATIVE_VERSION }
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     const events = []
     c.delivery(client => ({
       sendEvent: (payload) => {

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -20,7 +20,7 @@ module.exports = {
 
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
+      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
 
       // attach it to the request
       req.bugsnag = requestClient
@@ -34,7 +34,7 @@ module.exports = {
       dom.on('error', (err) => {
         req.bugsnag.notify(createEventFromErr(err, handledState), () => {}, (e, event) => {
           if (e) client._logger.error('Failed to send event to Bugsnag')
-          req.bugsnag.config.onUncaughtException(err, event, client._logger)
+          req.bugsnag._config.onUncaughtException(err, event, client._logger)
         })
         if (!res.headersSent) {
           res.statusCode = 500

--- a/packages/plugin-express/test/express.test.js
+++ b/packages/plugin-express/test/express.test.js
@@ -2,14 +2,11 @@ const { describe, it, expect } = global
 
 // const express = require('express')
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const plugin = require('../')
 
 describe('plugin: express', () => {
   it('exports two middleware functions', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     c.use(plugin)
     const middleware = c.getPlugin('express')
     expect(typeof middleware.requestHandler).toBe('function')

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -4,7 +4,7 @@ const MAX_SCRIPT_LENGTH = 500000
 
 module.exports = {
   init: (client, doc = document, win = window) => {
-    if (!client.config.trackInlineScripts) return
+    if (!client._config.trackInlineScripts) return
 
     const originalLocation = win.location.href
     let html = ''
@@ -52,7 +52,7 @@ module.exports = {
       }, {})
     }
 
-    client.config.onError.unshift(event => {
+    client._config.onError.unshift(event => {
       // remove any of our own frames that may be part the stack this
       // happens before the inline script check as it happens for all errors
       event.stacktrace = filter(event.stacktrace, f => !(/__trace__$/.test(f.method)))

--- a/packages/plugin-inline-script-content/test/inline-script-content.test.js
+++ b/packages/plugin-inline-script-content/test/inline-script-content.test.js
@@ -4,7 +4,6 @@ const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
 const Event = require('@bugsnag/core/event')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: inline script content', () => {
   it('should add an onError callback which captures the HTML content if file=current url', () => {
@@ -29,13 +28,11 @@ Lorem ipsum dolor sit amet.
     }
     const window = { location: { href: 'https://app.bugsnag.com/errors' } }
 
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, document, window)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('BadThing', 'Happens in script tags', [
       { fileName: window.location.href, lineNumber: 10 }
@@ -50,9 +47,7 @@ Lorem ipsum dolor sit amet.
     const prevHandler = () => { done() }
     const document = { documentElement: { outerHTML: '' }, onreadystatechange: prevHandler }
     const window = { location: { href: 'https://app.bugsnag.com/errors' }, document }
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     client.use(plugin, document, window)
     // check it installed a new onreadystatechange handler
     expect(document.onreadystatechange === prevHandler).toBe(false)
@@ -67,9 +62,7 @@ Lorem ipsum dolor sit amet.
     function EventTarget () {}
     EventTarget.prototype.addEventListener = addEventListener
     window.EventTarget = EventTarget
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH', trackInlineScripts: false })
-    client.configure()
+    const client = new Client({ apiKey: 'API_KEY_YEAH', trackInlineScripts: false })
     client.use(plugin, document, window)
     // check the addEventListener function was not wrapped
     expect(window.EventTarget.prototype.addEventListener).toBe(addEventListener)
@@ -99,13 +92,11 @@ Lorem ipsum dolor sit amet.
     }
     const window = { location: { href: 'https://app.bugsnag.com/errors' } }
 
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, document, window)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('BadThing', 'Happens in script tags', [
       { fileName: window.location.href, lineNumber: 10 }
@@ -138,13 +129,11 @@ Lorem ipsum dolor sit amet.
     }
     const window = { location: { href: 'https://app.bugsnag.com/errors' } }
 
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, document, window)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('BadThing', 'Happens in script tags', [
       { fileName: window.location.href, lineNumber: 7 }
@@ -176,13 +165,11 @@ Lorem ipsum dolor sit amet.
     }
     const window = { location: { href: 'https://app.bugsnag.com/errors' } }
 
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, document, window)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     const spy = spyOn(client._logger, 'error')
     client.notify(new Event('EmptyStacktrace', 'Has nothing in it', []))
@@ -223,9 +210,7 @@ Lorem ipsum dolor sit amet.
     window.addEventListener('click', myfun)
 
     const spy = spyOn(Window.prototype, 'removeEventListener')
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     client.use(plugin, document, window)
 
     window.removeEventListener('click', myfun)
@@ -243,13 +228,11 @@ Lorem ipsum dolor sit amet.
     }
     const window = { location: { href: 'https://app.bugsnag.com/errors' } }
 
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     client.use(plugin, document, window)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('Error', 'oh', [
       { fileName: window.location.href, lineNumber: 1 }

--- a/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
+++ b/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
@@ -7,7 +7,7 @@ module.exports = {
   init: (client, win = window) => {
     if (!('addEventListener' in win)) return
 
-    if (!client.config.enabledBreadcrumbTypes || !includes(client.config.enabledBreadcrumbTypes, 'user')) return
+    if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'user')) return
 
     win.addEventListener('click', (event) => {
       let targetText, targetSelector

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
@@ -3,13 +3,10 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: interaction breadcrumbs', () => {
   it('should drop a breadcrumb when an element is clicked', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
@@ -17,9 +14,7 @@ describe('plugin: interaction breadcrumbs', () => {
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
@@ -27,9 +22,7 @@ describe('plugin: interaction breadcrumbs', () => {
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["user"]', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['user'] })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['user'] })
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))

--- a/packages/plugin-intercept/test/intercept.test.js
+++ b/packages/plugin-intercept/test/intercept.test.js
@@ -1,7 +1,6 @@
 const { describe, it, expect } = global
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const plugin = require('../')
 const fs = require('fs')
 
@@ -31,13 +30,11 @@ function pload (index, cb) {
 
 describe('plugin: intercept', () => {
   it('does nothing with a happy-case callback', done => {
-    const c = new Client(VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'api_key' })
     c.delivery(client => ({
       sendEvent: () => expect(true).toBe(false),
       sendSession: () => {}
     }))
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
     c.use(plugin)
     const intercept = c.getPlugin('intercept')
     load(1, intercept((item) => {
@@ -47,7 +44,7 @@ describe('plugin: intercept', () => {
   })
 
   it('sends an event when the callback recieves an error', done => {
-    const c = new Client(VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'api_key' })
     c.delivery(client => ({
       sendEvent: (payload) => {
         expect(payload.events[0].errorMessage).toBe('no item available')
@@ -55,8 +52,6 @@ describe('plugin: intercept', () => {
       },
       sendSession: () => {}
     }))
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
     c.use(plugin)
     const intercept = c.getPlugin('intercept')
     load(4, intercept((item) => {
@@ -66,13 +61,11 @@ describe('plugin: intercept', () => {
   })
 
   it('works with resolved promises', done => {
-    const c = new Client(VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'api_key' })
     c.delivery(client => ({
       sendEvent: () => expect(true).toBe(false),
       sendSession: () => {}
     }))
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
     c.use(plugin)
     const intercept = c.getPlugin('intercept')
     pload(0).then(item => {
@@ -82,7 +75,7 @@ describe('plugin: intercept', () => {
   })
 
   it('works with rejected promises', done => {
-    const c = new Client(VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'api_key' })
     c.delivery(client => ({
       sendEvent: (payload) => {
         expect(payload.events[0].errorMessage).toBe('no item available')
@@ -90,8 +83,6 @@ describe('plugin: intercept', () => {
       },
       sendSession: () => {}
     }))
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
     c.use(plugin)
     const intercept = c.getPlugin('intercept')
     pload(7).then(item => {
@@ -101,7 +92,7 @@ describe('plugin: intercept', () => {
   })
 
   it('should add a stacktrace when missing', done => {
-    const c = new Client(VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'api_key' })
     c.delivery(client => ({
       sendEvent: (payload, cb) => {
         expect(payload.events[0].errorMessage).toBe('ENOENT: no such file or directory, open \'does not exist\'')
@@ -111,10 +102,6 @@ describe('plugin: intercept', () => {
       },
       sendSession: () => {}
     }))
-    c.setOptions({
-      apiKey: 'api_key'
-    })
-    c.configure()
     c.use(plugin)
     const intercept = c.getPlugin('intercept')
     fs.readFile('does not exist', intercept(data => {

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -17,7 +17,7 @@ module.exports = {
     const requestHandler = async (ctx, next) => {
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
+      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
 
       ctx.bugsnag = requestClient
 
@@ -46,7 +46,7 @@ module.exports = {
     requestHandler.v1 = function * (next) {
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
+      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
 
       this.bugsnag = requestClient
 

--- a/packages/plugin-koa/test/koa.test.js
+++ b/packages/plugin-koa/test/koa.test.js
@@ -2,14 +2,11 @@ const { describe, it, expect } = global
 
 // const express = require('express')
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const plugin = require('../')
 
 describe('plugin: koa', () => {
   it('exports two middleware functions', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     c.use(plugin)
     const middleware = c.getPlugin('koa')
     expect(typeof middleware.requestHandler).toBe('function')
@@ -20,9 +17,7 @@ describe('plugin: koa', () => {
 
   describe('requestHandler', () => {
     it('should call through to app.onerror to ensure the error is logged out', (done) => {
-      const c = new Client(VALID_NOTIFIER)
-      c.setOptions({ apiKey: 'api_key' })
-      c.configure()
+      const c = new Client({ apiKey: 'api_key' })
       c.use(plugin)
       const middleware = c.getPlugin('koa')
       const mockCtx = {

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -6,7 +6,7 @@ const { includes } = require('@bugsnag/core/lib/es-utils')
 exports.init = (client, win = window) => {
   if (!('addEventListener' in win)) return
 
-  if (!client.config.enabledBreadcrumbTypes || !includes(client.config.enabledBreadcrumbTypes, 'navigation')) return
+  if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'navigation')) return
 
   // returns a function that will drop a breadcrumb with a given name
   const drop = name => () => client.leaveBreadcrumb(name, {}, 'navigation')
@@ -62,7 +62,7 @@ const wrapHistoryFn = (client, target, fn, win) => {
     // if throttle plugin is in use, refresh the event sent count
     if (typeof client.refresh === 'function') client.refresh()
     // if the client is operating in auto session-mode, a new route should trigger a new session
-    if (client.config.autoTrackSessions) client.startSession()
+    if (client._config.autoTrackSessions) client.startSession()
     // Internet Explorer will convert `undefined` to a string when passed, causing an unintended redirect
     // to '/undefined'. therefore we only pass the url if it's not undefined.
     orig.apply(target, [state, title].concat(url !== undefined ? url : []))

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -3,13 +3,10 @@ const { describe, it, expect } = global
 const plugin = require('../navigation-breadcrumbs')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: navigation breadcrumbs', () => {
   it('should drop breadcrumb for navigational activity', done => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
 
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
@@ -35,9 +32,7 @@ describe('plugin: navigation breadcrumbs', () => {
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
     winHandlers.load.forEach((h) => h.call(window))
@@ -48,9 +43,7 @@ describe('plugin: navigation breadcrumbs', () => {
   })
 
   it('should start a new session if autoTrackSessions=true', (done) => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.sessionDelegate({
       startSession: client => {
         done()
@@ -64,9 +57,7 @@ describe('plugin: navigation breadcrumbs', () => {
   })
 
   it('should not a new session if autoTrackSessions=false', (done) => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoTrackSessions: false })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoTrackSessions: false })
     c.sessionDelegate({
       startSession: client => {
         expect('shouldn’t get here').toBe(false)
@@ -82,9 +73,7 @@ describe('plugin: navigation breadcrumbs', () => {
   })
 
   it('should be enabled when enabledReleaseStages=["navigation"]', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledReleaseStages: ['navigation'] })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledReleaseStages: ['navigation'] })
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
     winHandlers.load.forEach((h) => h.call(window))

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -13,8 +13,8 @@ let win
 let getIgnoredUrls
 
 const defaultIgnoredUrls = () => [
-  client.config.endpoints.notify,
-  client.config.endpoints.sessions
+  client._config.endpoints.notify,
+  client._config.endpoints.sessions
 ]
 
 /*
@@ -22,7 +22,7 @@ const defaultIgnoredUrls = () => [
  */
 exports.name = 'networkBreadcrumbs'
 exports.init = (_client, _getIgnoredUrls = defaultIgnoredUrls, _win = window) => {
-  if (!_client.config.enabledBreadcrumbTypes || !includes(_client.config.enabledBreadcrumbTypes, 'request')) return
+  if (!_client._config.enabledBreadcrumbTypes || !includes(_client._config.enabledBreadcrumbTypes, 'request')) return
 
   client = _client
   win = _win

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect, jasmine, afterEach } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 // mock XMLHttpRequest
 function XMLHttpRequest () {
@@ -46,9 +45,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should leave a breadcrumb when an XMLHTTPRequest resolves', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
@@ -70,9 +67,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should not leave duplicate breadcrumbs if open() is called twice', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, undefined, window)
 
     const request = new window.XMLHttpRequest()
@@ -85,9 +80,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should leave a breadcrumb when an XMLHTTPRequest has a failed response', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
@@ -108,9 +101,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should leave a breadcrumb when an XMLHTTPRequest has a network error', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
@@ -131,13 +122,11 @@ describe('plugin: network breadcrumbs', () => {
   it('should not leave a breadcrumb for request to bugsnag notify endpoint', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, undefined, window)
 
     const request = new window.XMLHttpRequest()
-    request.open('GET', client.config.endpoints.notify)
+    request.open('GET', client._config.endpoints.notify)
     request.send(false, 200)
 
     expect(client.breadcrumbs.length).toBe(0)
@@ -146,13 +135,11 @@ describe('plugin: network breadcrumbs', () => {
   it('should not leave a breadcrumb for session tracking requests', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, undefined, window)
 
     const request = new window.XMLHttpRequest()
-    request.open('GET', client.config.endpoints.sessions)
+    request.open('GET', client._config.endpoints.sessions)
     request.send(false, 200)
     expect(client.breadcrumbs.length).toBe(0)
   })
@@ -160,9 +147,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should leave a breadcrumb when a fetch() resolves', (done) => {
     const window = { XMLHttpRequest, fetch }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, () => [], window)
 
     window.fetch('/', {}, false, 200).then(() => {
@@ -182,9 +167,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should leave a breadcrumb when a fetch() has a failed response', (done) => {
     const window = { XMLHttpRequest, fetch }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, () => [], window)
 
     window.fetch('/does-not-exist', {}, false, 404).then(() => {
@@ -204,9 +187,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should leave a breadcrumb when a fetch() has a network error', (done) => {
     const window = { XMLHttpRequest, fetch }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin, () => [], window)
 
     window.fetch('https://another-domain.xyz/foo/bar', {}, true).catch(() => {
@@ -225,9 +206,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()
@@ -240,9 +219,7 @@ describe('plugin: network breadcrumbs', () => {
   it('should be enabled when enabledBreadcrumbTypes=["request"]', () => {
     const window = { XMLHttpRequest }
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['request'] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['request'] })
     client.use(plugin, () => [], window)
 
     const request = new window.XMLHttpRequest()

--- a/packages/plugin-node-device/device.js
+++ b/packages/plugin-node-device/device.js
@@ -6,7 +6,7 @@ const { isoDate } = require('@bugsnag/core/lib/es-utils')
 module.exports = {
   init: (client) => {
     const device = {
-      hostname: client.config.hostname,
+      hostname: client._config.hostname,
       runtimeVersions: { node: process.versions.node }
     }
 
@@ -14,7 +14,7 @@ module.exports = {
     client.device = { ...device, ...client.device }
 
     // add time just as the event is sent
-    client.config.onError.unshift((event) => {
+    client._config.onError.unshift((event) => {
       event.device = { ...event.device, time: isoDate() }
     })
   }

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -11,17 +11,14 @@ const schema = {
     message: 'should be a string'
   }
 }
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const ISO_8601 = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
 
 describe('plugin: node device', () => {
   it('should set device = { hostname, runtimeVersions } add an onError callback which adds device time', done => {
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure(schema)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' }, schema)
     client.use(plugin)
 
-    expect(client.config.onError.length).toBe(1)
+    expect(client._config.onError.length).toBe(1)
     expect(client.device.hostname).toBe('test-machine.local')
     expect(client.device.runtimeVersions).toBeDefined()
     expect(client.device.runtimeVersions.node).toEqual(process.versions.node)

--- a/packages/plugin-node-in-project/in-project.js
+++ b/packages/plugin-node-in-project/in-project.js
@@ -2,9 +2,9 @@ const { map } = require('@bugsnag/core/lib/es-utils')
 const normalizePath = require('@bugsnag/core/lib/path-normalizer')
 
 module.exports = {
-  init: client => client.config.onError.push(event => {
-    if (!client.config.projectRoot) return
-    const projectRoot = normalizePath(client.config.projectRoot)
+  init: client => client._config.onError.push(event => {
+    if (!client._config.projectRoot) return
+    const projectRoot = normalizePath(client._config.projectRoot)
     event.stacktrace = map(event.stacktrace, stackframe => {
       stackframe.inProject = typeof stackframe.file === 'string' &&
         stackframe.file.indexOf(projectRoot) === 0 &&

--- a/packages/plugin-node-in-project/test/in-project.test.js
+++ b/packages/plugin-node-in-project/test/in-project.test.js
@@ -5,11 +5,17 @@ const { join } = require('path')
 const Event = require('@bugsnag/core/event')
 const Client = require('@bugsnag/core/client')
 const { schema } = require('@bugsnag/core/config')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: node in project', () => {
   it('should mark stackframes as "inProject" if it is a descendent of the "projectRoot"', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -22,15 +28,6 @@ describe('plugin: node in project', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'in project test', [
@@ -51,7 +48,14 @@ describe('plugin: node in project', () => {
   })
 
   it('should mark stackframes as "out of project" if it is not a descendent of "projectRoot"', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -64,15 +68,6 @@ describe('plugin: node in project', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'in project test', [
@@ -93,7 +88,14 @@ describe('plugin: node in project', () => {
   })
 
   it('should work with node_modules and node internals', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -105,15 +107,6 @@ describe('plugin: node in project', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'in project test', [
@@ -130,7 +123,14 @@ describe('plugin: node in project', () => {
   })
 
   it('should tolerate stackframe.file not being a string', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -143,15 +143,6 @@ describe('plugin: node in project', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'in project test', [

--- a/packages/plugin-node-surrounding-code/surrounding-code.js
+++ b/packages/plugin-node-surrounding-code/surrounding-code.js
@@ -8,7 +8,7 @@ const byline = require('byline')
 
 module.exports = {
   init: client => {
-    if (!client.config.sendCode) return
+    if (!client._config.sendCode) return
 
     const loadSurroundingCode = (stackframe, cache) => new Promise((resolve, reject) => {
       try {
@@ -28,7 +28,7 @@ module.exports = {
       }
     })
 
-    client.config.onError.push(event => new Promise((resolve, reject) => {
+    client._config.onError.push(event => new Promise((resolve, reject) => {
       const cache = Object.create(null)
       pMapSeries(event.stacktrace.map(stackframe => () => loadSurroundingCode(stackframe, cache)))
         .then(resolve)

--- a/packages/plugin-node-surrounding-code/test/surrounding-code.test.js
+++ b/packages/plugin-node-surrounding-code/test/surrounding-code.test.js
@@ -12,11 +12,10 @@ const plugin = require('../')
 const { join } = require('path')
 const Event = require('@bugsnag/core/event')
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: node surrounding code', () => {
   it('should load code successfully for stackframes whose files exist', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key' })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -41,8 +40,6 @@ describe('plugin: node surrounding code', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key' })
-    client.configure()
     client.use(plugin)
 
     client.notify(new Event('Error', 'surrounding code loading test', [
@@ -63,7 +60,7 @@ describe('plugin: node surrounding code', () => {
   })
 
   it('should tolerate missing files for some stackframes', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key' })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -76,8 +73,6 @@ describe('plugin: node surrounding code', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key' })
-    client.configure()
     client.use(plugin)
 
     client.notify(new Event('Error', 'surrounding code loading test', [
@@ -98,7 +93,7 @@ describe('plugin: node surrounding code', () => {
   })
 
   it('behaves sensibly for code at the beginning and end of a file', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key' })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -120,8 +115,6 @@ describe('plugin: node surrounding code', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key' })
-    client.configure()
     client.use(plugin)
 
     client.notify(new Event('Error', 'surrounding code loading test', [
@@ -139,7 +132,7 @@ describe('plugin: node surrounding code', () => {
   })
 
   it('only loads code once for the same file/line/column', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key' })
 
     const startCount = createReadStreamCount
 
@@ -160,8 +153,6 @@ describe('plugin: node surrounding code', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key' })
-    client.configure()
     client.use(plugin)
 
     client.notify(new Event('Error', 'surrounding code loading test', [
@@ -209,7 +200,7 @@ describe('plugin: node surrounding code', () => {
   })
 
   it('truncates lines to a sensible number of characters', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key' })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -223,8 +214,6 @@ describe('plugin: node surrounding code', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key' })
-    client.configure()
     client.use(plugin)
 
     client.notify(new Event('Error', 'surrounding code loading test', [

--- a/packages/plugin-node-uncaught-exception/uncaught-exception.js
+++ b/packages/plugin-node-uncaught-exception/uncaught-exception.js
@@ -3,7 +3,7 @@ const createEventFromErr = require('@bugsnag/core/lib/event-from-error')
 let _handler
 module.exports = {
   init: client => {
-    if (!client.config.autoDetectErrors) return
+    if (!client._config.autoDetectErrors) return
     _handler = err => {
       client.notify(createEventFromErr(err, {
         severity: 'error',
@@ -11,7 +11,7 @@ module.exports = {
         severityReason: { type: 'unhandledException' }
       }), () => {}, (e, event) => {
         if (e) client._logger.error('Failed to send event to Bugsnag')
-        client.config.onUncaughtException(err, event, client._logger)
+        client._config.onUncaughtException(err, event, client._logger)
       })
     }
     process.on('uncaughtException', _handler)

--- a/packages/plugin-node-unhandled-rejection/test/unhandled-rejection.test.js
+++ b/packages/plugin-node-unhandled-rejection/test/unhandled-rejection.test.js
@@ -2,15 +2,12 @@ const { describe, it, expect } = global
 
 const Client = require('@bugsnag/core/client')
 const schema = require('@bugsnag/core/config').schema
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const plugin = require('../')
 
 describe('plugin: node unhandled rejection handler', () => {
   it('should listen to the process#unhandledRejection event', () => {
     const before = process.listeners('unhandledRejection').length
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     c.use(plugin)
     const after = process.listeners('unhandledRejection').length
     expect(before < after).toBe(true)
@@ -19,9 +16,7 @@ describe('plugin: node unhandled rejection handler', () => {
 
   it('does not add a process#unhandledRejection listener if autoDetectErrors=false', () => {
     const before = process.listeners('unhandledRejection').length
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key', autoDetectErrors: false })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key', autoDetectErrors: false })
     c.use(plugin)
     const after = process.listeners('unhandledRejection').length
     expect(after).toBe(before)
@@ -29,21 +24,14 @@ describe('plugin: node unhandled rejection handler', () => {
 
   it('does not add a process#unhandledRejection listener if autoDetectUnhandledRejections=false', () => {
     const before = process.listeners('unhandledRejection').length
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key', autoDetectUnhandledRejections: false })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key', autoDetectUnhandledRejections: false })
     c.use(plugin)
     const after = process.listeners('unhandledRejection').length
     expect(after).toBe(before)
   })
 
   it('should call the configured onUnhandledRejection callback', done => {
-    const c = new Client(VALID_NOTIFIER)
-    c.delivery(client => ({
-      sendEvent: (...args) => args[args.length - 1](),
-      sendSession: (...args) => args[args.length - 1]()
-    }))
-    c.setOptions({
+    const c = new Client({
       apiKey: 'api_key',
       onUnhandledRejection: (err, event) => {
         expect(err.message).toBe('never gonna catch me')
@@ -54,8 +42,7 @@ describe('plugin: node unhandled rejection handler', () => {
         plugin.destroy()
         done()
       }
-    })
-    c.configure({
+    }, {
       ...schema,
       onUnhandledRejection: {
         validate: val => typeof val === 'function',
@@ -63,17 +50,16 @@ describe('plugin: node unhandled rejection handler', () => {
         defaultValue: () => {}
       }
     })
+    c.delivery(client => ({
+      sendEvent: (...args) => args[args.length - 1](),
+      sendSession: (...args) => args[args.length - 1]()
+    }))
     c.use(plugin)
     process.listeners('unhandledRejection')[1](new Error('never gonna catch me'))
   })
 
   it('should tolerate delivery errors', done => {
-    const c = new Client(VALID_NOTIFIER)
-    c.delivery(client => ({
-      sendEvent: (...args) => args[args.length - 1](new Error('floop')),
-      sendSession: (...args) => args[args.length - 1]()
-    }))
-    c.setOptions({
+    const c = new Client({
       apiKey: 'api_key',
       onUnhandledRejection: (err, event) => {
         expect(err.message).toBe('never gonna catch me')
@@ -84,8 +70,7 @@ describe('plugin: node unhandled rejection handler', () => {
         plugin.destroy()
         done()
       }
-    })
-    c.configure({
+    }, {
       ...schema,
       onUnhandledRejection: {
         validate: val => typeof val === 'function',
@@ -93,6 +78,10 @@ describe('plugin: node unhandled rejection handler', () => {
         defaultValue: () => {}
       }
     })
+    c.delivery(client => ({
+      sendEvent: (...args) => args[args.length - 1](new Error('floop')),
+      sendSession: (...args) => args[args.length - 1]()
+    }))
     c.use(plugin)
     process.listeners('unhandledRejection')[1](new Error('never gonna catch me'))
   })

--- a/packages/plugin-node-unhandled-rejection/unhandled-rejection.js
+++ b/packages/plugin-node-unhandled-rejection/unhandled-rejection.js
@@ -3,7 +3,7 @@ const createEventFromErr = require('@bugsnag/core/lib/event-from-error')
 let _handler
 module.exports = {
   init: client => {
-    if (!client.config.autoDetectErrors || !client.config.autoDetectUnhandledRejections) return
+    if (!client._config.autoDetectErrors || !client._config.autoDetectUnhandledRejections) return
     _handler = err => {
       client.notify(createEventFromErr(err, {
         severity: 'error',
@@ -11,7 +11,7 @@ module.exports = {
         severityReason: { type: 'unhandledPromiseRejection' }
       }), () => {}, (e, event) => {
         if (e) client._logger.error('Failed to send event to Bugsnag')
-        client.config.onUnhandledRejection(err, event, client._logger)
+        client._config.onUnhandledRejection(err, event, client._logger)
       })
     }
     process.on('unhandledRejection', _handler)

--- a/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
@@ -2,7 +2,7 @@ const { AppState } = require('react-native')
 
 module.exports = {
   init: client => {
-    if (!client.config.enabledBreadcrumbTypes || !client.config.enabledBreadcrumbTypes.includes('state')) return
+    if (!client._config.enabledBreadcrumbTypes || !client._config.enabledBreadcrumbTypes.includes('state')) return
 
     AppState.addEventListener('change', state => {
       client.leaveBreadcrumb('App state changed', { state }, 'state')

--- a/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect } = global
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: react native app state breadcrumbs', () => {
   it('should create a breadcrumb when the AppState#change event happens', () => {
@@ -17,9 +16,7 @@ describe('plugin: react native app state breadcrumbs', () => {
       'react-native': { AppState }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')
@@ -49,9 +46,7 @@ describe('plugin: react native app state breadcrumbs', () => {
       'react-native': { AppState }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
@@ -68,9 +63,7 @@ describe('plugin: react native app state breadcrumbs', () => {
       'react-native': { AppState }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
@@ -87,9 +80,7 @@ describe('plugin: react native app state breadcrumbs', () => {
       'react-native': { AppState }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')

--- a/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
@@ -2,7 +2,7 @@ const { NetInfo } = require('react-native')
 
 module.exports = {
   init: client => {
-    if (!client.config.enabledBreadcrumbTypes || !client.config.enabledBreadcrumbTypes.includes('state')) return
+    if (!client._config.enabledBreadcrumbTypes || !client._config.enabledBreadcrumbTypes.includes('state')) return
 
     NetInfo.addEventListener('connectionChange', ({ type, effectiveType }) => {
       client.leaveBreadcrumb(

--- a/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect } = global
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: react native connectivity breadcrumbs', () => {
   it('should create a breadcrumb when the NetInfo#connectionChange event happens', () => {
@@ -17,9 +16,7 @@ describe('plugin: react native connectivity breadcrumbs', () => {
       'react-native': { NetInfo }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')
@@ -49,9 +46,7 @@ describe('plugin: react native connectivity breadcrumbs', () => {
       'react-native': { NetInfo }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
@@ -68,9 +63,7 @@ describe('plugin: react native connectivity breadcrumbs', () => {
       'react-native': { NetInfo }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
@@ -87,9 +80,7 @@ describe('plugin: react native connectivity breadcrumbs', () => {
       'react-native': { NetInfo }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')

--- a/packages/plugin-react-native-global-error-handler/error-handler.js
+++ b/packages/plugin-react-native-global-error-handler/error-handler.js
@@ -6,7 +6,7 @@ const createEventFromErr = require('@bugsnag/core/lib/event-from-error')
 
 module.exports = {
   init: (client, ErrorUtils = global.ErrorUtils) => {
-    if (!client.config.autoDetectErrors) return
+    if (!client._config.autoDetectErrors) return
     if (!ErrorUtils) {
       client._logger.warn('ErrorUtils is not defined. Can’t attach a global error handler.')
       return

--- a/packages/plugin-react-native-global-error-handler/test/error-handler.test.js
+++ b/packages/plugin-react-native-global-error-handler/test/error-handler.test.js
@@ -3,7 +3,6 @@
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 class MockErrorUtils {
   constructor () {
@@ -21,17 +20,14 @@ class MockErrorUtils {
 
 describe('plugin: react native global error handler', () => {
   it('should set a global error handler', () => {
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const eu = new MockErrorUtils()
     client.use(plugin, eu)
     expect(typeof eu.getGlobalHandler()).toBe('function')
   })
 
   it('should warn if ErrorUtils is not defined', done => {
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({
+    const client = new Client({
       apiKey: 'API_KEY_YEAH',
       logger: {
         debug: () => {},
@@ -43,18 +39,15 @@ describe('plugin: react native global error handler', () => {
         error: () => {}
       }
     })
-    client.configure()
     client.use(plugin)
   })
 
   it('should call through to an exising handler', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     client.delivery(client => ({
       sendSession: () => {},
       sendEvent: (...args) => args[args.length - 1](null)
     }))
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     const eu = new MockErrorUtils()
     const error = new Error('floop')
     eu.setGlobalHandler(function (err, isFatal) {
@@ -67,7 +60,7 @@ describe('plugin: react native global error handler', () => {
   })
 
   it('should have the correct handled state', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     client.delivery(client => ({
       sendSession: () => {},
       sendEvent: (payload, cb) => {
@@ -78,8 +71,6 @@ describe('plugin: react native global error handler', () => {
         done()
       }
     }))
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
     const eu = new MockErrorUtils()
     client.use(plugin, eu)
     eu._globalHandler(new Error('argh'))

--- a/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
@@ -2,7 +2,7 @@ const { Dimensions } = require('react-native')
 
 module.exports = {
   init: client => {
-    if (!client.config.enabledBreadcrumbTypes || !client.config.enabledBreadcrumbTypes.includes('state')) return
+    if (!client._config.enabledBreadcrumbTypes || !client._config.enabledBreadcrumbTypes.includes('state')) return
 
     let lastOrientation
 

--- a/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect } = global
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: react native orientation breadcrumbs', () => {
   it('should create a breadcrumb when the Dimensions#change event happens', () => {
@@ -19,9 +18,7 @@ describe('plugin: react native orientation breadcrumbs', () => {
       'react-native': { Dimensions }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
 
     currentDimensions = { height: 100, width: 200 }
 
@@ -58,9 +55,7 @@ describe('plugin: react native orientation breadcrumbs', () => {
       'react-native': { Dimensions }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null })
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
@@ -77,9 +72,7 @@ describe('plugin: react native orientation breadcrumbs', () => {
       'react-native': { Dimensions }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     client.use(plugin)
 
     expect(_cb).toBe(undefined)
@@ -97,9 +90,7 @@ describe('plugin: react native orientation breadcrumbs', () => {
       'react-native': { Dimensions }
     })
 
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
-    client.configure()
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'] })
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')

--- a/packages/plugin-react-native-unhandled-rejection/rejection-handler.js
+++ b/packages/plugin-react-native-unhandled-rejection/rejection-handler.js
@@ -7,7 +7,7 @@ const createEventFromErr = require('@bugsnag/core/lib/event-from-error')
 
 module.exports = {
   init: (client) => {
-    if (!client.config.autoDetectErrors || !client.config.autoDetectUnhandledRejections) return () => {}
+    if (!client._config.autoDetectErrors || !client._config.autoDetectUnhandledRejections) return () => {}
     rnPromise.enable({
       allRejections: true,
       onUnhandled: (id, error) => {

--- a/packages/plugin-react-native-unhandled-rejection/test/rejection-handler.test.js
+++ b/packages/plugin-react-native-unhandled-rejection/test/rejection-handler.test.js
@@ -2,7 +2,6 @@
 
 const plugin = require('../')
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 // use the promise polyfill that RN uses, otherwise the unhandled rejections in
 // this test go to node's process#unhandledRejection event
@@ -10,9 +9,7 @@ const RnPromise = require('promise/setimmediate')
 
 describe('plugin: react native rejection handler', () => {
   it('should hook in to the promise rejection tracker', done => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     c.delivery(client => ({
       sendEvent: (payload) => {
         const r = JSON.parse(JSON.stringify(payload))
@@ -35,9 +32,7 @@ describe('plugin: react native rejection handler', () => {
   })
 
   it('should be disabled when autoDetectErrors=false', done => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key', autoDetectErrors: false })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key', autoDetectErrors: false })
     c.delivery(client => ({
       sendReport: (report) => {
         expect(report).not.toBeTruthy()
@@ -57,9 +52,7 @@ describe('plugin: react native rejection handler', () => {
   })
 
   it('should be disbaled when autoDetectUnhandledRejections=false', done => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key', autoDetectUnhandledRejections: false })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key', autoDetectUnhandledRejections: false })
     c.delivery(client => ({
       sendEvent: (payload) => {
         expect(payload).not.toBeTruthy()

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -19,7 +19,7 @@ module.exports = {
 
       // Get a client to be scoped to this request. If sessions are enabled, use the
       // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client.config.autoTrackSessions ? client.startSession() : clone(client)
+      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
 
       // attach it to the request
       req.bugsnag = requestClient
@@ -33,7 +33,7 @@ module.exports = {
       dom.on('error', (err) => {
         req.bugsnag.notify(createEventFromErr(err, handledState), () => {}, (e, event) => {
           if (e) client._logger.error('Failed to send event to Bugsnag')
-          req.bugsnag.config.onUncaughtException(err, event, client._logger)
+          req.bugsnag._config.onUncaughtException(err, event, client._logger)
         })
         if (!res.headersSent) {
           const body = 'Internal server error'

--- a/packages/plugin-restify/test/restify.test.js
+++ b/packages/plugin-restify/test/restify.test.js
@@ -1,14 +1,11 @@
 const { describe, it, expect } = global
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const plugin = require('../')
 
 describe('plugin: restify', () => {
   it('exports two middleware functions', () => {
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
+    const c = new Client({ apiKey: 'api_key' })
     c.use(plugin)
     const middleware = c.getPlugin('restify')
     expect(typeof middleware.requestHandler).toBe('function')

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -7,7 +7,7 @@ const Backoff = require('backo')
 
 module.exports = {
   init: client => {
-    const sessionTracker = new SessionTracker(client.config.sessionSummaryInterval)
+    const sessionTracker = new SessionTracker(client._config.sessionSummaryInterval)
     sessionTracker.on('summary', sendSessionSummary(client))
     sessionTracker.start()
     client.sessionDelegate({
@@ -32,7 +32,7 @@ const sendSessionSummary = client => sessionCounts => {
   const releaseStage = inferReleaseStage(client)
 
   // exit early if the current releaseStage is not enabled
-  if (client.config.enabledReleaseStages.length > 0 && !includes(client.config.enabledReleaseStages, releaseStage)) {
+  if (client._config.enabledReleaseStages.length > 0 && !includes(client._config.enabledReleaseStages, releaseStage)) {
     client._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
     return
   }
@@ -58,7 +58,7 @@ const sendSessionSummary = client => sessionCounts => {
 
   function req (cb) {
     client._delivery.sendSession({
-      notifier: client.notifier,
+      notifier: client._notifier,
       device: client.device,
       app: { ...{ releaseStage }, ...client.app },
       sessionCounts

--- a/packages/plugin-server-session/test/session.test.js
+++ b/packages/plugin-server-session/test/session.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect } = global
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 const Emitter = require('events')
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: server sessions', () => {
   it('should send the session', done => {
@@ -20,10 +19,7 @@ describe('plugin: server sessions', () => {
     const plugin = proxyquire('../session', {
       './tracker': TrackerMock
     })
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({
-      apiKey: 'aaaa-aaaa-aaaa-aaaa'
-    })
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.delivery(client => ({
       sendEvent: () => {},
       sendSession: (session, cb = () => {}) => {
@@ -33,7 +29,6 @@ describe('plugin: server sessions', () => {
       }
     }))
 
-    c.configure()
     c.use(plugin)
     c.startSession()
   })
@@ -53,8 +48,7 @@ describe('plugin: server sessions', () => {
       './tracker': TrackerMock
     })
 
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({
+    const c = new Client({
       apiKey: 'aaaa-aaaa-aaaa-aaaa',
       logger: {
         debug: () => {},
@@ -77,7 +71,6 @@ describe('plugin: server sessions', () => {
       }
     }))
 
-    c.configure()
     c.use(plugin)
     c.startSession()
   })
@@ -95,8 +88,7 @@ describe('plugin: server sessions', () => {
     }
     const plugin = proxyquire('../session', { './tracker': TrackerMock })
 
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({
+    const c = new Client({
       apiKey: 'aaaa-aaaa-aaaa-aaaa',
       endpoints: { notify: 'bloo', sessions: 'blah' },
       enabledReleaseStages: ['qa'],
@@ -120,7 +112,6 @@ describe('plugin: server sessions', () => {
       }
     }))
 
-    c.configure()
     c.use(plugin)
     c.startSession()
   })
@@ -133,9 +124,7 @@ describe('plugin: server sessions', () => {
     }
     const plugin = proxyquire('../session', { './tracker': TrackerMock })
 
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.use(plugin)
 
     c.leaveBreadcrumb('tick')

--- a/packages/plugin-simple-throttle/test/throttle.test.js
+++ b/packages/plugin-simple-throttle/test/throttle.test.js
@@ -3,16 +3,11 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: throttle', () => {
   it('prevents more than maxEvents being sent', () => {
     const payloads = []
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({
-      apiKey: 'aaaa-aaaa-aaaa-aaaa'
-    })
-    c.configure()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.use(plugin)
     c.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     for (let i = 0; i < 100; i++) c.notify(new Error('This is fail'))

--- a/packages/plugin-simple-throttle/throttle.js
+++ b/packages/plugin-simple-throttle/throttle.js
@@ -10,9 +10,9 @@ module.exports = {
     let n = 0
 
     // add onError hook
-    client.config.onError.push((event) => {
+    client._config.onError.push((event) => {
       // have max events been sent already?
-      if (n >= client.config.maxEvents) return false
+      if (n >= client._config.maxEvents) return false
       n++
     })
 

--- a/packages/plugin-strip-project-root/strip-project-root.js
+++ b/packages/plugin-strip-project-root/strip-project-root.js
@@ -2,9 +2,9 @@ const { map } = require('@bugsnag/core/lib/es-utils')
 const normalizePath = require('@bugsnag/core/lib/path-normalizer')
 
 module.exports = {
-  init: client => client.config.onError.push(event => {
-    if (!client.config.projectRoot) return
-    const projectRoot = normalizePath(client.config.projectRoot)
+  init: client => client._config.onError.push(event => {
+    if (!client._config.projectRoot) return
+    const projectRoot = normalizePath(client._config.projectRoot)
     event.stacktrace = map(event.stacktrace, stackframe => {
       if (typeof stackframe.file === 'string' && stackframe.file.indexOf(projectRoot) === 0) {
         stackframe.file = stackframe.file.replace(projectRoot, '')

--- a/packages/plugin-strip-project-root/test/strip-project-root.test.js
+++ b/packages/plugin-strip-project-root/test/strip-project-root.test.js
@@ -5,11 +5,17 @@ const { join } = require('path')
 const Event = require('@bugsnag/core/event')
 const Client = require('@bugsnag/core/client')
 const { schema } = require('@bugsnag/core/config')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: strip project root', () => {
   it('should remove the project root if it matches the start of the stackframe’s file', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -22,15 +28,6 @@ describe('plugin: strip project root', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'strip project root test', [
@@ -51,7 +48,14 @@ describe('plugin: strip project root', () => {
   })
 
   it('should not remove a matching substring if it is not at the start', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -64,15 +68,6 @@ describe('plugin: strip project root', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'strip project root test', [
@@ -93,7 +88,14 @@ describe('plugin: strip project root', () => {
   })
 
   it('should work with node_modules and node internals', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -105,15 +107,6 @@ describe('plugin: strip project root', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'strip project root test', [
@@ -130,7 +123,14 @@ describe('plugin: strip project root', () => {
   })
 
   it('should tolerate stackframe.file not being a string', done => {
-    const client = new Client(VALID_NOTIFIER)
+    const client = new Client({ apiKey: 'api_key', projectRoot: '/app' }, {
+      ...schema,
+      projectRoot: {
+        validate: () => true,
+        defaultValue: () => '',
+        message: ''
+      }
+    })
 
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -143,15 +143,6 @@ describe('plugin: strip project root', () => {
       sendSession: () => {}
     }))
 
-    client.setOptions({ apiKey: 'api_key', projectRoot: '/app' })
-    client.configure({
-      ...schema,
-      projectRoot: {
-        validate: () => true,
-        defaultValue: () => '',
-        message: ''
-      }
-    })
     client.use(plugin)
 
     client.notify(new Event('Error', 'strip project root test', [

--- a/packages/plugin-strip-query-string/strip-query-string.js
+++ b/packages/plugin-strip-query-string/strip-query-string.js
@@ -5,7 +5,7 @@ const { map } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = {
   init: (client) => {
-    client.config.onError.push(event => {
+    client._config.onError.push(event => {
       event.stacktrace = map(event.stacktrace, frame => ({ ...frame, file: strip(frame.file) }))
     })
   }

--- a/packages/plugin-strip-query-string/test/strip-query-string.test.js
+++ b/packages/plugin-strip-query-string/test/strip-query-string.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: strip query string', () => {
   it('should strip querystrings and fragments from urls', () => {
@@ -32,16 +31,14 @@ describe('plugin: strip query string', () => {
   })
 
   it('runs the strip onError callback without errors', () => {
-    const client = new Client(VALID_NOTIFIER)
-    const payloads = []
-    let originalStacktrace
-    client.setOptions({
+    const client = new Client({
       apiKey: 'API_KEY_YEAH',
       onError: event => {
         originalStacktrace = event.stacktrace.map(f => f)
       }
     })
-    client.configure()
+    const payloads = []
+    let originalStacktrace
     client.use(plugin)
 
     client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))

--- a/packages/plugin-vue/test/index.test.js
+++ b/packages/plugin-vue/test/index.test.js
@@ -2,17 +2,15 @@ const { describe, it, expect } = global
 const plugin = require('../src')
 const BugsnagClient = require('@bugsnag/core/client')
 
-const NOTIFIER = { name: 'bugsnag-vue-test', version: '0.0.0', url: 'http://yes.please' }
-
 describe('bugsnag vue', () => {
   it('throws when missing Vue', () => {
     expect(() => {
-      plugin.init(new BugsnagClient(NOTIFIER))
+      plugin.init(new BugsnagClient({ apiKey: 'API_KEYYY' }))
     }).toThrow()
   })
 
   it('installs Vue.config.errorHandler', done => {
-    const client = new BugsnagClient(NOTIFIER)
+    const client = new BugsnagClient({ apiKey: 'API_KEYYY' })
     // client.logger(console)
     client.delivery(client => ({
       sendEvent: (payload) => {
@@ -22,8 +20,6 @@ describe('bugsnag vue', () => {
         done()
       }
     }))
-    client.setOptions({ apiKey: 'API_KEYYY' })
-    client.configure()
     const Vue = { config: {} }
     client.use(plugin, Vue)
     expect(typeof Vue.config.errorHandler).toBe('function')

--- a/packages/plugin-window-onerror/onerror.js
+++ b/packages/plugin-window-onerror/onerror.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   init: (client, win = window) => {
-    if (!client.config.autoDetectErrors) return
+    if (!client._config.autoDetectErrors) return
     function onerror (messageOrEvent, url, lineNo, charNo, error) {
       // Ignore errors with no info due to CORS settings
       if (lineNo === 0 && /Script error\.?/.test(messageOrEvent)) {

--- a/packages/plugin-window-onerror/test/onerror.test.js
+++ b/packages/plugin-window-onerror/test/onerror.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect, beforeEach } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 let window
 
@@ -11,27 +10,21 @@ describe('plugin: window onerror', () => {
   beforeEach(() => { window = {} })
 
   it('should set a window.onerror event handler', () => {
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH' })
-    client.configure()
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
     client.use(plugin, window)
     expect(typeof window.onerror).toBe('function')
   })
 
   it('should not add a window.onerror event handler when autoDetectErrors=false', () => {
-    const client = new Client(VALID_NOTIFIER)
-    client.setOptions({ apiKey: 'API_KEY_YEAH', autoDetectErrors: false })
-    client.configure()
+    const client = new Client({ apiKey: 'API_KEY_YEAH', autoDetectErrors: false })
     client.use(plugin, window)
     expect(window.onerror).toBe(undefined)
   })
 
   describe('window.onerror function', () => {
     it('captures uncaught errors in timer callbacks', done => {
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 
@@ -79,10 +72,8 @@ describe('plugin: window onerror', () => {
     it('calls any previously registered window.onerror callback', done => {
       window.onerror = () => done()
 
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 
@@ -90,10 +81,8 @@ describe('plugin: window onerror', () => {
     })
 
     it('handles single argument usage of window.onerror', () => {
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 
@@ -110,10 +99,8 @@ describe('plugin: window onerror', () => {
     })
 
     it('handles single argument usage of window.onerror with extra parameter', () => {
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 
@@ -191,10 +178,8 @@ describe('plugin: window onerror', () => {
     // }
 
     it('extracts meaning from non-error values as error messages', function (done) {
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 
@@ -228,10 +213,8 @@ describe('plugin: window onerror', () => {
         expect(payloads.length).toBe(1)
         done()
       }
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 
@@ -250,10 +233,8 @@ describe('plugin: window onerror', () => {
         expect(payloads.length).toBe(0)
         done()
       }
-      const client = new Client(VALID_NOTIFIER)
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       const payloads = []
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
       client.use(plugin, window)
       client.delivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
 

--- a/packages/plugin-window-unhandled-rejection/test/unhandled-rejection.test.js
+++ b/packages/plugin-window-unhandled-rejection/test/unhandled-rejection.test.js
@@ -3,7 +3,6 @@ const { describe, it, expect, spyOn } = global
 const plugin = require('../')
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 let listener = null
 const window = {
@@ -18,9 +17,7 @@ const window = {
 describe('plugin: unhandled rejection', () => {
   describe('window.onunhandledrejection function', () => {
     it('captures unhandled promise rejections', done => {
-      const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client.use(plugin, window)
       client.delivery(client => ({
         sendEvent: (payload) => {
@@ -38,9 +35,7 @@ describe('plugin: unhandled rejection', () => {
     })
 
     it('handles bad user input', done => {
-      const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client.use(plugin, window)
       client.delivery(client => ({
         sendEvent: (payload) => {
@@ -103,9 +98,7 @@ describe('plugin: unhandled rejection', () => {
     // })
 
     it('handles errors with non-string stacks', done => {
-      const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client.use(plugin, window)
       client.delivery(client => ({
         sendEvent: (payload) => {
@@ -126,9 +119,7 @@ describe('plugin: unhandled rejection', () => {
     })
 
     it('tolerates event.detail propties which throw', done => {
-      const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY_YEAH' })
-      client.configure()
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client.use(plugin, window)
       client.delivery(client => ({
         sendEvent: (payload) => {
@@ -156,9 +147,7 @@ describe('plugin: unhandled rejection', () => {
         addEventListener: () => {}
       }
       const addEventListenerSpy = spyOn(window, 'addEventListener')
-      const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY_YEAH', autoDetectErrors: false })
-      client.configure()
+      const client = new Client({ apiKey: 'API_KEY_YEAH', autoDetectErrors: false })
       client.use(plugin, window)
       expect(addEventListenerSpy).toHaveBeenCalledTimes(0)
     })
@@ -168,9 +157,7 @@ describe('plugin: unhandled rejection', () => {
         addEventListener: () => {}
       }
       const addEventListenerSpy = spyOn(window, 'addEventListener')
-      const client = new Client(VALID_NOTIFIER)
-      client.setOptions({ apiKey: 'API_KEY_YEAH', autoDetectUnhandledRejections: false })
-      client.configure()
+      const client = new Client({ apiKey: 'API_KEY_YEAH', autoDetectUnhandledRejections: false })
       client.use(plugin, window)
       expect(addEventListenerSpy).toHaveBeenCalledTimes(0)
     })

--- a/packages/plugin-window-unhandled-rejection/unhandled-rejection.js
+++ b/packages/plugin-window-unhandled-rejection/unhandled-rejection.js
@@ -8,7 +8,7 @@ const isError = require('@bugsnag/core/lib/iserror')
  */
 let _listener
 exports.init = (client, win = window) => {
-  if (!client.config.autoDetectErrors || !client.config.autoDetectUnhandledRejections) return
+  if (!client._config.autoDetectErrors || !client._config.autoDetectUnhandledRejections) return
   const listener = evt => {
     let error = evt.reason
     let isBluebird = false


### PR DESCRIPTION
The existing configuration routine was laborious and can be simplified to be done in one fell swoop

This is just an implementation detail really – this logic is done internally in each exported notififer – but it removes some methods from the public client interface (making it compliant with the spec).

```diff
  var NOTIFIER_DETAILS = { name: 'Bugsnag x', url: 'https://bugsnag.com', version: '0.0' }
- const client = new Client(NOTIFIER_DETAILS)
- client.setOptions(userOpts)
- client.configure(customSchema)
+ const client = new Client(userOpts, schema, NOTIFIER_DETAILS)
```

One benefit of the configuration being done via the constructor is that we can remove some of the "client not configured" errors – it's now impossible to have an instance of a client that's not configured.

Since loads of unit tests create `Client`s directly, this changeset is pretty big, but it does end up removing a lot of boilerplate lines from those tests.

The other change in this PR is to store config at `client._config` (`_` to signify that it is private) and remove its `public` definition from the types to match up with the spec.