### PR TITLE
V7: Don't apply default error class/message when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add `pauseSession()` and `resumeSession()` methods to `Client` [#666](https://github.com/bugsnag/bugsnag-js/pull/666)
 - Remove `client.request` property [#672](https://github.com/bugsnag/bugsnag-js/pull/672)
 - Remove `client.device` property [#673](https://github.com/bugsnag/bugsnag-js/pull/673)
+- Stop applying default error class/message when none is supplied [#676](https://github.com/bugsnag/bugsnag-js/pull/676)
 
 ## 6.5.0 (2019-12-16)
 

--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -20,8 +20,8 @@ class BugsnagEvent {
     this.breadcrumbs = []
     this.context = undefined
     this.device = undefined
-    this.errorClass = stringOrFallback(errorClass, '[no error class]')
-    this.errorMessage = stringOrFallback(errorMessage, '[no error message]')
+    this.errorClass = ensureString(errorClass)
+    this.errorMessage = ensureString(errorMessage)
     this.groupingHash = undefined
     this._metadata = {}
     this.request = undefined
@@ -123,7 +123,7 @@ const defaultHandledState = () => ({
   severityReason: { type: 'handledException' }
 })
 
-const stringOrFallback = (str, fallback) => typeof str === 'string' && str ? str : fallback
+const ensureString = (str) => typeof str === 'string' ? str : ''
 
 // Helpers
 


### PR DESCRIPTION
This should be left blank and it should be left up to the the dashboard to show something appropriate.