### PR TITLE
refactor(core): Update breadcrumb metadata type to match implementation

### DIFF
--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -259,7 +259,6 @@ describe('@bugsnag/core/client', () => {
       expect(client._breadcrumbs.length).toBe(1)
       expect(client._breadcrumbs[0].type).toBe('error')
       expect(client._breadcrumbs[0].message).toBe('Error')
-      // @ts-ignore
       expect(client._breadcrumbs[0].metadata.stacktrace).toBe(undefined)
       // the error shouldn't appear as a breadcrumb for itself
       expect(payloads[0].events[0].breadcrumbs.length).toBe(0)

--- a/packages/core/types/breadcrumb.d.ts
+++ b/packages/core/types/breadcrumb.d.ts
@@ -1,8 +1,8 @@
-import { BreadcrumbType, BreadcrumbMetadataValue } from './common'
+import { BreadcrumbType } from './common'
 
 declare class Breadcrumb {
   public message: string;
-  public metadata: BreadcrumbMetadataValue;
+  public metadata: { [key: string]: any };
   public type: BreadcrumbType;
   public timestamp: Date;
 }

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -1,7 +1,6 @@
 import Breadcrumb from './breadcrumb'
 import {
   NotifiableError,
-  BreadcrumbMetadataValue,
   BreadcrumbType,
   Plugin,
   OnErrorCallback,
@@ -31,7 +30,7 @@ declare class Client {
   // breadcrumbs
   public leaveBreadcrumb(
     message: string,
-    metadata?: { [key: string]: BreadcrumbMetadataValue },
+    metadata?: { [key: string]: any },
     type?: BreadcrumbType
   ): void;
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -87,9 +87,6 @@ export type NotifiableError = Error
 | { name: string, message: string }
 | any;
 
-type Primitive = boolean | string | number | undefined | null;
-export type BreadcrumbMetadataValue = Primitive | Primitive[];
-
 export type BreadcrumbType = 'error' | 'log' | 'manual' | 'navigation' | 'process' | 'request' | 'state' | 'user';
 
 interface Device {


### PR DESCRIPTION
Breadcrumb metadata can be arbitrary depth. Removes the need for the temporary `@ts-ignore` annotation in the test.