### PR TITLE
V7: static interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Move context to a private property on `Client`, and get/set via `getContext()/setContext()` [#681](https://github.com/bugsnag/bugsnag-js/pull/681)
 - Update `@bugsnag/safe-json-stringify` to replace redacted values with `[REDACTED]` [#683](https://github.com/bugsnag/bugsnag-js/pull/683)
 - Refactor type definitions [#682](https://github.com/bugsnag/bugsnag-js/pull/682)
+- Add static `Bugsnag` client interface [#685](https://github.com/bugsnag/bugsnag-js/pull/685)
 
 ### Fixed
 - (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -23,8 +23,8 @@
     "clean": "rm -fr dist && mkdir dist",
     "bundle-types": "../../bin/bundle-types",
     "build": "npm run clean && npm run build:dist && npm run build:dist:min && npm run bundle-types",
-    "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
-    "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=bugsnag | ../../bin/minify dist/bugsnag.min.js",
+    "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
+    "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/minify dist/bugsnag.min.js",
     "test:types": "jasmine 'types/**/*.test.js'",
     "cdn-upload": "./bin/cdn-upload",
     "postversion": "npm run build"

--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -70,18 +70,19 @@ const Bugsnag = {
   },
   init: (opts) => {
     if (Bugsnag._client) {
-      Bugsnag._client._logger.warn('init() called twice')
+      Bugsnag._client._logger.warn('Bugsnag.init() was called more than once. Ignoring.')
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
     Bugsnag._client._depth += 1
+    return Bugsnag._client
   }
 }
 
 reduce(keys(Client.prototype), (accum, m) => {
   if (/^_/.test(m)) return accum
   accum[m] = function () {
-    if (!Bugsnag._client) return console.log(`Bugsnag.${m}(…) was called before Bugsnag.init()`)
+    if (!Bugsnag._client) return console.log(`Bugsnag.${m}() was called before Bugsnag.init()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
   return accum

--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -7,7 +7,7 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
-const { reduce, keys } = require('@bugsnag/core/lib/es-utils')
+const { map, keys } = require('@bugsnag/core/lib/es-utils')
 
 // extend the base config schema with some browser-specific options
 const schema = { ...require('@bugsnag/core/config').schema, ...require('./config') }
@@ -79,14 +79,13 @@ const Bugsnag = {
   }
 }
 
-reduce(keys(Client.prototype), (accum, m) => {
-  if (/^_/.test(m)) return accum
-  accum[m] = function () {
+map(keys(Client.prototype), (m) => {
+  if (/^_/.test(m)) return
+  Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.log(`Bugsnag.${m}() was called before Bugsnag.init()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
-  return accum
-}, Bugsnag)
+})
 
 module.exports = Bugsnag
 

--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -1,14 +1,17 @@
-import { Client, Breadcrumb, Event, Session, Config } from "@bugsnag/core";
+import { Client, Config, BugsnagStatic } from "@bugsnag/core";
 
 interface BrowserConfig extends Config {
   maxEvents?: number;
   collectUserIp?: boolean;
 }
 
-// two ways to call the exported function: apiKey or config object
-declare function bugsnag(apiKeyOrOpts: string | BrowserConfig): Client;
+interface BrowserBugsnagStatic extends BugsnagStatic {
+  init(apiKeyOrOpts: string | BrowserConfig): void;
+  createClient(apiKeyOrOpts: string | BrowserConfig): Client;
+}
 
-// commonjs/requirejs export
-export default bugsnag;
-export { BrowserConfig }
+declare const Bugsnag: BrowserBugsnagStatic;
+
+export default Bugsnag;
 export * from "@bugsnag/core";
+export { BrowserConfig }

--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -6,7 +6,7 @@ interface BrowserConfig extends Config {
 }
 
 interface BrowserBugsnagStatic extends BugsnagStatic {
-  init(apiKeyOrOpts: string | BrowserConfig): void;
+  init(apiKeyOrOpts: string | BrowserConfig): Client;
   createClient(apiKeyOrOpts: string | BrowserConfig): Client;
 }
 

--- a/packages/browser/types/test/fixtures/all-options.ts
+++ b/packages/browser/types/test/fixtures/all-options.ts
@@ -1,5 +1,5 @@
-import bugsnag, { Breadcrumb, Session } from "../../.."
-bugsnag({
+import Bugsnag, { Breadcrumb, Session } from "../../.."
+Bugsnag.init({
   apiKey: "abc",
   appVersion: "1.2.3",
   appType: "worker",

--- a/packages/browser/types/test/fixtures/breadcrumb-types.ts
+++ b/packages/browser/types/test/fixtures/breadcrumb-types.ts
@@ -1,5 +1,5 @@
-import bugsnag from "../../..";
-const bugsnagClient = bugsnag({
+import Bugsnag from "../../..";
+Bugsnag.init({
   apiKey: 'api_key',
   onError: (event) => {
     event.breadcrumbs.map(breadcrumb => {

--- a/packages/browser/types/test/fixtures/notify-callback.ts
+++ b/packages/browser/types/test/fixtures/notify-callback.ts
@@ -1,6 +1,6 @@
-import bugsnag from "../../..";
-const bugsnagClient = bugsnag('api_key');
-bugsnagClient.notify(new Error('123'), (event) => {
+import Bugsnag from "../../..";
+Bugsnag.init('api_key');
+Bugsnag.notify(new Error('123'), (event) => {
   return false
 }, (err, event) => {
   console.log(event.originalError)

--- a/packages/browser/types/test/fixtures/plugins.ts
+++ b/packages/browser/types/test/fixtures/plugins.ts
@@ -1,7 +1,7 @@
-import bugsnag from "../../..";
-const bugsnagClient = bugsnag('api_key');
-bugsnagClient.use({
+import Bugsnag from "../../..";
+Bugsnag.init('api_key');
+Bugsnag.use({
   name: 'foobar',
   init: client => 10
 })
-console.log(bugsnagClient.getPlugin('foo') === 10)
+console.log(Bugsnag.getPlugin('foo') === 10)

--- a/packages/core/types/bugsnag.d.ts
+++ b/packages/core/types/bugsnag.d.ts
@@ -1,0 +1,66 @@
+import Client from "./client";
+import Event from "./event";
+import {
+  BreadcrumbType,
+  BreadcrumbMetadataValue,
+  Config,
+  NotifiableError,
+  OnErrorCallback,
+  OnSessionCallback,
+  OnBreadcrumbCallback,
+  User,
+  Plugin
+} from "./common";
+
+export default interface BugsnagStatic {
+  init(apiKeyOrOpts: string | Config): void;
+
+  createClient(apiKeyOrOpts: string | Config): Client;
+
+  // reporting errors
+  notify(
+    error: NotifiableError,
+    onError?: OnErrorCallback,
+    cb?: (err: any, event: Event) => void
+  ): void;
+
+  // breadcrumbs
+  leaveBreadcrumb(
+    message: string,
+    metadata?: { [key: string]: BreadcrumbMetadataValue },
+    type?: BreadcrumbType
+  ): void;
+
+  // metadata
+  addMetadata(section: string, values: { [key: string]: any }): void;
+  addMetadata(section: string, key: string, value: any): void;
+  getMetadata(section: string, key?: string): any;
+  clearMetadata(section: string, key?: string): void;
+
+  // context
+  getContext(): string | undefined;
+  setContext(c: string): void;
+
+  // user
+  getUser(): User;
+  setUser(id?: string, email?: string, name?: string): void;
+
+  // sessions
+  startSession(): Client;
+  pauseSession(): void;
+  resumeSession(): Client;
+
+  // callbacks
+  addOnError(fn: OnErrorCallback): void;
+  removeOnError(fn: OnErrorCallback): void;
+
+  addOnSession(fn: OnSessionCallback): void;
+  removeOnSession(fn: OnSessionCallback): void;
+
+  addOnBreadcrumb(fn: OnBreadcrumbCallback): void;
+  removeOnBreadcrumb(fn: OnBreadcrumbCallback): void;
+
+  // plugins
+  use(plugin: Plugin, ...args: any[]): Client;
+  getPlugin(name: string): any;
+}

--- a/packages/core/types/bugsnag.d.ts
+++ b/packages/core/types/bugsnag.d.ts
@@ -13,7 +13,7 @@ import {
 } from "./common";
 
 export default interface BugsnagStatic {
-  init(apiKeyOrOpts: string | Config): void;
+  init(apiKeyOrOpts: string | Config): Client;
 
   createClient(apiKeyOrOpts: string | Config): Client;
 

--- a/packages/core/types/bugsnag.d.ts
+++ b/packages/core/types/bugsnag.d.ts
@@ -12,55 +12,7 @@ import {
   Plugin
 } from "./common";
 
-export default interface BugsnagStatic {
+export default interface BugsnagStatic extends Client {
   init(apiKeyOrOpts: string | Config): Client;
-
   createClient(apiKeyOrOpts: string | Config): Client;
-
-  // reporting errors
-  notify(
-    error: NotifiableError,
-    onError?: OnErrorCallback,
-    cb?: (err: any, event: Event) => void
-  ): void;
-
-  // breadcrumbs
-  leaveBreadcrumb(
-    message: string,
-    metadata?: { [key: string]: BreadcrumbMetadataValue },
-    type?: BreadcrumbType
-  ): void;
-
-  // metadata
-  addMetadata(section: string, values: { [key: string]: any }): void;
-  addMetadata(section: string, key: string, value: any): void;
-  getMetadata(section: string, key?: string): any;
-  clearMetadata(section: string, key?: string): void;
-
-  // context
-  getContext(): string | undefined;
-  setContext(c: string): void;
-
-  // user
-  getUser(): User;
-  setUser(id?: string, email?: string, name?: string): void;
-
-  // sessions
-  startSession(): Client;
-  pauseSession(): void;
-  resumeSession(): Client;
-
-  // callbacks
-  addOnError(fn: OnErrorCallback): void;
-  removeOnError(fn: OnErrorCallback): void;
-
-  addOnSession(fn: OnSessionCallback): void;
-  removeOnSession(fn: OnSessionCallback): void;
-
-  addOnBreadcrumb(fn: OnBreadcrumbCallback): void;
-  removeOnBreadcrumb(fn: OnBreadcrumbCallback): void;
-
-  // plugins
-  use(plugin: Plugin, ...args: any[]): Client;
-  getPlugin(name: string): any;
 }

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -23,7 +23,6 @@ export interface Config {
   metadata?: { [key: string]: any };
   releaseStage?: string;
   user?: {} | null;
-  [key: string]: any;
 }
 
 export type OnErrorCallback = (event: Event, cb?: (err: null | Error) => void) => void | Promise<void> | boolean;

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2,6 +2,7 @@ import Breadcrumb from "./breadcrumb";
 import Client from "./client";
 import Event from "./event";
 import Session from "./session";
+import BugsnagStatic from "./bugsnag";
 
 export * from "./common";
-export { Breadcrumb, Client, Event, Session };
+export { Breadcrumb, Client, Event, Session, BugsnagStatic };

--- a/packages/core/types/test/test.ts
+++ b/packages/core/types/test/test.ts
@@ -22,7 +22,6 @@ describe('Type definitions', () => {
     expect(client.Breadcrumb).toBeDefined()
     expect(client.Event).toBeDefined()
     expect(client.Session).toBeDefined()
-
   })
 
   it('works for reporting errors', done => {

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -84,11 +84,12 @@ const Bugsnag = {
   },
   init: (opts) => {
     if (Bugsnag._client) {
-      Bugsnag._client._logger.warn('init() called twice')
+      Bugsnag._client._logger.warn('Bugsnag.init() was called more than once. Ignoring.')
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
     Bugsnag._client._depth += 1
+    return Bugsnag._client
   }
 }
 
@@ -97,7 +98,7 @@ const Bugsnag = {
 reduce(Object.getOwnPropertyNames(Client.prototype), (accum, m) => {
   if (/^_/.test(m)) return accum
   accum[m] = function () {
-    if (!Bugsnag._client) return console.warn(`Bugsnag.${m}(…) was called before Bugsnag.init()`)
+    if (!Bugsnag._client) return console.warn(`Bugsnag.${m}() was called before Bugsnag.init()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
   return accum

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -10,7 +10,7 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
-const { reduce } = require('@bugsnag/core/lib/es-utils')
+const { map } = require('@bugsnag/core/lib/es-utils')
 
 const delivery = require('@bugsnag/delivery-expo')
 
@@ -95,14 +95,13 @@ const Bugsnag = {
 
 // Object.keys(Client.prototype) does not work on native classes
 // because the methods are non enumerable
-reduce(Object.getOwnPropertyNames(Client.prototype), (accum, m) => {
-  if (/^_/.test(m)) return accum
-  accum[m] = function () {
+map(Object.getOwnPropertyNames(Client.prototype), (m) => {
+  if (/^_/.test(m)) return
+  Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.warn(`Bugsnag.${m}() was called before Bugsnag.init()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
-  return accum
-}, Bugsnag)
+})
 
 module.exports = Bugsnag
 

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -1,8 +1,6 @@
-import { Client, Config } from "@bugsnag/core";
+import { Client, Config, BugsnagStatic } from "@bugsnag/core";
 
-// two ways to call the exported function: apiKey or config object
-declare function bugsnag(apiKeyOrOpts?: string | Config): Client;
+declare const Bugsnag: BugsnagStatic;
 
-// commonjs/requirejs export
-export default bugsnag;
+export default Bugsnag;
 export * from "@bugsnag/core";

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -1,5 +1,5 @@
-import bugsnag, { Breadcrumb, Session } from "../../.."
-bugsnag({
+import Bugsnag, { Breadcrumb, Session } from "../../.."
+Bugsnag.init({
   apiKey: "abc",
   appVersion: "1.2.3",
   appType: "worker",
@@ -25,7 +25,5 @@ bugsnag({
   user: null,
   metadata: {},
   logger: undefined,
-  filters: ["foo",/bar/],
-  collectUserIp: true,
-  maxEvents: 10
+  filters: ["foo",/bar/]
 })

--- a/packages/expo/types/test/fixtures/breadcrumb-types.ts
+++ b/packages/expo/types/test/fixtures/breadcrumb-types.ts
@@ -1,5 +1,5 @@
-import bugsnag from "../../..";
-const bugsnagClient = bugsnag({
+import Bugsnag from "../../..";
+Bugsnag.init({
   apiKey: 'api_key',
   onError: (event) => {
     event.breadcrumbs.map(breadcrumb => {

--- a/packages/expo/types/test/fixtures/plugins.ts
+++ b/packages/expo/types/test/fixtures/plugins.ts
@@ -1,7 +1,7 @@
-import bugsnag from "../../..";
-const bugsnagClient = bugsnag('api_key');
-bugsnagClient.use({
+import Bugsnag from "../../..";
+Bugsnag.init('api_key');
+Bugsnag.use({
   name: 'foobar',
   init: client => 10
 })
-console.log(bugsnagClient.getPlugin('foo') === 10)
+console.log(Bugsnag.getPlugin('foo') === 10)

--- a/packages/js/types.d.ts
+++ b/packages/js/types.d.ts
@@ -1,5 +1,12 @@
-import { Client, BrowserConfig } from "@bugsnag/browser";
+import { Client, Config, BrowserConfig, BugsnagStatic } from "@bugsnag/browser";
 import { NodeConfig } from "@bugsnag/node";
-declare function bugsnag(apiKeyOrOpts: string | NodeConfig | BrowserConfig): Client;
-export default bugsnag;
+
+interface UniversalBugsnagStatic extends BugsnagStatic {
+  init(apiKeyOrOpts: string | BrowserConfig | NodeConfig): void;
+  createClient(apiKeyOrOpts: string | BrowserConfig | NodeConfig): Client;
+}
+
+declare const Bugsnag: UniversalBugsnagStatic;
+
+export default Bugsnag;
 export * from "@bugsnag/browser"

--- a/packages/js/types.d.ts
+++ b/packages/js/types.d.ts
@@ -2,7 +2,7 @@ import { Client, Config, BrowserConfig, BugsnagStatic } from "@bugsnag/browser";
 import { NodeConfig } from "@bugsnag/node";
 
 interface UniversalBugsnagStatic extends BugsnagStatic {
-  init(apiKeyOrOpts: string | BrowserConfig | NodeConfig): void;
+  init(apiKeyOrOpts: string | BrowserConfig | NodeConfig): Client;
   createClient(apiKeyOrOpts: string | BrowserConfig | NodeConfig): Client;
 }
 

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -7,6 +7,8 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
+const { reduce, keys } = require('@bugsnag/core/lib/es-utils')
+
 const delivery = require('@bugsnag/delivery-node')
 
 // extend the base config schema with some node-specific options
@@ -37,33 +39,52 @@ const plugins = [
   pluginContextualize
 ]
 
-module.exports = (opts, userPlugins = []) => {
-  // handle very simple use case where user supplies just the api key as a string
-  if (typeof opts === 'string') opts = { apiKey: opts }
+const Bugsnag = {
+  _client: null,
+  createClient: (opts) => {
+    // handle very simple use case where user supplies just the api key as a string
+    if (typeof opts === 'string') opts = { apiKey: opts }
+    if (!opts) opts = {}
 
-  const bugsnag = new Client(opts, schema, { name, version, url })
+    const bugsnag = new Client(opts, schema, { name, version, url })
 
-  bugsnag._setDelivery(delivery)
+    bugsnag._setDelivery(delivery)
 
-  plugins.forEach(pl => bugsnag.use(pl))
+    plugins.forEach(pl => bugsnag.use(pl))
 
-  bugsnag._logger.debug('Loaded!')
+    bugsnag._logger.debug('Loaded!')
 
-  bugsnag.leaveBreadcrumb = function () {
-    bugsnag._logger.warn('Breadcrumbs are not supported in Node.js yet')
+    bugsnag.leaveBreadcrumb = function () {
+      bugsnag._logger.warn('Breadcrumbs are not supported in Node.js yet')
+    }
+
+    return bugsnag
+  },
+  init: (opts) => {
+    if (Bugsnag._client) {
+      Bugsnag._client._logger.warn('init() called twice')
+      return Bugsnag._client
+    }
+    Bugsnag._client = Bugsnag.createClient(opts)
+    Bugsnag._client._depth += 1
   }
-
-  return bugsnag
 }
 
-// Angular's DI system needs this interface to match what is exposed
-// in the type definition file (types/bugsnag.d.ts)
-module.exports.Bugsnag = {
-  Client,
-  Event,
-  Session,
-  Breadcrumb
-}
+reduce(keys(Client.prototype), (accum, m) => {
+  if (/^_/.test(m)) return accum
+  accum[m] = function () {
+    if (!Bugsnag._client) return console.error(`Bugsnag.${m}(…) was called before Bugsnag.init()`)
+    return Bugsnag._client[m].apply(Bugsnag._client, arguments)
+  }
+  return accum
+}, Bugsnag)
+
+module.exports = Bugsnag
+
+module.exports.Client = Client
+module.exports.Event = Event
+module.exports.Session = Session
+module.exports.Breadcrumb = Breadcrumb
 
 // Export a "default" property for compatibility with ESM imports
-module.exports.default = module.exports
+module.exports.default = Bugsnag

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -7,7 +7,7 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
-const { reduce, keys } = require('@bugsnag/core/lib/es-utils')
+const { map, keys } = require('@bugsnag/core/lib/es-utils')
 
 const delivery = require('@bugsnag/delivery-node')
 
@@ -71,14 +71,13 @@ const Bugsnag = {
   }
 }
 
-reduce(keys(Client.prototype), (accum, m) => {
-  if (/^_/.test(m)) return accum
-  accum[m] = function () {
+map(keys(Client.prototype), (m) => {
+  if (/^_/.test(m)) return
+  Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.error(`Bugsnag.${m}() was called before Bugsnag.init()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
-  return accum
-}, Bugsnag)
+})
 
 module.exports = Bugsnag
 

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -62,18 +62,19 @@ const Bugsnag = {
   },
   init: (opts) => {
     if (Bugsnag._client) {
-      Bugsnag._client._logger.warn('init() called twice')
+      Bugsnag._client._logger.warn('Bugsnag.init() was called more than once. Ignoring.')
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
     Bugsnag._client._depth += 1
+    return Bugsnag._client
   }
 }
 
 reduce(keys(Client.prototype), (accum, m) => {
   if (/^_/.test(m)) return accum
   accum[m] = function () {
-    if (!Bugsnag._client) return console.error(`Bugsnag.${m}(…) was called before Bugsnag.init()`)
+    if (!Bugsnag._client) return console.error(`Bugsnag.${m}() was called before Bugsnag.init()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
   return accum

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -1,4 +1,4 @@
-import { Client, Breadcrumb, Event, Session, Logger, Config } from "@bugsnag/core";
+import { Client, Event, Logger, Config, BugsnagStatic } from "@bugsnag/core";
 
 type AfterErrorCb = (err: any, event: Event, logger: Logger) => void;
 
@@ -11,10 +11,13 @@ interface NodeConfig extends Config {
   sendCode?: boolean;
 }
 
-// two ways to call the exported function: apiKey or config object
-declare function bugsnag(apiKeyOrOpts: string | NodeConfig): Client;
+interface NodeBugsnagStatic extends BugsnagStatic {
+  init(apiKeyOrOpts: string | NodeConfig): void;
+  createClient(apiKeyOrOpts: string | NodeConfig): Client;
+}
 
-// commonjs/requirejs export
-export default bugsnag;
+declare const Bugsnag: NodeBugsnagStatic;
+
+export default Bugsnag;
 export * from "@bugsnag/core";
 export { NodeConfig };

--- a/packages/node/types/bugsnag.d.ts
+++ b/packages/node/types/bugsnag.d.ts
@@ -12,7 +12,7 @@ interface NodeConfig extends Config {
 }
 
 interface NodeBugsnagStatic extends BugsnagStatic {
-  init(apiKeyOrOpts: string | NodeConfig): void;
+  init(apiKeyOrOpts: string | NodeConfig): Client;
   createClient(apiKeyOrOpts: string | NodeConfig): Client;
 }
 

--- a/packages/plugin-angular/src/index.ts
+++ b/packages/plugin-angular/src/index.ts
@@ -1,12 +1,16 @@
 import { ErrorHandler, Injectable } from "@angular/core";
-import { Client, Plugin } from "@bugsnag/js";
+import Bugsnag, { Client, Plugin } from "@bugsnag/js";
 
 @Injectable()
 export class BugsnagErrorHandler extends ErrorHandler {
   public bugsnagClient: Client;
-  constructor(bugsnagClient: Client) {
+  constructor(client?: Client) {
     super();
-    this.bugsnagClient = bugsnagClient;
+    if (client) {
+      this.bugsnagClient = client;
+    } else {
+      this.bugsnagClient = ((Bugsnag as any)._client as Client)
+    }
   }
 
   public handleError(error: any): void {

--- a/test/browser/features/fixtures/auto_detect_errors/script/a.html
+++ b/test/browser/features/fixtures/auto_detect_errors/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         autoDetectErrors: false
@@ -18,7 +18,7 @@
       throw new Error('auto detect errors does not work')
     </script>
     <script>
-      bugsnagClient.notify(new Error('manual notify does work'))
+      Bugsnag.notify(new Error('manual notify does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/csp/script/a.html
+++ b/test/browser/features/fixtures/csp/script/a.html
@@ -7,7 +7,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      var bugsnagClient = Bugsnag.createClient({
         apiKey: API_KEY,
         endpoints: {
           notify: ENDPOINT,

--- a/test/browser/features/fixtures/handled/browserify/src/a.js
+++ b/test/browser/features/fixtures/handled/browserify/src/a.js
@@ -1,6 +1,6 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
-bugsnagClient.notify(new Error('bad things'))
+Bugsnag.notify(new Error('bad things'))

--- a/test/browser/features/fixtures/handled/browserify/src/b.js
+++ b/test/browser/features/fixtures/handled/browserify/src/b.js
@@ -1,10 +1,10 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 try {
   foo.bar()
 } catch (e) {
-  bugsnagClient.notify(e)
+  Bugsnag.notify(e)
 }

--- a/test/browser/features/fixtures/handled/browserify/src/c.js
+++ b/test/browser/features/fixtures/handled/browserify/src/c.js
@@ -1,12 +1,12 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 go()
   .then(function () {})
   .catch(function (e) {
-    bugsnagClient.notify(e)
+    Bugsnag.notify(e)
   })
 
 function go() {

--- a/test/browser/features/fixtures/handled/rollup/src/a.js
+++ b/test/browser/features/fixtures/handled/rollup/src/a.js
@@ -1,6 +1,6 @@
-import bugsnag from '@bugsnag/browser'
+import Bugsnag from '@bugsnag/browser'
 import config from './lib/config'
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
-bugsnagClient.notify(new Error('bad things'))
+Bugsnag.notify(new Error('bad things'))

--- a/test/browser/features/fixtures/handled/rollup/src/b.js
+++ b/test/browser/features/fixtures/handled/rollup/src/b.js
@@ -1,10 +1,10 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 try {
   foo.bar()
 } catch (e) {
-  bugsnagClient.notify(e)
+  Bugsnag.notify(e)
 }

--- a/test/browser/features/fixtures/handled/rollup/src/c.js
+++ b/test/browser/features/fixtures/handled/rollup/src/c.js
@@ -1,12 +1,12 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 go()
   .then(function () {})
   .catch(function (e) {
-    bugsnagClient.notify(e)
+    Bugsnag.notify(e)
   })
 
 function go() {

--- a/test/browser/features/fixtures/handled/script/a.html
+++ b/test/browser/features/fixtures/handled/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('bad things'))
+      Bugsnag.notify(new Error('bad things'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/script/b.html
+++ b/test/browser/features/fixtures/handled/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -17,7 +17,7 @@
       try {
         foo.bar()
       } catch (e) {
-        bugsnagClient.notify(e)
+        Bugsnag.notify(e)
       }
     </script>
   </body>

--- a/test/browser/features/fixtures/handled/script/c.html
+++ b/test/browser/features/fixtures/handled/script/c.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -24,7 +24,7 @@
       go()
         .then(function () {})
         .catch(function (e) {
-          bugsnagClient.notify(e)
+          Bugsnag.notify(e)
         })
 
       function go() {

--- a/test/browser/features/fixtures/handled/script/d.html
+++ b/test/browser/features/fixtures/handled/script/d.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -15,7 +15,7 @@
   <body>
     <script>
       function a () {
-        bugsnagClient.notify({ name: 'Errr', message: 'make a stacktrace for me' })
+        Bugsnag.notify({ name: 'Errr', message: 'make a stacktrace for me' })
       }
       function b () { a() }
       function c () { b() }

--- a/test/browser/features/fixtures/handled/script/e.html
+++ b/test/browser/features/fixtures/handled/script/e.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -15,7 +15,7 @@
   <body>
     <script>
       function a () {
-        bugsnagClient.notify('make a stacktrace for me')
+        Bugsnag.notify('make a stacktrace for me')
       }
       function b () { a() }
       function c () { b() }

--- a/test/browser/features/fixtures/handled/typescript/src/a.ts
+++ b/test/browser/features/fixtures/handled/typescript/src/a.ts
@@ -1,6 +1,6 @@
-import bugsnag from '@bugsnag/browser'
+import Bugsnag from '@bugsnag/browser'
 import config from './lib/config'
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
-bugsnagClient.notify(new Error('bad things'))
+Bugsnag.notify(new Error('bad things'))

--- a/test/browser/features/fixtures/handled/typescript/src/b.ts
+++ b/test/browser/features/fixtures/handled/typescript/src/b.ts
@@ -1,12 +1,12 @@
 declare var foo: any
 
-import bugsnag from '@bugsnag/browser'
+import Bugsnag from '@bugsnag/browser'
 import config from './lib/config'
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 try {
   foo.bar()
 } catch (e) {
-  bugsnagClient.notify(e)
+  Bugsnag.notify(e)
 }

--- a/test/browser/features/fixtures/handled/typescript/src/c.ts
+++ b/test/browser/features/fixtures/handled/typescript/src/c.ts
@@ -1,12 +1,12 @@
-import bugsnag from '@bugsnag/browser'
+import Bugsnag from '@bugsnag/browser'
 import config from './lib/config'
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 go()
   .then(function () {})
   .catch(function (e: any) {
-    bugsnagClient.notify(e)
+    Bugsnag.notify(e)
   })
 
 function go() {

--- a/test/browser/features/fixtures/handled/webpack3/src/a.js
+++ b/test/browser/features/fixtures/handled/webpack3/src/a.js
@@ -1,6 +1,6 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
-bugsnagClient.notify(new Error('bad things'))
+Bugsnag.notify(new Error('bad things'))

--- a/test/browser/features/fixtures/handled/webpack3/src/b.js
+++ b/test/browser/features/fixtures/handled/webpack3/src/b.js
@@ -1,10 +1,10 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 try {
   foo.bar()
 } catch (e) {
-  bugsnagClient.notify(e)
+  Bugsnag.notify(e)
 }

--- a/test/browser/features/fixtures/handled/webpack3/src/c.js
+++ b/test/browser/features/fixtures/handled/webpack3/src/c.js
@@ -1,12 +1,12 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 go()
   .then(function () {})
   .catch(function (e) {
-    bugsnagClient.notify(e)
+    Bugsnag.notify(e)
   })
 
 function go() {

--- a/test/browser/features/fixtures/handled/webpack4/src/a.js
+++ b/test/browser/features/fixtures/handled/webpack4/src/a.js
@@ -1,6 +1,6 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
-bugsnagClient.notify(new Error('bad things'))
+Bugsnag.notify(new Error('bad things'))

--- a/test/browser/features/fixtures/handled/webpack4/src/b.js
+++ b/test/browser/features/fixtures/handled/webpack4/src/b.js
@@ -1,10 +1,10 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 try {
   foo.bar()
 } catch (e) {
-  bugsnagClient.notify(e)
+  Bugsnag.notify(e)
 }

--- a/test/browser/features/fixtures/handled/webpack4/src/c.js
+++ b/test/browser/features/fixtures/handled/webpack4/src/c.js
@@ -1,12 +1,12 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
+Bugsnag.init(config)
 
 go()
   .then(function () {})
   .catch(function (e) {
-    bugsnagClient.notify(e)
+    Bugsnag.notify(e)
   })
 
 function go() {

--- a/test/browser/features/fixtures/ip_redaction/script/a.html
+++ b/test/browser/features/fixtures/ip_redaction/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         collectUserIp: false
@@ -15,7 +15,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('ip redaction does work'))
+      Bugsnag.notify(new Error('ip redaction does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/ip_redaction/script/b.html
+++ b/test/browser/features/fixtures/ip_redaction/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         collectUserIp: false,
@@ -16,7 +16,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('ip redaction does work'))
+      Bugsnag.notify(new Error('ip redaction does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/navigation/script/a.html
+++ b/test/browser/features/fixtures/navigation/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/on_error/script/a.html
+++ b/test/browser/features/fixtures/on_error/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         onError: function (event) {
@@ -17,7 +17,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('on error does work'))
+      Bugsnag.notify(new Error('on error does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/on_error/script/b.html
+++ b/test/browser/features/fixtures/on_error/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         onError: function (event) {
@@ -17,7 +17,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('on error does work'))
+      Bugsnag.notify(new Error('on error does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/on_error/script/d.html
+++ b/test/browser/features/fixtures/on_error/script/d.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('on error does work'), function (event) {
+      Bugsnag.notify(new Error('on error does work'), function (event) {
         event.addMetadata('on_error', 'notify_opts', 'works')
       })
     </script>

--- a/test/browser/features/fixtures/on_error/script/e.html
+++ b/test/browser/features/fixtures/on_error/script/e.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('on error does work'), function (event) {
+      Bugsnag.notify(new Error('on error does work'), function (event) {
         return false
       })
     </script>

--- a/test/browser/features/fixtures/plugin_angular/ng/src/app/app.module.ts
+++ b/test/browser/features/fixtures/plugin_angular/ng/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { BugsnagErrorHandler } from '@bugsnag/plugin-angular';
 import bugsnagClient from './bugsnag';
 
 export function errorHandlerFactory() {
-  return new BugsnagErrorHandler(bugsnagClient)
+  return new BugsnagErrorHandler(bugsnagClient);
 }
 
 import { AppComponent } from './app.component';

--- a/test/browser/features/fixtures/plugin_angular/ng/src/app/bugsnag.ts
+++ b/test/browser/features/fixtures/plugin_angular/ng/src/app/bugsnag.ts
@@ -1,9 +1,9 @@
-import bugsnag from '@bugsnag/browser';
+import Bugsnag from '@bugsnag/js';
 
 var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
 var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
 
-const bugsnagClient = bugsnag({
+const bugsnagClient = Bugsnag.createClient({
   apiKey: API_KEY,
   endpoints: {
     notify: ENDPOINT,

--- a/test/browser/features/fixtures/plugin_react/webpack4/src/app.js
+++ b/test/browser/features/fixtures/plugin_react/webpack4/src/app.js
@@ -1,13 +1,13 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var bugsnagReact = require('@bugsnag/plugin-react')
 var React = require('react')
 var ReactDOM = require('react-dom')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
-bugsnagClient.use(bugsnagReact, React)
+Bugsnag.init(config)
+Bugsnag.use(bugsnagReact, React)
 
-var ErrorBoundary = bugsnagClient.getPlugin('react')
+var ErrorBoundary = Bugsnag.getPlugin('react')
 
 function onError () {
 }

--- a/test/browser/features/fixtures/plugin_vue/webpack4/src/app.js
+++ b/test/browser/features/fixtures/plugin_vue/webpack4/src/app.js
@@ -1,10 +1,10 @@
-var bugsnag = require('@bugsnag/browser')
+var Bugsnag = require('@bugsnag/browser')
 var bugsnagVue = require('@bugsnag/plugin-vue')
 var Vue = require('vue/dist/vue.common.js')
 var config = require('./lib/config')
 
-var bugsnagClient = bugsnag(config)
-bugsnagClient.use(bugsnagVue, Vue)
+Bugsnag.init(config)
+Bugsnag.use(bugsnagVue, Vue)
 
 var app = new Vue({
   el: '#app',

--- a/test/browser/features/fixtures/redaction/script/a.html
+++ b/test/browser/features/fixtures/redaction/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
       })
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('sensitive?'), function (event) {
+      Bugsnag.notify(new Error('sensitive?'), function (event) {
         event.setUser('21')
         event.addMetadata('user', { password: '123456' })
       })

--- a/test/browser/features/fixtures/redaction/script/b.html
+++ b/test/browser/features/fixtures/redaction/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         filters: [ 'api_key', 'secret' ]
@@ -15,10 +15,10 @@
   </head>
   <body>
     <script>
-      bugsnagClient.addMetadata('details', {
+      Bugsnag.addMetadata('details', {
         api_key: 'fffffffff'
       })
-      bugsnagClient.notify(new Error('sensitive?'), function (event) {
+      Bugsnag.notify(new Error('sensitive?'), function (event) {
         event.setUser('21')
         event.addMetadata('user', { password: '123456', secret: 'don’t tell anyone' })
       })

--- a/test/browser/features/fixtures/redaction/script/c.html
+++ b/test/browser/features/fixtures/redaction/script/c.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         filters: [ 'stacktrace', 'secret' ]
@@ -15,11 +15,11 @@
   </head>
   <body>
     <script>
-      bugsnagClient.addMetadata('details', {
+      Bugsnag.addMetadata('details', {
         stacktrace: [ 'a', 'b' ]
       })
       function handle () {
-        bugsnagClient.notify(new Error('sensitive?'), function (event) {
+        Bugsnag.notify(new Error('sensitive?'), function (event) {
           event.setUser('21')
           event.addMetadata('user', { password: '123456', secret: 'don’t tell anyone' })
         })

--- a/test/browser/features/fixtures/redaction/script/d.html
+++ b/test/browser/features/fixtures/redaction/script/d.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         filters: [ /details\d/ ]
@@ -15,11 +15,11 @@
   </head>
   <body>
     <script>
-      bugsnagClient.addMetadata('extra', 'details0', {})
-      bugsnagClient.addMetadata('extra', 'details1', /foobar/)
-      bugsnagClient.addMetadata('extra', 'details2', { unlucky: [ 13 ]  })
-      bugsnagClient.addMetadata('extra', 'detailsA', 'aaaa')
-      bugsnagClient.notify(new Error('sensitive?'))
+      Bugsnag.addMetadata('extra', 'details0', {})
+      Bugsnag.addMetadata('extra', 'details1', /foobar/)
+      Bugsnag.addMetadata('extra', 'details2', { unlucky: [ 13 ]  })
+      Bugsnag.addMetadata('extra', 'detailsA', 'aaaa')
+      Bugsnag.notify(new Error('sensitive?'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/release_stage/script/a.html
+++ b/test/browser/features/fixtures/release_stage/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'production'
@@ -15,7 +15,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('release stage does work'))
+      Bugsnag.notify(new Error('release stage does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/release_stage/script/b.html
+++ b/test/browser/features/fixtures/release_stage/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'development'
@@ -15,7 +15,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('release stage does work'))
+      Bugsnag.notify(new Error('release stage does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/release_stage/script/c.html
+++ b/test/browser/features/fixtures/release_stage/script/c.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'qa',
@@ -16,7 +16,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('release stage does work'))
+      Bugsnag.notify(new Error('release stage does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/release_stage/script/d.html
+++ b/test/browser/features/fixtures/release_stage/script/d.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         releaseStage: 'staging',
@@ -16,7 +16,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('release stage does work'))
+      Bugsnag.notify(new Error('release stage does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/sessions/script/a.html
+++ b/test/browser/features/fixtures/sessions/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: {
           notify: ENDPOINT,

--- a/test/browser/features/fixtures/sessions/script/b.html
+++ b/test/browser/features/fixtures/sessions/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         autoTrackSessions: false,
         endpoints: {

--- a/test/browser/features/fixtures/strict_mode/script/a.html
+++ b/test/browser/features/fixtures/strict_mode/script/a.html
@@ -6,7 +6,7 @@
     <script type="module">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      window.bugsnagClient = window.bugsnag({
+      window.bugsnagClient = window.Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -24,9 +24,9 @@
     <script type="module">
       var customError = {
         name: 'Unlikely scenario',
-        stack: window.bugsnagClient.Event.getStacktrace()
+        stack: window.Bugsnag.Event.getStacktrace()
       }
-      window.bugsnagClient.notify(customError)
+      window.Bugsnag.notify(customError)
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/unhandled/script/a.html
+++ b/test/browser/features/fixtures/unhandled/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/unhandled/script/b.html
+++ b/test/browser/features/fixtures/unhandled/script/b.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/unhandled/script/c.html
+++ b/test/browser/features/fixtures/unhandled/script/c.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/unhandled/script/d.html
+++ b/test/browser/features/fixtures/unhandled/script/d.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/unhandled/script/e.html
+++ b/test/browser/features/fixtures/unhandled/script/e.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/unhandled/script/f.html
+++ b/test/browser/features/fixtures/unhandled/script/f.html
@@ -7,7 +7,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/unhandled/script/g.html
+++ b/test/browser/features/fixtures/unhandled/script/g.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })

--- a/test/browser/features/fixtures/user_info/script/a.html
+++ b/test/browser/features/fixtures/user_info/script/a.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         user: {
@@ -18,7 +18,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('user info does work'))
+      Bugsnag.notify(new Error('user info does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/user_info/script/b.html
+++ b/test/browser/features/fixtures/user_info/script/b.html
@@ -6,16 +6,16 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
-      bugsnagClient.setUser('cjhc05e8u0000peojhf4vfd68', 'bug@sn.ag', 'Bug S. Nag')
+      Bugsnag.setUser('cjhc05e8u0000peojhf4vfd68', 'bug@sn.ag', 'Bug S. Nag')
     </script>
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('user info does work'))
+      Bugsnag.notify(new Error('user info does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/user_info/script/d.html
+++ b/test/browser/features/fixtures/user_info/script/d.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('user info does work'), function (event) {
+      Bugsnag.notify(new Error('user info does work'), function (event) {
         event.setUser('cjhc06q3d0000q9ojtam2y3w5', 'bug@sn.ag', 'Bug S. Nag')
       })
     </script>

--- a/test/browser/features/fixtures/user_info/script/e.html
+++ b/test/browser/features/fixtures/user_info/script/e.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' }
       })
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('user info does work'))
+      Bugsnag.notify(new Error('user info does work'))
     </script>
   </body>
 </html>

--- a/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/app_state_breadcrumbs.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
 import { endpoints } from './bugsnag'
-import bugsnag from '@bugsnag/expo'
+import Bugsnag from '@bugsnag/expo'
 
 export default class AppStateBreadcrumbs extends Component {
   constructor(props) {
@@ -15,7 +15,7 @@ export default class AppStateBreadcrumbs extends Component {
   defaultAppStateBreadcrumbsBehaviour = () => {
     this.setState(() => (
       {
-        client: bugsnag({
+        client: Bugsnag.createClient({
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false
@@ -28,7 +28,7 @@ export default class AppStateBreadcrumbs extends Component {
   disabledAppStateBreadcrumbsBehaviour = () => {
     this.setState(() => (
       {
-        client: bugsnag({
+        client: Bugsnag.createClient({
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false,
@@ -42,7 +42,7 @@ export default class AppStateBreadcrumbs extends Component {
   disabledAllAppStateBreadcrumbsBehaviour = () => {
     this.setState(() => (
       {
-        client: bugsnag({
+        client: Bugsnag.createClient({
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false,
@@ -56,7 +56,7 @@ export default class AppStateBreadcrumbs extends Component {
   overrideAppStateBreadcrumbsBehaviour = () => {
     this.setState(() => (
       {
-        client: bugsnag({
+        client: Bugsnag.createClient({
           endpoints: endpoints,
           autoDetectErrors: false,
           autoTrackSessions: false,

--- a/test/expo/features/fixtures/test-app/app/bugsnag.js
+++ b/test/expo/features/fixtures/test-app/app/bugsnag.js
@@ -1,11 +1,11 @@
-import bugsnag from '@bugsnag/expo'
+import Bugsnag from '@bugsnag/expo'
 
 const endpoints = {
   notify: 'http://bs-local.com:9339',
   sessions: 'http://bs-local.com:9339'
 }
 
-const bugsnagClient = bugsnag({
+const bugsnagClient = Bugsnag.createClient({
   endpoints: endpoints,
   autoTrackSessions: false
 })

--- a/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/console_breadcrumbs.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
 import { endpoints } from './bugsnag'
-import bugsnag from '@bugsnag/expo'
+import Bugsnag from '@bugsnag/expo'
 
 export default class ConsoleBreadcrumbs extends Component {
   constructor(props) {
@@ -14,7 +14,7 @@ export default class ConsoleBreadcrumbs extends Component {
 
   defaultConsoleBreadcrumbsBehaviour = () => {
     this.triggerConsoleBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false
@@ -25,7 +25,7 @@ export default class ConsoleBreadcrumbs extends Component {
 
   disabledConsoleBreadcrumbsBehaviour = () => {
     this.triggerConsoleBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
@@ -37,7 +37,7 @@ export default class ConsoleBreadcrumbs extends Component {
 
   disabledAllConsoleBreadcrumbsBehaviour = () => {
     this.triggerConsoleBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
@@ -49,7 +49,7 @@ export default class ConsoleBreadcrumbs extends Component {
 
   overrideConsoleBreadcrumbsBehaviour = () => {
     this.triggerConsoleBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,

--- a/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
+++ b/test/expo/features/fixtures/test-app/app/network_breadcrumbs.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
 import { endpoints } from './bugsnag'
-import bugsnag from '@bugsnag/expo'
+import Bugsnag from '@bugsnag/expo'
 
 export default class NetworkBreadcrumbs extends Component {
   constructor(props) {
@@ -14,7 +14,7 @@ export default class NetworkBreadcrumbs extends Component {
 
   defaultNetworkBreadcrumbsBehaviour = () => {
     this.triggerNetworkBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false
@@ -25,7 +25,7 @@ export default class NetworkBreadcrumbs extends Component {
 
   disabledNetworkBreadcrumbsBehaviour = () => {
     this.triggerNetworkBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
@@ -37,7 +37,7 @@ export default class NetworkBreadcrumbs extends Component {
 
   disabledAllNetworkBreadcrumbsBehaviour = () => {
     this.triggerNetworkBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,
@@ -49,7 +49,7 @@ export default class NetworkBreadcrumbs extends Component {
 
   overrideNetworkBreadcrumbsBehaviour = () => {
     this.triggerNetworkBreadcrumbsError(
-      bugsnag({
+      Bugsnag.createClient({
         endpoints: endpoints,
         autoDetectErrors: false,
         autoTrackSessions: false,

--- a/test/expo/features/fixtures/test-app/app/sessions.js
+++ b/test/expo/features/fixtures/test-app/app/sessions.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
 import { endpoints, bugsnagClient } from './bugsnag'
-import bugsnag from '@bugsnag/expo'
+import Bugsnag from '@bugsnag/expo'
 
 export default class Sessions extends Component {
   autoSession = () => {
-    bugsnag({
+    Bugsnag.createClient({
       endpoints: endpoints,
       autoDetectErrors: false,
       autoTrackSessions: true

--- a/test/node/features/fixtures/connect/scenarios/app.js
+++ b/test/node/features/fixtures/connect/scenarios/app.js
@@ -1,16 +1,17 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var bugsnagExpress = require('@bugsnag/plugin-express')
 var connect = require('connect')
 
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
     sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
   }
-}).use(bugsnagExpress)
+})
+Bugsnag.use(bugsnagExpress)
 
-var middleware = bugsnagClient.getPlugin('express')
+var middleware = Bugsnag.getPlugin('express')
 
 var app = connect()
 

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -1,16 +1,18 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var bugsnagExpress = require('@bugsnag/plugin-express')
 var express = require('express')
 
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
     sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
   }
-}).use(bugsnagExpress)
+})
 
-var middleware = bugsnagClient.getPlugin('express')
+Bugsnag.use(bugsnagExpress)
+
+var middleware = Bugsnag.getPlugin('express')
 
 var app = express()
 

--- a/test/node/features/fixtures/handled/scenarios/intercept-callback.js
+++ b/test/node/features/fixtures/handled/scenarios/intercept-callback.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,8 +8,8 @@ var bugsnagClient = bugsnag({
   }
 })
 
-var intercept = bugsnagClient.getPlugin('intercept')
+var intercept = Bugsnag.getPlugin('intercept')
 fs.readFile('does not exist', intercept(function (data) {
   // callback should never get called so the following event is _not_ expected
-  bugsnagClient.notify(new Error('nope'))
+  Bugsnag.notify(new Error('nope'))
 }))

--- a/test/node/features/fixtures/handled/scenarios/intercept-rejection.js
+++ b/test/node/features/fixtures/handled/scenarios/intercept-rejection.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -17,5 +17,5 @@ function pRead (path) {
   })
 }
 
-var intercept = bugsnagClient.getPlugin('intercept')
+var intercept = Bugsnag.getPlugin('intercept')
 pRead('does not exist').catch(intercept())

--- a/test/node/features/fixtures/handled/scenarios/notify-promise-catch.js
+++ b/test/node/features/fixtures/handled/scenarios/notify-promise-catch.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -10,7 +10,7 @@ var bugsnagClient = bugsnag({
 go()
   .then(function () {})
   .catch(function (e) {
-    bugsnagClient.notify(e)
+    Bugsnag.notify(e)
   })
 
 function go () {

--- a/test/node/features/fixtures/handled/scenarios/notify-string.js
+++ b/test/node/features/fixtures/handled/scenarios/notify-string.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -7,4 +7,4 @@ var bugsnagClient = bugsnag({
   }
 })
 
-bugsnagClient.notify('create an error for me')
+Bugsnag.notify('create an error for me')

--- a/test/node/features/fixtures/handled/scenarios/notify-try-catch.js
+++ b/test/node/features/fixtures/handled/scenarios/notify-try-catch.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -10,5 +10,5 @@ var bugsnagClient = bugsnag({
 try {
   foo_bar() // eslint-disable-line
 } catch (e) {
-  bugsnagClient.notify(e)
+  Bugsnag.notify(e)
 }

--- a/test/node/features/fixtures/handled/scenarios/notify.js
+++ b/test/node/features/fixtures/handled/scenarios/notify.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -7,4 +7,4 @@ var bugsnagClient = bugsnag({
   }
 })
 
-bugsnagClient.notify(new Error('hi from the abyss'))
+Bugsnag.notify(new Error('hi from the abyss'))

--- a/test/node/features/fixtures/koa-1x/scenarios/app.js
+++ b/test/node/features/fixtures/koa-1x/scenarios/app.js
@@ -1,16 +1,18 @@
-const bugsnag = require('@bugsnag/node')
+const Bugsnag = require('@bugsnag/node')
 const bugsnagKoa = require('@bugsnag/plugin-koa')
 const Koa = require('koa')
 
-const bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
     sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
   }
-}).use(bugsnagKoa)
+})
 
-const middleware = bugsnagClient.getPlugin('koa')
+Bugsnag.use(bugsnagKoa)
+
+const middleware = Bugsnag.getPlugin('koa')
 
 const app = new Koa()
 

--- a/test/node/features/fixtures/koa/scenarios/app.js
+++ b/test/node/features/fixtures/koa/scenarios/app.js
@@ -1,16 +1,18 @@
-const bugsnag = require('@bugsnag/node')
+const Bugsnag = require('@bugsnag/node')
 const bugsnagKoa = require('@bugsnag/plugin-koa')
 const Koa = require('koa')
 
-const bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
     sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
   }
-}).use(bugsnagKoa)
+})
 
-const middleware = bugsnagClient.getPlugin('koa')
+Bugsnag.use(bugsnagKoa)
+
+const middleware = Bugsnag.getPlugin('koa')
 
 const app = new Koa()
 

--- a/test/node/features/fixtures/project_root/scenarios/appdir/project-root-custom.js
+++ b/test/node/features/fixtures/project_root/scenarios/appdir/project-root-custom.js
@@ -1,8 +1,8 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var lodash = require('lodash')
 var call = require('../../out')
 
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -15,6 +15,6 @@ var bugsnagClient = bugsnag({
 // error has a stackframe from inside node_modules
 call(function () {
   lodash.throttle(function () {
-    bugsnagClient.notify(new Error('project root'))
+    Bugsnag.notify(new Error('project root'))
   })()
 })

--- a/test/node/features/fixtures/project_root/scenarios/project-root-default.js
+++ b/test/node/features/fixtures/project_root/scenarios/project-root-default.js
@@ -1,7 +1,7 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var lodash = require('lodash')
 
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -12,5 +12,5 @@ var bugsnagClient = bugsnag({
 // the purpose of this seemingly pointless throttle call is just to make sure the
 // error has a stackframe from inside node_modules
 lodash.throttle(function () {
-  bugsnagClient.notify(new Error('project root'))
+  Bugsnag.notify(new Error('project root'))
 })()

--- a/test/node/features/fixtures/project_root/scenarios/project-root-null.js
+++ b/test/node/features/fixtures/project_root/scenarios/project-root-null.js
@@ -1,7 +1,7 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var lodash = require('lodash')
 
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -13,5 +13,5 @@ var bugsnagClient = bugsnag({
 // the purpose of this seemingly pointless throttle call is just to make sure the
 // error has a stackframe from inside node_modules
 lodash.throttle(function () {
-  bugsnagClient.notify(new Error('project root'))
+  Bugsnag.notify(new Error('project root'))
 })()

--- a/test/node/features/fixtures/proxy/scenarios/config-proxy.js
+++ b/test/node/features/fixtures/proxy/scenarios/config-proxy.js
@@ -1,6 +1,6 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var ProxyAgent = require('http-proxy-agent')
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,4 +8,4 @@ var bugsnagClient = bugsnag({
   },
   agent: new ProxyAgent('http://corporate-proxy:3128')
 })
-bugsnagClient.notify(new Error('hi via proxy'))
+Bugsnag.notify(new Error('hi via proxy'))

--- a/test/node/features/fixtures/proxy/scenarios/misconfigured-proxy.js
+++ b/test/node/features/fixtures/proxy/scenarios/misconfigured-proxy.js
@@ -1,6 +1,6 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var ProxyAgent = require('http-proxy-agent')
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,4 +8,4 @@ var bugsnagClient = bugsnag({
   },
   agent: new ProxyAgent('http://whoops:32228')
 })
-bugsnagClient.notify(new Error('hi via proxy'))
+Bugsnag.notify(new Error('hi via proxy'))

--- a/test/node/features/fixtures/restify/scenarios/app.js
+++ b/test/node/features/fixtures/restify/scenarios/app.js
@@ -1,17 +1,19 @@
-var bugsnag = require('@bugsnag/node')
+var Bugsnag = require('@bugsnag/node')
 var bugsnagExpress = require('@bugsnag/plugin-restify')
 var restify = require('restify')
 var errors = require('restify-errors')
 
-var bugsnagClient = bugsnag({
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
     sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
   }
-}).use(bugsnagExpress)
+})
 
-var middleware = bugsnagClient.getPlugin('restify')
+Bugsnag.use(bugsnagExpress)
+
+var middleware = Bugsnag.getPlugin('restify')
 
 var server = restify.createServer()
 

--- a/test/node/features/fixtures/sessions/scenarios/start-session-100.js
+++ b/test/node/features/fixtures/sessions/scenarios/start-session-100.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,7 +8,7 @@ var bugsnagClient = bugsnag({
   sessionSummaryInterval: 1000
 })
 
-for (var i = 0; i < 100; i++) bugsnagClient.startSession()
+for (var i = 0; i < 100; i++) Bugsnag.startSession()
 
 // keep the process open a little bit so that the session has time to get sent
 setTimeout(function () {}, 5000)

--- a/test/node/features/fixtures/sessions/scenarios/start-session-async.js
+++ b/test/node/features/fixtures/sessions/scenarios/start-session-async.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,9 +8,9 @@ var bugsnagClient = bugsnag({
   sessionSummaryInterval: 1000
 })
 
-for (var i = 0; i < 50; i++) bugsnagClient.startSession()
+for (var i = 0; i < 50; i++) Bugsnag.startSession()
 setTimeout(function () {
-  for (var i = 0; i < 50; i++) bugsnagClient.startSession()
+  for (var i = 0; i < 50; i++) Bugsnag.startSession()
 }, 1500)
 
 // keep the process open a little bit so that the session has time to get sent

--- a/test/node/features/fixtures/sessions/scenarios/start-session-auto-off.js
+++ b/test/node/features/fixtures/sessions/scenarios/start-session-auto-off.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -9,7 +9,7 @@ var bugsnagClient = bugsnag({
   sessionSummaryInterval: 1000
 })
 
-bugsnagClient.startSession()
+Bugsnag.startSession()
 
 // keep the process open a little bit so that the session has time to get sent
 setTimeout(function () {}, 5000)

--- a/test/node/features/fixtures/sessions/scenarios/start-session-notify.js
+++ b/test/node/features/fixtures/sessions/scenarios/start-session-notify.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,7 +8,7 @@ var bugsnagClient = bugsnag({
   sessionSummaryInterval: 1000
 })
 
-var sessionClient = bugsnagClient.startSession()
+var sessionClient = Bugsnag.startSession()
 setTimeout(function () {
   sessionClient.notify(new Error('in a session'))
 }, 1500)

--- a/test/node/features/fixtures/sessions/scenarios/start-session.js
+++ b/test/node/features/fixtures/sessions/scenarios/start-session.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,7 +8,7 @@ var bugsnagClient = bugsnag({
   sessionSummaryInterval: 1000
 })
 
-bugsnagClient.startSession()
+Bugsnag.startSession()
 
 // keep the process open a little bit so that the session has time to get sent
 setTimeout(function () {}, 5000)

--- a/test/node/features/fixtures/surrounding_code/scenarios/send-code-default.js
+++ b/test/node/features/fixtures/surrounding_code/scenarios/send-code-default.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -17,7 +17,7 @@ function add (a) {
 add(5)(2) // -> 7
 subtract(5)(2) // -> 3
 
-bugsnagClient.notify(new Error('surround me'))
+Bugsnag.notify(new Error('surround me'))
 
 function subtract (a) {
   return function (b) {

--- a/test/node/features/fixtures/surrounding_code/scenarios/send-code-off.js
+++ b/test/node/features/fixtures/surrounding_code/scenarios/send-code-off.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -17,7 +17,7 @@ function add (a) {
 add(5)(2) // -> 7
 subtract(5)(2) // -> 3
 
-bugsnagClient.notify(new Error('surround me'))
+Bugsnag.notify(new Error('surround me'))
 
 function subtract (a) {
   return function (b) {

--- a/test/node/features/fixtures/surrounding_code/scenarios/send-code-on.js
+++ b/test/node/features/fixtures/surrounding_code/scenarios/send-code-on.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -17,7 +17,7 @@ function add (a) {
 add(5)(2) // -> 7
 subtract(5)(2) // -> 3
 
-bugsnagClient.notify(new Error('surround me'))
+Bugsnag.notify(new Error('surround me'))
 
 function subtract (a) {
   return function (b) {

--- a/test/node/features/fixtures/surrounding_code/scenarios/template.json
+++ b/test/node/features/fixtures/surrounding_code/scenarios/template.json
@@ -2,7 +2,7 @@
   "17": "add(5)(2) // -> 7",
   "18": "subtract(5)(2) // -> 3",
   "19": "",
-  "20": "bugsnagClient.notify(new Error('surround me'))",
+  "20": "Bugsnag.notify(new Error('surround me'))",
   "21": "",
   "22": "function subtract (a) {",
   "23": "  return function (b) {"

--- a/test/node/features/fixtures/unhandled/scenarios/contextualize.js
+++ b/test/node/features/fixtures/unhandled/scenarios/contextualize.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -8,7 +8,7 @@ var bugsnagClient = bugsnag({
   }
 })
 
-var contextualize = bugsnagClient.getPlugin('contextualize')
+var contextualize = Bugsnag.getPlugin('contextualize')
 contextualize(function () {
   fs.createReadStream('does not exist')
 }, function (event) {

--- a/test/node/features/fixtures/unhandled/scenarios/thrown-error-not-caught-auto-notify-off.js
+++ b/test/node/features/fixtures/unhandled/scenarios/thrown-error-not-caught-auto-notify-off.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,

--- a/test/node/features/fixtures/unhandled/scenarios/thrown-error-not-caught.js
+++ b/test/node/features/fixtures/unhandled/scenarios/thrown-error-not-caught.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,

--- a/test/node/features/fixtures/unhandled/scenarios/unhandled-promise-rejection-auto-notify-off.js
+++ b/test/node/features/fixtures/unhandled/scenarios/unhandled-promise-rejection-auto-notify-off.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,

--- a/test/node/features/fixtures/unhandled/scenarios/unhandled-promise-rejection.js
+++ b/test/node/features/fixtures/unhandled/scenarios/unhandled-promise-rejection.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,

--- a/test/node/features/fixtures/webpack/src/index.js
+++ b/test/node/features/fixtures/webpack/src/index.js
@@ -1,5 +1,5 @@
-var bugsnag = require('@bugsnag/node')
-var bugsnagClient = bugsnag({
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.init({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
     notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
@@ -7,4 +7,4 @@ var bugsnagClient = bugsnag({
   }
 })
 
-bugsnagClient.notify(new Error('hello from a webpack node bundle'))
+Bugsnag.notify(new Error('hello from a webpack node bundle'))


### PR DESCRIPTION
This PR adds a static interface to the notifier, meaning that developers using Bugsnag don't have to hold on to a reference to `Client` in their applications (though they can if they want to).