### PR TITLE
Update user in React Native Cocoa layer

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
@@ -13,7 +13,7 @@
               withData:(NSDictionary *)update;
 
 - (void)updateContext:(NSString *)context;
-- (void)updateUser:(NSString *)id
+- (void)updateUser:(NSString *)userId
          withEmail:(NSString *)email
           withName:(NSString *)name;
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -41,10 +41,10 @@ RCT_EXPORT_METHOD(updateContext
 }
 
 RCT_EXPORT_METHOD(updateUser
-                  :(NSString *)id
+                  :(NSString *)userId
          withEmail:(NSString *)email
           withName:(NSString *)name) {
-  //TODO
+    [Bugsnag setUser:userId withName:name andEmail:email];
 }
 
 RCT_EXPORT_METHOD(dispatch


### PR DESCRIPTION
Updates the user in the React Native Cocoa layer when the JS layer invokes this method. Also renames the `id` parameter as this could cause [confusion](https://developer.apple.com/documentation/objectivec/id) in Objective-C.