### PR TITLE
V7: Add methods to pause and resume sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Refactor `notify()` to not accept events (they go via `_notify()` instead). Consolidate `Event` static methods into a single `.create()` utility, used by all automatic errors detection components. [#664](https://github.com/bugsnag/bugsnag-js/pull/664)
 - Refactor `notify()` to not accept events (they go via `_notify()` instead). Consolidate `Event` static methods into a single `.create()` utility, used by all automatic error detection components. [#664](https://github.com/bugsnag/bugsnag-js/pull/664)
 - Add methods to pause and resume sessions [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
+- Add `pauseSession()` and `resumeSession()` methods to `Client` [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
 
 ## 6.4.3 (2019-10-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add `onBreadcrumb` and `onSession` callbacks. [#665](https://github.com/bugsnag/bugsnag-js/pull/665)
 - Refactor `notify()` to not accept events (they go via `_notify()` instead). Consolidate `Event` static methods into a single `.create()` utility, used by all automatic errors detection components. [#664](https://github.com/bugsnag/bugsnag-js/pull/664)
 - Refactor `notify()` to not accept events (they go via `_notify()` instead). Consolidate `Event` static methods into a single `.create()` utility, used by all automatic error detection components. [#664](https://github.com/bugsnag/bugsnag-js/pull/664)
+- Add methods to pause and resume sessions [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
 
 ## 6.4.3 (2019-10-21)
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -176,6 +176,14 @@ class BugsnagClient {
     this._cbs.b = filter(this._cbs.b, f => f !== fn)
   }
 
+  pauseSession () {
+    return this._sessionDelegate.pauseSession(this)
+  }
+
+  resumeSession () {
+    return this._sessionDelegate.resumeSession(this)
+  }
+
   leaveBreadcrumb (message, metadata, type) {
     // coerce bad values so that the defaults get set
     message = typeof message === 'string' ? message : ''

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -23,6 +23,7 @@ module.exports = (client) => {
 
   clone._logger = client._logger
   clone._delivery = client._delivery
+  clone._sessionDelegate = client._sessionDelegate
 
   return clone
 }

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -613,6 +613,30 @@ describe('@bugsnag/core/client', () => {
     })
   })
 
+  describe('pause/resumeSession()', () => {
+    it('forwards on calls to the session delegate', () => {
+      const client = new Client({ apiKey: 'API_KEY' })
+      const sessionDelegate = {
+        startSession: () => {},
+        pauseSession: () => {},
+        resumeSession: () => {}
+      }
+      client._sessionDelegate = sessionDelegate
+
+      const startSpy = spyOn(sessionDelegate, 'startSession')
+      const pauseSpy = spyOn(sessionDelegate, 'pauseSession')
+      const resumeSpy = spyOn(sessionDelegate, 'resumeSession')
+      client._sessionDelegate = sessionDelegate
+
+      client.startSession()
+      expect(startSpy).toHaveBeenCalledTimes(1)
+      client.pauseSession()
+      expect(pauseSpy).toHaveBeenCalledTimes(1)
+      client.resumeSession()
+      expect(resumeSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('getUser() / setUser()', () => {
     it('sets and retrieves user properties', () => {
       const c = new Client({ apiKey: 'aaaa' })

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -22,6 +22,11 @@ declare class Client {
   public getUser(): { id?: string; email?: string; name?: string };
   public setUser(id?: string, email?: string, name?: string): void;
 
+  // sessions
+  public startSession(): Client;
+  public pauseSession(): void;
+  public resumeSession(): Client;
+
   public use(plugin: common.Plugin, ...args: any[]): Client;
   public getPlugin(name: string): any;
   public notify(
@@ -35,7 +40,6 @@ declare class Client {
     cb?: (err: any, event: Event) => void,
   ): void;
   public leaveBreadcrumb(message: string, metadata?: { [key: string]: common.BreadcrumbMetadataValue }, type?: string): void;
-  public startSession(): Client;
 }
 
 export default Client;

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -9,6 +9,7 @@ const sessionDelegate = {
   startSession: (client, session) => {
     const sessionClient = client
     sessionClient._session = session
+    sessionClient._pausedSession = null
 
     const releaseStage = inferReleaseStage(sessionClient)
 
@@ -32,5 +33,18 @@ const sessionDelegate = {
     })
 
     return sessionClient
+  },
+  resumeSession: (client) => {
+    if (client._pausedSession) {
+      client._session = client._pausedSession
+      client._pausedSession = null
+      return client
+    } else {
+      return client.startSession()
+    }
+  },
+  pauseSession: (client) => {
+    client._pausedSession = client._session
+    client._session = null
   }
 }

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -14,8 +14,22 @@ module.exports = {
       startSession: (client, session) => {
         const sessionClient = clone(client)
         sessionClient._session = session
+        sessionClient._pausedSession = null
         sessionTracker.track(sessionClient._session)
         return sessionClient
+      },
+      pauseSession: (client) => {
+        client._pausedSession = client._session
+        client._session = null
+      },
+      resumeSession: (client) => {
+        if (client._pausedSession) {
+          client._session = client._pausedSession
+          client._pausedSession = null
+          return client
+        } else {
+          return client.startSession()
+        }
       }
     }
   },

--- a/packages/plugin-server-session/test/session.test.js
+++ b/packages/plugin-server-session/test/session.test.js
@@ -140,4 +140,27 @@ describe('plugin: server sessions', () => {
     expect(sessionClient.breadcrumbs.length).toBe(2)
     expect(Object.keys(sessionClient._metadata).length).toBe(2)
   })
+
+  it('should support pausing/resuming sessions', () => {
+    class TrackerMock extends Emitter {
+      start () {}
+      stop () {}
+      track () {}
+    }
+    const plugin = proxyquire('../session', { './tracker': TrackerMock })
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
+    c.use(plugin)
+    const sessionClient = c.startSession()
+    const sid0 = sessionClient._session.id
+    sessionClient.pauseSession()
+    const s1 = sessionClient._session
+    sessionClient.resumeSession()
+    const sid2 = sessionClient._session.id
+    expect(sid2).toBe(sid0)
+    expect(s1).toBe(null)
+    sessionClient._session = null
+    const resumedClient = sessionClient.resumeSession()
+    expect(resumedClient._session).toBeTruthy()
+  })
 })

--- a/packages/plugin-server-session/test/session.test.js
+++ b/packages/plugin-server-session/test/session.test.js
@@ -151,16 +151,29 @@ describe('plugin: server sessions', () => {
 
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.use(plugin)
+
+    // start a session and get its id
     const sessionClient = c.startSession()
     const sid0 = sessionClient._session.id
+
+    // ensure pausing the session clears the client._session property
     sessionClient.pauseSession()
     const s1 = sessionClient._session
+    const psid1 = sessionClient._pausedSession.id
+    expect(s1).toBe(null)
+    expect(psid1).toBe(sid0)
+
+    // ensure resuming the session gets back the original session (not a new one)
     sessionClient.resumeSession()
     const sid2 = sessionClient._session.id
     expect(sid2).toBe(sid0)
-    expect(s1).toBe(null)
+
+    // ensure resumeSession() starts a new one when no paused session exists
     sessionClient._session = null
+    sessionClient._pausedSession = null
     const resumedClient = sessionClient.resumeSession()
     expect(resumedClient._session).toBeTruthy()
+    const sid3 = resumedClient._session.id
+    expect(sid3).not.toBe(sid0)
   })
 })


### PR DESCRIPTION
Adds the following methods to `Client`:

- `pauseSession()`
- `resumeSession()`

This is a feature that existed on other notifiers and has been added to the spec.