### PR TITLE
V7: static interface migration

### DIFF
--- a/packages/expo-cli/lib/insert.js
+++ b/packages/expo-cli/lib/insert.js
@@ -23,6 +23,6 @@ module.exports = async (projectRoot) => {
 }
 
 module.exports.code =
-`import bugsnag from '@bugsnag/expo';
-const bugsnagClient = bugsnag();
+`import Bugsnag from '@bugsnag/expo';
+Bugsnag.init();
 `

--- a/packages/expo-cli/lib/test/fixtures/already-configured-00/App.js
+++ b/packages/expo-cli/lib/test/fixtures/already-configured-00/App.js
@@ -1,8 +1,8 @@
-import bugsnag from '@bugsnag/expo'
+import Bugsnag from '@bugsnag/expo'
 import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 
-const bugsnagClient = bugsnag()
+Bugsnag.init()
 
 export default class App extends React.Component {
   render () {

--- a/packages/expo-cli/lib/test/fixtures/already-configured-01/App.js
+++ b/packages/expo-cli/lib/test/fixtures/already-configured-01/App.js
@@ -1,8 +1,8 @@
-const bugsnag = require('@bugsnag/expo')
+const Bugsnag = require('@bugsnag/expo')
 const React = require('react')
 const { StyleSheet, Text, View } = require('react-native')
 
-const bugsnagClient = bugsnag()
+Bugsnag.init()
 
 export default class App extends React.Component {
   render () {

--- a/packages/expo-cli/lib/test/insert.test.js
+++ b/packages/expo-cli/lib/test/insert.test.js
@@ -11,7 +11,7 @@ describe('expo-cli: insert', () => {
     const msg = await insert(projectRoot)
     expect(msg).toBe(undefined)
     const appJs = await promisify(readFile)(`${projectRoot}/App.js`, 'utf8')
-    expect(appJs).toMatch(/^import bugsnag from '@bugsnag\/expo';\sconst bugsnagClient = bugsnag\(\);\s/)
+    expect(appJs).toMatch(/^import Bugsnag from '@bugsnag\/expo';\sBugsnag.init\(\);\s/)
   })
 
   it('shouldn’t insert if @bugsnag/expo is already imported (import)', async () => {

--- a/packages/plugin-angular/README.md
+++ b/packages/plugin-angular/README.md
@@ -19,16 +19,16 @@ yarn add @bugsnag/js @bugsnag/plugin-angular
 In your the root of your angular app, typically `app.module.ts`:
 
 ```typescript
-// Import bugsnag-js and bugsnag-angular
-import BugsnagErrorHandler from 'bugsnag-angular'
-import bugsnag from 'bugsnag-js'
+// Import bugsnag-js and @bugsnag/angular
+import { BugsnagErrorHandler } from '@bugsnag/plugin-angular'
+import Bugsnag from 'bugsnag-js'
 
 // configure Bugsnag ASAP, before any other imports
-const bugsnagClient = bugsnag('API_KEY')
+Bugsnag.init('API_KEY')
 
-// create a factory which will return the bugsnag error handler
+// create a factory which will return the Bugsnag error handler
 export function errorHandlerFactory() {
-  return new BugsnagErrorHandler(bugsnagClient)
+  return new BugsnagErrorHandler()
 }
 
 import { ErrorHandler, NgModule } from '@angular/core'

--- a/packages/plugin-angular/README.md
+++ b/packages/plugin-angular/README.md
@@ -19,7 +19,7 @@ yarn add @bugsnag/js @bugsnag/plugin-angular
 In your the root of your angular app, typically `app.module.ts`:
 
 ```typescript
-// Import bugsnag-js and @bugsnag/angular
+// Import bugsnag-js and @bugsnag/plugin-angular
 import { BugsnagErrorHandler } from '@bugsnag/plugin-angular'
 import Bugsnag from 'bugsnag-js'
 

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -26,7 +26,7 @@ Depending on how your application is structured, usage differs slightly:
 ```js
 // initialize bugsnag ASAP, before other imports
 import Bugsnag from '@bugsnag/js'
-Bugsnag('API_KEY')
+Bugsnag.init('API_KEY')
 
 import ReactDOM from 'react-dom'
 import React from 'react'

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -25,16 +25,16 @@ Depending on how your application is structured, usage differs slightly:
 
 ```js
 // initialize bugsnag ASAP, before other imports
-import bugsnag from '@bugsnag/js'
-const bugsnagClient = bugsnag('API_KEY')
+import Bugsnag from '@bugsnag/js'
+Bugsnag('API_KEY')
 
 import ReactDOM from 'react-dom'
 import React from 'react'
 import bugsnagReact from '@bugsnag/plugin-react'
-bugsnagClient.use(bugsnagReact, React)
+Bugsnag.use(bugsnagReact, React)
 
 // wrap your entire app tree in the ErrorBoundary provided
-const ErrorBoundary = bugsnagClient.getPlugin('react');
+const ErrorBoundary = Bugsnag.getPlugin('react');
 ReactDOM.render(
   <ErrorBoundary>
     <YourApp />

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -20,11 +20,11 @@ yarn add bugsnag-js @bugsnag/plugin-vue
 
 ```js
 const Vue = require('vue')
-const bugsnag = require('@bugsnag/js')
+const Bugsnag = require('@bugsnag/js')
 const bugsnagVue = require('@bugsnag/plugin-vue')
 
-const bugsnagClient = bugsnag('API_KEY')
-bugsnagClient.use(bugsnagVue, Vue)
+Bugsnag.init('API_KEY')
+Bugsnag.use(bugsnagVue, Vue)
 ```
 
 ## Support

--- a/test/browser/features/fixtures/release_stage/script/e.html
+++ b/test/browser/features/fixtures/release_stage/script/e.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         enabledReleaseStages: null,
@@ -16,7 +16,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('release stage does work'))
+      Bugsnag.notify(new Error('release stage does work'))
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/release_stage/script/f.html
+++ b/test/browser/features/fixtures/release_stage/script/f.html
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
-      var bugsnagClient = bugsnag({
+      Bugsnag.init({
         apiKey: API_KEY,
         endpoints: { notify: ENDPOINT, sessions: '/noop' },
         enabledReleaseStages: []
@@ -15,7 +15,7 @@
   </head>
   <body>
     <script>
-      bugsnagClient.notify(new Error('release stage does work'))
+      Bugsnag.notify(new Error('release stage does work'))
     </script>
   </body>
 </html>


### PR DESCRIPTION
Updates some places the old `bugsnag()` interface was used:

- the `expo-cli` that inserts Bugsnag initialisation
- some new release stage tests which were added in parallel with the static interface (fixes some broken tests)
- the readmes of some plugins