### PR TITLE
fix(plugin-expo-device): Correct device.{modelName->model} property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Add `getUser()` and `setUser()` methods to `Session` [#692](https://github.com/bugsnag/bugsnag-js/pull/692)
 - Ensure automatic context is not used when `setContext(null)` has been called [#694](https://github.com/bugsnag/bugsnag-js/pull/694)
 - Rename `filters` option to `redactedKeys` [#704](https://github.com/bugsnag/bugsnag-js/pull/704)
+- Rename `device.modelName` to `device.model` [#726](https://github.com/bugsnag/bugsnag-js/pull/726)
 
 ## 6.5.1 (2020-01-08)
 

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -24,7 +24,7 @@ module.exports = {
     const device = {
       id: Constants.installationId,
       manufacturer: Constants.platform.ios ? 'Apple' : undefined,
-      modelName: Constants.platform.ios ? Constants.platform.ios.model : undefined,
+      model: Constants.platform.ios ? Constants.platform.ios.model : undefined,
       modelNumber: Constants.platform.ios ? Constants.platform.ios.platform : undefined,
       osName: Platform.OS,
       osVersion: Constants.platform.ios ? Constants.platform.ios.systemVersion : Constants.systemVersion,

--- a/packages/plugin-expo-device/test/device.test.js
+++ b/packages/plugin-expo-device/test/device.test.js
@@ -91,6 +91,8 @@ describe('plugin: expo device', () => {
         const now = (new Date()).toISOString()
         expect(now >= r.events[0].device.time).toBe(true)
         expect(before <= r.events[0].device.time).toBe(true)
+        expect(r.events[0].device.model).toBe(IOS_MODEL)
+        expect(r.events[0].device.modelNumber).toBe(IOS_PLATFORM)
         expect(r.events[0].device.osName).toBe('ios')
         expect(r.events[0].device.osVersion).toBe(IOS_VERSION)
         expect(r.events[0].device.runtimeVersions).toEqual({


### PR DESCRIPTION
This property was not named as per the [Error Reporting API](https://bugsnagerrorreportingapi.docs.apiary.io/#reference/0/notify).