### PR TITLE
V7: Remove client request prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Refactor `notify()` to not accept events (they go via `_notify()` instead). Consolidate `Event` static methods into a single `.create()` utility, used by all automatic error detection components. [#664](https://github.com/bugsnag/bugsnag-js/pull/664)
 - Add methods to pause and resume sessions [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
 - Add `pauseSession()` and `resumeSession()` methods to `Client` [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
+- Remove `client.request` property [#672](https://github.com/bugsnag/bugsnag-js/pull/672)
 
 ## 6.4.3 (2019-10-21)
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -37,7 +37,6 @@ class BugsnagClient {
     this.app = {}
     this.context = undefined
     this.device = undefined
-    this.request = undefined
     this._user = {}
 
     // callbacks:
@@ -225,7 +224,6 @@ class BugsnagClient {
     event.app = { ...{ releaseStage }, ...event.app, ...this.app }
     event.context = event.context || this.context || undefined
     event.device = { ...event.device, ...this.device }
-    event.request = { ...event.request, ...this.request }
     event._metadata = { ...event._metadata, ...this._metadata }
     event._user = { ...event._user, ...this._user }
     event.breadcrumbs = this.breadcrumbs.slice(0)

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -11,7 +11,6 @@ module.exports = (client) => {
   // so ensure they are are (shallow) cloned
   clone.breadcrumbs = client.breadcrumbs.slice()
   clone._metadata = { ...client._metadata }
-  clone.request = { ...client.request }
   clone._user = { ...client._user }
 
   clone._cbs = {

--- a/packages/plugin-browser-request/test/request.test.js
+++ b/packages/plugin-browser-request/test/request.test.js
@@ -24,10 +24,10 @@ describe('plugin: request', () => {
     const payloads = []
     client.use(plugin, window)
 
-    client.request = { url: 'foobar' }
-
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
-    client.notify(new Error('noooo'))
+    client.notify(new Error('noooo'), event => {
+      event.request.url = 'foobar'
+    })
 
     expect(payloads.length).toEqual(1)
     expect(payloads[0].events[0].request).toEqual({ url: 'foobar' })


### PR DESCRIPTION
`client.request` should not exist – `request` now exists on `Event` only.