### PR TITLE
CI: Update Expo Android Builder to use Node 12

### DIFF
--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -2,7 +2,7 @@ FROM openjdk:8-jdk-stretch
 
 RUN apt-get update
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 


### PR DESCRIPTION
Updates Expo Android builder image to use Node 12, resolving dependency installation issues.