### PR TITLE
Ensure web server plugins include request info for handled errors

### DIFF
--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -27,11 +27,13 @@ module.exports = {
       // extract request info and pass it to the relevant bugsnag properties
       const { request, metadata } = getRequestAndMetadataFromReq(req)
       requestClient.addMetadata('request', metadata)
+      requestClient.addOnError((event) => {
+        event.request = { ...event.request, ...request }
+      }, true)
 
       // unhandled errors caused by this request
       dom.on('error', (err) => {
         const event = client.Event.create(err, false, handledState, 'express middleware', 1)
-        event.request = request
         req.bugsnag._notify(event, () => {}, (e, event) => {
           if (e) client._logger.error('Failed to send event to Bugsnag')
           req.bugsnag._config.onUncaughtException(err, event, client._logger)

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -26,11 +26,13 @@ module.exports = {
       // extract request info and pass it to the relevant bugsnag properties
       const { request, metadata } = getRequestAndMetadataFromReq(req)
       requestClient.addMetadata('request', metadata)
+      requestClient.addOnError((event) => {
+        event.request = { ...event.request, ...request }
+      }, true)
 
       // unhandled errors caused by this request
       dom.on('error', (err) => {
         const event = client.Event.create(err, false, handledState, 'restify middleware', 1)
-        event.request = request
         req.bugsnag._notify(event, () => {}, (e, event) => {
           if (e) client._logger.error('Failed to send event to Bugsnag')
           req.bugsnag._config.onUncaughtException(err, event, client._logger)

--- a/test/node/features/express.feature
+++ b/test/node/features/express.feature
@@ -91,3 +91,17 @@ Scenario: throwing non-Error error
   And the exception "errorClass" equals "InvalidError"
   And the exception "message" matches "^express middleware received a non-error\."
   And the exception "type" equals "nodejs"
+
+Scenario: a handled error passed to req.bugsnag.notify()
+  Then I open the URL "http://express/handled"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "handled"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://express/handled"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -64,6 +64,11 @@ app.get('/throw-non-error', function (req, res, next) {
   throw 1 // eslint-disable-line
 })
 
+app.get('/handled', function (req, res, next) {
+  req.bugsnag.notify(new Error('handled'))
+  res.end('OK')
+})
+
 app.use(middleware.errorHandler)
 
 app.listen(80)

--- a/test/node/features/fixtures/koa-1x/scenarios/app.js
+++ b/test/node/features/fixtures/koa-1x/scenarios/app.js
@@ -49,6 +49,9 @@ app.use(function * (next) {
     this.throw(400, 'thrown')
   } else if (this.path === '/throw-non-error') {
     throw 'error' // eslint-disable-line
+  } else if (this.path === '/handled') {
+    this.bugsnag.notify(new Error('handled'))
+    yield next
   } else {
     yield next
   }

--- a/test/node/features/fixtures/koa/scenarios/app.js
+++ b/test/node/features/fixtures/koa/scenarios/app.js
@@ -51,6 +51,9 @@ app.use(async (ctx, next) => {
     ctx.throw(400, 'thrown')
   } else if (ctx.path === '/throw-non-error') {
     throw 'error' // eslint-disable-line
+  } else if (ctx.path === '/handled') {
+    ctx.bugsnag.notify(new Error('handled'))
+    await next()
   } else {
     await next()
   }

--- a/test/node/features/fixtures/restify/scenarios/app.js
+++ b/test/node/features/fixtures/restify/scenarios/app.js
@@ -75,6 +75,11 @@ server.get('/internal', function (req, res, next) {
   return next(err)
 })
 
+server.get('/handled', function (req, res, next) {
+  req.bugsnag.notify(new Error('handled'))
+  res.end('OK')
+})
+
 server.on('restifyError', middleware.errorHandler)
 
 server.listen(80)

--- a/test/node/features/koa-1x.feature
+++ b/test/node/features/koa-1x.feature
@@ -57,7 +57,21 @@ Scenario: throwing non-Error error
   And the exception "message" matches "^koa middleware received a non-error\."
   And the exception "type" equals "nodejs"
 
-Scenario: A non-5XX error created with with ctx.throw()
+Scenario: A non-5XX error created with ctx.throw()
   Then I open the URL "http://koa-1x/ctx-throw-400"
   And I wait for 1 second
   Then I should receive no requests
+
+Scenario: A handled error with ctx.bugsnag.notify()
+  Then I open the URL "http://koa-1x/handled"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "handled"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://koa-1x/handled"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -70,7 +70,21 @@ Scenario: throwing non-Error error
   And the exception "message" matches "^koa middleware received a non-error\."
   And the exception "type" equals "nodejs"
 
-Scenario: A non-5XX error created with with ctx.throw()
+Scenario: A non-5XX error created with ctx.throw()
   Then I open the URL "http://koa/ctx-throw-400"
   And I wait for 1 second
   Then I should receive no requests
+
+Scenario: A handled error with ctx.bugsnag.notify()
+  Then I open the URL "http://koa/handled"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "handled"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://koa/handled"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null

--- a/test/node/features/restify.feature
+++ b/test/node/features/restify.feature
@@ -73,3 +73,17 @@ Scenario: an explicit internal server error
   And the exception "message" equals "oh noes!"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+
+Scenario: a handled error passed to req.bugsnag.notify()
+  Then I open the URL "http://restify/handled"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "handled"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://restify/handled"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null


### PR DESCRIPTION
UAT revealed an issue where request data (and metadata) was not included for handled errors on web server frameworks.

This PR adds that data via `onError` callbacks scoped to the request client and adds tests to ensure the data is in the payload.