### PR TITLE
feat(plugin-react-native-client-sync): Maintain client state between JS<->Native

### DIFF
--- a/packages/plugin-react-native-client-sync/README.md
+++ b/packages/plugin-react-native-client-sync/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/plugin-react-native-client-sync
+
+This plugin maintains client state between the JS client and the native client in React Native. It is included in the React Native notifier.
+
+## License
+MIT

--- a/packages/plugin-react-native-client-sync/client-sync.js
+++ b/packages/plugin-react-native-client-sync/client-sync.js
@@ -21,16 +21,16 @@ module.exports = {
     }
 
     const origAddMetadata = client.addMetadata
-    client.addMetadata = function () {
+    client.addMetadata = function (key) {
       const ret = origAddMetadata.apply(this, arguments)
-      NativeClient.updateMetaData(client._metadata)
+      NativeClient.updateMetadata(key, client._metadata[key])
       return ret
     }
 
     const origClearMetadata = client.clearMetadata
-    client.clearMetadata = function () {
+    client.clearMetadata = function (key) {
       const ret = origClearMetadata.apply(this, arguments)
-      NativeClient.updateMetaData(client._metadata)
+      NativeClient.updateMetaData(key, client._metadata[key])
       return ret
     }
 
@@ -53,16 +53,17 @@ module.exports = {
 
     nativeSubscribe(event => {
       switch (event.type) {
-        case 'USER_UPDATE':
-          origSetUser.call(client, event.value.id, event.value.email, event.value.name)
+        case 'UserUpdate':
+          origSetUser.call(client, event.data.id, event.data.email, event.data.name)
           break
-        case 'METADATA_UPDATE':
-          origAddMetadata.call(client, event.value)
+        case 'MetadataUpdate':
+          Object.keys(event.data).forEach(k => {
+            origAddMetadata.call(client, k, event.data[k])
+          })
           break
-        case 'CONTEXT_UPDATE':
-          origSetContext.call(client, event.value)
+        case 'ContextUpdate':
+          origSetContext.call(client, event.data)
           break
-        // etc.
         default:
       }
     })

--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "7.0.0-alpha.1",
-    "iserror": "^0.0.2",
     "proxyquire": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This plugin is responsible for communicating state changes from JS -> Native and from Native -> JS. The following data is considered state that needs to be synchronised:

- breadcrumbs
- user
- context
- metadata

From JS -> Native, the changes can be propagated directly via methods on the native `BugsnagReactNative` class that is surfaced to JS.

From Native -> JS, the changes must be delivered via events and the implementation for this differs slightly based on the native platform.

The unit test CI job will not pass for this PR because of some other RN plugins that are beyond the scope of this PR. The unit tests for the client sync plugin do pass.