### PR TITLE
Fix expo publish: Add top level node modules to watched folders

### DIFF
--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -15,6 +15,8 @@ RUN npx lerna run build --scope "@bugsnag/expo" --scope "@bugsnag/plugin-react"
 
 RUN npx lerna exec --scope "@bugsnag/plugin-react-native-unhandled-rejection" -- npm prune --production
 
+RUN rm -rf node_modules
+
 WORKDIR /app
 
 COPY test/expo test/expo

--- a/test/expo/features/fixtures/test-app/metro.config.js
+++ b/test/expo/features/fixtures/test-app/metro.config.js
@@ -2,16 +2,11 @@ const { resolve, join } = require('path')
 const { readdirSync } = require('fs')
 
 const pkgs = resolve(__dirname, '../../../../../packages')
-const mods = resolve(__dirname, '../../../../../node_modules')
 
 const watchFolders = [ __dirname, join(__dirname, 'node_modules') ]
   .concat(
     readdirSync(pkgs)
       .map(pkg => join(pkgs, pkg))
-  )
-  .concat(
-    readdirSync(mods)
-      .map(pkg => join(mods, pkg))
   )
 
 module.exports = {

--- a/test/expo/features/fixtures/test-app/metro.config.js
+++ b/test/expo/features/fixtures/test-app/metro.config.js
@@ -2,11 +2,16 @@ const { resolve, join } = require('path')
 const { readdirSync } = require('fs')
 
 const pkgs = resolve(__dirname, '../../../../../packages')
+const mods = resolve(__dirname, '../../../../../node_modules')
 
 const watchFolders = [ __dirname, join(__dirname, 'node_modules') ]
   .concat(
     readdirSync(pkgs)
       .map(pkg => join(pkgs, pkg))
+  )
+  .concat(
+    readdirSync(mods)
+      .map(pkg => join(mods, pkg))
   )
 
 module.exports = {


### PR DESCRIPTION
This fixes the issue with metro bundler being unable to hash the required to-level module `react-native`.

This fix may potentially be problematic, as it may introduce directories and modules into the expo test fixture that we may not want included.