### PR TITLE
fix(delivery-x-domain-request): Fix incorrect "this" reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Changed
 
-- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696) 
+- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696)
+
+### Fixed
+
+- (delivery-x-domain-request): Correct `this`->`client` reference when attempting to log an error [#722](https://github.com/bugsnag/bugsnag-js/pull/722) 
 
 ## 6.5.1 (2020-01-08)
 

--- a/packages/delivery-x-domain-request/delivery.js
+++ b/packages/delivery-x-domain-request/delivery.js
@@ -29,7 +29,7 @@ module.exports = (client, win = window) => ({
       try {
         req.send(payload.session(session, client.config.filters))
       } catch (e) {
-        this._logger.error(e)
+        client._logger.error(e)
         cb(e)
       }
     }, 0)

--- a/packages/delivery-x-domain-request/test/delivery.test.js
+++ b/packages/delivery-x-domain-request/test/delivery.test.js
@@ -42,6 +42,30 @@ describe('delivery:XDomainRequest', () => {
     })
   })
 
+  it('calls back with an error when report sending fails', done => {
+    // mock XDomainRequest class
+    function XDomainRequest () {}
+    XDomainRequest.prototype.open = function (method, url) {
+      this.method = method
+      this.url = url
+    }
+    XDomainRequest.prototype.send = function (method, url) {
+      throw new Error('send error')
+    }
+    const window = { XDomainRequest, location: { protocol: 'https://' } }
+    const payload = { sample: 'payload' }
+    const config = {
+      apiKey: 'aaaaaaaa',
+      endpoints: { notify: '/echo/', sessions: '/sessions/' },
+      filters: []
+    }
+    delivery({ _logger: { error: () => {} }, config }, window).sendReport(payload, (err) => {
+      expect(err).not.toBe(null)
+      expect(err.message).toBe('send error')
+      done()
+    })
+  })
+
   it('sends sessions successfully', done => {
     const requests = []
 
@@ -77,6 +101,30 @@ describe('delivery:XDomainRequest', () => {
         /\/sessions\/\?apiKey=aaaaaaaa&payloadVersion=1&sentAt=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}\.\d{3}Z/
       )
       expect(requests[0].data).toBe(JSON.stringify(payload))
+      done()
+    })
+  })
+
+  it('calls back with an error when session sending fails', done => {
+    // mock XDomainRequest class
+    function XDomainRequest () {}
+    XDomainRequest.prototype.open = function (method, url) {
+      this.method = method
+      this.url = url
+    }
+    XDomainRequest.prototype.send = function (method, url) {
+      throw new Error('send error')
+    }
+    const window = { XDomainRequest, location: { protocol: 'https://' } }
+    const payload = { sample: 'payload' }
+    const config = {
+      apiKey: 'aaaaaaaa',
+      endpoints: { notify: '/echo/', sessions: '/sessions/' },
+      filters: []
+    }
+    delivery({ _logger: { error: () => {} }, config }, window).sendSession(payload, (err) => {
+      expect(err).not.toBe(null)
+      expect(err.message).toBe('send error')
       done()
     })
   })


### PR DESCRIPTION
Fix bad reference of `this` -> `client` when attempting to use the logger.