### PR TITLE
feat(delivery-react-native): Build specified payload to send over bridge

### DIFF
--- a/packages/delivery-react-native/README.md
+++ b/packages/delivery-react-native/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/delivery-react-native
+
+This delivery mechanism defers to the native platform to send events. It is included in the React Native notifier.
+
+## License
+MIT

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -16,5 +16,7 @@ module.exports = (client, NativeClient) => ({
       groupingHash: event.groupingHash
     }).then(() => cb()).catch(cb)
   },
-  sendSession: () => {}
+  sendSession: () => {
+    client._logger.warn('@bugsnag/delivery-react-native sendSession() should never be called', new Error().stack)
+  }
 })

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -1,11 +1,20 @@
 module.exports = (client, NativeClient) => ({
   sendEvent: (payload, cb = () => {}) => {
     const event = payload.events[0]
-    // this is because JS beforeSend operates on the event – report is not in scope
-    // report.threads = event.get('threads')
-    NativeClient.dispatch(event.toJSON()).then(() => cb()).catch(cb)
+    NativeClient.dispatch({
+      errors: event.errors,
+      severity: event.severity,
+      severityReason: event._handledState.severityReason,
+      unhandled: event.unhandled,
+      app: event.app,
+      device: event.device,
+      threads: event.threads,
+      breadcrumbs: event.breadcrumbs,
+      context: event.context,
+      user: event._user,
+      metadata: event._metadata,
+      groupingHash: event.groupingHash
+    }).then(() => cb()).catch(cb)
   },
-  sendSession: () => {
-    // TODO: log/warn here? If this gets used the something has gone wrong…
-  }
+  sendSession: () => {}
 })

--- a/packages/delivery-react-native/package.json
+++ b/packages/delivery-react-native/package.json
@@ -20,7 +20,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "^6.3.0"
+    "@bugsnag/core": "^7.0.0-alpha.1"
   },
   "devDependencies": {
     "jasmine": "3.1.0",

--- a/packages/delivery-react-native/test/delivery.test.js
+++ b/packages/delivery-react-native/test/delivery.test.js
@@ -1,25 +1,41 @@
 /* global describe, it, expect */
 
 const Client = require('@bugsnag/core/client')
-const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 const delivery = require('../')
 
 describe('delivery: react native', () => {
-  it('sends using the native dispatch() method', done => {
+  it('sends the correct payload using the native client’s dispatch() method', done => {
+    const sent = []
     const NativeClient = {
-      dispatch: () => new Promise((resolve) => resolve(1))
+      dispatch: (event) => {
+        sent.push(event)
+        return new Promise((resolve) => resolve(true))
+      }
     }
-    const c = new Client(VALID_NOTIFIER)
-    c.setOptions({ apiKey: 'api_key' })
-    c.configure()
-    c.delivery(client => delivery(client, NativeClient))
-    const threads = [{}, {}]
-    c.notify(new Error('123'), report => {
-      report.set('threads', threads)
-    }, (err, report) => {
+    const c = new Client({ apiKey: 'api_key' })
+    c._setDelivery(client => delivery(client, NativeClient))
+    c.leaveBreadcrumb('hi')
+    c.setContext('test screen')
+    c.setUser('123')
+    c.notify(new Error('oh no'), (e) => {
+      e.groupingHash = 'ER_GRP_098'
+    }, (err, event) => {
       expect(err).not.toBeTruthy()
-      expect(report.get('errorMessage')).toBe('123')
-      expect(report.get('threads')).toEqual(threads)
+      expect(sent.length).toBe(1)
+      expect(sent[0].errors[0].errorMessage).toBe('oh no')
+      expect(sent[0].severity).toBe('warning')
+      expect(sent[0].severityReason.type).toBe('handledException')
+      expect(sent[0].unhandled).toBe(false)
+      expect(sent[0].app).toEqual({ releaseStage: 'production', version: null, type: null })
+      expect(sent[0].device).toEqual({})
+      // TODO enable once event.threads exists
+      // expect(sent[0].threads).toEqual({})
+      expect(sent[0].breadcrumbs.length).toBe(1)
+      expect(sent[0].breadcrumbs[0].message).toBe('hi')
+      expect(sent[0].context).toBe('test screen')
+      expect(sent[0].user).toEqual({ id: '123', email: undefined, name: undefined })
+      expect(sent[0].metadata).toEqual({})
+      expect(sent[0].groupingHash).toEqual('ER_GRP_098')
       done()
     })
   })


### PR DESCRIPTION
This update takes the prototyped `@bugsnag/delivery-react-native` component and makes it ready to use:

- Added a readme
- Depend on local version of `@bugsnag/core` (from the local monorepo rather than fetching an old version from npm)
- Update the payload that gets transferred to the native layer
- Update the unit test based on the new implementation

The unit tests will not pass for this because of some other plugins that are beyond the scope of this PR.

To test that the values are crossing the bridge as expected, you can drill down to `BugsnagReactNative.java` in the node modules of the RN project you are testing on and add the following:

```java
    import android.util.Log;

    // ... snip    

    @ReactMethod
    private void dispatch(ReadableMap payload, Promise promise) {
        Log.i("Bugsnag", payload.getArray("errors").getMap(0).getString("errorClass"));
        Log.i("Bugsnag", payload.getArray("errors").getMap(0).getString("errorMessage"));
        Log.i("Bugsnag", payload.getString("severity"));
        //...
    }
```

(full path `node_modules/@bugsnag/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.java`)

Then you can filter logcat just to the `Bugsnag` logs like so `adb logcat Bugsnag "*:S"`.