### PR TITLE
V7: Rename trackError -> _track and remove from public types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Stop applying default error class/message when none is supplied [#676](https://github.com/bugsnag/bugsnag-js/pull/676)
 - Remove Bugsnag* prefix from internal class names [#679](https://github.com/bugsnag/bugsnag-js/pull/679)
 - Remove `client.app` property [#677](https://github.com/bugsnag/bugsnag-js/pull/677)
+- Rename and make private the `Session` method `trackError()` -> `_track()` [#675](https://github.com/bugsnag/bugsnag-js/pull/675)
 
 ## 6.5.0 (2019-12-16)
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -231,7 +231,7 @@ class Client {
     event.breadcrumbs = this.breadcrumbs.slice(0)
 
     if (this._session) {
-      this._session.trackError(event)
+      this._session._track(event)
       event.session = this._session
     }
 

--- a/packages/core/session.js
+++ b/packages/core/session.js
@@ -17,7 +17,7 @@ class Session {
     }
   }
 
-  trackError (event) {
+  _track (event) {
     this[event._handledState.unhandled ? '_unhandled' : '_handled'] += 1
   }
 }

--- a/packages/core/test/session.test.js
+++ b/packages/core/test/session.test.js
@@ -11,7 +11,7 @@ describe('@bugsnag/core/session', () => {
       expect(s.events).toEqual({ handled: 0, unhandled: 0 })
     })
   })
-  describe('track()', () => {
+  describe('_track()', () => {
     it('returns the correct data structure', () => {
       const s = new Session()
       s._track({ _handledState: { unhandled: true } })

--- a/packages/core/test/session.test.js
+++ b/packages/core/test/session.test.js
@@ -11,14 +11,14 @@ describe('@bugsnag/core/session', () => {
       expect(s.events).toEqual({ handled: 0, unhandled: 0 })
     })
   })
-  describe('trackError()', () => {
+  describe('track()', () => {
     it('returns the correct data structure', () => {
       const s = new Session()
-      s.trackError({ _handledState: { unhandled: true } })
-      s.trackError({ _handledState: { unhandled: false } })
-      s.trackError({ _handledState: { unhandled: true } })
-      s.trackError({ _handledState: { unhandled: true } })
-      s.trackError({ _handledState: { unhandled: false } })
+      s._track({ _handledState: { unhandled: true } })
+      s._track({ _handledState: { unhandled: false } })
+      s._track({ _handledState: { unhandled: true } })
+      s._track({ _handledState: { unhandled: true } })
+      s._track({ _handledState: { unhandled: false } })
       expect(s.toJSON().events).toEqual({ handled: 2, unhandled: 3 })
     })
   })

--- a/packages/core/types/session.d.ts
+++ b/packages/core/types/session.d.ts
@@ -7,7 +7,6 @@ declare class Session {
     _handled: number;
     _unhandled: number;
   };
-  public trackError: (event: Event) => void;
 }
 
 export default Session;


### PR DESCRIPTION
Sessions are now part of the public interface via `onSession` callbacks, so the public `trackError()` function has been suitably renamed (it takes events not errors) and made private.