### PR TITLE
V7: Remove client `app` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Remove `client.device` property [#673](https://github.com/bugsnag/bugsnag-js/pull/673)
 - Stop applying default error class/message when none is supplied [#676](https://github.com/bugsnag/bugsnag-js/pull/676)
 - Remove Bugsnag* prefix from internal class names [#679](https://github.com/bugsnag/bugsnag-js/pull/679)
+- Remove `client.app` property [#677](https://github.com/bugsnag/bugsnag-js/pull/677)
 
 ## 6.5.0 (2019-12-16)
 

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -3,7 +3,6 @@ module.exports = (client) => {
 
   // changes to these properties should be reflected in the original client
   clone._config = client._config
-  clone.app = client.app
   clone.context = client.context
 
   // changes to these properties should not be reflected in the original client,

--- a/packages/core/lib/infer-release-stage.js
+++ b/packages/core/lib/infer-release-stage.js
@@ -1,4 +1,0 @@
-module.exports = client =>
-  client.app && typeof client.app.releaseStage === 'string'
-    ? client.app.releaseStage
-    : client._config.releaseStage

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -172,34 +172,7 @@ describe('@bugsnag/core/client', () => {
       process.nextTick(() => done())
     })
 
-    it('supports setting releaseStage via client.app.releaseStage', done => {
-      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['production'] })
-      client._setDelivery(client => ({
-        sendEvent: (payload) => {
-          fail('sendEvent() should not be called')
-        }
-      }))
-      client.app.releaseStage = 'staging'
-
-      client.notify(new Error('oh em eff gee'))
-
-      // give the event loop a tick to see if the event gets sent
-      process.nextTick(() => done())
-    })
-
     it('includes releaseStage in event.app', done => {
-      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['staging'] })
-      client._setDelivery(client => ({
-        sendEvent: (payload) => {
-          expect(payload.events[0].app.releaseStage).toBe('staging')
-          done()
-        }
-      }))
-      client.app.releaseStage = 'staging'
-      client.notify(new Error('oh em eff gee'))
-    })
-
-    it('includes releaseStage in event.app when set via config', done => {
       const client = new Client({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['staging'], releaseStage: 'staging' })
       client._setDelivery(client => ({
         sendEvent: (payload) => {
@@ -210,19 +183,7 @@ describe('@bugsnag/core/client', () => {
       client.notify(new Error('oh em eff gee'))
     })
 
-    it('prefers client.app.releaseStage over config.releaseStage', done => {
-      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledReleaseStages: ['testing'], releaseStage: 'staging' })
-      client._setDelivery(client => ({
-        sendEvent: (payload) => {
-          expect(payload.events[0].app.releaseStage).toBe('testing')
-          done()
-        }
-      }))
-      client.app.releaseStage = 'testing'
-      client.notify(new Error('oh em eff gee'))
-    })
-
-    it('populates client.app.version if config.appVersion is supplied', done => {
+    it('populates app.version if config.appVersion is supplied', done => {
       const client = new Client({ apiKey: 'API_KEY_YEAH', appVersion: '1.2.3' })
       client._setDelivery(client => ({
         sendEvent: (payload) => {

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -4,8 +4,6 @@ import Event from "./event";
 import Session from "./session";
 
 declare class Client {
-  public app: object;
-  public device: object;
   public context: string | void;
 
   // metadata

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -48,6 +48,10 @@ module.exports = (opts) => {
     opts.apiKey = Constants.manifest.extra.bugsnag.apiKey
   }
 
+  if (!opts.appVersion && Constants.manifest && Constants.manifest.version) {
+    opts.appVersion = Constants.manifest.version
+  }
+
   const bugsnag = new Client(opts, schema, { name, version, url })
 
   bugsnag._setDelivery(delivery)

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -1,5 +1,4 @@
 const { includes } = require('@bugsnag/core/lib/es-utils')
-const inferReleaseStage = require('@bugsnag/core/lib/infer-release-stage')
 
 module.exports = {
   init: client => { client._sessionDelegate = sessionDelegate }
@@ -11,10 +10,8 @@ const sessionDelegate = {
     sessionClient._session = session
     sessionClient._pausedSession = null
 
-    const releaseStage = inferReleaseStage(sessionClient)
-
     // exit early if the current releaseStage is not enabled
-    if (sessionClient._config.enabledReleaseStages.length > 0 && !includes(sessionClient._config.enabledReleaseStages, releaseStage)) {
+    if (sessionClient._config.enabledReleaseStages.length > 0 && !includes(sessionClient._config.enabledReleaseStages, sessionClient._config.releaseStage)) {
       sessionClient._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
       return sessionClient
     }
@@ -22,7 +19,7 @@ const sessionDelegate = {
     sessionClient._delivery.sendSession({
       notifier: sessionClient._notifier,
       device: session.device,
-      app: { ...{ releaseStage }, ...sessionClient.app },
+      app: session.app,
       sessions: [
         {
           id: sessionClient._session.id,

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -25,6 +25,12 @@ module.exports = {
       }
     }
 
+    client.addOnSession(session => {
+      if (Constants.manifest.revisionId) {
+        session.app.codeBundleId = Constants.manifest.revisionId
+      }
+    })
+
     client.addOnError(event => {
       const now = new Date()
       const inForeground = AppState.currentState === 'active'
@@ -34,14 +40,10 @@ module.exports = {
         event.app.durationInForeground = now - lastEnteredForeground
       }
       event.addMetadata('app', { nativeBundleVersion, nativeVersionCode })
+
+      if (Constants.manifest.revisionId) {
+        event.app.codeBundleId = Constants.manifest.revisionId
+      }
     }, true)
-
-    if (!client.app.version && Constants.manifest.version) {
-      client.app.version = Constants.manifest.version
-    }
-
-    if (Constants.manifest.revisionId) {
-      client.app.codeBundleId = Constants.manifest.revisionId
-    }
   }
 }

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -3,38 +3,7 @@
 const proxyquire = require('proxyquire').noPreserveCache().noCallThru()
 const Client = require('@bugsnag/core/client')
 
-describe('plugin: expo device', () => {
-  it('should should use version if defined (all platforms)', done => {
-    const VERSION = '1.0.0'
-    const plugin = proxyquire('../', {
-      'expo-constants': {
-        default: {
-          platform: {
-          },
-          manifest: { version: VERSION }
-        }
-      },
-      'react-native': {
-        AppState: {
-          addEventListener: () => {},
-          currentState: 'active'
-        }
-      }
-    })
-    const c = new Client({ apiKey: 'api_key' })
-
-    c.use(plugin)
-    c._setDelivery(client => ({
-      sendEvent: (payload) => {
-        const r = JSON.parse(JSON.stringify(payload))
-        expect(r).toBeTruthy()
-        expect(r.events[0].app.version).toBe(VERSION)
-        done()
-      }
-    }))
-    c.notify(new Error('flip'))
-  })
-
+describe('plugin: expo app', () => {
   it('should should use revisionId if defined (all platforms)', done => {
     const VERSION = '1.0.0'
     const REVISION_ID = '1.0.0-r132432'

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -1,5 +1,4 @@
 const { includes } = require('@bugsnag/core/lib/es-utils')
-const inferReleaseStage = require('@bugsnag/core/lib/infer-release-stage')
 const { intRange } = require('@bugsnag/core/lib/validators')
 const clone = require('@bugsnag/core/lib/clone-client')
 const SessionTracker = require('./tracker')
@@ -44,10 +43,8 @@ module.exports = {
 }
 
 const sendSessionSummary = client => sessionCounts => {
-  const releaseStage = inferReleaseStage(client)
-
   // exit early if the current releaseStage is not enabled
-  if (client._config.enabledReleaseStages.length > 0 && !includes(client._config.enabledReleaseStages, releaseStage)) {
+  if (client._config.enabledReleaseStages.length > 0 && !includes(client._config.enabledReleaseStages, client._config.releaseStage)) {
     client._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
     return
   }
@@ -75,7 +72,11 @@ const sendSessionSummary = client => sessionCounts => {
     const payload = {
       notifier: client._notifier,
       device: {},
-      app: { ...{ releaseStage }, ...client.app },
+      app: {
+        releaseStage: client._config.releaseStage,
+        version: client._config.appVersion,
+        type: client._config.appType
+      },
       sessionCounts
     }
 


### PR DESCRIPTION
`client.app` has been removed. Only `event.app` is available now.

This switches to using `onSession` and `onError` callbacks to add `app` data to payloads.

Since the `version`, `releaseStage` values can no longer be updated at runtime, logic that checked various places has been simplified to refer to the immutable value from config.