### PR TITLE
chore (build): bump to docker-compose-buildkite-plugin v.3.1.0

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -4,13 +4,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build: expo-publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
@@ -18,12 +18,12 @@ steps:
   - label: ':docker: Build expo maze runner image'
     timeout_in_minutes: 10
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build: expo-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
@@ -33,13 +33,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build: expo-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -51,7 +51,7 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           run: expo-publisher
 
   - wait
@@ -62,7 +62,7 @@ steps:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           run: expo-android-builder
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -84,7 +84,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -98,7 +98,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -114,7 +114,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -128,7 +128,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -142,7 +142,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -156,7 +156,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -170,7 +170,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -184,7 +184,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: ':docker: Prepare package.json'
     timeout_in_minutes: 1
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           run: minimal-packager
     artifact_paths: min_packages.tar
 
@@ -13,14 +13,14 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
@@ -38,21 +38,21 @@ steps:
   - label: 'Lint'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: ci
     command: 'npm run test:lint'
 
   - label: 'Unit tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: ci
     command: 'npm run test:unit'
 
   - label: 'Type checks/tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: ci
     command: 'npm run test:types'
 
@@ -61,7 +61,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build:
             - browser-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
@@ -73,7 +73,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build:
             - node-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
@@ -85,7 +85,7 @@ steps:
   - label: ':chrome: v43 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -96,7 +96,7 @@ steps:
   - label: ':chrome: v61 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -107,7 +107,7 @@ steps:
   - label: ':ie: v8 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -118,7 +118,7 @@ steps:
   - label: ':ie: v9 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -129,7 +129,7 @@ steps:
   - label: ':ie: v10 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -140,7 +140,7 @@ steps:
   - label: ':ie: v11 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -152,7 +152,7 @@ steps:
   - label: ':edge: v14 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -163,7 +163,7 @@ steps:
   - label: ':edge: v15 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -174,7 +174,7 @@ steps:
   - label: ':safari: v6 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -185,7 +185,7 @@ steps:
   - label: ':safari: v10 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -196,7 +196,7 @@ steps:
   - label: ':desktop_computer: Opera v12 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -207,7 +207,7 @@ steps:
   - label: ':iphone: iOS 10.3 Browser tests'
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -219,7 +219,7 @@ steps:
   - label: ':android: Samsung Galaxy S8 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -230,7 +230,7 @@ steps:
   - label: ':firefox: v30 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -241,7 +241,7 @@ steps:
   - label: ':firefox: v56 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -252,7 +252,7 @@ steps:
   - label: ':node: Node 4'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:
@@ -262,7 +262,7 @@ steps:
   - label: ':node: Node 6'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:
@@ -272,7 +272,7 @@ steps:
   - label: ':node: Node 8'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:
@@ -281,7 +281,7 @@ steps:
   - label: ':node: Node 10'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:
@@ -290,7 +290,7 @@ steps:
   - label: ':node: Node 12'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:


### PR DESCRIPTION
Update to docker-compose-buildkite-plugin v.3.1.0 in preparation for Buildkite agent v4.3.5