### PR TITLE
fix params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)
+- (plugin-express), (plugin-restify): Send request metadata as the correct `notify()` parameter [#687](https://github.com/bugsnag/bugsnag-js/pull/687)
 
 ## 6.5.0 (2019-12-16)
 

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -52,7 +52,7 @@ module.exports = {
         client._logger.warn(
           'req.bugsnag is not defined. Make sure the @bugsnag/plugin-express requestHandler middleware is added first.'
         )
-        client.notify(createReportFromErr(err, handledState, getRequestAndMetaDataFromReq(req)))
+        client.notify(createReportFromErr(err, handledState), getRequestAndMetaDataFromReq(req)))
       }
       next(err)
     }

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -52,7 +52,7 @@ module.exports = {
         client._logger.warn(
           'req.bugsnag is not defined. Make sure the @bugsnag/plugin-express requestHandler middleware is added first.'
         )
-        client.notify(createReportFromErr(err, handledState), getRequestAndMetaDataFromReq(req)))
+        client.notify(createReportFromErr(err, handledState), getRequestAndMetaDataFromReq(req))
       }
       next(err)
     }

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -56,7 +56,7 @@ module.exports = {
         client._logger.warn(
           'req.bugsnag is not defined. Make sure the @bugsnag/plugin-restify requestHandler middleware is added first.'
         )
-        client.notify(createReportFromErr(err, handledState, getRequestAndMetaDataFromReq(req)))
+        client.notify(createReportFromErr(err, handledState), getRequestAndMetaDataFromReq(req))
       }
       cb()
     }


### PR DESCRIPTION
`getRequestAndMetaDataFromReq` is incorrectly nested inside `createReportFromErr`.

Koa plugin: https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-koa/src/koa.js#L73