### PR TITLE
feat(browser): Integrate maxEvents functionality with new interface

### DIFF
--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -79,7 +79,7 @@ const Bugsnag = {
   }
 }
 
-map(keys(Client.prototype), (m) => {
+map(['resetEventCount'].concat(keys(Client.prototype)), (m) => {
   if (/^_/.test(m)) return
   Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.log(`Bugsnag.${m}() was called before Bugsnag.start()`)

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -68,6 +68,9 @@ declare class Client {
   public use(plugin: Plugin, ...args: any[]): Client;
   public getPlugin(name: string): any;
 
+  // implemented on the browser notifier only
+  public resetEventCount?(): void;
+
   // access to internal classes
   public Breadcrumb: typeof Breadcrumb;
   public Event: typeof Event;

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -59,8 +59,8 @@ const wrapHistoryFn = (client, target, fn, win) => {
   const orig = target[fn]
   target[fn] = (state, title, url) => {
     client.leaveBreadcrumb(`History ${fn}`, stateChangeToMetadata(win, state, title, url), 'navigation')
-    // if throttle plugin is in use, refresh the event sent count
-    if (typeof client.refresh === 'function') client.refresh()
+    // if throttle plugin is in use, reset the event sent count
+    if (typeof client.resetEventCount === 'function') client.resetEventCount()
     // if the client is operating in auto session-mode, a new route should trigger a new session
     if (client._config.autoTrackSessions) client.startSession()
     // Internet Explorer will convert `undefined` to a string when passed, causing an unintended redirect

--- a/packages/plugin-simple-throttle/README.md
+++ b/packages/plugin-simple-throttle/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a safety mechanism to prevent too many events being sent to Bugsnag, saving client bandwidth and error quotas using a simple threshold – i.e. do not send more than `n` events. It defines a configuration option `maxEvents` which can be used to customize the behaviour. It is included in the browser notifier.
 
-**Note:** to support long-lived browser applications, this plugin defines a `refresh()` function which gets called when the URL of the page changes. This resets the count, allowing new events to be sent.
+**Note:** to support long-lived browser applications, this plugin defines a `resetEventCount()` method on the client which gets called when the URL of the page changes. This resets the count, allowing new events to be sent.
 
 ## License
 MIT

--- a/packages/plugin-simple-throttle/throttle.js
+++ b/packages/plugin-simple-throttle/throttle.js
@@ -16,7 +16,7 @@ module.exports = {
       n++
     })
 
-    client.refresh = () => { n = 0 }
+    client.resetEventCount = () => { n = 0 }
   },
   configSchema: {
     maxEvents: {


### PR DESCRIPTION
- Ensure counts can be reset via the static interface as well as the client instance
- Rename `refresh`->`resetEventCount`
- Add method to type definitions