### PR TITLE
V7: revert top level metadata

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -235,6 +235,13 @@ It remains possible to supply initial metadata in configuration:
   })
 ```
 
+Previously, it was possible to add "top-level" metadata, i.e. data that you did not provide a specific `section` name for. In the dashboard, this would display under a tab with the heading "Custom". Since a section name is now required, for continuity both visually and for any custom filters you may have set up based on such data, you should set the section name to `'custom'`:
+
+```diff
+- bugsnagClient.metaData = { processId: 'aa874cbd', role: 'image-resizer' }
++ Bugsnag.addMetadata('custom', { processId: 'aa874cbd', role: 'image-resizer' })
+```
+
 #### Context
 
 On the client, context is now managed via `get/setContext()`:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,8 +5,6 @@ Upgrading
 
 __This version contains many breaking changes__. It is part of an effort to unify our notifier libraries across platforms, making the user interface more consistent, and implementations better on multi-layered environments where multiple Bugsnag libraries need to work together (such as React Native).
 
-__As a result of upgrading, your project may see new error groups for existing errors.__ This is because JavaScript errors are grouped by comparing the surrounding code.
-
 ### New static interface
 
 In most applications, the desire is to create a single Bugsnag client – it's rare that you'd want to instantiate multiple clients. We've made static initialization the primary interface, so that the user experience is optimized around the main use case – creating a single client:
@@ -237,15 +235,6 @@ It remains possible to supply initial metadata in configuration:
   })
 ```
 
-All metadata is now required to have a section. If you were previously supplying metadata without a section name (this would display on your dashboard under the "Custom" tab), we have enabled passing `null` as the section name for continuity:
-
-```js
-- bugsnagClient.metaData.assetUrl = config.assetUrl
-+ Bugsnag.addMetadata(null, 'assetUrl', config.assetUrl)
-```
-
-You should only use this method if you have a custom filter based on some top-level metadata, otherwise you should supply a section name for your metadata.
-
 #### Context
 
 On the client, context is now managed via `get/setContext()`:
@@ -287,21 +276,7 @@ Here are some examples:
 ```diff
   // changing severity
 - bugsnagClient.notify(err, { severity: 'info' })
-+ Bugsnag.notify(err, event => { event.severity = 'info' })
-
-  // adding metadata
-- bugsnagClient.notify(err, {
--   metaData: {
--     component: { 
--       instanceId: component.instanceId
--     }
--   }
-- })
-+ Bugsnag.notify(err, event => {
-+   event.addMetadata('component, {
-+     instanceId: component.instanceId
-+   }
-+ })
++ Bugsnag.notify(err, event => { severity: 'info' })
 
   // preventing send
 - bugsnagClient.notify(err, report => {

--- a/packages/core/lib/metadata-delegate.js
+++ b/packages/core/lib/metadata-delegate.js
@@ -1,7 +1,7 @@
 const assign = require('./es-utils/assign')
 
 const add = (state, section, keyOrObj, maybeVal) => {
-  if (!section && section !== null) return
+  if (!section) return
   let updates
 
   // addMetadata("section", null) -> clears section
@@ -14,14 +14,11 @@ const add = (state, section, keyOrObj, maybeVal) => {
   // exit if we don't have an updates object at this point
   if (!updates) return
 
-  if (section !== null) {
-    // ensure a section with this name exists
-    if (!state[section] || typeof state[section] !== 'object') state[section] = {}
-    // merge the updates with the existing section
-    state[section] = assign({}, state[section], updates)
-  } else {
-    assign(state, updates)
-  }
+  // ensure a section with this name exists
+  if (!state[section]) state[section] = {}
+
+  // merge the updates with the existing section
+  state[section] = assign({}, state[section], updates)
 }
 
 const get = (state, section, key) => {

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -654,18 +654,6 @@ describe('@bugsnag/core/client', () => {
       expect(client.getMetadata('a', 'b')).toBe(undefined)
       client.clearMetadata('a')
       expect(client.getMetadata('a')).toBe(undefined)
-
-      // check that top-level metadata can be added with section=null
-      client.addMetadata(null, 'top', 'val')
-      expect(client._metadata).toEqual({ top: 'val' })
-      client.addMetadata('top', 'key', 'val')
-      expect(client._metadata).toEqual({ top: { key: 'val' } })
-
-      client._metadata = {}
-
-      client.addMetadata('replace', 'key', 'origval')
-      client.addMetadata(null, 'replace', { diffkey: 'replaceval' })
-      expect(client._metadata).toEqual({ replace: { diffkey: 'replaceval' } })
     })
 
     it('can be set in config', () => {

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -34,8 +34,8 @@ declare class Client {
   ): void;
 
   // metadata
-  public addMetadata(section: string | null, values: { [key: string]: any }): void;
-  public addMetadata(section: string | null, key: string, value: any): void;
+  public addMetadata(section: string, values: { [key: string]: any }): void;
+  public addMetadata(section: string, key: string, value: any): void;
   public getMetadata(section: string, key?: string): any;
   public clearMetadata(section: string, key?: string): void;
 


### PR DESCRIPTION
Removes the feature that was added in #787, and provides guidance on how to maintain consistency with the display and custom filters after the upgrade.