### PR TITLE
fix(expo): Pin NetInfo dependency to compatible version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+### Fixed
+- (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)
+
 ## 6.5.0 (2019-12-16)
 
 ### Added

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^6.5.0",
-    "@react-native-community/netinfo": "^5.0.0",
+    "@react-native-community/netinfo": "4.6.0",
     "expo-file-system": "^6.0.2"
   },
   "devDependencies": {

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -20,7 +20,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@react-native-community/netinfo": "^5.0.0"
+    "@react-native-community/netinfo": "4.6.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^6.5.0",


### PR DESCRIPTION
https://github.com/expo/expo/blob/e4e48cdf989dc403105affd6498827162760abf7/packages/expo/bundledNativeModules.json#L3

`4.6.0` is the latest version allowed by Expo.