### PR TITLE
RN: Support setting codeBundleId in JS config

### DIFF
--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -20,7 +20,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "7.0.0-rc.1",
+    "@bugsnag/core": "7.0.0-rc.2",
     "proxyquire": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -20,7 +20,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "7.0.0-rc.1"
+    "@bugsnag/core": "7.0.0-rc.2"
   },
   "devDependencies": {
     "jasmine": "3.1.0",

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
@@ -65,6 +65,15 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    private fun updateCodeBundleId(id: String?) {
+        try {
+            plugin.updateCodeBundleId(id)
+        } catch (exc: Throwable) {
+            logFailure("updateCodeBundleId", exc)
+        }
+    }
+
+    @ReactMethod
     private fun leaveBreadcrumb(map: ReadableMap) {
         try {
             plugin.leaveBreadcrumb(map.toHashMap())

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -67,15 +67,15 @@
     "typescript": "^3.3.3"
   },
   "dependencies": {
-    "@bugsnag/core": "7.0.0-rc.1",
+    "@bugsnag/core": "7.0.0-rc.2",
     "@bugsnag/delivery-react-native": "7.0.0-alpha.1",
-    "@bugsnag/plugin-console-breadcrumbs": "7.0.0-rc.1",
-    "@bugsnag/plugin-network-breadcrumbs": "7.0.0-rc.1",
+    "@bugsnag/plugin-console-breadcrumbs": "7.0.0-rc.2",
+    "@bugsnag/plugin-network-breadcrumbs": "7.0.0-rc.2",
     "@bugsnag/plugin-react": "7.0.0-rc.0",
     "@bugsnag/plugin-react-native-client-sync": "7.0.0-alpha.1",
     "@bugsnag/plugin-react-native-event-sync": "7.0.0-alpha.1",
-    "@bugsnag/plugin-react-native-global-error-handler": "7.0.0-rc.1",
+    "@bugsnag/plugin-react-native-global-error-handler": "7.0.0-rc.2",
     "@bugsnag/plugin-react-native-session": "7.0.0-alpha.1",
-    "@bugsnag/plugin-react-native-unhandled-rejection": "7.0.0-rc.1"
+    "@bugsnag/plugin-react-native-unhandled-rejection": "7.0.0-rc.2"
   }
 }

--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -1,4 +1,5 @@
 const { schema } = require('@bugsnag/core/config')
+const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 
 const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context']
 
@@ -35,13 +36,15 @@ const freeze = opts => {
   return new Proxy(opts, {
     set (obj, prop, value) {
       if (!ALLOWED_IN_JS.includes(prop)) {
-        throw new Error(`[bugsnag] Cannot set "${prop}" configuration option in JS. This must be set in the native layer.`)
+        console.warn(new Error(`[bugsnag] Cannot set "${prop}" configuration option in JS. This must be set in the native layer.`))
+        return
       }
       return Reflect.set(...arguments)
     },
     deleteProperty (target, prop) {
       if (!ALLOWED_IN_JS.includes(prop)) {
-        throw new Error(`[bugsnag] Cannot delete "${prop}" configuration option in JS. This must be set in the native layer.`)
+        console.warn(new Error(`[bugsnag] Cannot delete "${prop}" configuration option in JS. This must be set in the native layer.`))
+        return
       }
       return Reflect.deleteProperty(...arguments)
     }

--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -1,13 +1,18 @@
 const { schema } = require('@bugsnag/core/config')
 const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 
-const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context']
+const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId']
 
 module.exports.schema = {
   ...schema,
   logger: {
     ...schema.logger,
     defaultValue: () => getPrefixedConsole()
+  },
+  codeBundleId: {
+    defaultValue: () => null,
+    message: 'should be a string',
+    validate: val => (val === null || stringWithLength(val))
   }
 }
 

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -62,6 +62,10 @@ const Bugsnag = {
       Object.keys(opts.metadata).forEach(k => bugsnag.addMetadata(k, opts.metadata[k]))
     }
 
+    if (opts.codeBundleId) {
+      NativeClient.updateCodeBundleId(opts.codeBundleId)
+    }
+
     bugsnag._logger.debug('Loaded!')
 
     return bugsnag

--- a/packages/react-native/src/test/config.test.ts
+++ b/packages/react-native/src/test/config.test.ts
@@ -22,20 +22,22 @@ describe('react-native config: load()', () => {
     }).toThrow(/Configuration could not be loaded from native client/)
   })
 
-  it('should throw if the user attempts to modify native config', () => {
+  it('should warn if the user attempts to modify native config', () => {
+    const warnSpy = jest.fn()
     const mockNativeClient = {
       configure: () => ({
         apiKey: '123',
         autoDetectErrors: true
       })
     }
-    expect(() => {
-      const config = load(mockNativeClient)
-      config.apiKey = '456'
-    }).toThrow(/Cannot set "apiKey" configuration option in JS. This must be set in the native layer./)
-    expect(() => {
-      const config = load(mockNativeClient)
-      config.autoDetectErrors = false
-    }).toThrow(/Cannot set "autoDetectErrors" configuration option in JS. This must be set in the native layer./)
+
+    const config = load(mockNativeClient, warnSpy)
+
+    config.apiKey = '456'
+    config.autoDetectErrors = false
+
+    expect(warnSpy.mock.calls.length).toBe(2)
+    expect(warnSpy.mock.calls[0][0]).toMatch(/Cannot set "apiKey" configuration option in JS. This must be set in the native layer./)
+    expect(warnSpy.mock.calls[1][0]).toMatch(/Cannot set "autoDetectErrors" configuration option in JS. This must be set in the native layer./)
   })
 })


### PR DESCRIPTION
Adds `codeBundleId` to the JS config schema, and if it is set, passes it through to the native layer.