### PR TITLE
chore: apply linting to .ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --scope '@bugsnag/node' --scope '@bugsnag/browser' --scope '@bugsnag/expo' && lerna run build --ignore '@bugsnag/node' --ignore '@bugsnag/browser' --ignore '@bugsnag/expo'",
-    "test:lint": "eslint . --report-unused-disable-directives",
+    "test:lint": "eslint --ext .ts,.js --report-unused-disable-directives --max-warnings=0 .",
     "test:unit": "lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",
     "test:types": "lerna run test:types",
     "test:test-container-registry-login": "$(aws ecr get-login --profile=opensource --no-include-email)",

--- a/packages/core/types/bugsnag.d.ts
+++ b/packages/core/types/bugsnag.d.ts
@@ -1,16 +1,5 @@
 import Client from "./client";
-import Event from "./event";
-import {
-  BreadcrumbType,
-  BreadcrumbMetadataValue,
-  Config,
-  NotifiableError,
-  OnErrorCallback,
-  OnSessionCallback,
-  OnBreadcrumbCallback,
-  User,
-  Plugin
-} from "./common";
+import { Config } from "./common";
 
 export default interface BugsnagStatic extends Client {
   start(apiKeyOrOpts: string | Config): Client;

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -132,5 +132,5 @@ interface Request {
 export interface User {
   id?: string;
   email?: string;
-  name?: string
+  name?: string;
 }

--- a/packages/core/types/session.d.ts
+++ b/packages/core/types/session.d.ts
@@ -1,4 +1,3 @@
-import Event from "./event";
 import { App, Device, User } from "./common";
 
 declare class Session {

--- a/packages/core/types/test/test.ts
+++ b/packages/core/types/test/test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
 import Bugsnag, { Client, Config } from '../..'
 import "jasmine"
 

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -1,4 +1,4 @@
-import { Client, Config, BugsnagStatic } from "@bugsnag/core";
+import { BugsnagStatic } from "@bugsnag/core";
 
 declare const Bugsnag: BugsnagStatic;
 

--- a/packages/js/types.d.ts
+++ b/packages/js/types.d.ts
@@ -1,4 +1,4 @@
-import { Client, Config, BrowserConfig, BugsnagStatic } from "@bugsnag/browser";
+import { Client, BrowserConfig, BugsnagStatic } from "@bugsnag/browser";
 import { NodeConfig } from "@bugsnag/node";
 
 interface UniversalBugsnagStatic extends BugsnagStatic {


### PR DESCRIPTION
eslint was not being run on .ts files. This fixes that and the subsequent lint errors/warnings.