### PR TITLE
Serialize android configuration in react-native bridge

### DIFF
--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.kt
@@ -2,6 +2,7 @@ package com.bugsnag.reactnative
 
 import com.bugsnag.android.Client
 import com.bugsnag.android.InternalHooks
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -29,7 +30,9 @@ class BugsnagReactNative(reactContext: ReactApplicationContext) :
 
         // TODO: I think we also want to return values for state here too:
         // i.e of user, context and metadata
-        return configSerializer.serialize(config)
+        val map = HashMap<String, Any?>()
+        configSerializer.serialize(map, config)
+        return map.toWritableMap()
     }
 
     override fun getName(): String {

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
@@ -24,7 +24,9 @@ public class ConfigSerializer implements WritableMapSerializer<ImmutableConfig> 
         map.put("enabledReleaseStages", config.getEnabledReleaseStages());
         map.put("releaseStage", config.getReleaseStage());
         map.put("buildUuid", config.getBuildUuid());
-        map.put("appVersion", config.getAppVersion());
+        if (config.getAppVersion() != null) {
+            map.put("appVersion", config.getAppVersion());
+        }
         map.put("versionCode", config.getVersionCode());
         map.put("codeBundleId", config.getCodeBundleId());
         map.put("type", config.getAppType());

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/ConfigSerializer.java
@@ -1,39 +1,66 @@
 package com.bugsnag.reactnative;
 
+import com.bugsnag.android.BreadcrumbType;
+import com.bugsnag.android.EndpointConfiguration;
+import com.bugsnag.android.ErrorTypes;
 import com.bugsnag.android.ImmutableConfig;
 
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class ConfigSerializer implements WritableMapSerializer<ImmutableConfig> {
 
     @Override
-    public WritableMap serialize(ImmutableConfig config) {
-        WritableMap map = new WritableNativeMap();
+    public void serialize(Map<String, Object> map, ImmutableConfig config) {
+        map.put("apiKey", config.getApiKey());
+        map.put("autoDetectErrors", config.getAutoDetectErrors());
+        map.put("autoTrackSessions", config.getAutoTrackSessions());
+        map.put("sendThreads", config.getSendThreads().toString());
+        map.put("discardClasses", config.getDiscardClasses());
+        map.put("projectPackages", config.getProjectPackages());
+        map.put("enabledReleaseStages", config.getEnabledReleaseStages());
+        map.put("releaseStage", config.getReleaseStage());
+        map.put("buildUuid", config.getBuildUuid());
+        map.put("appVersion", config.getAppVersion());
+        map.put("versionCode", config.getVersionCode());
+        map.put("codeBundleId", config.getCodeBundleId());
+        map.put("type", config.getAppType());
+        map.put("persistUser", config.getPersistUser());
+        map.put("launchCrashThresholdMs", (int) config.getLaunchCrashThresholdMs());
+        map.put("maxBreadcrumbs", config.getMaxBreadcrumbs());
+        map.put("enabledBreadcrumbTypes", serializeBreadrumbTypes(config));
+        map.put("enabledErrorTypes", serializeErrorTypes(config));
+        map.put("endpoints", serializeEndpoints(config));
+    }
 
-        WritableMap endpoints = new WritableNativeMap();
-        endpoints.putString("notify", config.getEndpoints().getNotify());
-        endpoints.putString("sessions", config.getEndpoints().getSessions());
-        map.putMap("endpoints", endpoints);
-
-        map.putString("apiKey", config.getApiKey());
-
-        String appVersion = config.getAppVersion();
-        if (appVersion != null) {
-            map.putString("appVersion", appVersion);
+    private Collection<String> serializeBreadrumbTypes(ImmutableConfig config) {
+        Collection<String> crumbTypes = new HashSet<>();
+        Set<BreadcrumbType> types = config.getEnabledBreadcrumbTypes();
+        if (types != null) {
+            for (BreadcrumbType type : types) {
+                crumbTypes.add(type.toString());
+            }
         }
+        return crumbTypes;
+    }
 
-        String releaseStage = config.getReleaseStage();
-        if (releaseStage != null) {
-            map.putString("releaseStage", releaseStage);
-        }
+    private Map<String, Object> serializeErrorTypes(ImmutableConfig config) {
+        Map<String, Object> map = new HashMap<>();
+        ErrorTypes errorTypes = config.getEnabledErrorTypes();
+        map.put("anrs", errorTypes.getAnrs());
+        map.put("ndkCrashes", errorTypes.getNdkCrashes());
+        map.put("unhandledExceptions", errorTypes.getUnhandledExceptions());
+        return map;
+    }
 
-        map.putString("buildUuid", config.getBuildUuid());
-        // map.putBoolean("sendThreads", config.getSendThreads());
-        map.putBoolean("autoTrackSessions", config.getAutoTrackSessions());
-        // map.putBoolean("detectAnrs", config.getDetectAnrs());
-        // map.putBoolean("detectNdkCrashes", config.getDetectNdkCrashes());
-
+    private Map<String, Object> serializeEndpoints(ImmutableConfig config) {
+        Map<String, Object> map = new HashMap<>();
+        EndpointConfiguration endpoints = config.getEndpoints();
+        map.put("notify", endpoints.getNotify());
+        map.put("sessions", endpoints.getSessions());
         return map;
     }
 }

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/MapExtensions.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/MapExtensions.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.reactnative
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.bridge.WritableNativeMap
+
+internal fun Map<String, Any?>.toWritableMap(): WritableMap {
+    val nativeMap = WritableNativeMap()
+
+    entries.forEach {
+        val key = it.key
+        when (val obj = it.value) {
+            null -> nativeMap.putNull(key)
+            is Boolean -> nativeMap.putBoolean(key, obj)
+            is Int -> nativeMap.putInt(key, obj)
+            is Number -> nativeMap.putDouble(key, obj as Double)
+            is String -> nativeMap.putString(key, obj)
+            is Map<*, *> -> nativeMap.putMap(key, Arguments.makeNativeMap(obj as MutableMap<String, Any>))
+            is Collection<*> ->  nativeMap.putArray(key, Arguments.makeNativeArray<Any>(obj.toTypedArray()))
+            else -> throw IllegalArgumentException("Could not convert $obj to native map")
+        }
+    }
+    return nativeMap
+}

--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/WritableMapSerializer.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/WritableMapSerializer.java
@@ -1,7 +1,7 @@
 package com.bugsnag.reactnative;
 
-import com.facebook.react.bridge.WritableMap;
+import java.util.Map;
 
 interface WritableMapSerializer<T> {
-    WritableMap serialize(T obj);
+    void serialize(Map<String, Object> map, T obj);
 }

--- a/packages/react-native/android/src/test/java/com/bugsnag/reactnative/ConfigSerializerTest.java
+++ b/packages/react-native/android/src/test/java/com/bugsnag/reactnative/ConfigSerializerTest.java
@@ -1,0 +1,91 @@
+package com.bugsnag.reactnative;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.android.BreadcrumbType;
+import com.bugsnag.android.DefaultDelivery;
+import com.bugsnag.android.EndpointConfiguration;
+import com.bugsnag.android.ErrorTypes;
+import com.bugsnag.android.ImmutableConfig;
+import com.bugsnag.android.NoopLogger;
+import com.bugsnag.android.Thread;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class ConfigSerializerTest {
+
+    private ImmutableConfig config;
+
+    /**
+     * Constructs an immutable config object
+     */
+    @Before
+    public void setUp() throws Exception {
+        config = new ImmutableConfig(
+                "123456abcdeabcde",
+                new ErrorTypes(),
+                true,
+                true,
+                Thread.ThreadSendPolicy.ALWAYS,
+                Collections.singleton("com.example.DiscardClass"),
+                Collections.singleton("production"),
+                Collections.singleton("com.example"),
+                new HashSet<>(Collections.singletonList(BreadcrumbType.MANUAL)),
+                "production",
+                "builduuid-123",
+                "1.4.3",
+                55,
+                "code-id-123",
+                "android",
+                new DefaultDelivery(null, NoopLogger.INSTANCE),
+                new EndpointConfiguration(),
+                true,
+                55,
+                NoopLogger.INSTANCE,
+                22
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void serialize() {
+        ConfigSerializer serializer = new ConfigSerializer();
+        Map<String, Object> map = new HashMap<>();
+        serializer.serialize(map, config);
+
+        assertEquals("123456abcdeabcde", map.get("apiKey"));
+        assertTrue((Boolean) map.get("autoDetectErrors"));
+        assertTrue((Boolean) map.get("autoTrackSessions"));
+        assertEquals("ALWAYS", map.get("sendThreads"));
+        assertEquals(Collections.singleton("com.example.DiscardClass"), map.get("discardClasses"));
+        assertEquals(Collections.singleton("production"), map.get("enabledReleaseStages"));
+        assertEquals(Collections.singleton("com.example"), map.get("projectPackages"));
+        assertEquals("production", map.get("releaseStage"));
+        assertEquals("builduuid-123", map.get("buildUuid"));
+        assertEquals("1.4.3", map.get("appVersion"));
+        assertEquals(55, map.get("versionCode"));
+        assertEquals("code-id-123", map.get("codeBundleId"));
+        assertEquals("android", map.get("type"));
+        assertTrue((Boolean) map.get("persistUser"));
+        assertEquals(55, map.get("launchCrashThresholdMs"));
+        assertEquals(22, map.get("maxBreadcrumbs"));
+        assertEquals(Collections.singleton("manual"), map.get("enabledBreadcrumbTypes"));
+
+        Map<String, Object> errorTypes = (Map<String, Object>) map.get("enabledErrorTypes");
+        assertTrue((Boolean) errorTypes.get("anrs"));
+        assertFalse((Boolean) errorTypes.get("ndkCrashes"));
+        assertTrue((Boolean) errorTypes.get("unhandledExceptions"));
+
+        Map<String, Object> endpoints = (Map<String, Object>) map.get("endpoints");
+        assertEquals("https://notify.bugsnag.com", endpoints.get("notify"));
+        assertEquals("https://sessions.bugsnag.com", endpoints.get("sessions"));
+    }
+}


### PR DESCRIPTION
## Goal
Serializes the Android configuration into a `WritableMap` that can be crossed across the RN bridge, for use by the JS notifier when it initialises.

This PR depends on #739 which has not yet been merged.

## Changeset

- Altered the `WritableMapSerializer` method to take a `Map` parameter rather than a `WritableNativeMap`. The `WritableNativeMap` relies on the Android framework and is therefore much harder to unit test.
- Added an [extension function](https://kotlinlang.org/docs/reference/extensions.html) that converts a `Map` into a `WritableNativeMap`, which reduces the surface area of code that interacts with React Native Java APIs.
- Updated `ConfigSerializer` to serialize all configuration options that might be needed by the JS layer.

## Tests

- Added unit test for the `ConfigSerializer` class
- Verified manually in an example app that bugsnag loads and is capable of sending a handled JS error. Note: you currently **must** alter the `releaseStage` serialized in `ConfigSerializer` to `"production"` as the JS layer incorrectly crashes when this is a null value.