### PR TITLE
fix: Ensure depth is only incremented when calling via facade

### DIFF
--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -78,7 +78,6 @@ const Bugsnag = {
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
-    Bugsnag._client._depth += 1
     return Bugsnag._client
   }
 }
@@ -87,7 +86,10 @@ map(['resetEventCount'].concat(keys(Client.prototype)), (m) => {
   if (/^_/.test(m)) return
   Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.log(`Bugsnag.${m}() was called before Bugsnag.start()`)
-    return Bugsnag._client[m].apply(Bugsnag._client, arguments)
+    Bugsnag._client._depth += 1
+    const ret = Bugsnag._client[m].apply(Bugsnag._client, arguments)
+    Bugsnag._client._depth -= 1
+    return ret
   }
 })
 

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -70,7 +70,6 @@ const Bugsnag = {
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
-    Bugsnag._client._depth += 1
     return Bugsnag._client
   }
 }
@@ -81,7 +80,10 @@ Object.getOwnPropertyNames(Client.prototype).map((m) => {
   if (/^_/.test(m)) return
   Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.warn(`Bugsnag.${m}() was called before Bugsnag.start()`)
-    return Bugsnag._client[m].apply(Bugsnag._client, arguments)
+    Bugsnag._client._depth += 1
+    const ret = Bugsnag._client[m].apply(Bugsnag._client, arguments)
+    Bugsnag._client._depth -= 1
+    return ret
   }
 })
 

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -62,7 +62,6 @@ const Bugsnag = {
       return Bugsnag._client
     }
     Bugsnag._client = Bugsnag.createClient(opts)
-    Bugsnag._client._depth += 1
     return Bugsnag._client
   }
 }
@@ -71,7 +70,10 @@ Object.keys(Client.prototype).forEach((m) => {
   if (/^_/.test(m)) return
   Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.error(`Bugsnag.${m}() was called before Bugsnag.start()`)
-    return Bugsnag._client[m].apply(Bugsnag._client, arguments)
+    Bugsnag._client._depth += 1
+    const ret = Bugsnag._client[m].apply(Bugsnag._client, arguments)
+    Bugsnag._client._depth -= 1
+    return ret
   }
 })
 

--- a/test/browser/features/fixtures/handled/script/f.html
+++ b/test/browser/features/fixtures/handled/script/f.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      window.client = Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      function a () {
+        window.client.notify({ name: 'Error', message: 'make a stacktrace for me' })
+      }
+      function b () { a() }
+      function c () { b() }
+      c()
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/handled/script/g.html
+++ b/test/browser/features/fixtures/handled/script/g.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      window.client = Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      function a () {
+        window.client.notify('make a stacktrace for me')
+      }
+      function b () { a() }
+      function c () { b() }
+      c()
+    </script>
+  </body>
+</html>

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -73,3 +73,29 @@ Scenario: calling notify() with a string, getting a generated stacktrace
 
   # this ensures the first generated stackframe doesn't come from bugsnag's source
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+
+Scenario: calling window.client.notify() with an object, getting a generated stacktrace
+  When I navigate to the URL "/handled/script/f.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "make a stacktrace for me"
+  And the exception "type" equals "browserjs"
+
+  # this ensure the stacktrace features all of the nested stackframes
+  And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+  And the payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
+  And the payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
+
+Scenario: calling window.client.notify() with a string, getting a generated stacktrace
+  When I navigate to the URL "/handled/script/g.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "make a stacktrace for me"
+  And the exception "type" equals "browserjs"
+
+  # this ensure the stacktrace features all of the nested stackframes
+  And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+  And the payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
+  And the payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"

--- a/test/node/features/fixtures/handled/scenarios/global-notify-string.js
+++ b/test/node/features/fixtures/handled/scenarios/global-notify-string.js
@@ -1,0 +1,15 @@
+var Bugsnag = require('@bugsnag/node')
+var client = Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  }
+})
+
+function a () {
+  client.notify({ name: 'Error', message: 'make a stacktrace for me' })
+}
+function b () { a() }
+function c () { b() }
+c()

--- a/test/node/features/handled_errors.feature
+++ b/test/node/features/handled_errors.feature
@@ -80,3 +80,18 @@ Scenario: calling notify with a string
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/notify-string.js"
   And the "lineNumber" of stack frame 0 equals 10
+
+Scenario: calling an assigned client.notify with an object
+  And I run the service "handled" with the command "node scenarios/global-notify-string"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "severityReason.type" equals "handledException"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "make a stacktrace for me"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/global-notify-string.js"
+  And the "method" of stack frame 0 equals "a"
+  And the "method" of stack frame 1 equals "b"
+  And the "method" of stack frame 2 equals "c"


### PR DESCRIPTION
Fixes a bug where calling `notify()` on a client initialised with `Bugsnag.start()` incorrectly removes stackframes.

Take the following example:

```js
Bugsnag.start('API_KEY')
Bugsnag.notify('strrrriinnggg')
```

Internally, when `start()` is called, the created client has its `_depth` parameter incremented, so that when a non error object (such as a string) is reported, the notifier knows how many frames to remove. There is one more frame to remove than when calling the client.notify() method directly because of the `Bugsnag.*` facade.

However, the following use case is also valid:

```js
const client = Bugsnag.start('API_KEY')
client.notify('strrrriinnggg')
```

In this instance, `_depth` was incremented but the client method is called directly, resulting in the generated error having 1 too many stackframes removed.

The approach I've taken doesn't seem ideal, but I couldn't think of a better way to it. I played around using a [`with` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with) but to no avail.

The risks of this approach are:
- It only works for synchrounous method calls. The `_depth` property is only accessed synchronously so this shouldn't be a problem. If we had to make it be the correct value for async methods it would add a lot of complexity, since at the moment there is no concurrency to worry about.
- If any of the methods `throw`, then the value won't be reset. It's a spec requirement that none of our methods throw anyway, so again this shouldn't be a problem. However we should pay some attention to that.