### PR TITLE
fix(core): Default configs to undefined instead of null

### DIFF
--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -11,14 +11,14 @@ module.exports.schema = {
     validate: stringWithLength
   },
   appVersion: {
-    defaultValue: () => null,
+    defaultValue: () => undefined,
     message: 'should be a string',
-    validate: value => value === null || stringWithLength(value)
+    validate: value => value === undefined || stringWithLength(value)
   },
   appType: {
-    defaultValue: () => null,
+    defaultValue: () => undefined,
     message: 'should be a string',
-    validate: value => value === null || stringWithLength(value)
+    validate: value => value === undefined || stringWithLength(value)
   },
   autoDetectErrors: {
     defaultValue: () => true,


### PR DESCRIPTION
The spec says that `appVersion` and `appType` should default to `null`.

Due to JSON serialisation rules (`null` is valid JSON so gets output), this results in the string `"null"` showing in the dashboard if neither of these config values are set by the developer.

I have revised my interpretation of `null` in the spec to mean loosely a `NothingType`, for which `undefined` is a satisfactory value. I've checked this over with @tomlongridge and he's happy with that.

Now these values default to `undefined`, which is not part of JSON, so get omitted during the serialisation process and only show in the dashboard if they are set by the developer.