### PR TITLE
Allow specifying different node_modules location for React Native Android

### DIFF
--- a/packages/react-native/CONTRIBUTING.md
+++ b/packages/react-native/CONTRIBUTING.md
@@ -38,6 +38,8 @@ registry=http://localhost:4873
 
 Currently this branch relies on a snapshotted version of bugsnag-android, which should _just work_.
 
+The tests can be run with by running `./gradlew test -Pbugsnagdev=true` from the `android` directory.
+
 #### iOS
 
 The cocoa notifier is vendored in to this repo so nothing special is required there.

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -49,15 +49,21 @@ dependencies {
     testImplementation "org.mockito:mockito-core:2.28.2"
 }
 
+// All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+// once released, it should look in the node_modules at the root of the project.
+//
+// In development, we need to edit this to look at the top-level node_modules of
+// the monorepo instead.
+def facebookRepo = "$rootDir/../node_modules/react-native/android"
+
+if (safeExtGet("bugsnagdev", false)) {
+    project.logger.lifecycle("Development mode enabled, searching for dependencies at top of monorepo.")
+    facebookRepo = "$rootDir/../../../node_modules/react-native/android"
+}
+
 allprojects {
     repositories {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            // once released, it should look in the node_modules at the root of the project
-            url "$rootDir/../node_modules/react-native/android"
-            // in development, it needs to look at the top-level node_modules of the monorepo
-            url "$rootDir/../../../node_modules/react-native/android"
-        }
+        maven { url facebookRepo }
         mavenLocal()
         jcenter()
         google()

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
@@ -27,7 +27,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
 
     override fun getName(): String = "BugsnagReactNative"
 
-    private fun logFailure(msg: String, exc: Throwable) {
+    fun logFailure(msg: String, exc: Throwable) {
         logger.e("Failed to call $msg on bugsnag-plugin-react-native, continuing", exc)
     }
 
@@ -37,12 +37,12 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
      * be used.
      */
     @ReactMethod
-    private fun configureAsync(env: ReadableMap, promise: Promise) {
+    fun configureAsync(env: ReadableMap, promise: Promise) {
       promise.resolve(configure(env))
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    private fun configure(env: ReadableMap): WritableMap {
+    fun configure(env: ReadableMap): WritableMap {
         return try {
             val client = Bugsnag.getClient()
             bridge = reactContext.getJSModule(RCTDeviceEventEmitter::class.java)
@@ -59,7 +59,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     /**
      * Serializes a MessageEvent into a WritableMap and sends it across the React Bridge
      */
-    private fun emitEvent(event: MessageEvent) {
+    fun emitEvent(event: MessageEvent) {
         logger.d("Received MessageEvent: ${event.type}")
 
         val map = Arguments.createMap()
@@ -75,7 +75,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun updateCodeBundleId(id: String?) {
+    fun updateCodeBundleId(id: String?) {
         try {
             plugin.updateCodeBundleId(id)
         } catch (exc: Throwable) {
@@ -84,7 +84,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun leaveBreadcrumb(map: ReadableMap) {
+    fun leaveBreadcrumb(map: ReadableMap) {
         try {
             plugin.leaveBreadcrumb(map.toHashMap())
         } catch (exc: Throwable) {
@@ -93,7 +93,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun startSession() {
+    fun startSession() {
         try {
             plugin.startSession()
         } catch (exc: Throwable) {
@@ -102,7 +102,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun pauseSession() {
+    fun pauseSession() {
         try {
             plugin.pauseSession()
         } catch (exc: Throwable) {
@@ -111,7 +111,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun resumeSession() {
+    fun resumeSession() {
         try {
             plugin.resumeSession()
         } catch (exc: Throwable) {
@@ -120,7 +120,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun updateContext(context: String?) {
+    fun updateContext(context: String?) {
         try {
             plugin.updateContext(context)
         } catch (exc: Throwable) {
@@ -129,7 +129,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun updateMetadata(section: String, data: ReadableMap?) {
+    fun updateMetadata(section: String, data: ReadableMap?) {
         try {
             plugin.updateMetadata(section, data?.toHashMap())
         } catch (exc: Throwable) {
@@ -138,7 +138,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun updateUser(id: String?, email: String?, name: String?) {
+    fun updateUser(id: String?, email: String?, name: String?) {
         try {
             plugin.updateUser(id, email, name)
         } catch (exc: Throwable) {
@@ -147,7 +147,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun dispatch(payload: ReadableMap, promise: Promise) {
+    fun dispatch(payload: ReadableMap, promise: Promise) {
         try {
             plugin.dispatch(payload.toHashMap())
             promise.resolve(true)
@@ -158,7 +158,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    private fun getPayloadInfo(payload: ReadableMap, promise: Promise) {
+    fun getPayloadInfo(payload: ReadableMap, promise: Promise) {
         try {
             val unhandled = payload.getBoolean("unhandled")
             val info = plugin.getPayloadInfo(unhandled)

--- a/packages/react-native/android/src/test/java/com/bugsnag/android/BugsnagReactNativeTest.kt
+++ b/packages/react-native/android/src/test/java/com/bugsnag/android/BugsnagReactNativeTest.kt
@@ -89,6 +89,6 @@ class BugsnagReactNativeTest {
     @Test
     fun getPayloadInfo() {
         brn.getPayloadInfo(map, promise)
-        verify(plugin, times(1)).getPayloadInfo()
+        verify(plugin, times(1)).getPayloadInfo(false)
     }
 }


### PR DESCRIPTION
## Goal

During development the `@bugsnag/react-native` package needs to access AARs in facebook's `react-native` module, which is installed at the top of the monorepo. This enables running Gradle tasks from the `packages/react-native` directory.

However, during typical end-user usage, this node_module should be accessed only from an application's node_modules folder. The previous build script added both of these locations at once as a maven repository, which caused a classloader error to crash the example app when node_modules were installed in both locations.

This changeset fixes this issue so that only one maven repository can be specified, and fixes unit tests in this directory.

## Changeset

- Tests should now be run using `./gradlew test -Pbugsnagdev=true` in the `packages/react-native` directory
- Altered build.gradle file to default to using the typical location for `node_modules`, and use the top level of the monorepo if the `bugsnagdev` flag is set
- Fixed unit tests in `packages/react-native`

## Tests
Tested by running the example app with node_modules installed in both directories, and by running the unit tests in `packages/react-native`.