### PR TITLE
refactor(react-native): Update init->start and latest bugsnag-android interface

### DIFF
--- a/examples/reactnative/App.js
+++ b/examples/reactnative/App.js
@@ -12,7 +12,7 @@ import { NativeModules } from 'react-native';
 
 // setup bugsnag client to capture errors automatically
 import Bugsnag from '@bugsnag/react-native';
-Bugsnag.init();
+Bugsnag.start();
 
 function triggerException() {
   bogusFunction(); // eslint-disable-line no-undef

--- a/examples/reactnative/android/app/src/main/java/com/reactnative/MainApplication.java
+++ b/examples/reactnative/android/app/src/main/java/com/reactnative/MainApplication.java
@@ -47,7 +47,7 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     BugsnagReactNativePlugin.register();
-    Bugsnag.init(this);
+    Bugsnag.start(this);
     SoLoader.init(this, /* native exopackage */ false);
   }
 }

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    api 'com.bugsnag:bugsnag-android:4.22.999'
+    api 'com.bugsnag:bugsnag-android:4.22.1001'
     implementation 'com.facebook.react:react-native:+'
 
     androidTestImplementation "junit:junit:4.12"

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
@@ -29,7 +29,7 @@ public class ConfigSerializer implements WritableMapSerializer<ImmutableConfig> 
         }
 
         map.putString("buildUuid", config.getBuildUuid());
-        map.putBoolean("sendThreads", config.getSendThreads());
+        // map.putBoolean("sendThreads", config.getSendThreads());
         map.putBoolean("autoTrackSessions", config.getAutoTrackSessions());
         // map.putBoolean("detectAnrs", config.getDetectAnrs());
         // map.putBoolean("detectNdkCrashes", config.getDetectNdkCrashes());

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -70,9 +70,9 @@ const Bugsnag = {
       ? bugsnag.startSession()
       : bugsnag
   },
-  init: (opts) => {
+  start: (opts) => {
     if (Bugsnag._client) {
-      Bugsnag._client._logger.warn('Bugsnag.init() was called more than once. Ignoring.')
+      Bugsnag._client._logger.warn('Bugsnag.start() was called more than once. Ignoring.')
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
@@ -86,7 +86,7 @@ const Bugsnag = {
 Object.getOwnPropertyNames(Client.prototype).map((m) => {
   if (/^_/.test(m)) return
   Bugsnag[m] = function () {
-    if (!Bugsnag._client) return console.warn(`Bugsnag.${m}() was called before Bugsnag.init()`)
+    if (!Bugsnag._client) return console.warn(`Bugsnag.${m}() was called before Bugsnag.start()`)
     return Bugsnag._client[m].apply(Bugsnag._client, arguments)
   }
 })


### PR DESCRIPTION
- Renames the JS `init()` method to be `start()`.
- Updates the Android implementation to be compatible with the latest changes on the bugsnag-android `configuration-immutability-refactor` branch