### PR TITLE
Update getPayloadInfo() to take boolean param

### DIFF
--- a/examples/reactnative/android/app/src/main/java/com/reactnative/MainApplication.java
+++ b/examples/reactnative/android/app/src/main/java/com/reactnative/MainApplication.java
@@ -3,7 +3,7 @@ package com.reactnative;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
-import com.bugsnag.reactnative.BugsnagPackage;
+import com.bugsnag.android.BugsnagPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -46,7 +46,6 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
-    BugsnagReactNativePlugin.register();
     Bugsnag.start(this);
     SoLoader.init(this, /* native exopackage */ false);
   }

--- a/packages/plugin-react-native-event-sync/event-sync.js
+++ b/packages/plugin-react-native-event-sync/event-sync.js
@@ -6,7 +6,7 @@ module.exports = {
         breadcrumbs,
         app,
         device
-      } = await NativeClient.getPayloadInfo()
+      } = await NativeClient.getPayloadInfo({ unhandled: event.unhandled })
 
       event.breadcrumbs = breadcrumbs
       event.app = { ...event.app, ...app }

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
@@ -109,9 +109,10 @@ class BugsnagReactNative(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun getPayloadInfo(promise: Promise) {
+    private fun getPayloadInfo(payload: ReadableMap, promise: Promise) {
         try {
-            val info = plugin.getPayloadInfo()
+            val unhandled = payload.getBoolean("unhandled")
+            val info = plugin.getPayloadInfo(unhandled)
             promise.resolve(Arguments.makeNativeMap(info))
         } catch (exc: Throwable) {
             logFailure("getPayloadInfo", exc)

--- a/packages/react-native/android/src/test/java/com/bugsnag/android/BugsnagReactNativeTest.kt
+++ b/packages/react-native/android/src/test/java/com/bugsnag/android/BugsnagReactNativeTest.kt
@@ -88,7 +88,7 @@ class BugsnagReactNativeTest {
 
     @Test
     fun getPayloadInfo() {
-        brn.getPayloadInfo(promise)
+        brn.getPayloadInfo(map, promise)
         verify(plugin, times(1)).getPayloadInfo()
     }
 }


### PR DESCRIPTION
`getPayloadInfo()` needs to take a boolean parameter to indicate the handledState, so that the native layer can determine whether to collect a thread trace or not.

This change updates the JS layer to pass in the `event.unhandled` value in a map, and updates `BugsnagReactNative` to pass this value into the plugin.

Verified by testing an example app manually with and without the change and ensuring an error was only sent when both changes were in place.