### PR TITLE
Update expo CI entitlements for iOS

### DIFF
--- a/test/expo/scripts/build-ios-locally.sh
+++ b/test/expo/scripts/build-ios-locally.sh
@@ -7,7 +7,7 @@ docker-compose run expo-publisher
 
 cd test/expo/features/fixtures/test-app && \
 npm i turtle-cli@0.14 bunyan --no-save --no-package-lock && \
-perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/xdl/build/detach/IosNSBundle.js && \
+perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js && \
 node_modules/.bin/turtle build:ios \
   -c test/expo/features/fixtures/test-app/app.json \
   --team-id $APPLE_TEAM_ID \

--- a/test/expo/scripts/build-ios-locally.sh
+++ b/test/expo/scripts/build-ios-locally.sh
@@ -8,6 +8,7 @@ docker-compose run expo-publisher
 cd test/expo/features/fixtures/test-app && \
 npm i turtle-cli@0.14 bunyan --no-save --no-package-lock && \
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js && \
+perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/\@expo/xdl/build/detach/IosNSBundle.js && \
 node_modules/.bin/turtle build:ios \
   -c test/expo/features/fixtures/test-app/app.json \
   --team-id $APPLE_TEAM_ID \

--- a/test/expo/scripts/build-ios.sh
+++ b/test/expo/scripts/build-ios.sh
@@ -7,6 +7,7 @@ rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH/build/*
 cd test/expo/features/fixtures/test-app
 npm i turtle-cli@0.14 bunyan
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js
+perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/\@expo/xdl/build/detach/IosNSBundle.js
 mkdir -p ~/expo-bundle-files
 cp node_modules/\@expo/xdl/build/detach/IosNSBundle.js ~/expo-bundle-files/$EXPO_RELEASE_CHANNEL.js
 node_modules/.bin/turtle build:ios \

--- a/test/expo/scripts/build-ios.sh
+++ b/test/expo/scripts/build-ios.sh
@@ -8,8 +8,6 @@ cd test/expo/features/fixtures/test-app
 npm i turtle-cli@0.14 bunyan
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/\@expo/xdl/build/detach/IosNSBundle.js
-mkdir -p ~/expo-bundle-files
-cp node_modules/\@expo/xdl/build/detach/IosNSBundle.js ~/expo-bundle-files/$EXPO_RELEASE_CHANNEL.js
 node_modules/.bin/turtle build:ios \
   -c ./app.json \
   --team-id $APPLE_TEAM_ID \

--- a/test/expo/scripts/build-ios.sh
+++ b/test/expo/scripts/build-ios.sh
@@ -6,7 +6,7 @@ set -e
 rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH/build/*
 cd test/expo/features/fixtures/test-app
 npm i turtle-cli@0.14 bunyan
-perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/turtle-cli/node_modules/xdl/build/detach/IosNSBundle.js
+perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js
 node_modules/.bin/turtle build:ios \
   -c ./app.json \
   --team-id $APPLE_TEAM_ID \

--- a/test/expo/scripts/build-ios.sh
+++ b/test/expo/scripts/build-ios.sh
@@ -7,6 +7,8 @@ rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH/build/*
 cd test/expo/features/fixtures/test-app
 npm i turtle-cli@0.14 bunyan
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js
+mkdir -p ~/expo-bundle-files
+cp node_modules/\@expo/xdl/build/detach/IosNSBundle.js >> ~/expo-bundle-files/$EXPO_RELEASE_CHANNEL.js
 node_modules/.bin/turtle build:ios \
   -c ./app.json \
   --team-id $APPLE_TEAM_ID \

--- a/test/expo/scripts/build-ios.sh
+++ b/test/expo/scripts/build-ios.sh
@@ -8,7 +8,7 @@ cd test/expo/features/fixtures/test-app
 npm i turtle-cli@0.14 bunyan
 perl -0777 -i.original -pe "s/entitlements\\['aps-environment'\\] =[^;]+;//gs" node_modules/\@expo/xdl/build/detach/IosNSBundle.js
 mkdir -p ~/expo-bundle-files
-cp node_modules/\@expo/xdl/build/detach/IosNSBundle.js >> ~/expo-bundle-files/$EXPO_RELEASE_CHANNEL.js
+cp node_modules/\@expo/xdl/build/detach/IosNSBundle.js ~/expo-bundle-files/$EXPO_RELEASE_CHANNEL.js
 node_modules/.bin/turtle build:ios \
   -c ./app.json \
   --team-id $APPLE_TEAM_ID \


### PR DESCRIPTION
Updates the iOS build script to remove APS-entitlements from XDL in following XDL being repositioned in `node_modules`