### PR TITLE
fix(delivery-expo): Ensure error properties are correctly indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+### Fixed
+- Ensure Expo delivery logs event details correctly (instead of `undefined`) [#804](https://github.com/bugsnag/bugsnag-js/pull/804)
+
 ## 7.0.0 (2020-04-14)
 
 ### Added

--- a/packages/delivery-expo/delivery.js
+++ b/packages/delivery-expo/delivery.js
@@ -55,7 +55,7 @@ module.exports = (client, fetch = global.fetch) => {
           enqueue('event', { url, opts })
           return cb(null)
         }
-        client._logger.info(`Sending event ${event.events[0].errorClass}: ${event.events[0].errorMessage}`)
+        client._logger.info(`Sending event ${event.events[0].errors[0].errorClass}: ${event.events[0].errors[0].errorMessage}`)
         send(url, opts, err => {
           if (err) return onerror(err, { url, opts }, 'event', cb)
           cb(null)

--- a/packages/delivery-expo/test/delivery.test.js
+++ b/packages/delivery-expo/test/delivery.test.js
@@ -61,7 +61,7 @@ describe('delivery: expo', () => {
       expect(err).toBeUndefined()
 
       const payload = {
-        events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }]
+        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
       }
       const config = {
         apiKey: 'aaaaaaaa',
@@ -96,7 +96,9 @@ describe('delivery: expo', () => {
     server.listen((err) => {
       expect(err).toBeUndefined()
 
-      const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+      const payload = {
+        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+      }
       const config = {
         apiKey: 'aaaaaaaa',
         endpoints: { notify: 'blah', sessions: `http://0.0.0.0:${server.address().port}/sessions/` },
@@ -132,7 +134,9 @@ describe('delivery: expo', () => {
       './network-status': MockNetworkStatus
     })
 
-    const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+    const payload = {
+      events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+    }
     const config = {
       apiKey: 'aaaaaaaa',
       endpoints: { notify: 'http://0.0.0.0:9999/notify/' },
@@ -166,7 +170,9 @@ describe('delivery: expo', () => {
     server.listen((err) => {
       expect(err).toBeUndefined()
 
-      const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+      const payload = {
+        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+      }
       const config = {
         apiKey: 'aaaaaaaa',
         endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` },
@@ -198,7 +204,9 @@ describe('delivery: expo', () => {
       './network-status': MockNetworkStatus
     })
 
-    const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+    const payload = {
+      events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+    }
     const config = {
       apiKey: 'aaaaaaaa',
       endpoints: { sessions: 'http://0.0.0.0:9999/sessions/' },
@@ -234,7 +242,9 @@ describe('delivery: expo', () => {
 
     server.listen((err) => {
       expect(err).toBeFalsy()
-      const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+      const payload = {
+        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+      }
       const config = {
         apiKey: 'aaaaaaaa',
         endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` },
@@ -272,7 +282,9 @@ describe('delivery: expo', () => {
 
     server.listen((err) => {
       expect(err).toBeFalsy()
-      const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+      const payload = {
+        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+      }
       const config = {
         apiKey: 'aaaaaaaa',
         endpoints: { notify: `http://0.0.0.0:${server.address().port}/notify/` },
@@ -302,7 +314,10 @@ describe('delivery: expo', () => {
       './network-status': MockNetworkStatus
     })
 
-    const payload = { sample: 'payload', attemptImmediateDelivery: false }
+    const payload = {
+      events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }],
+      attemptImmediateDelivery: false
+    }
     const config = {
       apiKey: 'aaaaaaaa',
       endpoints: { notify: 'https://some-address.com' },
@@ -384,7 +399,9 @@ describe('delivery: expo', () => {
       './redelivery': NoopRedelivery,
       './network-status': MockNetworkStatus
     })
-    const payload = { events: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }
+    const payload = {
+      events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+    }
     const config = {
       apiKey: 'aaaaaaaa',
       endpoints: { notify: 'http://some-address.com' },


### PR DESCRIPTION
Fixes a bug that causes the following to be logged for each event sent:

`[bugsnag] Sending event undefined: undefined`