### PR TITLE
Supporting leaving breadcrumb in react native android layer

### DIFF
--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.reactnative
 
+import com.bugsnag.android.BreadcrumbType
 import com.bugsnag.android.Client
 import com.bugsnag.android.InternalHooks
 import com.facebook.react.bridge.Arguments
@@ -10,6 +11,7 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
+import java.util.Locale
 
 class BugsnagReactNative(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
@@ -41,7 +43,11 @@ class BugsnagReactNative(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun leaveBreadcrumb(map: ReadableMap) {
-        client.leaveBreadcrumb("Breadcrumb from JS: TODO")
+        val msg = map.getString("message")!!
+        val type = BreadcrumbType.valueOf(map.getString("type")!!.toUpperCase(Locale.US))
+        val data = map.getMap("metadata")
+        val metadata: Map<String, Any?> = data?.toHashMap() ?: emptyMap()
+        client.leaveBreadcrumb(msg, type, metadata)
     }
 
     @ReactMethod

--- a/packages/react-native/android/src/test/java/com/bugsnag/reactnative/LeaveBreadcrumbTest.kt
+++ b/packages/react-native/android/src/test/java/com/bugsnag/reactnative/LeaveBreadcrumbTest.kt
@@ -1,0 +1,79 @@
+package com.bugsnag.reactnative
+
+import com.bugsnag.android.BreadcrumbType
+import com.bugsnag.android.Client
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class LeaveBreadcrumbTest {
+
+    @Mock
+    lateinit var ctx: ReactApplicationContext
+
+    @Mock
+    lateinit var client: Client
+
+    @Mock
+    lateinit var crumbMap: ReadableMap
+
+    @Mock
+    lateinit var metadataMap: ReadableMap
+
+    private lateinit var brn: BugsnagReactNative
+
+    @Before
+    fun setUp() {
+        brn = BugsnagReactNative(ctx)
+        brn.client = client
+    }
+
+    @Test
+    fun leaveBreadcrumb() {
+        // setup breadcrumb data
+        `when`(crumbMap.getString("message")).thenReturn("JS: invoked API")
+        `when`(crumbMap.getString("type")).thenReturn("request")
+        `when`(crumbMap.getMap("metadata")).thenReturn(metadataMap)
+
+        // setup metadata
+        val metadata: HashMap<String, Any?> = hashMapOf(
+            "customFoo" to "Flobber",
+            "isJs" to true,
+            "naughtyValue" to null
+        )
+        `when`(metadataMap.toHashMap()).thenReturn(metadata)
+
+        // leave a breadcrumb and verify its structure
+        brn.leaveBreadcrumb(crumbMap)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("JS: invoked API"),
+            eq(BreadcrumbType.REQUEST),
+            eq(metadata)
+        )
+    }
+
+    @Test
+    fun leaveBreadcrumbNoMetadata() {
+        // leave a breadcrumb and verify its structure
+        `when`(crumbMap.getString("message")).thenReturn("JS: invoked API")
+        `when`(crumbMap.getString("type")).thenReturn("request")
+        `when`(crumbMap.getMap("metadata")).thenReturn(null)
+        brn.leaveBreadcrumb(crumbMap)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("JS: invoked API"),
+            eq(BreadcrumbType.REQUEST),
+            eq(emptyMap())
+        )
+    }
+}


### PR DESCRIPTION
## Goal

When the JS bridge calls `leaveBreadcrumb` on `BugsnagReactNative` an Android breadcrumb should be added. 

## Changeset

Called `Client#leaveBreadcrumb` with the message, type, and metadata passed from the JS layer. This records the breadcrumb on the Android layer.

## Tests

Added a unit test that verifies `leaveBreadcrumb` calls the appropriate method on `Client` when invoked with the right parameters in a `ReadableMap`.