### PR TITLE
fix(core): Ensure enabledErrorTypes option is extended and validated correctly

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -110,7 +110,11 @@ class Client {
           accum.errors[key] = schema[key].message
           accum.config[key] = defaultValue
         } else {
-          accum.config[key] = opts[key]
+          if (schema[key].allowPartialObject) {
+            accum.config[key] = assign(defaultValue, opts[key])
+          } else {
+            accum.config[key] = opts[key]
+          }
         }
       } else {
         accum.config[key] = defaultValue

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -8,7 +8,7 @@ const stringWithLength = require('./lib/validators/string-with-length')
 const listOfFunctions = require('./lib/validators/list-of-functions')
 
 const BREADCRUMB_TYPES = ['navigation', 'request', 'process', 'log', 'user', 'state', 'error', 'manual']
-const defaultErrorTypes = { unhandledExceptions: true, unhandledRejections: true }
+const defaultErrorTypes = () => ({ unhandledExceptions: true, unhandledRejections: true })
 
 module.exports.schema = {
   apiKey: {
@@ -32,14 +32,14 @@ module.exports.schema = {
     validate: value => value === true || value === false
   },
   enabledErrorTypes: {
-    defaultValue: () => defaultErrorTypes,
+    defaultValue: () => defaultErrorTypes(),
     message: 'should be an object containing the flags { unhandledExceptions:true|false, unhandledRejections:true|false }',
     allowPartialObject: true,
     validate: value => {
       // ensure we have an object
       if (typeof value !== 'object' || !value) return false
       const providedKeys = keys(value)
-      const defaultKeys = keys(defaultErrorTypes)
+      const defaultKeys = keys(defaultErrorTypes())
       // ensure it only has a subset of the allowed keys
       if (filter(providedKeys, k => includes(defaultKeys, k)).length < providedKeys.length) return false
       // ensure all of the values are boolean

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -3,7 +3,6 @@ const reduce = require('./lib/es-utils/reduce')
 const keys = require('./lib/es-utils/keys')
 const isArray = require('./lib/es-utils/is-array')
 const includes = require('./lib/es-utils/includes')
-const assign = require('./lib/es-utils/assign')
 const intRange = require('./lib/validators/int-range')
 const stringWithLength = require('./lib/validators/string-with-length')
 const listOfFunctions = require('./lib/validators/list-of-functions')
@@ -33,15 +32,18 @@ module.exports.schema = {
     validate: value => value === true || value === false
   },
   enabledErrorTypes: {
-    defaultValue: (val) => assign({}, defaultErrorTypes, val),
+    defaultValue: () => defaultErrorTypes,
     message: 'should be an object containing the flags { unhandledExceptions:true|false, unhandledRejections:true|false }',
+    allowPartialObject: true,
     validate: value => {
       // ensure we have an object
       if (typeof value !== 'object' || !value) return false
+      const providedKeys = keys(value)
+      const defaultKeys = keys(defaultErrorTypes)
       // ensure it only has a subset of the allowed keys
-      if (keys(value).sort().join(',') !== keys(defaultErrorTypes).sort().join(',')) return false
+      if (filter(providedKeys, k => includes(defaultKeys, k)).length < providedKeys.length) return false
       // ensure all of the values are boolean
-      if (filter(keys(value), k => typeof value[k] === 'boolean').length === keys.length) return false
+      if (filter(keys(value), k => typeof value[k] !== 'boolean').length > 0) return false
       return true
     }
   },

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -25,6 +25,17 @@ describe('@bugsnag/core/client', () => {
       const client = new Client({ apiKey: 'API_KEY_YEAH' })
       expect(client._config.apiKey).toBe('API_KEY_YEAH')
     })
+
+    it('extends partial options', () => {
+      const client = new Client({
+        apiKey: 'API_KEY',
+        enabledErrorTypes: { unhandledExceptions: false }
+      })
+      expect(client._config.enabledErrorTypes).toEqual({
+        unhandledExceptions: false,
+        unhandledRejections: true
+      })
+    })
   })
 
   describe('use()', () => {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -23,4 +23,25 @@ describe('@bugsnag/core/config', () => {
       expect(enabledBreadcrumbTypesValidator(['UNKNOWN_BREADCRUMB_TYPE'])).toBe(false)
     })
   })
+
+  describe('enabledErrorTypes', () => {
+    it('is ok with an empty object', () => {
+      const enabledErrorTypesValidator = config.schema.enabledErrorTypes.validate
+      expect(enabledErrorTypesValidator({})).toBe(true)
+    })
+
+    it('works with a subset of error types', () => {
+      const enabledErrorTypesValidator = config.schema.enabledErrorTypes.validate
+      expect(enabledErrorTypesValidator({ unhandledExceptions: true })).toBe(true)
+    })
+
+    it('fails when an additional unsupported type is provided', () => {
+      const enabledErrorTypesValidator = config.schema.enabledErrorTypes.validate
+      expect(enabledErrorTypesValidator({
+        unhandledExceptions: true,
+        unhandledRejections: false,
+        unwantedDistractions: true
+      })).toBe(false)
+    })
+  })
 })

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -9,8 +9,8 @@ export interface Config {
   appType?: string
   autoDetectErrors?: boolean
   enabledErrorTypes?: {
-    unhandledExceptions: boolean
-    unhandledRejections: boolean
+    unhandledExceptions?: boolean
+    unhandledRejections?: boolean
   }
   autoTrackSessions?: boolean
   context?: string


### PR DESCRIPTION
Fixes an issue where this option wasn't properly extending the provided input with the defaults. Also fixes an issue validating that all of the values are boolean.