### PR TITLE
Chore (Node example app maintenance)

### DIFF
--- a/examples/plain-node/Dockerfile
+++ b/examples/plain-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 WORKDIR /usr/src/app
 

--- a/examples/plain-node/app.js
+++ b/examples/plain-node/app.js
@@ -26,9 +26,6 @@ console.log(`
   h = report a (h)andled error
     Creates a new error and reports it with a call to .notify(err).
 
-  l = (l)eave a breadcrumb
-    Calls the leaveBreadcrumb() method.
-
   b = calling notify with a (b)efore send callback
     Runs custom logic before a report is sent. This contrived example will
     pseudo-randomly prevent 50% of the reports from sending.
@@ -40,7 +37,7 @@ process.stdin.on('data', function (d) {
   switch (d) {
     case 'u': return unhandledError()
     case 'h': return handledError()
-    case 'l': return leaveBreadcrumb()
+    //case 'l': return leaveBreadcrumb()
     case 'b': return beforeSend()
     default: return unknown(d)
   }
@@ -62,6 +59,7 @@ function handledError () {
   bugsnagClient.notify(new Error('scheduling clash'))
 }
 
+// TODO Breadcrumbs not yet implemented for Node
 function leaveBreadcrumb () {
   console.log('leaving a breadcrumb…')
   // you can record all kinds of events which will be sent along with error reports

--- a/examples/typescript/Dockerfile
+++ b/examples/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 WORKDIR /usr/src/app
 

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "tsc",
-    "start": "node src/app.js"
+    "start": "npm run build && node src/app.js"
   },
   "dependencies": {
     "@bugsnag/core": "^5.0.0-alpha.1",

--- a/examples/typescript/src/app.ts
+++ b/examples/typescript/src/app.ts
@@ -28,9 +28,6 @@ console.log(`
   h = report a (h)andled error
     Creates a new error and reports it with a call to .notify(err).
 
-  l = (l)eave a breadcrumb
-    Calls the leaveBreadcrumb() method.
-
   b = calling notify with a (b)efore send callback
     Runs custom logic before a report is sent. This contrived example will
     pseudo-randomly prevent 50% of the reports from sending.
@@ -42,7 +39,7 @@ process.stdin.on('data', function (d: Buffer) {
   switch (str) {
     case 'u': return unhandledError()
     case 'h': return handledError()
-    case 'l': return leaveBreadcrumb()
+    //case 'l': return leaveBreadcrumb()
     case 'b': return beforeSend()
     default: return unknown(str)
   }
@@ -64,6 +61,7 @@ function handledError () {
   bugsnagClient.notify(new Error('scheduling clash'))
 }
 
+// TODO Breadcrumbs not yet implemented for Node
 function leaveBreadcrumb () {
   console.log('leaving a breadcrumb…')
   // you can record all kinds of events which will be sent along with error reports


### PR DESCRIPTION
- update example Node apps to latest version of Node
- remove manual breadcrumbs as not currently supported by Node
- resolve issue in typescript example where .ts was not transpiled