### PR TITLE
Update metadata in Cocoa react-native layer

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -35,10 +35,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
     };
 }
 
-RCT_EXPORT_METHOD(updateMetadata
-                  :(NSString *)section
-          withData:(NSDictionary *)update) {
-  //TODO
+RCT_EXPORT_METHOD(updateMetadata:(NSString *)section
+                        withData:(NSDictionary *)update) {
+    if (update == nil) {
+        [Bugsnag clearMetadataFromSection:section];
+    } else {
+        [Bugsnag addMetadata:update toSection:section];
+    }
 }
 
 RCT_EXPORT_METHOD(updateContext:(NSString *)context) {


### PR DESCRIPTION
Updates the metadata when the JS layer invokes the native method. If the update is nil, the section will be cleared, otherwise its values will be added to existing metadata.