### PR TITLE
fix(expo): Ensure types allow start() can be called with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - (plugin-vue): Fix plugin type definitions [#809](https://github.com/bugsnag/bugsnag-js/pull/809)
 - (delivery-expo): Ensure Expo delivery logs event details correctly (instead of `undefined`) [#804](https://github.com/bugsnag/bugsnag-js/pull/804)
 - (expo-cli): Ensure Expo cli inserts correct code depending on the version of the notifier [#808](https://github.com/bugsnag/bugsnag-js/pull/808)
+- (expo): Ensure types allow `.start()` with no arguments [#817](https://github.com/bugsnag/bugsnag-js/pull/817)
 
 ## 7.0.0 (2020-04-14)
 

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -1,6 +1,9 @@
-import { BugsnagStatic } from '@bugsnag/core'
+import { BugsnagStatic, Config, Client } from '@bugsnag/core'
 
-declare const Bugsnag: BugsnagStatic
+interface ExpoBugsnagStatic extends BugsnagStatic {
+  start(apiKeyOrOpts?: string | Config): Client
+}
+declare const Bugsnag: ExpoBugsnagStatic
 
 export default Bugsnag
 export * from '@bugsnag/core'

--- a/packages/expo/types/test/fixtures/all-options.ts
+++ b/packages/expo/types/test/fixtures/all-options.ts
@@ -30,3 +30,5 @@ Bugsnag.start({
   logger: undefined,
   redactedKeys: ["foo",/bar/]
 })
+
+Bugsnag.start()


### PR DESCRIPTION
The implementation of `start()` on Expo allows no arguments. This updates the types to reflect that.