### PR TITLE
refactor(core): Ensure leaveBreadcrumb() allows any type

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -11,6 +11,7 @@ const assign = require('./lib/es-utils/assign')
 const runCallbacks = require('./lib/callback-runner')
 const metadataDelegate = require('./lib/metadata-delegate')
 const runSyncCallbacks = require('./lib/sync-callback-runner')
+const BREADCRUMB_TYPES = require('./lib/breadcrumb-types')
 
 const noop = () => {}
 
@@ -227,14 +228,11 @@ class Client {
   leaveBreadcrumb (message, metadata, type) {
     // coerce bad values so that the defaults get set
     message = typeof message === 'string' ? message : ''
-    type = typeof type === 'string' ? type : 'manual'
+    type = (typeof type === 'string' && includes(BREADCRUMB_TYPES, type)) ? type : 'manual'
     metadata = typeof metadata === 'object' && metadata !== null ? metadata : {}
 
     // if no message, discard
     if (!message) return
-
-    // check the breadcrumb is the list of enabled types
-    if (!this._config.enabledBreadcrumbTypes || !includes(this._config.enabledBreadcrumbTypes, type)) return
 
     const crumb = new Breadcrumb(message, metadata, type)
 

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -8,7 +8,7 @@ const intRange = require('./lib/validators/int-range')
 const stringWithLength = require('./lib/validators/string-with-length')
 const listOfFunctions = require('./lib/validators/list-of-functions')
 
-const BREADCRUMB_TYPES = ['navigation', 'request', 'process', 'log', 'user', 'state', 'error', 'manual']
+const BREADCRUMB_TYPES = require('./lib/breadcrumb-types')
 const defaultErrorTypes = { unhandledExceptions: true, unhandledRejections: true }
 
 module.exports.schema = {

--- a/packages/core/lib/breadcrumb-types.js
+++ b/packages/core/lib/breadcrumb-types.js
@@ -1,0 +1,1 @@
+module.exports = ['navigation', 'request', 'process', 'log', 'user', 'state', 'error', 'manual']

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -435,6 +435,7 @@ describe('@bugsnag/core/client', () => {
       const client = new Client({
         apiKey: 'API_KEY_YEAH'
       })
+      // @ts-ignore
       client.leaveBreadcrumb('GET /jim', {}, 'requeeest')
       expect(client._breadcrumbs.length).toBe(1)
       expect(client._breadcrumbs[0].type).toBe('manual')

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -431,15 +431,13 @@ describe('@bugsnag/core/client', () => {
       expect(client._breadcrumbs.length).toBe(1)
     })
 
-    it('ignores breadcrumb types that aren’t in the enabled list', () => {
+    it('coerces breadcrumb types that aren’t valid to "manual"', () => {
       const client = new Client({
-        apiKey: 'API_KEY_YEAH',
-        enabledBreadcrumbTypes: ['manual']
+        apiKey: 'API_KEY_YEAH'
       })
-      client.leaveBreadcrumb('brrrrr')
-      client.leaveBreadcrumb('GET /jim', {}, 'request')
+      client.leaveBreadcrumb('GET /jim', {}, 'requeeest')
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0].message).toBe('brrrrr')
+      expect(client._breadcrumbs[0].type).toBe('manual')
     })
   })
 


### PR DESCRIPTION
- the restriction on type is lifted from `leaveBreadcrumb()`
- bad values for type are coreced into `"manual"`