### PR TITLE
V7: Callback refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Rename `metaData` -> `metadata` and add consistent `add/get/clearMetadata()` methods to `Client`/`Event` for manipulating metadata explicitly, rather than mutating a property [#658](https://github.com/bugsnag/bugsnag-js/pull/658)
 - Remove non-public methods from `Client` interface: `logger()`, `delivery()` and `sessionDelegate()` [#659](https://github.com/bugsnag/bugsnag-js/pull/659)
 - Update `leaveBreadcrumb()` type signature to return `void`. [#661](https://github.com/bugsnag/bugsnag-js/pull/661)
+- Add `onBreadcrumb` and `onSession` callbacks. [#665](https://github.com/bugsnag/bugsnag-js/pull/665)
 
 ## 6.4.3 (2019-10-21)
 

--- a/packages/browser/types/test/fixtures/all-options.ts
+++ b/packages/browser/types/test/fixtures/all-options.ts
@@ -5,15 +5,25 @@ bugsnag({
   appType: "worker",
   autoDetectErrors: true,
   autoDetectUnhandledRejections: true,
-  onError: [],
+  onError: [
+    event => true
+  ],
+  onBreadcrumb: b => {
+    console.log(b.message)
+    return false
+  },
+  onSession: s => {
+    console.log(s.id)
+    return true
+  }
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
   autoTrackSessions: true,
-  enabledReleaseStages: [],
+  enabledReleaseStages: ['zzz'],
   releaseStage: "production",
   maxBreadcrumbs: 20,
   enabledBreadcrumbTypes: ['manual','log','request'],
   user: null,
-  metaData: {},
+  metadata: {},
   logger: undefined,
   filters: ["foo",/bar/],
   collectUserIp: true,

--- a/packages/browser/types/test/fixtures/all-options.ts
+++ b/packages/browser/types/test/fixtures/all-options.ts
@@ -1,4 +1,4 @@
-import bugsnag from "../../.."
+import bugsnag, { Bugsnag } from "../../.."
 bugsnag({
   apiKey: "abc",
   appVersion: "1.2.3",
@@ -8,14 +8,14 @@ bugsnag({
   onError: [
     event => true
   ],
-  onBreadcrumb: b => {
+  onBreadcrumb: (b: Bugsnag.Breadcrumb) => {
     console.log(b.message)
     return false
   },
-  onSession: s => {
+  onSession: (s: Bugsnag.Session) => {
     console.log(s.id)
     return true
-  }
+  },
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
   autoTrackSessions: true,
   enabledReleaseStages: ['zzz'],

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -1,5 +1,5 @@
 const { filter, reduce, keys, isArray, includes } = require('./lib/es-utils')
-const { intRange, stringWithLength } = require('./lib/validators')
+const { intRange, stringWithLength, listOfFunctions } = require('./lib/validators')
 
 const BREADCRUMB_TYPES = ['navigation', 'request', 'process', 'log', 'user', 'state', 'error', 'manual']
 
@@ -32,7 +32,17 @@ module.exports.schema = {
   onError: {
     defaultValue: () => [],
     message: 'should be a function or array of functions',
-    validate: value => typeof value === 'function' || (isArray(value) && filter(value, f => typeof f === 'function').length === value.length)
+    validate: listOfFunctions
+  },
+  onSession: {
+    defaultValue: () => [],
+    message: 'should be a function or array of functions',
+    validate: listOfFunctions
+  },
+  onBreadcrumb: {
+    defaultValue: () => [],
+    message: 'should be a function or array of functions',
+    validate: listOfFunctions
   },
   endpoints: {
     defaultValue: () => ({

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -14,6 +14,13 @@ module.exports = (client) => {
   clone.request = { ...client.request }
   clone._user = { ...client._user }
 
+  clone._cbs = {
+    e: client._cbs.e.slice(),
+    s: client._cbs.s.slice(),
+    sp: client._cbs.sp.slice(),
+    b: client._cbs.b.slice()
+  }
+
   clone._logger = client._logger
   clone._delivery = client._delivery
 

--- a/packages/core/lib/sync-callback-runner.js
+++ b/packages/core/lib/sync-callback-runner.js
@@ -1,0 +1,14 @@
+module.exports = (callbacks, callbackArg, callbackType, logger) => {
+  let ignore = false
+  const cbs = callbacks.slice(0)
+  while (!ignore) {
+    if (!cbs.length) break
+    try {
+      ignore = cbs.pop()(callbackArg) === false
+    } catch (e) {
+      logger.error(`Error occurred in ${callbackType} callback, continuing anyway…`)
+      logger.error(e)
+    }
+  }
+  return ignore
+}

--- a/packages/core/lib/validators.js
+++ b/packages/core/lib/validators.js
@@ -1,6 +1,10 @@
+const { filter, isArray } = require('./es-utils')
+
 exports.intRange = (min = 1, max = Infinity) => value =>
   typeof value === 'number' &&
   parseInt('' + value, 10) === value &&
   value >= min && value <= max
 
 exports.stringWithLength = value => typeof value === 'string' && !!value.length
+
+exports.listOfFunctions = value => typeof value === 'function' || (isArray(value) && filter(value, f => typeof f === 'function').length === value.length)

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -563,7 +563,7 @@ describe('@bugsnag/core/client', () => {
       expect(sSpy).toHaveBeenCalledTimes(1)
       c.notify(new Error(), () => {}, () => {
         expect(bSpy).toHaveBeenCalledTimes(1)
-        expect(bSpy).toHaveBeenCalledTimes(1)
+        expect(eSpy).toHaveBeenCalledTimes(1)
 
         c.removeOnError(eSpy)
         c.removeOnSession(sSpy)
@@ -573,7 +573,7 @@ describe('@bugsnag/core/client', () => {
         expect(sSpy).toHaveBeenCalledTimes(1)
         c.notify(new Error(), () => {}, () => {
           expect(bSpy).toHaveBeenCalledTimes(1)
-          expect(bSpy).toHaveBeenCalledTimes(1)
+          expect(eSpy).toHaveBeenCalledTimes(1)
 
           done()
         })

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -412,6 +412,45 @@ describe('@bugsnag/core/client', () => {
       client.leaveBreadcrumb('toast')
       expect(client.breadcrumbs.length).toBe(0)
     })
+
+    it('doesn’t store the breadcrumb if an onBreadcrumb callback returns false', () => {
+      let calls = 0
+      const client = new Client({
+        apiKey: 'API_KEY_YEAH',
+        onBreadcrumb: b => {
+          calls++
+          return false
+        }
+      })
+      client.leaveBreadcrumb('message')
+      expect(calls).toBe(1)
+      expect(client.breadcrumbs.length).toBe(0)
+    })
+
+    it('tolerates errors in onBreadcrumb callbacks', () => {
+      let calls = 0
+      const client = new Client({
+        apiKey: 'API_KEY_YEAH',
+        onBreadcrumb: b => {
+          calls++
+          throw new Error('uh oh')
+        }
+      })
+      client.leaveBreadcrumb('message')
+      expect(calls).toBe(1)
+      expect(client.breadcrumbs.length).toBe(1)
+    })
+
+    it('ignores breadcrumb types that aren’t in the enabled list', () => {
+      const client = new Client({
+        apiKey: 'API_KEY_YEAH',
+        enabledBreadcrumbTypes: ['manual']
+      })
+      client.leaveBreadcrumb('brrrrr')
+      client.leaveBreadcrumb('GET /jim', {}, 'request')
+      expect(client.breadcrumbs.length).toBe(1)
+      expect(client.breadcrumbs[0].message).toBe('brrrrr')
+    })
   })
 
   describe('startSession()', () => {
@@ -426,20 +465,6 @@ describe('@bugsnag/core/client', () => {
         }
       }
       expect(client.startSession()).toBe(ret)
-    })
-
-    it('calls warns if a session delegate is not provided', (done) => {
-      const client = new Client({ apiKey: 'API_KEY' })
-      client._logger = {
-        debug: () => {},
-        info: () => {},
-        warn: (...args) => {
-          expect(args[0]).toMatch(/^No session/)
-          done()
-        },
-        error: () => {}
-      }
-      client.startSession()
     })
 
     it('tracks error counts using the session delegate and sends them in error payloads', (done) => {
@@ -473,6 +498,86 @@ describe('@bugsnag/core/client', () => {
       sessionClient.notify(new Error('broke'))
       sessionClient.notify(new Event('err', 'bad', [], { unhandled: true, severity: 'error', severityReason: { type: 'unhandledException' } }))
       sessionClient.notify(new Event('err', 'bad', [], { unhandled: true, severity: 'error', severityReason: { type: 'unhandledException' } }))
+    })
+
+    it('does not start the session if onSession returns false', () => {
+      const client = new Client({ apiKey: 'API_KEY', onSession: s => false })
+      const sessionDelegate = {
+        startSession: () => {},
+        pauseSession: () => {},
+        resumeSession: () => {}
+      }
+      client._sessionDelegate = sessionDelegate
+
+      const startSpy = spyOn(sessionDelegate, 'startSession')
+
+      client.startSession()
+      expect(startSpy).toHaveBeenCalledTimes(0)
+    })
+
+    it('tolerates errors in onSession callbacks', () => {
+      const client = new Client({
+        apiKey: 'API_KEY',
+        onSession: s => {
+          throw new Error('oh no')
+        }
+      })
+      const sessionDelegate = {
+        startSession: () => {},
+        pauseSession: () => {},
+        resumeSession: () => {}
+      }
+      client._sessionDelegate = sessionDelegate
+
+      const startSpy = spyOn(sessionDelegate, 'startSession')
+
+      client.startSession()
+      expect(startSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('callbacks', () => {
+    it('supports adding and removing onError/onSession/onBreadcrumb callbacks', (done) => {
+      const c = new Client({ apiKey: 'API_KEY' })
+      c._setDelivery(client => ({ sendEvent: (p, cb) => cb(null), sendSession: (s, cb) => cb(null) }))
+      c._logger = console
+      const sessionDelegate = {
+        startSession: () => {},
+        pauseSession: () => {},
+        resumeSession: () => {}
+      }
+      c._sessionDelegate = sessionDelegate
+      const eSpy = spyOn({ fn: () => {} }, 'fn')
+      const bSpy = spyOn({ fn: () => {} }, 'fn')
+      const sSpy = spyOn({ fn: () => {} }, 'fn')
+
+      c.addOnError(eSpy)
+      c.addOnSession(sSpy)
+      c.addOnBreadcrumb(bSpy)
+
+      expect(c._cbs.e.length).toBe(1)
+      expect(c._cbs.s.length).toBe(1)
+      expect(c._cbs.b.length).toBe(1)
+
+      c.startSession()
+      expect(sSpy).toHaveBeenCalledTimes(1)
+      c.notify(new Error(), () => {}, () => {
+        expect(bSpy).toHaveBeenCalledTimes(1)
+        expect(bSpy).toHaveBeenCalledTimes(1)
+
+        c.removeOnError(eSpy)
+        c.removeOnSession(sSpy)
+        c.removeOnBreadcrumb(bSpy)
+
+        c.startSession()
+        expect(sSpy).toHaveBeenCalledTimes(1)
+        c.notify(new Error(), () => {}, () => {
+          expect(bSpy).toHaveBeenCalledTimes(1)
+          expect(bSpy).toHaveBeenCalledTimes(1)
+
+          done()
+        })
+      })
     })
   })
 

--- a/packages/core/types/breadcrumb.d.ts
+++ b/packages/core/types/breadcrumb.d.ts
@@ -1,7 +1,9 @@
+import { BreadcrumbType, BreadcrumbMetadataValue } from "./common";
+
 declare class Breadcrumb {
   public message: string;
-  public metadata: object;
-  public type: string;
+  public metadata: BreadcrumbMetadataValue;
+  public type: BreadcrumbType;
   public timestamp: string;
 }
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -1,9 +1,13 @@
 import Client from "./client";
 import Event from "./event";
+import Session from "./session";
+import Breadcrumb from "./breadcrumb";
 
 export interface Config {
   apiKey: string;
   onError?: OnError | OnError[];
+  onBreadcrumb?: OnBreadcrumb | OnBreadcrumb[];
+  onSession?: OnSession | OnSession[];
   enabledBreadcrumbTypes?: BreadcrumbType[];
   autoDetectErrors?: boolean;
   autoDetectUnhandledRejections?: boolean;
@@ -22,6 +26,8 @@ export interface Config {
 }
 
 export type OnError = (event: Event, cb?: (err: null | Error) => void) => void | Promise<void> | boolean;
+export type OnSession = (session: Session) => boolean;
+export type OnBreadcrumb = (breadcrumb: Breadcrumb) => boolean;
 
 export interface Plugin {
   name?: string;

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -5,7 +5,17 @@ bugsnag({
   appType: "worker",
   autoDetectErrors: true,
   autoDetectUnhandledRejections: true,
-  onError: [],
+  onError: [
+    event => true
+  ],
+  onBreadcrumb: b => {
+    console.log(b.message)
+    return false
+  },
+  onSession: s => {
+    console.log(s.id)
+    return true
+  }
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
   autoTrackSessions: true,
   enabledReleaseStages: ['zzz'],

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -1,4 +1,4 @@
-import bugsnag from "../../.."
+import bugsnag, { Bugsnag } from "../../.."
 bugsnag({
   apiKey: "abc",
   appVersion: "1.2.3",
@@ -8,14 +8,14 @@ bugsnag({
   onError: [
     event => true
   ],
-  onBreadcrumb: b => {
+  onBreadcrumb: (b: Bugsnag.Breadcrumb) => {
     console.log(b.message)
     return false
   },
-  onSession: s => {
+  onSession: (s: Bugsnag.Session) => {
     console.log(s.id)
     return true
-  }
+  },
   endpoints: {"notify":"https://notify.bugsnag.com","sessions":"https://sessions.bugsnag.com"},
   autoTrackSessions: true,
   enabledReleaseStages: ['zzz'],

--- a/packages/plugin-browser-context/context.js
+++ b/packages/plugin-browser-context/context.js
@@ -3,9 +3,9 @@
  */
 module.exports = {
   init: (client, win = window) => {
-    client._config.onError.unshift(event => {
+    client.addOnError(event => {
       if (event.context) return
       event.context = win.location.pathname
-    })
+    }, true)
   }
 }

--- a/packages/plugin-browser-device/device.js
+++ b/packages/plugin-browser-device/device.js
@@ -14,8 +14,8 @@ module.exports = {
     client.device = { ...device, ...client.device }
 
     // add time just as the event is sent
-    client._config.onError.unshift((event) => {
+    client.addOnError((event) => {
       event.device = { ...event.device, time: isoDate() }
-    })
+    }, true)
   }
 }

--- a/packages/plugin-browser-device/test/device.test.js
+++ b/packages/plugin-browser-device/test/device.test.js
@@ -12,7 +12,7 @@ describe('plugin: device', () => {
     const payloads = []
     client.use(plugin, navigator)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
 
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Error('noooo'))

--- a/packages/plugin-browser-request/request.js
+++ b/packages/plugin-browser-request/request.js
@@ -3,9 +3,9 @@
  */
 module.exports = {
   init: (client, win = window) => {
-    client._config.onError.unshift(event => {
+    client.addOnError(event => {
       if (event.request && event.request.url) return
       event.request = { ...event.request, url: win.location.href }
-    })
+    }, true)
   }
 }

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -6,9 +6,9 @@ module.exports = {
 }
 
 const sessionDelegate = {
-  startSession: client => {
+  startSession: (client, session) => {
     const sessionClient = client
-    sessionClient._session = new client.BugsnagSession()
+    sessionClient._session = session
 
     const releaseStage = inferReleaseStage(sessionClient)
 

--- a/packages/plugin-client-ip/client-ip.js
+++ b/packages/plugin-client-ip/client-ip.js
@@ -5,7 +5,7 @@ module.exports = {
   init: (client) => {
     if (client._config.collectUserIp) return
 
-    client._config.onError.push(event => {
+    client.addOnError(event => {
       // If user.id is explicitly undefined, it will be missing from the payload. It needs
       // removing so that the following line replaces it
       if (event._user && typeof event._user.id === 'undefined') delete event._user.id

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -25,7 +25,7 @@ module.exports = {
       }
     }
 
-    client._config.onError.unshift(event => {
+    client.addOnError(event => {
       const now = new Date()
       const inForeground = AppState.currentState === 'active'
       event.app.inForeground = inForeground
@@ -34,7 +34,7 @@ module.exports = {
         event.app.durationInForeground = now - lastEnteredForeground
       }
       event.addMetadata('app', { nativeBundleVersion, nativeVersionCode })
-    })
+    }, true)
 
     if (!client.app.version && Constants.manifest.version) {
       client.app.version = Constants.manifest.version

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -37,7 +37,7 @@ module.exports = {
       }
     }
 
-    client._config.onError.unshift(event => {
+    client.addOnError(event => {
       event.device = {
         ...event.device,
         time: isoDate(),
@@ -47,6 +47,6 @@ module.exports = {
         isDevice: Constants.isDevice,
         appOwnership: Constants.appOwnership
       })
-    })
+    }, true)
   }
 }

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -52,7 +52,7 @@ module.exports = {
       }, {})
     }
 
-    client._config.onError.unshift(event => {
+    client.addOnError(event => {
       // remove any of our own frames that may be part the stack this
       // happens before the inline script check as it happens for all errors
       event.stacktrace = filter(event.stacktrace, f => !(/__trace__$/.test(f.method)))
@@ -76,7 +76,7 @@ module.exports = {
       // only attempt to grab some surrounding code if we have a line number
       if (!frame || !frame.lineNumber) return
       frame.code = addSurroundingCode(frame.lineNumber)
-    })
+    }, true)
 
     // Proxy all the timer functions whose callback is their 0th argument.
     // Keep a reference to the original setTimeout because we need it later

--- a/packages/plugin-inline-script-content/test/inline-script-content.test.js
+++ b/packages/plugin-inline-script-content/test/inline-script-content.test.js
@@ -32,7 +32,7 @@ Lorem ipsum dolor sit amet.
     const payloads = []
     client.use(plugin, document, window)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('BadThing', 'Happens in script tags', [
       { fileName: window.location.href, lineNumber: 10 }
@@ -96,7 +96,7 @@ Lorem ipsum dolor sit amet.
     const payloads = []
     client.use(plugin, document, window)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('BadThing', 'Happens in script tags', [
       { fileName: window.location.href, lineNumber: 10 }
@@ -133,7 +133,7 @@ Lorem ipsum dolor sit amet.
     const payloads = []
     client.use(plugin, document, window)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('BadThing', 'Happens in script tags', [
       { fileName: window.location.href, lineNumber: 7 }
@@ -169,7 +169,7 @@ Lorem ipsum dolor sit amet.
     const payloads = []
     client.use(plugin, document, window)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     const spy = spyOn(client._logger, 'error')
     client.notify(new Event('EmptyStacktrace', 'Has nothing in it', []))
@@ -232,7 +232,7 @@ Lorem ipsum dolor sit amet.
     const payloads = []
     client.use(plugin, document, window)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Event('Error', 'oh', [
       { fileName: window.location.href, lineNumber: 1 }

--- a/packages/plugin-koa/test/koa.test.js
+++ b/packages/plugin-koa/test/koa.test.js
@@ -7,6 +7,11 @@ const plugin = require('../')
 describe('plugin: koa', () => {
   it('exports two middleware functions', () => {
     const c = new Client({ apiKey: 'api_key' })
+    c._sessionDelegate = {
+      startSession: () => c,
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
     c.use(plugin)
     const middleware = c.getPlugin('koa')
     expect(typeof middleware.requestHandler).toBe('function')
@@ -18,6 +23,11 @@ describe('plugin: koa', () => {
   describe('requestHandler', () => {
     it('should call through to app.onerror to ensure the error is logged out', (done) => {
       const c = new Client({ apiKey: 'api_key' })
+      c._sessionDelegate = {
+        startSession: () => c,
+        pauseSession: () => {},
+        resumeSession: () => {}
+      }
       c.use(plugin)
       const middleware = c.getPlugin('koa')
       const mockCtx = {

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -7,6 +7,11 @@ const Client = require('@bugsnag/core/client')
 describe('plugin: navigation breadcrumbs', () => {
   it('should drop breadcrumb for navigational activity', done => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
+    c._sessionDelegate = {
+      startSession: () => {},
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
 
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
@@ -33,6 +38,11 @@ describe('plugin: navigation breadcrumbs', () => {
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
+    c._sessionDelegate = {
+      startSession: () => {},
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
     winHandlers.load.forEach((h) => h.call(window))
@@ -74,6 +84,11 @@ describe('plugin: navigation breadcrumbs', () => {
 
   it('should be enabled when enabledReleaseStages=["navigation"]', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledReleaseStages: ['navigation'] })
+    c._sessionDelegate = {
+      startSession: () => {},
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
     const { winHandlers, docHandlers, window } = getMockWindow()
     c.use(plugin, window)
     winHandlers.load.forEach((h) => h.call(window))

--- a/packages/plugin-node-device/device.js
+++ b/packages/plugin-node-device/device.js
@@ -14,8 +14,8 @@ module.exports = {
     client.device = { ...device, ...client.device }
 
     // add time just as the event is sent
-    client._config.onError.unshift((event) => {
+    client.addOnError((event) => {
       event.device = { ...event.device, time: isoDate() }
-    })
+    }, true)
   }
 }

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -18,7 +18,7 @@ describe('plugin: node device', () => {
     const client = new Client({ apiKey: 'API_KEY_YEAH' }, schema)
     client.use(plugin)
 
-    expect(client._config.onError.length).toBe(1)
+    expect(client._cbs.e.length).toBe(1)
     expect(client.device.hostname).toBe('test-machine.local')
     expect(client.device.runtimeVersions).toBeDefined()
     expect(client.device.runtimeVersions.node).toEqual(process.versions.node)

--- a/packages/plugin-node-in-project/in-project.js
+++ b/packages/plugin-node-in-project/in-project.js
@@ -2,7 +2,7 @@ const { map } = require('@bugsnag/core/lib/es-utils')
 const normalizePath = require('@bugsnag/core/lib/path-normalizer')
 
 module.exports = {
-  init: client => client._config.onError.push(event => {
+  init: client => client.addOnError(event => {
     if (!client._config.projectRoot) return
     const projectRoot = normalizePath(client._config.projectRoot)
     event.stacktrace = map(event.stacktrace, stackframe => {

--- a/packages/plugin-node-surrounding-code/surrounding-code.js
+++ b/packages/plugin-node-surrounding-code/surrounding-code.js
@@ -28,7 +28,7 @@ module.exports = {
       }
     })
 
-    client._config.onError.push(event => new Promise((resolve, reject) => {
+    client.addOnError(event => new Promise((resolve, reject) => {
       const cache = Object.create(null)
       pMapSeries(event.stacktrace.map(stackframe => () => loadSurroundingCode(stackframe, cache)))
         .then(resolve)

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -6,14 +6,14 @@ const SessionTracker = require('./tracker')
 const Backoff = require('backo')
 
 module.exports = {
-  init: client => {
+  init: (client) => {
     const sessionTracker = new SessionTracker(client._config.sessionSummaryInterval)
     sessionTracker.on('summary', sendSessionSummary(client))
     sessionTracker.start()
     client._sessionDelegate = {
-      startSession: client => {
+      startSession: (client, session) => {
         const sessionClient = clone(client)
-        sessionClient._session = new client.BugsnagSession()
+        sessionClient._session = session
         sessionTracker.track(sessionClient._session)
         return sessionClient
       }

--- a/packages/plugin-simple-throttle/throttle.js
+++ b/packages/plugin-simple-throttle/throttle.js
@@ -10,7 +10,7 @@ module.exports = {
     let n = 0
 
     // add onError hook
-    client._config.onError.push((event) => {
+    client.addOnError((event) => {
       // have max events been sent already?
       if (n >= client._config.maxEvents) return false
       n++

--- a/packages/plugin-strip-project-root/strip-project-root.js
+++ b/packages/plugin-strip-project-root/strip-project-root.js
@@ -2,7 +2,7 @@ const { map } = require('@bugsnag/core/lib/es-utils')
 const normalizePath = require('@bugsnag/core/lib/path-normalizer')
 
 module.exports = {
-  init: client => client._config.onError.push(event => {
+  init: client => client.addOnError(event => {
     if (!client._config.projectRoot) return
     const projectRoot = normalizePath(client._config.projectRoot)
     event.stacktrace = map(event.stacktrace, stackframe => {

--- a/packages/plugin-strip-query-string/strip-query-string.js
+++ b/packages/plugin-strip-query-string/strip-query-string.js
@@ -5,7 +5,7 @@ const { map } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = {
   init: (client) => {
-    client._config.onError.push(event => {
+    client.addOnError(event => {
       event.stacktrace = map(event.stacktrace, frame => ({ ...frame, file: strip(frame.file) }))
     })
   }


### PR DESCRIPTION
- Add public `onBreadcrumb` and `onSession` breadcrumbs
- Add private `onSessionPayload` breadcrumbs (will be required by a subsequent PR for attaching data to a session)
- Add client methods for adding/removing all kinds of callback
- Add config options for supplying public callbacks