### PR TITLE
Enable better BrowserStack test naming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,12 @@ services:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
       APP_LOCATION:
       DEVICE_TYPE:
+      BUILDKITE_BRANCH:
+      BUILDKITE_PIPELINE_NAME:
+      BUILDKITE_RETRY_COUNT:
+      BUILDKITE:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_STEP_KEY:
     networks:
       default:
         aliases:


### PR DESCRIPTION
Enable various Buildkite environment variables to be passed through to maze-runner which will help with linking particular Buildkite jobs to BrowserStack runs.
In this case, only the app-automate service will have the new names, which is currently only utilised by the Expo maze tests.