### PR TITLE
V7: Tweak enabledReleaseStages logic

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -242,7 +242,7 @@ class Client {
     }
 
     // exit early if events should not be sent on the current releaseStage
-    if (this._config.enabledReleaseStages.length > 0 && !includes(this._config.enabledReleaseStages, this._config.releaseStage)) {
+    if (this._config.enabledReleaseStages !== null && !includes(this._config.enabledReleaseStages, this._config.releaseStage)) {
       this._logger.warn('Event not sent due to releaseStage/enabledReleaseStages configuration')
       return cb(null, event)
     }

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -66,9 +66,9 @@ module.exports.schema = {
     validate: val => val === true || val === false
   },
   enabledReleaseStages: {
-    defaultValue: () => [],
+    defaultValue: () => null,
     message: 'should be an array of strings',
-    validate: value => isArray(value) && filter(value, f => typeof f === 'string').length === value.length
+    validate: value => value === null || (isArray(value) && filter(value, f => typeof f === 'string').length === value.length)
   },
   releaseStage: {
     defaultValue: () => 'production',

--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -11,7 +11,7 @@ const sessionDelegate = {
     sessionClient._pausedSession = null
 
     // exit early if the current releaseStage is not enabled
-    if (sessionClient._config.enabledReleaseStages.length > 0 && !includes(sessionClient._config.enabledReleaseStages, sessionClient._config.releaseStage)) {
+    if (sessionClient._config.enabledReleaseStages !== null && !includes(sessionClient._config.enabledReleaseStages, sessionClient._config.releaseStage)) {
       sessionClient._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
       return sessionClient
     }

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -44,7 +44,7 @@ module.exports = {
 
 const sendSessionSummary = client => sessionCounts => {
   // exit early if the current releaseStage is not enabled
-  if (client._config.enabledReleaseStages.length > 0 && !includes(client._config.enabledReleaseStages, client._config.releaseStage)) {
+  if (client._config.enabledReleaseStages !== null && !includes(client._config.enabledReleaseStages, client._config.releaseStage)) {
     client._logger.warn('Session not sent due to releaseStage/enabledReleaseStages configuration')
     return
   }

--- a/test/browser/features/fixtures/release_stage/script/e.html
+++ b/test/browser/features/fixtures/release_stage/script/e.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
+        enabledReleaseStages: null
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      bugsnagClient.notify(new Error('release stage does work'))
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/release_stage/script/e.html
+++ b/test/browser/features/fixtures/release_stage/script/e.html
@@ -9,7 +9,8 @@
       var bugsnagClient = bugsnag({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
-        enabledReleaseStages: null
+        enabledReleaseStages: null,
+        releaseStage: 'development'
       })
     </script>
   </head>

--- a/test/browser/features/fixtures/release_stage/script/f.html
+++ b/test/browser/features/fixtures/release_stage/script/f.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      var bugsnagClient = bugsnag({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
+        enabledReleaseStages: []
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      bugsnagClient.notify(new Error('release stage does work'))
+    </script>
+  </body>
+</html>

--- a/test/browser/features/release_stage.feature
+++ b/test/browser/features/release_stage.feature
@@ -23,3 +23,14 @@ Scenario: setting releaseStage=staging enabledReleaseStages=[production,staging]
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the event "app.releaseStage" equals "staging"
+
+Scenario: setting releaseStage=staging enabledReleaseStages=null
+  When I navigate to the URL "/release_stage/script/e.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the event "app.releaseStage" equals "production"
+
+Scenario: setting releaseStage=staging enabledReleaseStages=[]
+  When I navigate to the URL "/release_stage/script/f.html"
+  And I wait for 2 seconds
+  Then I should receive no requests

--- a/test/browser/features/release_stage.feature
+++ b/test/browser/features/release_stage.feature
@@ -24,13 +24,13 @@ Scenario: setting releaseStage=staging enabledReleaseStages=[production,staging]
   And the request is a valid browser payload for the error reporting API
   And the event "app.releaseStage" equals "staging"
 
-Scenario: setting releaseStage=staging enabledReleaseStages=null
+Scenario: setting enabledReleaseStages=null
   When I navigate to the URL "/release_stage/script/e.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the event "app.releaseStage" equals "production"
 
-Scenario: setting releaseStage=staging enabledReleaseStages=[]
+Scenario: setting enabledReleaseStages=[]
   When I navigate to the URL "/release_stage/script/f.html"
   And I wait for 2 seconds
   Then I should receive no requests

--- a/test/browser/features/release_stage.feature
+++ b/test/browser/features/release_stage.feature
@@ -24,11 +24,11 @@ Scenario: setting releaseStage=staging enabledReleaseStages=[production,staging]
   And the request is a valid browser payload for the error reporting API
   And the event "app.releaseStage" equals "staging"
 
-Scenario: setting enabledReleaseStages=null
+Scenario: setting releaseStage=development enabledReleaseStages=null
   When I navigate to the URL "/release_stage/script/e.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
-  And the event "app.releaseStage" equals "production"
+  And the event "app.releaseStage" equals "development"
 
 Scenario: setting enabledReleaseStages=[]
   When I navigate to the URL "/release_stage/script/f.html"


### PR DESCRIPTION
Tweaks based on recent changes to the spec:

- `enabledReleaseStages` should default to `null`
- `null` should mean all release stages are enabled
- empty array should mean no release stages are enabled