### PR TITLE
Stablize travis-ci bootstrapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "12"
 before_script:
   - mkdir .size
-  - npx lerna bootstrap --ignore @bugsnag/expo
+  - npx lerna bootstrap --ignore @bugsnag/expo --concurrency 1
   - npx lerna run build --scope @bugsnag/browser
   - cat packages/browser/dist/bugsnag.min.js | wc -c > .size/after-minified
   - cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .size/after-gzipped


### PR DESCRIPTION
Similar to #667 this PR limits the concurrency when running lerna bootstrap in order to remove the frequent failures encountered, as described [here](https://github.com/npm/cli/issues/496).