### PR TITLE
V7: allow top level metadata

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -235,6 +235,15 @@ It remains possible to supply initial metadata in configuration:
   })
 ```
 
+All metadata is now required to have a section. If you were previously supplying metadata without a section name (this would display on your dashboard under the "Custom" tab), we have enabled passing `null` as the section name for continuity:
+
+```js
+- bugsnagClient.metaData.assetUrl = config.assetUrl
++ Bugsnag.addMetadata(null, 'assetUrl', config.assetUrl)
+```
+
+You should only use this method if you have a custom filter based on some top-level metadata, otherwise you should supply a section name for your metadata.
+
 #### Context
 
 On the client, context is now managed via `get/setContext()`:

--- a/packages/core/lib/metadata-delegate.js
+++ b/packages/core/lib/metadata-delegate.js
@@ -1,7 +1,7 @@
 const assign = require('./es-utils/assign')
 
 const add = (state, section, keyOrObj, maybeVal) => {
-  if (!section) return
+  if (!section && section !== null) return
   let updates
 
   // addMetadata("section", null) -> clears section
@@ -14,11 +14,14 @@ const add = (state, section, keyOrObj, maybeVal) => {
   // exit if we don't have an updates object at this point
   if (!updates) return
 
-  // ensure a section with this name exists
-  if (!state[section]) state[section] = {}
-
-  // merge the updates with the existing section
-  state[section] = assign({}, state[section], updates)
+  if (section !== null) {
+    // ensure a section with this name exists
+    if (!state[section] || typeof state[section] !== 'object') state[section] = {}
+    // merge the updates with the existing section
+    state[section] = assign({}, state[section], updates)
+  } else {
+    assign(state, updates)
+  }
 }
 
 const get = (state, section, key) => {

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -639,6 +639,18 @@ describe('@bugsnag/core/client', () => {
       expect(client.getMetadata('a', 'b')).toBe(undefined)
       client.clearMetadata('a')
       expect(client.getMetadata('a')).toBe(undefined)
+
+      // check that top-level metadata can be added with section=null
+      client.addMetadata(null, 'top', 'val')
+      expect(client._metadata).toEqual({ top: 'val' })
+      client.addMetadata('top', 'key', 'val')
+      expect(client._metadata).toEqual({ top: { key: 'val' } })
+
+      client._metadata = {}
+
+      client.addMetadata('replace', 'key', 'origval')
+      client.addMetadata(null, 'replace', { diffkey: 'replaceval' })
+      expect(client._metadata).toEqual({ replace: { diffkey: 'replaceval' } })
     })
 
     it('can be set in config', () => {

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -34,8 +34,8 @@ declare class Client {
   ): void;
 
   // metadata
-  public addMetadata(section: string, values: { [key: string]: any }): void;
-  public addMetadata(section: string, key: string, value: any): void;
+  public addMetadata(section: string | null, values: { [key: string]: any }): void;
+  public addMetadata(section: string | null, key: string, value: any): void;
   public getMetadata(section: string, key?: string): any;
   public clearMetadata(section: string, key?: string): void;
 

--- a/packages/core/types/event.d.ts
+++ b/packages/core/types/event.d.ts
@@ -38,8 +38,8 @@ declare class Event {
   public setUser(id?: string, email?: string, name?: string): void;
 
   // metadata
-  public addMetadata(section: string, values: { [key: string]: any }): void;
-  public addMetadata(section: string, key: string, value: any): void;
+  public addMetadata(section: string | null, values: { [key: string]: any }): void;
+  public addMetadata(section: string | null, key: string, value: any): void;
   public getMetadata(section: string, key?: string): any;
   public clearMetadata(section: string, key?: string): void;
 }


### PR DESCRIPTION
To avoid breaking custom filters unnecessarily, this PR enables metadata to be supplied without a section key.