### PR TITLE
fix(react-native): jsOpts may not be set

### DIFF
--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -39,8 +39,10 @@ const Bugsnag = {
     } else {
       // load the native configuration
       opts = Configuration.load()
-      // mutate the options with anything supplied in JS. This will throw
-      Object.keys(jsOpts).forEach(k => { opts[k] = jsOpts[k] })
+      if (jsOpts && typeof jsOpts === 'object') {
+        // mutate the options with anything supplied in JS. This will throw
+        Object.keys(jsOpts).forEach(k => { opts[k] = jsOpts[k] })
+      }
     }
 
     const bugsnag = new Client(opts, schema, { name, version, url })


### PR DESCRIPTION
Only iterate over `jsOpts` if it was an object.
It can be `undefined` when `Bugsnag.start()` is called with no arguments in JS (as in the example app).