### PR TITLE
feat(node): Use util.inspect() before printing non-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696) 
+
 ## 6.5.1 (2020-01-08)
 
 ### Fixed

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -3,6 +3,7 @@ const { reduce } = require('@bugsnag/core/lib/es-utils')
 const { stringWithLength } = require('@bugsnag/core/lib/validators')
 const os = require('os')
 const process = require('process')
+const { inspect } = require('util')
 
 module.exports = {
   projectRoot: {
@@ -30,7 +31,7 @@ module.exports = {
   },
   onUncaughtException: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${printError(err)}`)
       process.exit(1)
     },
     message: 'should be a function',
@@ -38,12 +39,14 @@ module.exports = {
   },
   onUnhandledRejection: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Unhandled rejection${getContext(report)}…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Unhandled rejection${getContext(report)}…\n${printError(err)}`)
     },
     message: 'should be a function',
     validate: value => typeof value === 'function'
   }
 }
+
+const printError = err => err && err.stack ? err.stack : inspect(err)
 
 const getPrefixedConsole = () => {
   return reduce([ 'debug', 'info', 'warn', 'error' ], (accum, method) => {


### PR DESCRIPTION
`throw { ... }` or `reject({ ... })` is bad practice, but sometimes it happens. Previously (as
highlighted in #597), Bugsnag would just print `[object Object]`, which is unhelpful. This
uses util.inspect() to get a better textual representation of anything that doesn't have
a .stack property, before logging it to the console.

Partially fixes #597 (work on the `v7` branch addresses the part that affects the error report).