### PR TITLE
Release v6.5.2

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -4,13 +4,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build: expo-publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
@@ -18,12 +18,12 @@ steps:
   - label: ':docker: Build expo maze runner image'
     timeout_in_minutes: 10
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build: expo-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
@@ -33,13 +33,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build: expo-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -51,7 +51,7 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           run: expo-publisher
 
   - wait
@@ -62,7 +62,7 @@ steps:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           run: expo-android-builder
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -84,7 +84,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -98,7 +98,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -114,7 +114,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -128,7 +128,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -142,7 +142,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -156,7 +156,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -170,7 +170,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:
@@ -184,7 +184,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: expo-maze-runner
         use-aliases: true
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: ':docker: Prepare package.json'
     timeout_in_minutes: 1
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           run: minimal-packager
     artifact_paths: min_packages.tar
 
@@ -13,14 +13,14 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
@@ -38,21 +38,21 @@ steps:
   - label: 'Lint'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: ci
     command: 'npm run test:lint'
 
   - label: 'Unit tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: ci
     command: 'npm run test:unit'
 
   - label: 'Type checks/tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: ci
     command: 'npm run test:types'
 
@@ -61,7 +61,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build:
             - browser-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
@@ -73,7 +73,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.1.0:
           build:
             - node-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
@@ -85,7 +85,7 @@ steps:
   - label: ':chrome: v43 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -96,7 +96,7 @@ steps:
   - label: ':chrome: v61 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -107,7 +107,7 @@ steps:
   - label: ':ie: v8 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -118,7 +118,7 @@ steps:
   - label: ':ie: v9 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -129,7 +129,7 @@ steps:
   - label: ':ie: v10 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -140,7 +140,7 @@ steps:
   - label: ':ie: v11 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -152,7 +152,7 @@ steps:
   - label: ':edge: v14 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -163,7 +163,7 @@ steps:
   - label: ':edge: v15 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -174,7 +174,7 @@ steps:
   - label: ':safari: v6 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -185,7 +185,7 @@ steps:
   - label: ':safari: v10 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -196,7 +196,7 @@ steps:
   - label: ':desktop_computer: Opera v12 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -207,7 +207,7 @@ steps:
   - label: ':iphone: iOS 10.3 Browser tests'
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -219,7 +219,7 @@ steps:
   - label: ':android: Samsung Galaxy S8 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -230,7 +230,7 @@ steps:
   - label: ':firefox: v30 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -241,7 +241,7 @@ steps:
   - label: ':firefox: v56 Browser tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: browser-maze-runner
         use-aliases: true
     env:
@@ -252,27 +252,27 @@ steps:
   - label: ':node: Node 4'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "webpack.feature"]
     env:
       NODE_VERSION: "4"
-    command: '-e koa.feature -e koa-1x.feature -e webpack.feature'
 
   - label: ':node: Node 6'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature"]
     env:
       NODE_VERSION: "6"
-    command: '-e koa.feature -e koa-1x.feature'
 
   - label: ':node: Node 8'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:
@@ -281,7 +281,7 @@ steps:
   - label: ':node: Node 10'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:
@@ -290,7 +290,7 @@ steps:
   - label: ':node: Node 12'
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v2.6.0:
+      docker-compose#v3.1.0:
         run: node-maze-runner
         use-aliases: true
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Changed
 
-- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696) 
+- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696)
+
+### Fixed
+
+- (delivery-x-domain-request): Correct `this`->`client` reference when attempting to log an error [#722](https://github.com/bugsnag/bugsnag-js/pull/722) 
 
 ## 6.5.1 (2020-01-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 6.5.2 (2020-02-05)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696) 
+
 ## 6.5.1 (2020-01-08)
 
 ### Fixed

--- a/examples/plain-node/Dockerfile
+++ b/examples/plain-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 WORKDIR /usr/src/app
 

--- a/examples/plain-node/app.js
+++ b/examples/plain-node/app.js
@@ -26,9 +26,6 @@ console.log(`
   h = report a (h)andled error
     Creates a new error and reports it with a call to .notify(err).
 
-  l = (l)eave a breadcrumb
-    Calls the leaveBreadcrumb() method.
-
   b = calling notify with a (b)efore send callback
     Runs custom logic before a report is sent. This contrived example will
     pseudo-randomly prevent 50% of the reports from sending.
@@ -40,7 +37,7 @@ process.stdin.on('data', function (d) {
   switch (d) {
     case 'u': return unhandledError()
     case 'h': return handledError()
-    case 'l': return leaveBreadcrumb()
+    //case 'l': return leaveBreadcrumb()
     case 'b': return beforeSend()
     default: return unknown(d)
   }
@@ -62,6 +59,7 @@ function handledError () {
   bugsnagClient.notify(new Error('scheduling clash'))
 }
 
+// TODO Breadcrumbs not yet implemented for Node
 function leaveBreadcrumb () {
   console.log('leaving a breadcrumb…')
   // you can record all kinds of events which will be sent along with error reports

--- a/examples/typescript/Dockerfile
+++ b/examples/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 WORKDIR /usr/src/app
 

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "tsc",
-    "start": "node src/app.js"
+    "start": "npm run build && node src/app.js"
   },
   "dependencies": {
     "@bugsnag/core": "^5.0.0-alpha.1",

--- a/examples/typescript/src/app.ts
+++ b/examples/typescript/src/app.ts
@@ -28,9 +28,6 @@ console.log(`
   h = report a (h)andled error
     Creates a new error and reports it with a call to .notify(err).
 
-  l = (l)eave a breadcrumb
-    Calls the leaveBreadcrumb() method.
-
   b = calling notify with a (b)efore send callback
     Runs custom logic before a report is sent. This contrived example will
     pseudo-randomly prevent 50% of the reports from sending.
@@ -42,7 +39,7 @@ process.stdin.on('data', function (d: Buffer) {
   switch (str) {
     case 'u': return unhandledError()
     case 'h': return handledError()
-    case 'l': return leaveBreadcrumb()
+    //case 'l': return leaveBreadcrumb()
     case 'b': return beforeSend()
     default: return unknown(str)
   }
@@ -64,6 +61,7 @@ function handledError () {
   bugsnagClient.notify(new Error('scheduling clash'))
 }
 
+// TODO Breadcrumbs not yet implemented for Node
 function leaveBreadcrumb () {
   console.log('leaving a breadcrumb…')
   // you can record all kinds of events which will be sent along with error reports

--- a/packages/delivery-x-domain-request/delivery.js
+++ b/packages/delivery-x-domain-request/delivery.js
@@ -29,7 +29,7 @@ module.exports = (client, win = window) => ({
       try {
         req.send(payload.session(session, client.config.filters))
       } catch (e) {
-        this._logger.error(e)
+        client._logger.error(e)
         cb(e)
       }
     }, 0)

--- a/packages/delivery-x-domain-request/test/delivery.test.js
+++ b/packages/delivery-x-domain-request/test/delivery.test.js
@@ -42,6 +42,30 @@ describe('delivery:XDomainRequest', () => {
     })
   })
 
+  it('calls back with an error when report sending fails', done => {
+    // mock XDomainRequest class
+    function XDomainRequest () {}
+    XDomainRequest.prototype.open = function (method, url) {
+      this.method = method
+      this.url = url
+    }
+    XDomainRequest.prototype.send = function (method, url) {
+      throw new Error('send error')
+    }
+    const window = { XDomainRequest, location: { protocol: 'https://' } }
+    const payload = { sample: 'payload' }
+    const config = {
+      apiKey: 'aaaaaaaa',
+      endpoints: { notify: '/echo/', sessions: '/sessions/' },
+      filters: []
+    }
+    delivery({ _logger: { error: () => {} }, config }, window).sendReport(payload, (err) => {
+      expect(err).not.toBe(null)
+      expect(err.message).toBe('send error')
+      done()
+    })
+  })
+
   it('sends sessions successfully', done => {
     const requests = []
 
@@ -77,6 +101,30 @@ describe('delivery:XDomainRequest', () => {
         /\/sessions\/\?apiKey=aaaaaaaa&payloadVersion=1&sentAt=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}\.\d{3}Z/
       )
       expect(requests[0].data).toBe(JSON.stringify(payload))
+      done()
+    })
+  })
+
+  it('calls back with an error when session sending fails', done => {
+    // mock XDomainRequest class
+    function XDomainRequest () {}
+    XDomainRequest.prototype.open = function (method, url) {
+      this.method = method
+      this.url = url
+    }
+    XDomainRequest.prototype.send = function (method, url) {
+      throw new Error('send error')
+    }
+    const window = { XDomainRequest, location: { protocol: 'https://' } }
+    const payload = { sample: 'payload' }
+    const config = {
+      apiKey: 'aaaaaaaa',
+      endpoints: { notify: '/echo/', sessions: '/sessions/' },
+      filters: []
+    }
+    delivery({ _logger: { error: () => {} }, config }, window).sendSession(payload, (err) => {
+      expect(err).not.toBe(null)
+      expect(err.message).toBe('send error')
       done()
     })
   })

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -3,6 +3,7 @@ const { reduce } = require('@bugsnag/core/lib/es-utils')
 const { stringWithLength } = require('@bugsnag/core/lib/validators')
 const os = require('os')
 const process = require('process')
+const { inspect } = require('util')
 
 module.exports = {
   projectRoot: {
@@ -30,7 +31,7 @@ module.exports = {
   },
   onUncaughtException: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Uncaught exception${getContext(report)}, the process will now terminate…\n${printError(err)}`)
       process.exit(1)
     },
     message: 'should be a function',
@@ -38,12 +39,14 @@ module.exports = {
   },
   onUnhandledRejection: {
     defaultValue: () => (err, report, logger) => {
-      logger.error(`Unhandled rejection${getContext(report)}…\n${(err && err.stack) ? err.stack : err}`)
+      logger.error(`Unhandled rejection${getContext(report)}…\n${printError(err)}`)
     },
     message: 'should be a function',
     validate: value => typeof value === 'function'
   }
 }
+
+const printError = err => err && err.stack ? err.stack : inspect(err)
 
 const getPrefixedConsole = () => {
   return reduce([ 'debug', 'info', 'warn', 'error' ], (accum, method) => {


### PR DESCRIPTION
### Changed

- (node): Use `util.inspect()` on plain object errors when logging their value [#696](https://github.com/bugsnag/bugsnag-js/pull/696)

### Fixed

- (delivery-x-domain-request): Correct `this`->`client` reference when attempting to log an error [#722](https://github.com/bugsnag/bugsnag-js/pull/722) 