### PR TITLE
Add Cocoa test target for React Native

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		8AD256171D6DE5F600C7D842 /* BugsnagReactNative.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8AD256161D6DE5F600C7D842 /* BugsnagReactNative.h */; };
 		8AD256191D6DE5F600C7D842 /* BugsnagReactNative.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD256181D6DE5F600C7D842 /* BugsnagReactNative.m */; };
 		E72AE2B9241AA1BB00ED8972 /* BugsnagReactNativeEmitter.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 65AE6AA823D89BDC00301CC1 /* BugsnagReactNativeEmitter.h */; };
+		E72B3254241FC57E005FB2CA /* libBugsnagReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD256131D6DE5F600C7D842 /* libBugsnagReactNative.a */; };
+		E72B325B241FC771005FB2CA /* BugsnagReactNativeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E72B325A241FC771005FB2CA /* BugsnagReactNativeTest.m */; };
 		E7397E5B1F83BD7D0034242A /* libBugsnagStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7397E5A1F83BD750034242A /* libBugsnagStatic.a */; };
 /* End PBXBuildFile section */
 
@@ -30,6 +32,125 @@
 			proxyType = 2;
 			remoteGlobalIDString = 8A2C8F221C6BBD2300846019;
 			remoteInfo = Tests;
+		};
+		E72B322A241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
+			remoteInfo = React;
+		};
+		E72B322C241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28131D9B038B00D4039D;
+			remoteInfo = "React-tvOS";
+		};
+		E72B322E241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3C059A1DE3340900C268FA;
+			remoteInfo = yoga;
+		};
+		E72B3230241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3C06751DE3340C00C268FA;
+			remoteInfo = "yoga-tvOS";
+		};
+		E72B3232241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3CD9251DE5FBEC00167DC4;
+			remoteInfo = cxxreact;
+		};
+		E72B3234241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3CD9321DE5FBEE00167DC4;
+			remoteInfo = "cxxreact-tvOS";
+		};
+		E72B3236241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BDC1FC498900052F4D5;
+			remoteInfo = jsinspector;
+		};
+		E72B3238241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
+			remoteInfo = "jsinspector-tvOS";
+		};
+		E72B323A241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 139D7ECE1E25DB7D00323FB7;
+			remoteInfo = "third-party";
+		};
+		E72B323C241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D383D3C1EBD27B6005632C8;
+			remoteInfo = "third-party-tvOS";
+		};
+		E72B323E241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 139D7E881E25C6D100323FB7;
+			remoteInfo = "double-conversion";
+		};
+		E72B3240241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D383D621EBD27B9005632C8;
+			remoteInfo = "double-conversion-tvOS";
+		};
+		E72B3242241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EDEBC6D6214B3E7000DD5AC8;
+			remoteInfo = jsi;
+		};
+		E72B3244241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EDEBC73B214B45A300DD5AC8;
+			remoteInfo = jsiexecutor;
+		};
+		E72B3246241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = ED296FB6214C9A0900B7C4FE;
+			remoteInfo = "jsi-tvOS";
+		};
+		E72B3248241FC479005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = ED296FEE214C9CF800B7C4FE;
+			remoteInfo = "jsiexecutor-tvOS";
+		};
+		E72B3255241FC57E005FB2CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8AD2560B1D6DE5F600C7D842 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8AD256121D6DE5F600C7D842;
+			remoteInfo = BugsnagReactNative;
 		};
 		E7397E591F83BD750034242A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -64,6 +185,10 @@
 		8AD256131D6DE5F600C7D842 /* libBugsnagReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagReactNative.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AD256161D6DE5F600C7D842 /* BugsnagReactNative.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagReactNative.h; sourceTree = "<group>"; };
 		8AD256181D6DE5F600C7D842 /* BugsnagReactNative.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagReactNative.m; sourceTree = "<group>"; };
+		E72B3217241FC479005FB2CA /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		E72B324F241FC57E005FB2CA /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E72B3253241FC57E005FB2CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E72B325A241FC771005FB2CA /* BugsnagReactNativeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagReactNativeTest.m; sourceTree = "<group>"; };
 		E7397E6D1F83BF8F0034242A /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		E7397E721F83BF940034242A /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -74,6 +199,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7397E5B1F83BD7D0034242A /* libBugsnagStatic.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E72B324C241FC57E005FB2CA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E72B3254241FC57E005FB2CA /* libBugsnagReactNative.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,6 +226,7 @@
 		8AB63CFA1D918BEF0002381B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E72B3217241FC479005FB2CA /* React.xcodeproj */,
 				E7397E721F83BF940034242A /* libz.tbd */,
 				E7397E6D1F83BF8F0034242A /* libc++.tbd */,
 			);
@@ -104,6 +238,7 @@
 			children = (
 				8AB63CFA1D918BEF0002381B /* Frameworks */,
 				8AD256151D6DE5F600C7D842 /* BugsnagReactNative */,
+				E72B3250241FC57E005FB2CA /* Tests */,
 				8AF662D91D929B7800ABD39A /* Libraries */,
 				8AD256141D6DE5F600C7D842 /* Products */,
 			);
@@ -113,6 +248,7 @@
 			isa = PBXGroup;
 			children = (
 				8AD256131D6DE5F600C7D842 /* libBugsnagReactNative.a */,
+				E72B324F241FC57E005FB2CA /* Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -138,6 +274,38 @@
 			name = Libraries;
 			sourceTree = "<group>";
 		};
+		E72B3218241FC479005FB2CA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E72B322B241FC479005FB2CA /* libReact.a */,
+				E72B322D241FC479005FB2CA /* libReact.a */,
+				E72B322F241FC479005FB2CA /* libyoga.a */,
+				E72B3231241FC479005FB2CA /* libyoga.a */,
+				E72B3233241FC479005FB2CA /* libcxxreact.a */,
+				E72B3235241FC479005FB2CA /* libcxxreact.a */,
+				E72B3237241FC479005FB2CA /* libjsinspector.a */,
+				E72B3239241FC479005FB2CA /* libjsinspector-tvOS.a */,
+				E72B323B241FC479005FB2CA /* libthird-party.a */,
+				E72B323D241FC479005FB2CA /* libthird-party.a */,
+				E72B323F241FC479005FB2CA /* libdouble-conversion.a */,
+				E72B3241241FC479005FB2CA /* libdouble-conversion.a */,
+				E72B3243241FC479005FB2CA /* libjsi.a */,
+				E72B3245241FC479005FB2CA /* libjsiexecutor.a */,
+				E72B3247241FC479005FB2CA /* libjsi-tvOS.a */,
+				E72B3249241FC479005FB2CA /* libjsiexecutor-tvOS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E72B3250241FC57E005FB2CA /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				E72B3253241FC57E005FB2CA /* Info.plist */,
+				E72B325A241FC771005FB2CA /* BugsnagReactNativeTest.m */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -158,6 +326,24 @@
 			productReference = 8AD256131D6DE5F600C7D842 /* libBugsnagReactNative.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		E72B324E241FC57E005FB2CA /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E72B3257241FC57E005FB2CA /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				E72B324B241FC57E005FB2CA /* Sources */,
+				E72B324C241FC57E005FB2CA /* Frameworks */,
+				E72B324D241FC57E005FB2CA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E72B3256241FC57E005FB2CA /* PBXTargetDependency */,
+			);
+			name = Tests;
+			productName = Tests;
+			productReference = E72B324F241FC57E005FB2CA /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -169,6 +355,11 @@
 				TargetAttributes = {
 					8AD256121D6DE5F600C7D842 = {
 						CreatedOnToolsVersion = 7.3.1;
+					};
+					E72B324E241FC57E005FB2CA = {
+						CreatedOnToolsVersion = 11.3.1;
+						DevelopmentTeam = 372ZUL2ZB7;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -188,10 +379,15 @@
 					ProductGroup = 8A5ACBF41DC11D6D00879C6D /* Generated */;
 					ProjectRef = 8A5ACBF31DC11D6D00879C6D /* Bugsnag.xcodeproj */;
 				},
+				{
+					ProductGroup = E72B3218241FC479005FB2CA /* Products */;
+					ProjectRef = E72B3217241FC479005FB2CA /* React.xcodeproj */;
+				},
 			);
 			projectRoot = "";
 			targets = (
 				8AD256121D6DE5F600C7D842 /* BugsnagReactNative */,
+				E72B324E241FC57E005FB2CA /* Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -211,6 +407,118 @@
 			remoteRef = 8A5ACBFA1DC11D6D00879C6D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		E72B322B241FC479005FB2CA /* libReact.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libReact.a;
+			remoteRef = E72B322A241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B322D241FC479005FB2CA /* libReact.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libReact.a;
+			remoteRef = E72B322C241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B322F241FC479005FB2CA /* libyoga.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libyoga.a;
+			remoteRef = E72B322E241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3231241FC479005FB2CA /* libyoga.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libyoga.a;
+			remoteRef = E72B3230241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3233241FC479005FB2CA /* libcxxreact.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libcxxreact.a;
+			remoteRef = E72B3232241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3235241FC479005FB2CA /* libcxxreact.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libcxxreact.a;
+			remoteRef = E72B3234241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3237241FC479005FB2CA /* libjsinspector.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsinspector.a;
+			remoteRef = E72B3236241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3239241FC479005FB2CA /* libjsinspector-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsinspector-tvOS.a";
+			remoteRef = E72B3238241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B323B241FC479005FB2CA /* libthird-party.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libthird-party.a";
+			remoteRef = E72B323A241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B323D241FC479005FB2CA /* libthird-party.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libthird-party.a";
+			remoteRef = E72B323C241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B323F241FC479005FB2CA /* libdouble-conversion.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libdouble-conversion.a";
+			remoteRef = E72B323E241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3241241FC479005FB2CA /* libdouble-conversion.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libdouble-conversion.a";
+			remoteRef = E72B3240241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3243241FC479005FB2CA /* libjsi.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsi.a;
+			remoteRef = E72B3242241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3245241FC479005FB2CA /* libjsiexecutor.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjsiexecutor.a;
+			remoteRef = E72B3244241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3247241FC479005FB2CA /* libjsi-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsi-tvOS.a";
+			remoteRef = E72B3246241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E72B3249241FC479005FB2CA /* libjsiexecutor-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libjsiexecutor-tvOS.a";
+			remoteRef = E72B3248241FC479005FB2CA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		E7397E5A1F83BD750034242A /* libBugsnagStatic.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -219,6 +527,16 @@
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E72B324D241FC57E005FB2CA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8AD2560F1D6DE5F600C7D842 /* Sources */ = {
@@ -231,7 +549,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E72B324B241FC57E005FB2CA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E72B325B241FC771005FB2CA /* BugsnagReactNativeTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E72B3256241FC57E005FB2CA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8AD256121D6DE5F600C7D842 /* BugsnagReactNative */;
+			targetProxy = E72B3255241FC57E005FB2CA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		8AD2561A1D6DE5F600C7D842 /* Debug */ = {
@@ -341,6 +675,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/vendor/bugsnag-cocoa/Source/**",
+					"$(SRCROOT)/../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -358,6 +693,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/vendor/bugsnag-cocoa/Source/**",
+					"$(SRCROOT)/../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -365,6 +701,53 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		E72B3258241FC57E005FB2CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.example.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E72B3259241FC57E005FB2CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.example.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -385,6 +768,15 @@
 			buildConfigurations = (
 				8AD2561D1D6DE5F600C7D842 /* Debug */,
 				8AD2561E1D6DE5F600C7D842 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E72B3257241FC57E005FB2CA /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E72B3258241FC57E005FB2CA /* Debug */,
+				E72B3259241FC57E005FB2CA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/packages/react-native/ios/BugsnagReactNative.xcodeproj/xcshareddata/xcschemes/BugsnagReactNative.xcscheme
+++ b/packages/react-native/ios/BugsnagReactNative.xcodeproj/xcshareddata/xcschemes/BugsnagReactNative.xcscheme
@@ -26,18 +26,14 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -53,8 +49,6 @@
             ReferencedContainer = "container:BugsnagReactNative.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/packages/react-native/ios/Tests/BugsnagReactNativeTest.m
+++ b/packages/react-native/ios/Tests/BugsnagReactNativeTest.m
@@ -1,0 +1,21 @@
+//
+//  BugsnagReactNativeTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 16/03/2020.
+//  Copyright © 2020 Bugsnag, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface BugsnagReactNativeTest : XCTestCase
+
+@end
+
+@implementation BugsnagReactNativeTest
+
+- (void)testExample {
+    // TODO add tests
+}
+
+@end

--- a/packages/react-native/ios/Tests/Info.plist
+++ b/packages/react-native/ios/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Goal

Adds a target for running unit tests to `ios/BugsnagReactNative.xcodeproj`, as no unit tests have been added to the React Native iOS project previously.

This adds `BugsnagReactNativeTest` and `Info.plist` which have been auto-generated by XCode. The pbxproj file has also been updated to link npm devDependencies from `packages/react-native`, as otherwise the code would fail to compile.

## Testing
Built the xcodeproj and ran the tests from the `packages/react-native` folder, and by copying to the `examples/reactnative/node_modules` folder and confirming that the example app compiles without complaining about duplicate header files.
