### PR TITLE
feat(react-native): Remove unnecessary plugins

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    api 'com.bugsnag:bugsnag-android:4.22.1001'
+    api 'com.bugsnag:bugsnag-android:4.22.1002'
     implementation 'com.facebook.react:react-native:+'
 
     androidTestImplementation "junit:junit:4.12"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -70,12 +70,9 @@
     "@bugsnag/plugin-console-breadcrumbs": "7.0.0-alpha.1",
     "@bugsnag/plugin-network-breadcrumbs": "7.0.0-alpha.1",
     "@bugsnag/plugin-react": "7.0.0-alpha.1",
-    "@bugsnag/plugin-react-native-app-state-breadcrumbs": "7.0.0-alpha.1",
     "@bugsnag/plugin-react-native-client-sync": "7.0.0-alpha.1",
-    "@bugsnag/plugin-react-native-connectivity-breadcrumbs": "7.0.0-alpha.1",
     "@bugsnag/plugin-react-native-event-sync": "7.0.0-alpha.1",
     "@bugsnag/plugin-react-native-global-error-handler": "7.0.0-alpha.1",
-    "@bugsnag/plugin-react-native-orientation-breadcrumbs": "7.0.0-alpha.1",
     "@bugsnag/plugin-react-native-session": "7.0.0-alpha.1",
     "@bugsnag/plugin-react-native-unhandled-rejection": "7.0.0-alpha.1"
   }

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -23,18 +23,10 @@ const plugins = [
   require('@bugsnag/plugin-react-native-global-error-handler'),
   require('@bugsnag/plugin-react-native-unhandled-rejection'),
   require('@bugsnag/plugin-console-breadcrumbs'),
-  require('@bugsnag/plugin-network-breadcrumbs'),
-  require('@bugsnag/plugin-react-native-app-state-breadcrumbs'),
-  // require('@bugsnag/plugin-react-native-connectivity-breadcrumbs'),
-  require('@bugsnag/plugin-react-native-orientation-breadcrumbs')
+  require('@bugsnag/plugin-network-breadcrumbs')
 ]
 
 const bugsnagReact = require('@bugsnag/plugin-react')
-
-// The NetInfo module makes requests to this URL to detect if the device is connected
-// to the internet. We don't want these requests to be recorded as breadcrumbs.
-// see https://github.com/react-native-community/react-native-netinfo/blob/d39b18c61e220d518d8403b6f4f4ab5bcc8c973c/src/index.ts#L16
-const NET_INFO_REACHABILITY_URL = 'https://clients3.google.com/generate_204'
 
 const Bugsnag = {
   _client: null,
@@ -49,19 +41,7 @@ const Bugsnag = {
     bugsnag.use(eventSync, NativeClient)
     bugsnag.use(clientSync, NativeClient)
 
-    plugins.forEach(pl => {
-      switch (pl.name) {
-        case 'networkBreadcrumbs':
-          bugsnag.use(pl, () => [
-            bugsnag._config.endpoints.notify,
-            bugsnag._config.endpoints.sessions,
-            NET_INFO_REACHABILITY_URL
-          ])
-          break
-        default:
-          bugsnag.use(pl)
-      }
-    })
+    plugins.forEach(pl => bugsnag.use(pl))
     bugsnag.use(bugsnagReact, React)
 
     bugsnag._logger.debug('Loaded!')


### PR DESCRIPTION
The following plugins (which were built for Expo) implement functionality that already exists in the underlying native notifiers:

- `@bugsnag/plugin-react-native-connectivity-breadcrumbs`
- `@bugsnag/plugin-react-native-orientation-breadcrumbs`
- `@bugsnag/plugin-react-native-app-state-breadcrumbs`

They are therefore not needed as part of the React Native notifier, as they would result in duplicate breadcrumbs.