### PR TITLE
feat(react-native): Support remote debugging in Chrome

### DIFF
--- a/packages/plugin-react-native-client-sync/client-sync.js
+++ b/packages/plugin-react-native-client-sync/client-sync.js
@@ -3,7 +3,11 @@ const { DeviceEventEmitter, NativeEventEmitter, NativeModules, Platform } = requ
 module.exports = (NativeClient) => ({
   load: (client) => {
     client.addOnBreadcrumb(breadcrumb => {
-      NativeClient.leaveBreadcrumb(breadcrumb)
+      // we copy the breadcrumb's properties over to a new object to ensure its
+      // to JSON() method doesn't get called before passing the object over the
+      // bridge. This happens in the remote debugger and means the "message"
+      // property is incorrectly named "name"
+      NativeClient.leaveBreadcrumb({ ...breadcrumb })
     })
 
     const origSetUser = client.setUser

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
@@ -31,8 +31,18 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
         logger.e("Failed to call $msg on bugsnag-plugin-react-native, continuing", exc)
     }
 
+    /*
+     * This method exists for when the app is run in a remote debugger,
+     * where synchronous methods are not allowed. It should not ordinarily
+     * be used.
+     */
+    @ReactMethod
+    private fun configureAsync(env: ReadableMap, promise: Promise) {
+      promise.resolve(configure(env))
+    }
+
     @ReactMethod(isBlockingSynchronousMethod = true)
-    private fun configure(env : ReadableMap): WritableMap {
+    private fun configure(env: ReadableMap): WritableMap {
         return try {
             val client = Bugsnag.getClient()
             bridge = reactContext.getJSModule(RCTDeviceEventEmitter::class.java)

--- a/packages/react-native/src/test/config.test.ts
+++ b/packages/react-native/src/test/config.test.ts
@@ -9,7 +9,6 @@ describe('react-native config: load()', () => {
     }
     const config = load(mockNativeClient)
     expect(config.apiKey).toBe('123')
-    expect(config._didLoadFromConfig).toBe(true)
     expect(config._originalValues).toEqual({ apiKey: '123' })
   })
 

--- a/packages/react-native/types/bugsnag.d.ts
+++ b/packages/react-native/types/bugsnag.d.ts
@@ -1,13 +1,12 @@
-import { Client, BugsnagStatic, Config } from '@bugsnag/core'
+import { Client, Config } from '@bugsnag/core'
 
 // these properties are allowed to be configured in the JS layer
 type Configurable = 'onError' | 'onBreadcrumb' | 'logger' | 'metadata' | 'user' | 'context' | 'plugins'
 
 type ReactNativeConfig = Pick<Config, Configurable>
 
-interface ReactNativeBugsnagStatic extends BugsnagStatic {
-  start(apiKeyOrOpts?: string | ReactNativeConfig | LoadedConfig): Client
-  createClient(apiKeyOrOpts?: string | ReactNativeConfig | LoadedConfig): Client
+interface ReactNativeBugsnagStatic extends Client {
+  start(jsOpts?: ReactNativeConfig): Client
 }
 
 // the config returned from Configuration.load() includes
@@ -16,15 +15,8 @@ type NonConfigurable = Exclude<keyof Config, Configurable>
 // this utility is in typescript core but was only added in v3.5
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>
 
-type LoadedConfig = ReactNativeConfig & Readonly<Omit<Config, Configurable>>
-
-interface Configuration {
-  load(): LoadedConfig
-}
-
 declare const Bugsnag: ReactNativeBugsnagStatic
-declare const Configuration: Configuration
 
 export default Bugsnag
 export * from '@bugsnag/core'
-export { ReactNativeConfig, Configuration }
+export { ReactNativeConfig }

--- a/packages/react-native/types/test/fixtures/all-options.ts
+++ b/packages/react-native/types/test/fixtures/all-options.ts
@@ -1,4 +1,4 @@
-import Bugsnag, { Configuration, Breadcrumb, Session } from "../../.."
+import Bugsnag, { Breadcrumb, Session } from "../../.."
 Bugsnag.start({
   onError: [
     event => true
@@ -11,6 +11,3 @@ Bugsnag.start({
   metadata: {},
   logger: undefined,
 })
-
-const config = Configuration.load()
-Bugsnag.start(config)

--- a/packages/react-native/types/test/fixtures/plugins.ts
+++ b/packages/react-native/types/test/fixtures/plugins.ts
@@ -1,6 +1,5 @@
 import Bugsnag from "../../..";
 Bugsnag.start({
-  apiKey:'api_key',
   plugins: [{
     name: 'foobar',
     load: client => 10


### PR DESCRIPTION
This PR ensures that Bugsnag works when a React Native application is run in remote debugging mode, where the JS is executed in a Chrome browser.

Synchronous native methods are not allowed when debugging remotely, which we use for initialisation (to ensure no errors are missed). The approach, with caveats is as follows:

- `Configuration.load()` and `Bugsnag.createClient()` are removed from the public interface, reducing the impact of asynchronous behaviour
- In normal situations, the way Bugsnag initialises remains exactly the same
- In the remote debugger, `Bugsnag.start()` now returns a proxy which stubs a client, until the async configure method has completed. Until such point, it will no-op and log any synchronous method calls. After successful configuration it will forward method calls on to the initialised client.

N.B. this is only on Android for the time being.