### PR TITLE
Release/v6.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 6.6.1 (2020-04-03)
+
+### Fix
+
+- (expo): Ensure Expo packages that depend on `NetInfo` have their versions locked [#796](https://github.com/bugsnag/bugsnag-js/pull/796)
+- (expo-cli): Update Expo versions installed by the cli [#796](https://github.com/bugsnag/bugsnag-js/pull/796)
+
+Note, alongside this release, additional patches were made to previous minor versions of `@bugsnag/expo`: `6.5.3` and `6.4.4`. This is to ensure the correct version of `NetInfo` is depended on for SDK versions 36 and 34 respectively.
+
 ## 6.6.0 (2020-04-02)
 
 ### Changed

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -82,11 +82,11 @@ const selectVersion = async (dir) => {
       message = 'It looks like you’re using a version of Expo SDK <33. The last version of Bugsnag that supported your version of Expo is v6.3.0'
       defaultVersion = '6.3.0'
     } else if (isPre36) {
-      message = 'It looks like you’re using a version of Expo SDK <36. The last version of Bugsnag that supported your version of Expo is v6.4.1'
-      defaultVersion = '6.4.1'
+      message = 'It looks like you’re using a version of Expo SDK <36. The last version of Bugsnag that supported your version of Expo is v6.4.4'
+      defaultVersion = '6.4.4'
     } else if (isPre37) {
-      message = 'It looks like you’re using a version of Expo SDK <37. The last version of Bugsnag that supported your version of Expo is v6.5.1'
-      defaultVersion = '6.5.1'
+      message = 'It looks like you’re using a version of Expo SDK <37. The last version of Bugsnag that supported your version of Expo is v6.5.3'
+      defaultVersion = '6.5.3'
     }
 
     const { version } = await prompts({

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -79,8 +79,7 @@ const selectVersion = async (dir) => {
     const isPre37 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '37.0.0'))
 
     if (isPre33) {
-      message = 'It looks like you’re using a version of Expo SDK <33. The last version of Bugsnag that supported your version of Expo is v6.3.0'
-      defaultVersion = '6.3.0'
+      throw new Error('Expo SDK <33 is no longer supported')
     } else if (isPre36) {
       message = 'It looks like you’re using a version of Expo SDK <36. The last version of Bugsnag that supported your version of Expo is v6.4.4'
       defaultVersion = '6.4.4'

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@bugsnag/core": "^6.5.0",
-    "@bugsnag/delivery-expo": "^6.6.0",
+    "@bugsnag/delivery-expo": "6.6.0",
     "@bugsnag/plugin-browser-session": "^6.5.0",
     "@bugsnag/plugin-console-breadcrumbs": "^6.5.0",
     "@bugsnag/plugin-expo-app": "^6.5.0",
@@ -55,7 +55,7 @@
     "@bugsnag/plugin-network-breadcrumbs": "^6.5.0",
     "@bugsnag/plugin-react": "^6.5.0",
     "@bugsnag/plugin-react-native-app-state-breadcrumbs": "^6.5.0",
-    "@bugsnag/plugin-react-native-connectivity-breadcrumbs": "^6.6.0",
+    "@bugsnag/plugin-react-native-connectivity-breadcrumbs": "6.6.0",
     "@bugsnag/plugin-react-native-global-error-handler": "^6.5.0",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^6.5.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^6.5.0",


### PR DESCRIPTION
Ensure Expo packages have fixed dependencies on modules that use netinfo, so we ensure the correct version is used for each SDK.