### PR TITLE
fix: plugin typing

### DIFF
--- a/bin/bundle-types
+++ b/bin/bundle-types
@@ -3,6 +3,11 @@
 # exit on all errors
 set -e
 
+if [ -z "$1" ]; then
+  echo "ERROR: bin/bundle-types {name} :: {name} argument is required"
+  exit 1
+fi
+
 # ensure directory exists
 mkdir -p dist/types/bugsnag-core
 
@@ -13,4 +18,4 @@ cp node_modules/@bugsnag/core/types/*.d.ts dist/types/bugsnag-core
 cp types/*.d.ts dist/types
 
 # replace any references to @bugsnag/core with the new, bundled, local path
-cat types/bugsnag.d.ts | sed 's/@bugsnag\/core/\.\/bugsnag-core/' > dist/types/bugsnag.d.ts
+cat types/$1.d.ts | sed 's/@bugsnag\/core/\.\/bugsnag-core/' > dist/types/$1.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -3531,6 +3531,22 @@
       "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -6557,6 +6573,12 @@
           "dev": true
         }
       }
+    },
+    "csstype": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-typescript": "^7.8.3",
     "@types/jest": "^25.1.2",
     "@types/node": "^13.7.1",
+    "@types/react": "^16.9.23",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
     "babel-jest": "^25.1.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "size": "./bin/size",
     "clean": "rm -fr dist && mkdir dist",
-    "bundle-types": "../../bin/bundle-types",
+    "bundle-types": "../../bin/bundle-types bugsnag",
     "build": "npm run clean && npm run build:dist && npm run build:dist:min && npm run bundle-types",
     "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
     "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/minify dist/bugsnag.min.js",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "bundle-types": "../../bin/bundle-types",
+    "bundle-types": "../../bin/bundle-types bugsnag",
     "build": "npm run clean && npm run bundle-types",
     "test:types": "jasmine 'types/**/*.test.js'",
     "postversion": "npm run build"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "bundle-types": "../../bin/bundle-types",
+    "bundle-types": "../../bin/bundle-types bugsnag",
     "build": "npm run clean && npm run build:dist && npm run bundle-types",
     "build:dist": "../../bin/bundle src/notifier.js --node --exclude=iserror,stack-generator,error-stack-parser,pump,byline --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
     "postversion": "npm run build"

--- a/packages/plugin-express/types/bugsnag-express.d.ts
+++ b/packages/plugin-express/types/bugsnag-express.d.ts
@@ -1,3 +1,3 @@
-import { Bugsnag } from '@bugsnag/node'
-declare const bugsnagPluginExpress: Bugsnag.Plugin
+import { Plugin } from '@bugsnag/node'
+declare const bugsnagPluginExpress: Plugin
 export default bugsnagPluginExpress

--- a/packages/plugin-koa/types/bugsnag-koa.d.ts
+++ b/packages/plugin-koa/types/bugsnag-koa.d.ts
@@ -1,3 +1,3 @@
-import { Bugsnag } from '@bugsnag/node'
-declare const bugsnagPluginKoa: Bugsnag.Plugin
+import { Plugin } from '@bugsnag/node'
+declare const bugsnagPluginKoa: Plugin
 export default bugsnagPluginKoa

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@bugsnag/browser": "^7.0.0-rc.2",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^23.6.0",
     "jest": "^23.6.0",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -4,7 +4,7 @@
   "main": "dist/bugsnag-react.js",
   "description": "React integration for @bugsnag/js",
   "browser": "dist/bugsnag-react.js",
-  "types": "types/bugsnag-react.d.ts",
+  "types": "dist/types/bugsnag-plugin-react.d.ts",
   "homepage": "https://www.bugsnag.com/",
   "repository": {
     "type": "git",
@@ -14,27 +14,23 @@
     "access": "public"
   },
   "files": [
-    "dist",
-    "types"
+    "dist"
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "build": "npm run clean && npm run build:dist && npm run build:dist:min",
-    "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/index.js --standalone=bugsnag__react | ../../bin/extract-source-map dist/bugsnag-react.js",
-    "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/index.js --standalone=bugsnag__react | ../../bin/minify dist/bugsnag-react.min.js",
+    "bundle-types": "../../bin/bundle-types bugsnag-plugin-react",
+    "build": "npm run clean && ../../bin/bundle src/index.js | ../../bin/extract-source-map dist/bugsnag-react.js && npm run bundle-types",
     "test": "jest",
     "postversion": "npm run build"
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "peerDependencies": {
-    "@bugsnag/js": "*"
-  },
   "devDependencies": {
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@bugsnag/browser": "^7.0.0-rc.2",
+    "@bugsnag/core": "^7.0.0-rc.2",
+    "@types/react": "^16.9.23",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^23.6.0",
     "jest": "^23.6.0",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "bundle-types": "../../bin/bundle-types bugsnag-plugin-react",
-    "build": "npm run clean && ../../bin/bundle src/index.js | ../../bin/extract-source-map dist/bugsnag-react.js && npm run bundle-types",
+    "build": "npm run clean && ../../bin/bundle src/index.js --standalone=BugsnagPluginReact | ../../bin/extract-source-map dist/bugsnag-react.js && npm run bundle-types",
     "test": "jest",
     "postversion": "npm run build"
   },

--- a/packages/plugin-react/types/bugsnag-plugin-react.d.ts
+++ b/packages/plugin-react/types/bugsnag-plugin-react.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '@bugsnag/browser'
+import { Plugin } from '@bugsnag/core'
 import React from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/plugin-react/types/bugsnag-react.d.ts
+++ b/packages/plugin-react/types/bugsnag-react.d.ts
@@ -1,8 +1,11 @@
 import { Plugin } from '@bugsnag/browser'
-import React from 'react'
+import * as React from 'react'
 
-declare class BugsnagPluginReact extends Plugin {
-  constructor(React?: React)
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface BugsnagPluginReact extends Plugin { }
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+declare class BugsnagPluginReact {
+  constructor(react?: typeof React)
 }
 
 export default BugsnagPluginReact

--- a/packages/plugin-react/types/bugsnag-react.d.ts
+++ b/packages/plugin-react/types/bugsnag-react.d.ts
@@ -1,5 +1,5 @@
 import { Plugin } from '@bugsnag/browser'
-import * as React from 'react'
+import React from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface BugsnagPluginReact extends Plugin { }

--- a/packages/plugin-restify/types/bugsnag-restify.d.ts
+++ b/packages/plugin-restify/types/bugsnag-restify.d.ts
@@ -1,3 +1,3 @@
-import { Bugsnag } from '@bugsnag/node'
-declare const bugsnagPluginRestify: Bugsnag.Plugin
+import { Plugin } from '@bugsnag/node'
+declare const bugsnagPluginRestify: Plugin
 export default bugsnagPluginRestify

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -31,6 +31,7 @@
     "@bugsnag/js": "*"
   },
   "devDependencies": {
+    "@bugsnag/browser": "^7.0.0-rc.2",
     "@bugsnag/core": "^7.0.0-rc.2",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -4,7 +4,7 @@
   "description": "Vue.js integration for bugsnag-js",
   "main": "dist/bugsnag-vue.js",
   "browser": "dist/bugsnag-vue.js",
-  "types": "types/bugsnag-vue.d.ts",
+  "types": "dist/types/bugsnag-plugin-vue.d.ts",
   "homepage": "https://www.bugsnag.com/",
   "repository": {
     "type": "git",
@@ -14,14 +14,12 @@
     "access": "public"
   },
   "files": [
-    "dist",
-    "types"
+    "dist"
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "build": "npm run clean && npm run build:dist && npm run build:dist:min",
-    "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/index.js --standalone=bugsnag__vue | ../../bin/extract-source-map dist/bugsnag-vue.js",
-    "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/index.js --standalone=bugsnag__vue | ../../bin/minify dist/bugsnag-vue.min.js",
+    "bundle-types": "../../bin/bundle-types bugsnag-plugin-vue",
+    "build": "npm run clean && ../../bin/bundle src/index.js | ../../bin/extract-source-map dist/bugsnag-vue.js && npm run bundle-types",
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'",
     "postversion": "npm run build"
   },
@@ -31,7 +29,6 @@
     "@bugsnag/js": "*"
   },
   "devDependencies": {
-    "@bugsnag/browser": "^7.0.0-rc.2",
     "@bugsnag/core": "^7.0.0-rc.2",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "bundle-types": "../../bin/bundle-types bugsnag-plugin-vue",
-    "build": "npm run clean && ../../bin/bundle src/index.js | ../../bin/extract-source-map dist/bugsnag-vue.js && npm run bundle-types",
+    "build": "npm run clean && ../../bin/bundle src/index.js --standalone=BugsnagPluginVue | ../../bin/extract-source-map dist/bugsnag-vue.js && npm run bundle-types",
     "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'",
     "postversion": "npm run build"
   },

--- a/packages/plugin-vue/types/bugsnag-plugin-vue.d.ts
+++ b/packages/plugin-vue/types/bugsnag-plugin-vue.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '@bugsnag/browser'
+import { Plugin } from '@bugsnag/core'
 import Vue from 'vue'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/plugin-vue/types/bugsnag-vue.d.ts
+++ b/packages/plugin-vue/types/bugsnag-vue.d.ts
@@ -1,7 +1,10 @@
 import { Plugin } from '@bugsnag/browser'
 import Vue from 'vue'
 
-declare class BugsnagPluginVue extends Plugin {
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface BugsnagPluginVue extends Plugin { }
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+declare class BugsnagPluginVue {
   constructor(Vue?: Vue)
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,5 +64,6 @@
     "packages/plugin-react-native-app-state-breadcrumbs",
     "packages/plugin-react-native-unhandled-rejection",
     "packages/plugin-server-session",
+    "packages/plugin-react",
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,5 +65,6 @@
     "packages/plugin-react-native-unhandled-rejection",
     "packages/plugin-server-session",
     "packages/plugin-react",
+    "packages/plugin-vue",
   ]
 }


### PR DESCRIPTION
- Fixes typing issue with the React and Vue plugins with interface merging. See https://github.com/microsoft/TypeScript/issues/340 for details and fix.
- Adds plugin-react and plugin-vue to type checking so that declarations are checked.
- Fixes `Cannot use namespace 'React' as a type.ts(2709)` type error which allowed anything to be passed to the React plugin.