### PR TITLE
fix: Ensure breadcrumbs behave correctly

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -301,12 +301,14 @@ class Client {
         return cb(null, event)
       }
 
-      // only leave a crumb for the error if actually got sent
-      Client.prototype.leaveBreadcrumb.call(this, event.errors[0].errorClass, {
-        errorClass: event.errors[0].errorClass,
-        errorMessage: event.errors[0].errorMessage,
-        severity: event.severity
-      }, 'error')
+      if (includes(this._config.enabledBreadcrumbTypes, 'error')) {
+        // only leave a crumb for the error if actually got sent
+        Client.prototype.leaveBreadcrumb.call(this, event.errors[0].errorClass, {
+          errorClass: event.errors[0].errorClass,
+          errorMessage: event.errors[0].errorMessage,
+          severity: event.severity
+        }, 'error')
+      }
 
       if (originalSeverity !== event.severity) {
         event._handledState.severityReason = { type: 'userCallbackSetSeverity' }

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -487,6 +487,21 @@ describe('@bugsnag/core/client', () => {
       expect(client._breadcrumbs.length).toBe(1)
       expect(client._breadcrumbs[0].type).toBe('manual')
     })
+
+    it('only leaves an error breadcrumb if enabledBreadcrumbTypes contains "error"', (done) => {
+      const client = new Client({
+        apiKey: 'API_KEY_YEAH',
+        enabledBreadcrumbTypes: []
+      })
+      client._setDelivery(client => ({
+        sendSession: () => {},
+        sendEvent: (payload, cb) => cb(null)
+      }))
+      client.notify(new Error('oh no'), () => {}, () => {
+        expect(client._breadcrumbs.length).toBe(0)
+        done()
+      })
+    })
   })
 
   describe('startSession()', () => {

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -54,6 +54,8 @@ const Bugsnag = {
       bugsnag._logger.warn('Breadcrumbs are not supported in Node.js yet')
     }
 
+    bugsnag._config.enabledBreadcrumbTypes = []
+
     return bugsnag
   },
   start: (opts) => {


### PR DESCRIPTION
Now that leaveBreadcrumb() doesn't have the check of enabledBreadcrumbTypes, the notifier needs to check if "error" breadcrumbs are desired before adding them.

Additionally this commit forces Node not to leave any breadcrumbs at all, until they are switched on.