### PR TITLE
feat: Warn when API key is not 32 hex chars

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -124,9 +124,11 @@ class Client {
       return accum
     }, { errors: {}, config: {} })
 
-    // missing api key is the only fatal error
-    if (schema.apiKey && !config.apiKey) {
-      throw new Error('No Bugsnag API Key set')
+    if (schema.apiKey) {
+      // missing api key is the only fatal error
+      if (!config.apiKey) throw new Error('No Bugsnag API Key set')
+      // warn about an apikey that is not of the expected format
+      if (!/^[0-9a-f]{32}$/i.test(config.apiKey)) errors.apiKey = 'should be a string of 32 hexadecimal characters'
     }
 
     // update and elevate some options

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -36,6 +36,37 @@ describe('@bugsnag/core/client', () => {
         unhandledRejections: true
       })
     })
+
+    it('warns with a valid but incorrect-looking api key', () => {
+      const logger = {
+        debug: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn()
+      }
+      const client = new Client({
+        apiKey: 'API_KEY',
+        logger
+      })
+      expect(client).toBeTruthy()
+      expect(logger.warn.mock.calls.length).toBe(1)
+      expect(logger.warn.mock.calls[0][0].message).toBe('Invalid configuration\n  - apiKey should be a string of 32 hexadecimal characters, got "API_KEY"')
+    })
+
+    it('does not warn with a valid api key', () => {
+      const logger = {
+        debug: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn()
+      }
+      const client = new Client({
+        apiKey: '123456abcdef123456abcdef123456ab',
+        logger
+      })
+      expect(client).toBeTruthy()
+      expect(logger.warn.mock.calls.length).toBe(0)
+    })
   })
 
   describe('use()', () => {

--- a/packages/plugin-browser-session/test/session.test.js
+++ b/packages/plugin-browser-session/test/session.test.js
@@ -7,7 +7,7 @@ const VALID_NOTIFIER = { name: 't', version: '0', url: 'http://' }
 
 describe('plugin: sessions', () => {
   it('notifies the session endpoint', (done) => {
-    const c = new Client({ apiKey: 'API_KEY' }, undefined, [plugin], VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }, undefined, [plugin], VALID_NOTIFIER)
     c._setDelivery(client => ({
       sendSession: (session, cb) => {
         expect(typeof session).toBe('object')
@@ -23,7 +23,7 @@ describe('plugin: sessions', () => {
   })
 
   it('tracks handled/unhandled error counts and sends them in error payloads', (done) => {
-    const c = new Client({ apiKey: 'API_KEY' }, undefined, [plugin], VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }, undefined, [plugin], VALID_NOTIFIER)
     let i = 0
     c._setDelivery(client => ({
       sendSession: () => {},
@@ -50,7 +50,7 @@ describe('plugin: sessions', () => {
   })
 
   it('correctly infers releaseStage', (done) => {
-    const c = new Client({ apiKey: 'API_KEY', releaseStage: 'foo' }, undefined, [plugin], VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', releaseStage: 'foo' }, undefined, [plugin], VALID_NOTIFIER)
 
     c._setDelivery(client => ({
       sendSession: (session, cb) => {
@@ -63,7 +63,7 @@ describe('plugin: sessions', () => {
   })
 
   it('doesn’t send when releaseStage is not in enabledReleaseStages', (done) => {
-    const c = new Client({ apiKey: 'API_KEY', releaseStage: 'foo', enabledReleaseStages: ['baz'] }, undefined, [plugin], VALID_NOTIFIER)
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', releaseStage: 'foo', enabledReleaseStages: ['baz'] }, undefined, [plugin], VALID_NOTIFIER)
     c._setDelivery(client => ({
       sendSession: (session, cb) => {
         expect(true).toBe(false)
@@ -77,7 +77,7 @@ describe('plugin: sessions', () => {
     const logger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
     const warnSpy = spyOn(logger, 'warn')
     const c = new Client({
-      apiKey: 'API_KEY',
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       releaseStage: 'foo',
       endpoints: { notify: '/foo' },
       autoTrackSessions: false,
@@ -90,7 +90,7 @@ describe('plugin: sessions', () => {
   it('supports pausing and resuming sessions', (done) => {
     const payloads = []
     const c = new Client({
-      apiKey: 'API_KEY'
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     }, undefined, [plugin], VALID_NOTIFIER)
     c._setDelivery(client => ({
       sendEvent: (p, cb = () => {}) => {

--- a/packages/plugin-react-native-global-error-handler/test/error-handler.test.js
+++ b/packages/plugin-react-native-global-error-handler/test/error-handler.test.js
@@ -21,14 +21,14 @@ class MockErrorUtils {
 describe('plugin: react native global error handler', () => {
   it('should set a global error handler', () => {
     const eu = new MockErrorUtils()
-    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin(eu)] })
+    const client = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', plugins: [plugin(eu)] })
     expect(typeof eu.getGlobalHandler()).toBe('function')
     expect(client).toBe(client)
   })
 
   it('should warn if ErrorUtils is not defined', done => {
     const client = new Client({
-      apiKey: 'API_KEY_YEAH',
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       logger: {
         debug: () => {},
         info: () => {},
@@ -46,7 +46,7 @@ describe('plugin: react native global error handler', () => {
   it('should not set a global error handler when autoDetectErrors=false', () => {
     const eu = new MockErrorUtils()
     const client = new Client({
-      apiKey: 'API_KEY_YEAH',
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       autoDetectErrors: false,
       plugins: [plugin(eu)]
     })
@@ -57,7 +57,7 @@ describe('plugin: react native global error handler', () => {
   it('should not set a global error handler when enabledErrorTypes.unhandledExceptions=false', () => {
     const eu = new MockErrorUtils()
     const client = new Client({
-      apiKey: 'API_KEY_YEAH',
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       enabledErrorTypes: { unhandledExceptions: false, unhandledRejections: false },
       plugins: [plugin(eu)]
     })
@@ -67,7 +67,7 @@ describe('plugin: react native global error handler', () => {
 
   it('should call through to an existing handler', done => {
     const eu = new MockErrorUtils()
-    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin(eu)] })
+    const client = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', plugins: [plugin(eu)] })
     client._setDelivery(client => ({
       sendSession: () => {},
       sendEvent: (...args) => args[args.length - 1](null)
@@ -83,7 +83,7 @@ describe('plugin: react native global error handler', () => {
 
   it('should have the correct handled state', done => {
     const eu = new MockErrorUtils()
-    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin(eu)] })
+    const client = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', plugins: [plugin(eu)] })
     client._setDelivery(client => ({
       sendSession: () => {},
       sendEvent: (payload, cb) => {

--- a/packages/plugin-server-session/test/session.test.ts
+++ b/packages/plugin-server-session/test/session.test.ts
@@ -25,7 +25,7 @@ describe('plugin: server sessions', () => {
   })
 
   it('should send the session', done => {
-    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' }, undefined, [plugin])
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }, undefined, [plugin])
     c._setDelivery(client => ({
       sendEvent: () => {},
       sendSession: (session: any, cb = () => {}) => {
@@ -41,7 +41,7 @@ describe('plugin: server sessions', () => {
   it('should not send the session when releaseStage is not in enabledReleaseStages', done => {
     expect.assertions(1)
     const c = new Client({
-      apiKey: 'aaaa-aaaa-aaaa-aaaa',
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       logger: {
         debug: () => {},
         info: () => {},
@@ -68,7 +68,7 @@ describe('plugin: server sessions', () => {
   it('should include the correct app and device payload properties', done => {
     expect.assertions(5)
     const c = new Client({
-      apiKey: 'aaaa-aaaa-aaaa-aaaa',
+      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       endpoints: { notify: 'bloo', sessions: 'blah' },
       enabledReleaseStages: ['qa'],
       releaseStage: 'qa',
@@ -104,7 +104,7 @@ describe('plugin: server sessions', () => {
     }
     Tracker.mockImplementation(() => new TrackerMock() as any)
 
-    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' }, undefined, [plugin])
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }, undefined, [plugin])
 
     c.leaveBreadcrumb('tick')
     c._metadata = { datetime: { tz: 'GMT+1' } }
@@ -128,7 +128,7 @@ describe('plugin: server sessions', () => {
     }
     Tracker.mockImplementation(() => new TrackerMock() as any)
 
-    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' }, undefined, [plugin])
+    const c = new Client({ apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }, undefined, [plugin])
 
     // start a session and get its id
     const sessionClient = c.startSession()


### PR DESCRIPTION
The spec says to reject non-string, null or empty api keys. Anything else should be accepted, but if it is not exactly 32 hex chars, a warning should be printed.