### PR TITLE
feat(plugin-react-native-session): Test that all session methods defer to native client

### DIFF
--- a/packages/plugin-react-native-session/README.md
+++ b/packages/plugin-react-native-session/README.md
@@ -1,0 +1,6 @@
+# @bugsnag/plugin-react-native-session
+
+This plugin implements a session delegate which defers all session management to the underlying native platform. It is included in the React Native notifier.
+
+## License
+MIT

--- a/packages/plugin-react-native-session/test/session.test.js
+++ b/packages/plugin-react-native-session/test/session.test.js
@@ -7,20 +7,20 @@ describe('plugin: react native session', () => {
   it('adds missing methods and forwards calls to native client', () => {
     const NativeClient = {
       startSession: () => {},
-      stopSession: () => {},
+      pauseSession: () => {},
       resumeSession: () => {}
     }
 
     const startSpy = spyOn(NativeClient, 'startSession')
-    const stopSpy = spyOn(NativeClient, 'stopSession')
+    const pauseSpy = spyOn(NativeClient, 'pauseSession')
     const resumeSpy = spyOn(NativeClient, 'resumeSession')
 
     const c = new Client({ apiKey: 'api_key' })
     c.use(plugin, NativeClient)
     c.startSession()
     expect(startSpy).toHaveBeenCalledTimes(1)
-    c.stopSession()
-    expect(stopSpy).toHaveBeenCalledTimes(1)
+    c.pauseSession()
+    expect(pauseSpy).toHaveBeenCalledTimes(1)
     c.resumeSession()
     expect(resumeSpy).toHaveBeenCalledTimes(1)
   })

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -66,9 +66,7 @@ const Bugsnag = {
 
     bugsnag._logger.debug('Loaded!')
 
-    return bugsnag._config.autoTrackSessions
-      ? bugsnag.startSession()
-      : bugsnag
+    return bugsnag
   },
   start: (opts) => {
     if (Bugsnag._client) {


### PR DESCRIPTION
This plugin didn't need any implementation updates from the prototype. This PR:

- adds a readme
- updates the unit tests

I also removed the call to `startSession()` in the JS layer. If session tracking is enabled by default, a session will already have been started in the native layer and this would result in duplicate `startSession()` call.