### PR TITLE
RN: Support native error types being passed to JS config

### DIFF
--- a/packages/react-native/src/test/config.test.ts
+++ b/packages/react-native/src/test/config.test.ts
@@ -1,4 +1,4 @@
-import { load } from '../config'
+import { load, schema } from '../config'
 
 describe('react-native config: load()', () => {
   it('should load config from the provided NativeClient', () => {
@@ -39,5 +39,22 @@ describe('react-native config: load()', () => {
     expect(warnSpy.mock.calls.length).toBe(2)
     expect(warnSpy.mock.calls[0][0]).toMatch(/Cannot set "apiKey" configuration option in JS. This must be set in the native layer./)
     expect(warnSpy.mock.calls[1][0]).toMatch(/Cannot set "autoDetectErrors" configuration option in JS. This must be set in the native layer./)
+  })
+
+  it('supports native error types', () => {
+    expect(schema.enabledErrorTypes.validate({
+      unhandledExceptions: true,
+      unhandledRejections: true,
+      ndkCrashes: true,
+      anrs: false,
+      ooms: true
+    })).toBe(true)
+    expect(schema.enabledErrorTypes.validate({
+      unhandledExceptions: true,
+      unhandledRejections: true,
+      ndkCroshes: true,
+      anrs: false,
+      ooms: true
+    })).toBe(false)
   })
 })


### PR DESCRIPTION
The native layer tells JS about all the error types it supports, so the JS config should tolerate them.

The difference pre- and post- this PR is that a log like so should no longer appear:

```
03-12 16:37:55.753 27417 27482 W ReactNativeJS:   - enabledErrorTypes should be an object containing the flags { unhandledExceptions:true|false, unhandledRejections:true|false }, got {"ndkCrashes":false,"unhandledExceptions":true,"anrs":true}]
03-12 16:37:55.753 27417 27482 W ReactNativeJS:   line: 93591,
03-12 16:37:55.753 27417 27482 W ReactNativeJS:   column: 23,
03-12 16:37:55.753 27417 27482 W ReactNativeJS:   sourceURL: 'http://10.0.2.2:8081/index.delta?platform=android&dev=true&minify=false' }
```