### PR TITLE
V7: Remove client device prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add methods to pause and resume sessions [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
 - Add `pauseSession()` and `resumeSession()` methods to `Client` [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
 - Remove `client.request` property [#672](https://github.com/bugsnag/bugsnag-js/pull/672)
+- Remove `client.device` property [#673](https://github.com/bugsnag/bugsnag-js/pull/673)
 
 ## 6.4.3 (2019-10-21)
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -137,7 +137,7 @@ class BugsnagClient {
     const session = new BugsnagSession()
 
     // run onSession callbacks
-    const ignore = runSyncCallbacks(this._cbs.s.slice(0), session, 'onSession', this._logger)
+    const ignore = runSyncCallbacks(this._cbs.s, session, 'onSession', this._logger)
 
     if (ignore) {
       this._logger.debug('Session not started due to onSession callback')
@@ -197,7 +197,7 @@ class BugsnagClient {
     const crumb = new BugsnagBreadcrumb(message, metadata, type)
 
     // run onBreadcrumb callbacks
-    const ignore = runSyncCallbacks(this._cbs.b.slice(0), crumb, 'onBreadcrumb', this._logger)
+    const ignore = runSyncCallbacks(this._cbs.b, crumb, 'onBreadcrumb', this._logger)
 
     if (ignore) {
       this._logger.debug('Breadcrumb not attached due to onBreadcrumb callback')

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -36,7 +36,6 @@ class BugsnagClient {
     // setable props
     this.app = {}
     this.context = undefined
-    this.device = undefined
     this._user = {}
 
     // callbacks:
@@ -223,7 +222,6 @@ class BugsnagClient {
 
     event.app = { ...{ releaseStage }, ...event.app, ...this.app }
     event.context = event.context || this.context || undefined
-    event.device = { ...event.device, ...this.device }
     event._metadata = { ...event._metadata, ...this._metadata }
     event._user = { ...event._user, ...this._user }
     event.breadcrumbs = this.breadcrumbs.slice(0)

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -5,7 +5,6 @@ module.exports = (client) => {
   clone._config = client._config
   clone.app = client.app
   clone.context = client.context
-  clone.device = client.device
 
   // changes to these properties should not be reflected in the original client,
   // so ensure they are are (shallow) cloned

--- a/packages/core/lib/sync-callback-runner.js
+++ b/packages/core/lib/sync-callback-runner.js
@@ -1,6 +1,6 @@
 module.exports = (callbacks, callbackArg, callbackType, logger) => {
   let ignore = false
-  const cbs = callbacks.slice(0)
+  const cbs = callbacks.slice()
   while (!ignore) {
     if (!cbs.length) break
     try {

--- a/packages/plugin-browser-device/device.js
+++ b/packages/plugin-browser-device/device.js
@@ -10,12 +10,13 @@ module.exports = {
       userAgent: nav.userAgent
     }
 
-    // merge with anything already set on the client
-    client.device = { ...device, ...client.device }
-
     // add time just as the event is sent
     client.addOnError((event) => {
-      event.device = { ...event.device, time: isoDate() }
+      event.device = {
+        ...event.device,
+        ...device,
+        time: isoDate()
+      }
     }, true)
   }
 }

--- a/packages/plugin-browser-device/device.js
+++ b/packages/plugin-browser-device/device.js
@@ -10,6 +10,10 @@ module.exports = {
       userAgent: nav.userAgent
     }
 
+    client.addOnSession(session => {
+      session.device = { ...session.device, ...device }
+    })
+
     // add time just as the event is sent
     client.addOnError((event) => {
       event.device = {

--- a/packages/plugin-browser-device/test/device.test.js
+++ b/packages/plugin-browser-device/test/device.test.js
@@ -24,4 +24,25 @@ describe('plugin: device', () => {
     expect(payloads[0].events[0].device.locale).toBe(navigator.browserLanguage)
     expect(payloads[0].events[0].device.userAgent).toBe(navigator.userAgent)
   })
+
+  it('should add an onSession callback which captures device information', () => {
+    const client = new Client({ apiKey: 'API_KEY_YEAH' })
+    const payloads = []
+    client._sessionDelegate = {
+      startSession: (client, session) => {
+        client._delivery.sendSession(session)
+      }
+    }
+    client.use(plugin, navigator)
+
+    expect(client._cbs.s.length).toBe(1)
+
+    client._setDelivery(client => ({ sendSession: (payload) => payloads.push(payload) }))
+    client.startSession()
+
+    expect(payloads.length).toEqual(1)
+    expect(payloads[0].device).toBeDefined()
+    expect(payloads[0].device.locale).toBe(navigator.browserLanguage)
+    expect(payloads[0].device.userAgent).toBe(navigator.userAgent)
+  })
 })

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -1,6 +1,5 @@
 const { includes } = require('@bugsnag/core/lib/es-utils')
 const inferReleaseStage = require('@bugsnag/core/lib/infer-release-stage')
-const runSyncCallbacks = require('@bugsnag/core/lib/sync-callback-runner')
 
 module.exports = {
   init: client => { client._sessionDelegate = sessionDelegate }
@@ -20,9 +19,9 @@ const sessionDelegate = {
       return sessionClient
     }
 
-    const payload = {
+    sessionClient._delivery.sendSession({
       notifier: sessionClient._notifier,
-      device: {},
+      device: session.device,
       app: { ...{ releaseStage }, ...sessionClient.app },
       sessions: [
         {
@@ -31,15 +30,7 @@ const sessionDelegate = {
           user: sessionClient._user
         }
       ]
-    }
-
-    const ignore = runSyncCallbacks(sessionClient._cbs.sp.slice(0), payload, 'onSessionPayload', sessionClient._logger)
-    if (ignore) {
-      sessionClient._logger.debug('Session not sent due to onSessionPayload callback')
-      return sessionClient
-    }
-
-    sessionClient._delivery.sendSession(payload)
+    })
     return sessionClient
   },
   resumeSession: (client) => {

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -21,8 +21,7 @@ module.exports = {
     // get the initial orientation
     updateOrientation()
 
-    client.device = {
-      ...client.device,
+    const device = {
       id: Constants.installationId,
       manufacturer: Constants.platform.ios ? 'Apple' : undefined,
       modelName: Constants.platform.ios ? Constants.platform.ios.model : undefined,
@@ -37,12 +36,12 @@ module.exports = {
       }
     }
 
+    client._addOnSessionPayload(sp => {
+      sp.device = { ...sp.device, ...device }
+    })
+
     client.addOnError(event => {
-      event.device = {
-        ...event.device,
-        time: isoDate(),
-        orientation
-      }
+      event.device = { ...event.device, time: isoDate(), orientation, ...device }
       event.addMetadata('device', {
         isDevice: Constants.isDevice,
         appOwnership: Constants.appOwnership

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -36,8 +36,8 @@ module.exports = {
       }
     }
 
-    client._addOnSessionPayload(sp => {
-      sp.device = { ...sp.device, ...device }
+    client.addOnSession(session => {
+      session.device = { ...session.device, ...device }
     })
 
     client.addOnError(event => {

--- a/packages/plugin-node-device/device.js
+++ b/packages/plugin-node-device/device.js
@@ -10,12 +10,16 @@ module.exports = {
       runtimeVersions: { node: process.versions.node }
     }
 
-    // merge with anything already set on the client
-    client.device = { ...device, ...client.device }
+    client._addOnSessionPayload(sp => {
+      sp.device = {
+        ...sp.device,
+        ...device
+      }
+    })
 
     // add time just as the event is sent
     client.addOnError((event) => {
-      event.device = { ...event.device, time: isoDate() }
+      event.device = { ...event.device, ...device, time: isoDate() }
     }, true)
   }
 }

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -18,15 +18,16 @@ describe('plugin: node device', () => {
     const client = new Client({ apiKey: 'API_KEY_YEAH' }, schema)
     client.use(plugin)
 
+    expect(client._cbs.sp.length).toBe(1)
     expect(client._cbs.e.length).toBe(1)
-    expect(client.device.hostname).toBe('test-machine.local')
-    expect(client.device.runtimeVersions).toBeDefined()
-    expect(client.device.runtimeVersions.node).toEqual(process.versions.node)
 
     client._setDelivery(client => ({
       sendEvent: (payload) => {
         expect(payload.events[0].device).toBeDefined()
         expect(payload.events[0].device.time).toMatch(ISO_8601)
+        expect(payload.events[0].device.hostname).toBe('test-machine.local')
+        expect(payload.events[0].device.runtimeVersions).toBeDefined()
+        expect(payload.events[0].device.runtimeVersions.node).toEqual(process.versions.node)
         done()
       }
     }))

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -4,6 +4,7 @@ const { intRange } = require('@bugsnag/core/lib/validators')
 const clone = require('@bugsnag/core/lib/clone-client')
 const SessionTracker = require('./tracker')
 const Backoff = require('backo')
+const runSyncCallbacks = require('@bugsnag/core/lib/sync-callback-runner')
 
 module.exports = {
   init: (client) => {
@@ -71,11 +72,19 @@ const sendSessionSummary = client => sessionCounts => {
   }
 
   function req (cb) {
-    client._delivery.sendSession({
+    const payload = {
       notifier: client._notifier,
-      device: client.device,
+      device: {},
       app: { ...{ releaseStage }, ...client.app },
       sessionCounts
-    }, cb)
+    }
+
+    const ignore = runSyncCallbacks(client._cbs.sp.slice(0), payload, 'onSessionPayload', client._logger)
+    if (ignore) {
+      client._logger.debug('Session not sent due to onSessionPayload callback')
+      return cb(null)
+    }
+
+    client._delivery.sendSession(payload, cb)
   }
 }

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -79,7 +79,7 @@ const sendSessionSummary = client => sessionCounts => {
       sessionCounts
     }
 
-    const ignore = runSyncCallbacks(client._cbs.sp.slice(0), payload, 'onSessionPayload', client._logger)
+    const ignore = runSyncCallbacks(client._cbs.sp, payload, 'onSessionPayload', client._logger)
     if (ignore) {
       client._logger.debug('Session not sent due to onSessionPayload callback')
       return cb(null)

--- a/packages/plugin-server-session/test/session.test.js
+++ b/packages/plugin-server-session/test/session.test.js
@@ -98,7 +98,9 @@ describe('plugin: server sessions', () => {
     })
 
     // this is normally set by a plugin
-    c.device = { hostname: 'test-machine.local', runtimeVersions: { node: '0.0.1' } }
+    c._addOnSessionPayload(sp => {
+      sp.device = { hostname: 'test-machine.local', runtimeVersions: { node: '0.0.1' } }
+    })
 
     c._setDelivery(client => ({
       sendEvent: () => {},

--- a/test/expo/features/device.feature
+++ b/test/expo/features/device.feature
@@ -23,26 +23,6 @@ Scenario: Device data is included by default
   And the event "metaData.device.isDevice" is true
   And the event "metaData.device.appOwnership" equals "standalone"
 
-Scenario: Device data can be modified on the client
-  Given the element "deviceClientButton" is present
-  When I click the element "deviceClientButton"
-  Then I wait to receive a request
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "DeviceClientError"
-  And the event "device.id" is not null
-  And the event "device.osName" equals one of:
-    | android |
-    | ios     |
-  And the event "device.osVersion" equals "testOSVersion"
-  And the event "device.newThing" equals "this is new"
-  And the event "device.orientation" equals "portrait"
-  And the event "device.time" is not null
-  And the event "metaData.device.isDevice" is true
-  And the event "metaData.device.appOwnership" equals "standalone"
-  And the event "device.runtimeVersions.reactNative" matches "\d+\.\d+\.\d"
-  And the event "device.runtimeVersions.expoApp" matches "\d+\.\d+\.\d"
-  And the event "device.runtimeVersions.expoSdk" matches "\d+\.\d+\.\d"
-
 Scenario: Device data can be modified by a callback
   Given the element "deviceCallbackButton" is present
   When I click the element "deviceCallbackButton"

--- a/test/expo/features/fixtures/test-app/app/device.js
+++ b/test/expo/features/fixtures/test-app/app/device.js
@@ -7,12 +7,6 @@ export default class AppFeature extends Component {
     bugsnagClient.notify(new Error('DeviceDefaultError'))
   }
 
-  clientDevice = () => {
-    bugsnagClient.device.osVersion = 'testOSVersion'
-    bugsnagClient.device.newThing = 'this is new'
-    bugsnagClient.notify(new Error('DeviceClientError'))
-  }
-
   callbackDevice = () => {
     bugsnagClient.notify(new Error('DeviceCallbackError'), event => {
       event.device.model = 'brandNewPhone',
@@ -26,10 +20,6 @@ export default class AppFeature extends Component {
         <Button accessibilityLabel="deviceDefaultButton"
           title="defaultDevice"
           onPress={this.defaultDevice}
-        />
-        <Button accessibilityLabel="deviceClientButton"
-          title="clientDevice"
-          onPress={this.clientDevice}
         />
         <Button accessibilityLabel="deviceCallbackButton"
           title="callbackDevice"


### PR DESCRIPTION
`client.device` should not exist – `device` now exists on `Event` only.

The session payload callbacks are now hooked up to get `device` info into the session payload.