### PR TITLE
refactor: Keep timestamps as Date objects until serialisation

### DIFF
--- a/packages/core/breadcrumb.js
+++ b/packages/core/breadcrumb.js
@@ -1,7 +1,5 @@
-const { isoDate } = require('./lib/es-utils')
-
 class Breadcrumb {
-  constructor (message, metadata, type, timestamp = isoDate()) {
+  constructor (message, metadata, type, timestamp = new Date()) {
     this.type = type
     this.message = message
     this.metadata = metadata

--- a/packages/core/lib/es-utils.js
+++ b/packages/core/lib/es-utils.js
@@ -47,20 +47,4 @@ const keys = obj => {
 // Array#isArray
 const isArray = obj => Object.prototype.toString.call(obj) === '[object Array]'
 
-const _pad = n => n < 10 ? `0${n}` : n
-
-// Date#toISOString
-const isoDate = () => {
-  // from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
-  const d = new Date()
-  return d.getUTCFullYear() +
-    '-' + _pad(d.getUTCMonth() + 1) +
-    '-' + _pad(d.getUTCDate()) +
-    'T' + _pad(d.getUTCHours()) +
-    ':' + _pad(d.getUTCMinutes()) +
-    ':' + _pad(d.getUTCSeconds()) +
-    '.' + (d.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
-    'Z'
-}
-
-module.exports = { map, reduce, filter, includes, keys, isArray, isoDate }
+module.exports = { map, reduce, filter, includes, keys, isArray }

--- a/packages/core/session.js
+++ b/packages/core/session.js
@@ -1,10 +1,9 @@
-const { isoDate } = require('./lib/es-utils')
 const cuid = require('@bugsnag/cuid')
 
 class Session {
   constructor () {
     this.id = cuid()
-    this.startedAt = isoDate()
+    this.startedAt = new Date()
     this._handled = 0
     this._unhandled = 0
     this._user = {}

--- a/packages/core/test/breadcrumb.test.js
+++ b/packages/core/test/breadcrumb.test.js
@@ -5,7 +5,7 @@ const Breadcrumb = require('../breadcrumb')
 describe('@bugsnag/core/breadcrumb', () => {
   describe('toJSON()', () => {
     it('returns the correct data structure', () => {
-      const d = (new Date()).toISOString()
+      const d = new Date()
       expect(new Breadcrumb('artisan sourdough', {}, 'manual', d).toJSON()).toEqual({
         type: 'manual',
         name: 'artisan sourdough',

--- a/packages/core/test/session.test.js
+++ b/packages/core/test/session.test.js
@@ -7,7 +7,7 @@ describe('@bugsnag/core/session', () => {
     it('returns the correct data structure', () => {
       const s = new Session().toJSON()
       expect(typeof s.id).toBe('string')
-      expect(typeof s.startedAt).toBe('string')
+      expect(s.startedAt instanceof Date).toBe(true)
       expect(s.events).toEqual({ handled: 0, unhandled: 0 })
     })
   })

--- a/packages/core/types/breadcrumb.d.ts
+++ b/packages/core/types/breadcrumb.d.ts
@@ -4,7 +4,7 @@ declare class Breadcrumb {
   public message: string;
   public metadata: BreadcrumbMetadataValue;
   public type: BreadcrumbType;
-  public timestamp: string;
+  public timestamp: Date;
 }
 
 export default Breadcrumb

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -105,7 +105,7 @@ interface Device {
   runtimeVersions?: {
     [key: string]: any
   }
-  time?: string
+  time?: Date
   userAgent?: string
   [key: string]: any
 }

--- a/packages/core/types/session.d.ts
+++ b/packages/core/types/session.d.ts
@@ -1,7 +1,7 @@
 import { App, Device, User } from './common'
 
 declare class Session {
-  public startedAt: string;
+  public startedAt: Date;
   public id: string;
 
   public device?: Device;

--- a/packages/delivery-expo/delivery.js
+++ b/packages/delivery-expo/delivery.js
@@ -1,5 +1,4 @@
 const payload = require('@bugsnag/core/lib/json-payload')
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
 const UndeliveredPayloadQueue = require('./queue')
 const NetworkStatus = require('./network-status')
 const RedeliveryLoop = require('./redelivery')
@@ -48,7 +47,7 @@ module.exports = (client, fetch = global.fetch) => {
             'Content-Type': 'application/json',
             'Bugsnag-Api-Key': event.apiKey || client._config.apiKey,
             'Bugsnag-Payload-Version': '4',
-            'Bugsnag-Sent-At': isoDate()
+            'Bugsnag-Sent-At': (new Date()).toISOString()
           },
           body
         }
@@ -78,7 +77,7 @@ module.exports = (client, fetch = global.fetch) => {
             'Content-Type': 'application/json',
             'Bugsnag-Api-Key': client._config.apiKey,
             'Bugsnag-Payload-Version': '1',
-            'Bugsnag-Sent-At': isoDate()
+            'Bugsnag-Sent-At': (new Date()).toISOString()
           },
           body
         }

--- a/packages/delivery-node/delivery.js
+++ b/packages/delivery-node/delivery.js
@@ -1,5 +1,4 @@
 const payload = require('@bugsnag/core/lib/json-payload')
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
 const request = require('./request')
 
 module.exports = (client) => ({
@@ -16,7 +15,7 @@ module.exports = (client) => ({
           'Content-Type': 'application/json',
           'Bugsnag-Api-Key': event.apiKey || client._config.apiKey,
           'Bugsnag-Payload-Version': '4',
-          'Bugsnag-Sent-At': isoDate()
+          'Bugsnag-Sent-At': (new Date()).toISOString()
         },
         body: payload.event(event, client._config.redactedKeys),
         agent: client._config.agent
@@ -38,7 +37,7 @@ module.exports = (client) => ({
           'Content-Type': 'application/json',
           'Bugsnag-Api-Key': client._config.apiKey,
           'Bugsnag-Payload-Version': '1',
-          'Bugsnag-Sent-At': isoDate()
+          'Bugsnag-Sent-At': (new Date()).toISOString()
         },
         body: payload.session(session, client._config.redactedKeys),
         agent: client._config.agent

--- a/packages/delivery-x-domain-request/delivery.js
+++ b/packages/delivery-x-domain-request/delivery.js
@@ -1,5 +1,4 @@
 const payload = require('@bugsnag/core/lib/json-payload')
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = (client, win = window) => ({
   sendEvent: (event, cb = () => {}) => {
@@ -36,8 +35,11 @@ module.exports = (client, win = window) => ({
   }
 })
 
-const getApiUrl = (config, endpoint, version, win) =>
-  `${matchPageProtocol(config.endpoints[endpoint], win.location.protocol)}?apiKey=${encodeURIComponent(config.apiKey)}&payloadVersion=${version}&sentAt=${encodeURIComponent(isoDate())}`
+const getApiUrl = (config, endpoint, version, win) => {
+  const isoDate = JSON.parse(JSON.stringify(new Date()))
+  const url = matchPageProtocol(config.endpoints[endpoint], win.location.protocol)
+  return `${url}?apiKey=${encodeURIComponent(config.apiKey)}&payloadVersion=${version}&sentAt=${encodeURIComponent(isoDate)}`
+}
 
 const matchPageProtocol = module.exports._matchPageProtocol = (endpoint, pageProtocol) =>
   pageProtocol === 'http:'

--- a/packages/delivery-x-domain-request/delivery.js
+++ b/packages/delivery-x-domain-request/delivery.js
@@ -36,6 +36,9 @@ module.exports = (client, win = window) => ({
 })
 
 const getApiUrl = (config, endpoint, version, win) => {
+  // IE8 doesn't support Date.prototype.toISOstring(), but it does convert a date
+  // to an ISO string when you use JSON stringify. Simply parsing the result of
+  // JSON.stringify is smaller than using a toISOstring() polyfill.
   const isoDate = JSON.parse(JSON.stringify(new Date()))
   const url = matchPageProtocol(config.endpoints[endpoint], win.location.protocol)
   return `${url}?apiKey=${encodeURIComponent(config.apiKey)}&payloadVersion=${version}&sentAt=${encodeURIComponent(isoDate)}`

--- a/packages/delivery-xml-http-request/delivery.js
+++ b/packages/delivery-xml-http-request/delivery.js
@@ -1,5 +1,4 @@
 const payload = require('@bugsnag/core/lib/json-payload')
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
 
 module.exports = (client, win = window) => ({
   sendEvent: (event, cb = () => {}) => {
@@ -13,7 +12,7 @@ module.exports = (client, win = window) => ({
       req.setRequestHeader('Content-Type', 'application/json')
       req.setRequestHeader('Bugsnag-Api-Key', event.apiKey || client._config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '4')
-      req.setRequestHeader('Bugsnag-Sent-At', isoDate())
+      req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
       req.send(payload.event(event, client._config.redactedKeys))
     } catch (e) {
       client._logger.error(e)
@@ -30,7 +29,7 @@ module.exports = (client, win = window) => ({
       req.setRequestHeader('Content-Type', 'application/json')
       req.setRequestHeader('Bugsnag-Api-Key', client._config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '1')
-      req.setRequestHeader('Bugsnag-Sent-At', isoDate())
+      req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
       req.send(payload.session(session, client._config.redactedKeys))
     } catch (e) {
       client._logger.error(e)

--- a/packages/plugin-browser-device/device.js
+++ b/packages/plugin-browser-device/device.js
@@ -1,5 +1,3 @@
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
-
 /*
  * Automatically detects browser device details
  */
@@ -19,7 +17,7 @@ module.exports = {
       event.device = {
         ...event.device,
         ...device,
-        time: isoDate()
+        time: new Date()
       }
     }, true)
   }

--- a/packages/plugin-browser-device/test/device.test.js
+++ b/packages/plugin-browser-device/test/device.test.js
@@ -17,10 +17,9 @@ describe('plugin: device', () => {
     client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload) }))
     client.notify(new Error('noooo'))
 
-    const ISO_8601 = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
     expect(payloads.length).toEqual(1)
     expect(payloads[0].events[0].device).toBeDefined()
-    expect(payloads[0].events[0].device.time).toMatch(ISO_8601)
+    expect(payloads[0].events[0].device.time instanceof Date).toBe(true)
     expect(payloads[0].events[0].device.locale).toBe(navigator.browserLanguage)
     expect(payloads[0].events[0].device.userAgent).toBe(navigator.userAgent)
   })

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -1,6 +1,5 @@
 const Constants = require('expo-constants').default
 const { Dimensions, Platform } = require('react-native')
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
 const rnVersion = require('react-native/package.json').version
 
 module.exports = {
@@ -41,7 +40,7 @@ module.exports = {
     })
 
     client.addOnError(event => {
-      event.device = { ...event.device, time: isoDate(), orientation, ...device }
+      event.device = { ...event.device, time: new Date(), orientation, ...device }
       event.addMetadata('device', {
         isDevice: Constants.isDevice,
         appOwnership: Constants.appOwnership

--- a/packages/plugin-node-device/device.js
+++ b/packages/plugin-node-device/device.js
@@ -1,5 +1,3 @@
-const { isoDate } = require('@bugsnag/core/lib/es-utils')
-
 /*
  * Automatically detects browser device details
  */
@@ -19,7 +17,7 @@ module.exports = {
 
     // add time just as the event is sent
     client.addOnError((event) => {
-      event.device = { ...event.device, ...device, time: isoDate() }
+      event.device = { ...event.device, ...device, time: new Date() }
     }, true)
   }
 }

--- a/packages/plugin-node-device/test/device.test.js
+++ b/packages/plugin-node-device/test/device.test.js
@@ -11,7 +11,6 @@ const schema = {
     message: 'should be a string'
   }
 }
-const ISO_8601 = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i
 
 describe('plugin: node device', () => {
   it('should set device = { hostname, runtimeVersions } add an onError callback which adds device time', done => {
@@ -24,7 +23,7 @@ describe('plugin: node device', () => {
     client._setDelivery(client => ({
       sendEvent: (payload) => {
         expect(payload.events[0].device).toBeDefined()
-        expect(payload.events[0].device.time).toMatch(ISO_8601)
+        expect(payload.events[0].device.time instanceof Date).toBe(true)
         expect(payload.events[0].device.hostname).toBe('test-machine.local')
         expect(payload.events[0].device.runtimeVersions).toBeDefined()
         expect(payload.events[0].device.runtimeVersions.node).toEqual(process.versions.node)


### PR DESCRIPTION
As per the updated spec, ensures dates are instances of `Date` until they are serialised.

JSON serialises dates to `ISO8601` anyway, so anywhere dates are included in the body of the payload, the iso conversion now happens implicitly.

Where dates are used in headers, the conversion has to happen manually, but I found a terser way of doing this in IE8 (`JSON.parse(JSON.stringify(new Date()))` which meant we could ditch the `isoString()` function in `es-utils`. Hopefully this shaves a byte or two 🤞.