### PR TITLE
V7: Ensure context behaviour matches spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Refactor type definitions [#682](https://github.com/bugsnag/bugsnag-js/pull/682)
 - Add static `Bugsnag` client interface [#685](https://github.com/bugsnag/bugsnag-js/pull/685)
 - Add `getUser()` and `setUser()` methods to `Session` [#692](https://github.com/bugsnag/bugsnag-js/pull/692)
+- Ensure automatic context is not used when `setContext(null)` has been called [#694](https://github.com/bugsnag/bugsnag-js/pull/694)
 
 ### Fixed
 - (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)

--- a/packages/plugin-browser-context/context.js
+++ b/packages/plugin-browser-context/context.js
@@ -4,7 +4,7 @@
 module.exports = {
   init: (client, win = window) => {
     client.addOnError(event => {
-      if (event.context) return
+      if (event.context !== undefined) return
       event.context = win.location.pathname
     }, true)
   }

--- a/packages/plugin-browser-context/test/context.test.js
+++ b/packages/plugin-browser-context/test/context.test.js
@@ -11,29 +11,46 @@ const window = {
 }
 
 describe('plugin: context', () => {
-  it('sets client.context (and event.context) to window.location.pathname', () => {
+  it('sets client.context (and event.context) to window.location.pathname', done => {
     const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
     client.use(plugin, window)
 
-    client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
-    client.notify(new Error('noooo'))
+    client._setDelivery(client => ({
+      sendEvent: (payload, cb) => {
+        payloads.push(payload)
+        cb()
+      }
+    }))
 
-    expect(payloads.length).toEqual(1)
-    expect(payloads[0].events[0].context).toBe(window.location.pathname)
+    client.notify(new Error('noooo'), (event) => {
+      expect(event.context).toBe(window.location.pathname)
+    }, () => {
+      expect(payloads.length).toEqual(1)
+      expect(payloads[0].events[0].context).toBe(window.location.pathname)
+      done()
+    })
   })
 
-  it('sets doesn’t overwrite an existing context', () => {
+  it('sets doesn’t overwrite an existing context', done => {
     const client = new Client({ apiKey: 'API_KEY_YEAH' })
     const payloads = []
     client.use(plugin, window)
 
     client.setContext('something else')
 
-    client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
-    client.notify(new Error('noooo'))
-
-    expect(payloads.length).toEqual(1)
-    expect(payloads[0].events[0].context).toBe('something else')
+    client._setDelivery(client => ({
+      sendEvent: (payload, cb) => {
+        payloads.push(payload)
+        cb()
+      }
+    }))
+    client.notify(new Error('noooo'), (event) => {
+      expect(event.context.toBe('something else'))
+    }, () => {
+      expect(payloads.length).toEqual(1)
+      expect(payloads[0].events[0].context).toBe('something else')
+      done()
+    })
   })
 })


### PR DESCRIPTION
- The automatic value should only be used if a manual value is not supplied (including if `null` is supplied)
- The automatic value that will be used should be available in the `onError` callback so that the developer can inspect/change it