### PR TITLE
V7: Move context and breadcrumbs to private properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Remove `client.app` property [#677](https://github.com/bugsnag/bugsnag-js/pull/677)
 - Rename and make private the `Session` method `trackError()` -> `_track()` [#675](https://github.com/bugsnag/bugsnag-js/pull/675)
 - Update `Event` to support multiple errors [#680](https://github.com/bugsnag/bugsnag-js/pull/680)
+- Move breadcrumbs to a private property on `client._breadcrumbs` [#681](https://github.com/bugsnag/bugsnag-js/pull/681)
+- Move context to a private property on `Client`, and get/set via `getContext()/setContext()` [#681](https://github.com/bugsnag/bugsnag-js/pull/681)
 
 ## 6.5.0 (2019-12-16)
 

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -95,7 +95,7 @@ module.exports.schema = {
   },
   user: {
     defaultValue: () => null,
-    message: 'user should be an object',
+    message: 'should be an object',
     validate: (value) => typeof value === 'object'
   },
   metadata: {

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -88,9 +88,14 @@ module.exports.schema = {
       return includes(BREADCRUMB_TYPES, maybeType)
     }, true))
   },
+  context: {
+    defaultValue: () => undefined,
+    message: 'should be a string',
+    validate: value => value === undefined || typeof value === 'string'
+  },
   user: {
     defaultValue: () => null,
-    message: '(object) user should be an object',
+    message: 'user should be an object',
     validate: (value) => typeof value === 'object'
   },
   metadata: {

--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -1,15 +1,14 @@
 module.exports = (client) => {
   const clone = new client.Client({}, {}, client._notifier)
 
-  // changes to these properties should be reflected in the original client
   clone._config = client._config
-  clone.context = client.context
 
   // changes to these properties should not be reflected in the original client,
   // so ensure they are are (shallow) cloned
-  clone.breadcrumbs = client.breadcrumbs.slice()
+  clone._breadcrumbs = client._breadcrumbs.slice()
   clone._metadata = { ...client._metadata }
   clone._user = { ...client._user }
+  clone._context = client._context
 
   clone._cbs = {
     e: client._cbs.e.slice(),

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -244,10 +244,10 @@ describe('@bugsnag/core/client', () => {
       const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
       client.notify(new Error('foobar'))
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0].type).toBe('error')
-      expect(client.breadcrumbs[0].message).toBe('Error')
-      expect(client.breadcrumbs[0].metadata.stacktrace).toBe(undefined)
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0].type).toBe('error')
+      expect(client._breadcrumbs[0].message).toBe('Error')
+      expect(client._breadcrumbs[0].metadata.stacktrace).toBe(undefined)
       // the error shouldn't appear as a breadcrumb for itself
       expect(payloads[0].events[0].breadcrumbs.length).toBe(0)
     })
@@ -338,23 +338,23 @@ describe('@bugsnag/core/client', () => {
     it('creates a manual breadcrumb when a list of arguments are supplied', () => {
       const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client.leaveBreadcrumb('french stick')
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0].type).toBe('manual')
-      expect(client.breadcrumbs[0].message).toBe('french stick')
-      expect(client.breadcrumbs[0].metadata).toEqual({})
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0].type).toBe('manual')
+      expect(client._breadcrumbs[0].message).toBe('french stick')
+      expect(client._breadcrumbs[0].metadata).toEqual({})
     })
 
     it('caps the length of breadcrumbs at the configured limit', () => {
       const client = new Client({ apiKey: 'API_KEY_YEAH', maxBreadcrumbs: 3 })
       client.leaveBreadcrumb('malted rye')
-      expect(client.breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs.length).toBe(1)
       client.leaveBreadcrumb('medium sliced white hovis')
-      expect(client.breadcrumbs.length).toBe(2)
+      expect(client._breadcrumbs.length).toBe(2)
       client.leaveBreadcrumb('pumperninkel')
-      expect(client.breadcrumbs.length).toBe(3)
+      expect(client._breadcrumbs.length).toBe(3)
       client.leaveBreadcrumb('seedy farmhouse')
-      expect(client.breadcrumbs.length).toBe(3)
-      expect(client.breadcrumbs.map(b => b.message)).toEqual([
+      expect(client._breadcrumbs.length).toBe(3)
+      expect(client._breadcrumbs.map(b => b.message)).toEqual([
         'medium sliced white hovis',
         'pumperninkel',
         'seedy farmhouse'
@@ -367,18 +367,18 @@ describe('@bugsnag/core/client', () => {
       client.leaveBreadcrumb(null, { data: 'is useful' })
       client.leaveBreadcrumb(null, {}, null)
       client.leaveBreadcrumb(null, { t: 10 }, null, 4)
-      expect(client.breadcrumbs.length).toBe(0)
+      expect(client._breadcrumbs.length).toBe(0)
     })
 
     it('allows maxBreadcrumbs to be set to 0', () => {
       const client = new Client({ apiKey: 'API_KEY_YEAH', maxBreadcrumbs: 0 })
       client.leaveBreadcrumb('toast')
-      expect(client.breadcrumbs.length).toBe(0)
+      expect(client._breadcrumbs.length).toBe(0)
       client.leaveBreadcrumb('toast')
       client.leaveBreadcrumb('toast')
       client.leaveBreadcrumb('toast')
       client.leaveBreadcrumb('toast')
-      expect(client.breadcrumbs.length).toBe(0)
+      expect(client._breadcrumbs.length).toBe(0)
     })
 
     it('doesn’t store the breadcrumb if an onBreadcrumb callback returns false', () => {
@@ -392,7 +392,7 @@ describe('@bugsnag/core/client', () => {
       })
       client.leaveBreadcrumb('message')
       expect(calls).toBe(1)
-      expect(client.breadcrumbs.length).toBe(0)
+      expect(client._breadcrumbs.length).toBe(0)
     })
 
     it('tolerates errors in onBreadcrumb callbacks', () => {
@@ -406,7 +406,7 @@ describe('@bugsnag/core/client', () => {
       })
       client.leaveBreadcrumb('message')
       expect(calls).toBe(1)
-      expect(client.breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs.length).toBe(1)
     })
 
     it('ignores breadcrumb types that aren’t in the enabled list', () => {
@@ -416,8 +416,8 @@ describe('@bugsnag/core/client', () => {
       })
       client.leaveBreadcrumb('brrrrr')
       client.leaveBreadcrumb('GET /jim', {}, 'request')
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0].message).toBe('brrrrr')
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0].message).toBe('brrrrr')
     })
   })
 
@@ -546,6 +546,18 @@ describe('@bugsnag/core/client', () => {
           done()
         })
       })
+    })
+  })
+
+  describe('get/setContext()', () => {
+    it('modifies and retreives context', () => {
+      const c = new Client({ apiKey: 'API_KEY' })
+      c.setContext('str')
+      expect(c.getContext()).toBe('str')
+    })
+    it('can be set via config', () => {
+      const c = new Client({ apiKey: 'API_KEY', context: 'str' })
+      expect(c.getContext()).toBe('str')
     })
   })
 

--- a/packages/core/types/test/test.js
+++ b/packages/core/types/test/test.js
@@ -1,0 +1,96 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var __1 = __importDefault(require("../.."));
+require("jasmine");
+// the client's constructor isn't public in TS so this drops down to JS to create one for the tests
+function createClient(opts) {
+    var c = new __1.default.Client(opts, undefined, { name: 'Type Tests', version: 'nope', url: 'https://github.com/bugsnag/bugsnag-js' });
+    c._setDelivery(function () { return ({
+        sendSession: function (p, cb) { cb(); },
+        sendEvent: function (p, cb) { cb(); }
+    }); });
+    c._sessionDelegate = { startSession: function () { return c; }, pauseSession: function () { }, resumeSession: function () { } };
+    return c;
+}
+describe('Type definitions', function () {
+    it('has all the classes matching the types available at runtime', function () {
+        expect(__1.default.Client).toBeDefined();
+        expect(__1.default.Breadcrumb).toBeDefined();
+        expect(__1.default.Event).toBeDefined();
+        expect(__1.default.Session).toBeDefined();
+        var client = createClient({ apiKey: 'API_KEY' });
+        expect(client.Breadcrumb).toBeDefined();
+        expect(client.Event).toBeDefined();
+        expect(client.Session).toBeDefined();
+    });
+    it('works for reporting errors', function (done) {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.notify(new Error('uh oh'), function (event) {
+            expect(event.apiKey).toBe(undefined);
+            expect(event.context).toBe(undefined);
+            expect(event.errors[0].errorMessage).toBe('uh oh');
+            expect(event.errors[0].stacktrace.length > 0).toBe(true);
+            event.addMetadata('abc', { def: 'ghi' });
+            event.addMetadata('jkl', 'mno', 'pqr');
+            event.clearMetadata('jkl');
+            var val = event.getMetadata('jkl');
+            expect(val).toBe(undefined);
+        }, function (err, event) {
+            expect(err).toBe(undefined);
+            expect(event).toBeTruthy();
+            done();
+        });
+    });
+    it('works for reporting sessions', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        var sessionClient = client.startSession();
+        sessionClient.notify(new Error('oh'));
+        client.pauseSession();
+        client.resumeSession();
+    });
+    it('works for leaving breadcrumbs', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.leaveBreadcrumb('testing 123');
+        expect(client._breadcrumbs.length).toBe(1);
+        expect(client._breadcrumbs[0].message).toBe('testing 123');
+    });
+    it('works adding and removing onError callbacks', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.addOnError(function () { });
+        client.removeOnError(function () { });
+    });
+    it('works adding and removing onSession callbacks', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.addOnSession(function () { });
+        client.removeOnSession(function () { });
+    });
+    it('works adding and removing onBreadcrumb callbacks', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.addOnBreadcrumb(function () { });
+        client.removeOnBreadcrumb(function () { });
+    });
+    it('works manipulating metadata on client', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.addMetadata('abc', { def: 'ghi' });
+        client.addMetadata('jkl', 'mno', 'pqr');
+        client.clearMetadata('jkl');
+        var val = client.getMetadata('jkl');
+        expect(val).toBe(undefined);
+        expect(client.getMetadata('abc', 'def')).toBe('ghi');
+    });
+    it('works setting context', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.setContext('foo');
+        expect(client.getContext()).toBe('foo');
+    });
+    it('works setting/clearing user', function () {
+        var client = createClient({ apiKey: 'API_KEY' });
+        client.setUser('123', 'ben.gourley@bugsnag.com', 'Ben');
+        expect(client.getUser()).toEqual({ id: '123', name: 'Ben', email: 'ben.gourley@bugsnag.com' });
+        client.setUser(undefined, undefined, undefined);
+        expect(client.getUser()).toEqual({ id: undefined, name: undefined, email: undefined });
+    });
+});

--- a/packages/plugin-browser-context/test/context.test.js
+++ b/packages/plugin-browser-context/test/context.test.js
@@ -28,7 +28,7 @@ describe('plugin: context', () => {
     const payloads = []
     client.use(plugin, window)
 
-    client.context = 'something else'
+    client.setContext('something else')
 
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Error('noooo'))

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.js
@@ -20,11 +20,11 @@ describe('plugin: console breadcrumbs', () => {
         rabbit: 'sniffer'
       }
     })
-    expect(c.breadcrumbs.length).toBe(3)
-    expect(c.breadcrumbs[0].metadata['[0]']).toBe('check 1, 2')
-    expect(c.breadcrumbs[1].metadata['[0]']).toBe('null')
-    expect(c.breadcrumbs[2].metadata['[0]']).toBe('{"foo":[1,2,3,"four"]}')
-    expect(c.breadcrumbs[2].metadata['[1]']).toBe('{"pets":{"cat":"scratcher","dog":"pupper","rabbit":"sniffer"}}')
+    expect(c._breadcrumbs.length).toBe(3)
+    expect(c._breadcrumbs[0].metadata['[0]']).toBe('check 1, 2')
+    expect(c._breadcrumbs[1].metadata['[0]']).toBe('null')
+    expect(c._breadcrumbs[2].metadata['[0]']).toBe('{"foo":[1,2,3,"four"]}')
+    expect(c._breadcrumbs[2].metadata['[1]']).toBe('{"pets":{"cat":"scratcher","dog":"pupper","rabbit":"sniffer"}}')
     // undo the global side effects of wrapping console.* for the rest of the tests
     plugin.destroy()
   })
@@ -33,9 +33,9 @@ describe('plugin: console breadcrumbs', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' })
     c.use(plugin)
     expect(() => console.log(Object.create(null))).not.toThrow()
-    expect(c.breadcrumbs.length).toBe(1)
-    expect(c.breadcrumbs[0].message).toBe('Console output')
-    expect(c.breadcrumbs[0].metadata['[0]']).toBe('[Unknown value]')
+    expect(c._breadcrumbs.length).toBe(1)
+    expect(c._breadcrumbs[0].message).toBe('Console output')
+    expect(c._breadcrumbs[0].metadata['[0]']).toBe('[Unknown value]')
     plugin.destroy()
   })
 
@@ -43,7 +43,7 @@ describe('plugin: console breadcrumbs', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [] })
     c.use(plugin)
     console.log(123)
-    expect(c.breadcrumbs.length).toBe(0)
+    expect(c._breadcrumbs.length).toBe(0)
     plugin.destroy()
   })
 
@@ -51,7 +51,7 @@ describe('plugin: console breadcrumbs', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['log'] })
     c.use(plugin)
     console.log(123)
-    expect(c.breadcrumbs.length).toBe(1)
+    expect(c._breadcrumbs.length).toBe(1)
     plugin.destroy()
   })
 
@@ -59,7 +59,7 @@ describe('plugin: console breadcrumbs', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'development' })
     c.use(plugin)
     console.log(123)
-    expect(c.breadcrumbs.length).toBe(0)
+    expect(c._breadcrumbs.length).toBe(0)
     plugin.destroy()
   })
 })

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.js
@@ -10,7 +10,7 @@ describe('plugin: interaction breadcrumbs', () => {
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c.breadcrumbs.length).toBe(1)
+    expect(c._breadcrumbs.length).toBe(1)
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
@@ -18,7 +18,7 @@ describe('plugin: interaction breadcrumbs', () => {
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c.breadcrumbs.length).toBe(0)
+    expect(c._breadcrumbs.length).toBe(0)
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["user"]', () => {
@@ -26,7 +26,7 @@ describe('plugin: interaction breadcrumbs', () => {
     const { window, winHandlers, els } = getMockWindow()
     c.use(plugin, window)
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c.breadcrumbs.length).toBe(1)
+    expect(c._breadcrumbs.length).toBe(1)
   })
 })
 

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.js
@@ -25,13 +25,13 @@ describe('plugin: navigation breadcrumbs', () => {
 
     // first ensure that the pushState command works to change the url of the page
     window.history.replaceState(state, 'bar', 'network-breadcrumb-test.html')
-    expect(c.breadcrumbs[c.breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
+    expect(c._breadcrumbs[c._breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
 
     window.history.replaceState(state, 'bar')
     // then ensure that it works with `undefined` as the url parameter (IE11-specific issue)
-    expect(c.breadcrumbs[c.breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
+    expect(c._breadcrumbs[c._breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
 
-    expect(c.breadcrumbs.length).toBe(6)
+    expect(c._breadcrumbs.length).toBe(6)
 
     done()
   })
@@ -49,7 +49,7 @@ describe('plugin: navigation breadcrumbs', () => {
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
     window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
     window.history.replaceState({}, 'bar')
-    expect(c.breadcrumbs.length).toBe(0)
+    expect(c._breadcrumbs.length).toBe(0)
   })
 
   it('should start a new session if autoTrackSessions=true', (done) => {
@@ -95,7 +95,7 @@ describe('plugin: navigation breadcrumbs', () => {
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
     window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
     window.history.replaceState({}, 'bar')
-    expect(c.breadcrumbs.length).toBe(5)
+    expect(c._breadcrumbs.length).toBe(5)
   })
 })
 

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.js
@@ -60,8 +60,8 @@ describe('plugin: network breadcrumbs', () => {
     // tell the mock request to succeed with status code 200
     request.send(false, 200)
 
-    expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
       type: 'request',
       message: 'XMLHttpRequest succeeded',
       metadata: {
@@ -81,7 +81,7 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', '/')
     request.open('GET', '/')
     request.send(false, 200)
-    expect(client.breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs.length).toBe(1)
   })
 
   it('should leave a breadcrumb when an XMLHTTPRequest has a failed response', () => {
@@ -94,8 +94,8 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', '/this-does-not-exist')
     request.send(false, 404)
 
-    expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
       type: 'request',
       message: 'XMLHttpRequest failed',
       metadata: {
@@ -116,8 +116,8 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', 'https://another-domain.xyz/')
     request.send(true)
 
-    expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
       type: 'request',
       message: 'XMLHttpRequest error',
       metadata: {
@@ -136,7 +136,7 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', client._config.endpoints.notify)
     request.send(false, 200)
 
-    expect(client.breadcrumbs.length).toBe(0)
+    expect(client._breadcrumbs.length).toBe(0)
   })
 
   it('should not leave a breadcrumb for session tracking requests', () => {
@@ -148,7 +148,7 @@ describe('plugin: network breadcrumbs', () => {
     const request = new window.XMLHttpRequest()
     request.open('GET', client._config.endpoints.sessions)
     request.send(false, 200)
-    expect(client.breadcrumbs.length).toBe(0)
+    expect(client._breadcrumbs.length).toBe(0)
   })
 
   it('should leave a breadcrumb when a fetch() resolves', (done) => {
@@ -158,8 +158,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch('/', {}, false, 200).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -178,8 +178,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch('/', { method: null }, false, 405).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -200,8 +200,8 @@ describe('plugin: network breadcrumbs', () => {
     const request = new Request('/')
 
     window.fetch(request, {}, false, 200).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -222,8 +222,8 @@ describe('plugin: network breadcrumbs', () => {
     const request = new Request('/', { method: 'PUT' })
 
     window.fetch(request, {}, false, 200).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -242,8 +242,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch(null, {}, false, 404).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -262,8 +262,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch('/', null, false, 200).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -282,8 +282,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch(undefined, {}, false, 404).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -302,8 +302,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch(new Request('/foo', { method: 'GET' }), { method: 'PUT' }, false, 200).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -322,8 +322,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch(new Request('/foo'), { method: null }, false, 405).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -342,8 +342,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch(new Request('/foo'), { method: undefined }, false, 200).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -362,8 +362,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch('/does-not-exist', {}, false, 404).then(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -382,8 +382,8 @@ describe('plugin: network breadcrumbs', () => {
     client.use(plugin, () => [], window)
 
     window.fetch('https://another-domain.xyz/foo/bar', {}, true).catch(() => {
-      expect(client.breadcrumbs.length).toBe(1)
-      expect(client.breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs.length).toBe(1)
+      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
         type: 'request',
         message: 'fetch() error',
         metadata: {
@@ -404,7 +404,7 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', '/')
     request.send(false, 200)
 
-    expect(client.breadcrumbs.length).toBe(0)
+    expect(client._breadcrumbs.length).toBe(0)
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["request"]', () => {
@@ -417,6 +417,6 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', '/')
     request.send(false, 200)
 
-    expect(client.breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs.length).toBe(1)
   })
 })

--- a/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.js
@@ -20,19 +20,19 @@ describe('plugin: react native app state breadcrumbs', () => {
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')
-    expect(client.breadcrumbs.length).toBe(0)
+    expect(client._breadcrumbs.length).toBe(0)
 
     _cb('background')
-    expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0].type).toBe('state')
-    expect(client.breadcrumbs[0].message).toBe('App state changed')
-    expect(client.breadcrumbs[0].metadata).toEqual({ state: 'background' })
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0].type).toBe('state')
+    expect(client._breadcrumbs[0].message).toBe('App state changed')
+    expect(client._breadcrumbs[0].metadata).toEqual({ state: 'background' })
 
     _cb('active')
-    expect(client.breadcrumbs.length).toBe(2)
-    expect(client.breadcrumbs[1].type).toBe('state')
-    expect(client.breadcrumbs[1].message).toBe('App state changed')
-    expect(client.breadcrumbs[1].metadata).toEqual({ state: 'active' })
+    expect(client._breadcrumbs.length).toBe(2)
+    expect(client._breadcrumbs[1].type).toBe('state')
+    expect(client._breadcrumbs[1].message).toBe('App state changed')
+    expect(client._breadcrumbs[1].metadata).toEqual({ state: 'active' })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {

--- a/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.js
@@ -20,19 +20,19 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')
-    expect(client.breadcrumbs.length).toBe(0)
+    expect(client._breadcrumbs.length).toBe(0)
 
     _cb({ type: 'wifi', isConnected: true, isInternetReachable: true })
-    expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0].type).toBe('state')
-    expect(client.breadcrumbs[0].message).toBe('Connectivity changed')
-    expect(client.breadcrumbs[0].metadata).toEqual({ type: 'wifi', isConnected: true, isInternetReachable: true })
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0].type).toBe('state')
+    expect(client._breadcrumbs[0].message).toBe('Connectivity changed')
+    expect(client._breadcrumbs[0].metadata).toEqual({ type: 'wifi', isConnected: true, isInternetReachable: true })
 
     _cb({ type: 'none', isConnected: false, isInternetReachable: false })
-    expect(client.breadcrumbs.length).toBe(2)
-    expect(client.breadcrumbs[1].type).toBe('state')
-    expect(client.breadcrumbs[1].message).toBe('Connectivity changed')
-    expect(client.breadcrumbs[1].metadata).toEqual({ type: 'none', isConnected: false, isInternetReachable: false })
+    expect(client._breadcrumbs.length).toBe(2)
+    expect(client._breadcrumbs[1].type).toBe('state')
+    expect(client._breadcrumbs[1].message).toBe('Connectivity changed')
+    expect(client._breadcrumbs[1].metadata).toEqual({ type: 'none', isConnected: false, isInternetReachable: false })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {

--- a/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.js
@@ -25,23 +25,23 @@ describe('plugin: react native orientation breadcrumbs', () => {
     client.use(plugin)
 
     expect(typeof _cb).toBe('function')
-    expect(client.breadcrumbs.length).toBe(0)
+    expect(client._breadcrumbs.length).toBe(0)
 
     currentDimensions = { height: 200, width: 100 }
     _cb()
-    expect(client.breadcrumbs.length).toBe(1)
-    expect(client.breadcrumbs[0].message).toBe('Orientation changed')
-    expect(client.breadcrumbs[0].metadata).toEqual({ from: 'landscape', to: 'portrait' })
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0].message).toBe('Orientation changed')
+    expect(client._breadcrumbs[0].metadata).toEqual({ from: 'landscape', to: 'portrait' })
 
     currentDimensions = { height: 200, width: 100 }
     _cb()
-    expect(client.breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs.length).toBe(1)
 
     currentDimensions = { height: 100, width: 200 }
     _cb()
-    expect(client.breadcrumbs.length).toBe(2)
-    expect(client.breadcrumbs[1].message).toBe('Orientation changed')
-    expect(client.breadcrumbs[1].metadata).toEqual({ from: 'portrait', to: 'landscape' })
+    expect(client._breadcrumbs.length).toBe(2)
+    expect(client._breadcrumbs[1].message).toBe('Orientation changed')
+    expect(client._breadcrumbs[1].metadata).toEqual({ from: 'portrait', to: 'landscape' })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {

--- a/packages/plugin-server-session/test/session.test.js
+++ b/packages/plugin-server-session/test/session.test.js
@@ -137,9 +137,9 @@ describe('plugin: server sessions', () => {
     sessionClient.leaveBreadcrumb('tock')
     sessionClient.addMetadata('other', { widgetsAdded: 'cat,dog,mouse' })
 
-    expect(c.breadcrumbs.length).toBe(1)
+    expect(c._breadcrumbs.length).toBe(1)
     expect(Object.keys(c._metadata).length).toBe(1)
-    expect(sessionClient.breadcrumbs.length).toBe(2)
+    expect(sessionClient._breadcrumbs.length).toBe(2)
     expect(Object.keys(sessionClient._metadata).length).toBe(2)
   })
 

--- a/test/expo/features/fixtures/test-app/app/manual_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/manual_breadcrumbs.js
@@ -4,8 +4,8 @@ import { bugsnagClient } from './bugsnag'
 
 export default class ManualBreadcrumbs extends Component {
   manualBreadcrumb = () => {
-    while (bugsnagClient.breadcrumbs.length > 0) {
-      bugsnagClient.breadcrumbs.pop()
+    while (bugsnagClient._breadcrumbs.length > 0) {
+      bugsnagClient._breadcrumbs.pop()
     }
     bugsnagClient.leaveBreadcrumb("manualBreadcrumb", {
       reason: "testing"


### PR DESCRIPTION
Per the spec, context and breadcrumbs should be private.