### PR TITLE
Support updating metadata in react native android layer

### DIFF
--- a/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/reactnative/BugsnagReactNative.kt
@@ -61,8 +61,11 @@ class BugsnagReactNative(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun updateMetadata(section: String, data: ReadableMap) {
-        client.addMetadata(section, "TODO", "metadata update from js")
+    fun updateMetadata(section: String, data: ReadableMap?) {
+        when (data) {
+            null -> client.clearMetadata(section)
+            else -> client.addMetadata(section, data.toHashMap())
+        }
     }
 
     @ReactMethod

--- a/packages/react-native/android/src/test/java/com/bugsnag/reactnative/UpdateMetadataTest.kt
+++ b/packages/react-native/android/src/test/java/com/bugsnag/reactnative/UpdateMetadataTest.kt
@@ -1,0 +1,54 @@
+package com.bugsnag.reactnative
+
+import com.bugsnag.android.Client
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdateMetadataTest {
+
+    @Mock
+    lateinit var ctx: ReactApplicationContext
+
+    @Mock
+    lateinit var client: Client
+
+    @Mock
+    lateinit var map: ReadableMap
+
+    private lateinit var brn: BugsnagReactNative
+
+    @Before
+    fun setUp() {
+        brn = BugsnagReactNative(ctx)
+        brn.client = client
+    }
+
+    @Test
+    fun nullMetadataRemovesSection() {
+        brn.updateMetadata("foo", null)
+        verify(client, times(1)).clearMetadata("foo")
+    }
+
+    @Test
+    fun metadataAddSection() {
+        val data: HashMap<String, Any?> = hashMapOf(
+            "customFoo" to "Flobber",
+            "isJs" to true,
+            "naughtyValue" to null
+        )
+        `when`(map.toHashMap()).thenReturn(data)
+
+        brn.updateMetadata("foo", map)
+        verify(client, times(1)).addMetadata("foo", data)
+    }
+}


### PR DESCRIPTION
## Goal

When the JS bridge calls `updateMetadata` on `BugsnagReactNative` the native metadata should be removed if the section is `null`, or added if the map is not null.

## Changeset

Called `Client#addMetadata` and `Client#clearMetadata` depending on the `ReadableMap` parameter value. This updates the metadata stored in the Android layer.

## Tests

Added a unit test that verifies the appropriate method is called on `Client` for both scenarios.