### PR TITLE
Release v6.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "12"
 before_script:
   - mkdir .size
-  - npx lerna bootstrap --ignore @bugsnag/expo
+  - npx lerna bootstrap --ignore @bugsnag/expo --concurrency 1
   - npx lerna run build --scope @bugsnag/browser
   - cat packages/browser/dist/bugsnag.min.js | wc -c > .size/after-minified
   - cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .size/after-gzipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)
+- (plugin-express), (plugin-restify): Send request metadata as the correct `notify()` parameter [#687](https://github.com/bugsnag/bugsnag-js/pull/687)
 
 ## 6.5.0 (2019-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+### Fixed
+- (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)
+
 ## 6.5.0 (2019-12-16)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 6.5.1 (2020-01-08)
 
 ### Fixed
 - (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,54 @@ CI runs on Buildkite. Tests are run automatically on any branch from within this
 
 ⚠️ __Caution__: exercise due-diligence before creating a branch based on an external contribution – for example, be sure not to merge a bitcoin miner disguised as a bug fix!
 
-## Prereleases
+## Releases
+
+Before creating any release:
+
+- run `npm install` in the root of the project and `npm run bootstrap` to ensure the top-level node_modules and leaf node_modules are all correct for the branch you have checked out.
+- ensure you are logged in to npm and that you have access to publish to the following on npm
+  - any packages in the `@bugsnag` namespace
+  - the `bugsnag-expo-cli` package
+- ensure you have an AWS key pair with access to our S3 bucket and cloudfront distribution. Export these in your environment as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (if you're going to publish to the CDN)
+
+To start a release:
+
+- decide on a version number
+- create a new release branch from `next` with the version number in the branch name
+`git checkout -b release/vX.Y.Z`
+- update the version number and date in the changelog
+- make a PR from your release branch to `master` entitled `Release vX.Y.Z`
+- get the release PR reviewed – all code changes should have been reviewed already, this should be a review of the integration of all changes to be shipped and the changelog
+- consider shipping a [prerelease](#prereleases) to aid testing the release
+
+Once the release PR has been approved:
+
+- merge the PR into master
+- `git checkout master` and `git pull`
+
+You are now ready to make the release:
+
+```
+lerna version [major | minor | patch]
+lerna publish from-git
+```
+
+<small>Note: if a prerelease was made, to graduate it into a normal release you will want to use `patch` as the version.</small>
+
+At this point it is sensible to perform some manual smoke tests to ensure the new version on npm works as expected. Only then publish to the CDN:
+
+```
+lerna run cdn-upload
+```
+
+Finally:
+
+- create a release on GitHub https://github.com/bugsnag/bugsnag-js/releases/new
+- use the tag vX.Y.Z as the name of the release
+- copy the release notes from `CHANGELOG.md`
+- publish the release
+
+### Prereleases
 
 If you are starting a new prerelease, use one of the following commands:
 
@@ -85,15 +132,5 @@ The `--dist-tag next` part ensures that it is not installed by unsuspecting user
 If you want to publish the release to the CDN, use the following command:
 
 ```
-lerna run cdn-upload
-```
-
-## Releases
-
-To graduate a prerelease into a release you will want to use `patch` as the version.
-
-```
-lerna version [major | minor | patch]
-lerna publish from-git
 lerna run cdn-upload
 ```

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^6.5.0",
-    "@react-native-community/netinfo": "^5.0.0",
+    "@react-native-community/netinfo": "4.6.0",
     "expo-file-system": "^6.0.2"
   },
   "devDependencies": {

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -52,7 +52,7 @@ module.exports = {
         client._logger.warn(
           'req.bugsnag is not defined. Make sure the @bugsnag/plugin-express requestHandler middleware is added first.'
         )
-        client.notify(createReportFromErr(err, handledState, getRequestAndMetaDataFromReq(req)))
+        client.notify(createReportFromErr(err, handledState), getRequestAndMetaDataFromReq(req))
       }
       next(err)
     }

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -20,7 +20,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@react-native-community/netinfo": "^5.0.0"
+    "@react-native-community/netinfo": "4.6.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^6.5.0",

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -56,7 +56,7 @@ module.exports = {
         client._logger.warn(
           'req.bugsnag is not defined. Make sure the @bugsnag/plugin-restify requestHandler middleware is added first.'
         )
-        client.notify(createReportFromErr(err, handledState, getRequestAndMetaDataFromReq(req)))
+        client.notify(createReportFromErr(err, handledState), getRequestAndMetaDataFromReq(req))
       }
       cb()
     }


### PR DESCRIPTION
### Fixed
- (expo): Pin `@react-native-community/netinfo` dependency to exact version bundled by Expo [#691](https://github.com/bugsnag/bugsnag-js/pull/691)
- (plugin-express), (plugin-restify): Send request metadata as the correct `notify()` parameter [#687](https://github.com/bugsnag/bugsnag-js/pull/687)