### PR TITLE
Update React Bridge method signatures for Cocoa

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
@@ -7,12 +7,19 @@
 
 @interface BugsnagReactNative: NSObject<RCTBridgeModule>
 
-- (NSDictionary *)configure;
+- (void)configureAsync:(NSDictionary *)readableMap
+               resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject;
+
+- (NSDictionary *)configure:(NSDictionary *)readableMap;
+
+- (void)updateCodeBundleId:(NSString *)codeBundleId;
 
 - (void)updateMetadata:(NSString *)section
               withData:(NSDictionary *)update;
 
 - (void)updateContext:(NSString *)context;
+
 - (void)updateUser:(NSString *)userId
          withEmail:(NSString *)email
           withName:(NSString *)name;
@@ -22,10 +29,11 @@
 - (void)resumeSession;
 
 - (void)dispatch:(NSDictionary *)payload
-        resolve:(RCTPromiseResolveBlock)resolve
-         reject:(RCTPromiseRejectBlock)reject;
+         resolve:(RCTPromiseResolveBlock)resolve
+          reject:(RCTPromiseRejectBlock)reject;
 
-- (void)getPayloadInfo:(RCTPromiseResolveBlock)resolve
+- (void)getPayloadInfo:(NSDictionary *)payloadInfo
+               resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject;
 
 - (void)leaveBreadcrumb:(NSDictionary *)options;

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -12,21 +12,27 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure) {
-  if (![Bugsnag bugsnagStarted]) {
-    // TODO: fail loudly here
-    return nil;
-  }
+RCT_EXPORT_METHOD(configureAsync:(NSDictionary *)readableMap
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject) {
+    resolve([self configure:readableMap]);
+}
 
-  // TODO: use this emitter to notifier JS of changes to user, context and metadata
-  BugsnagReactNativeEmitter *emitter = [BugsnagReactNativeEmitter new];
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
+    if (![Bugsnag bugsnagStarted]) {
+        // TODO: fail loudly here
+        return nil;
+    }
 
-  // TODO: convert the entire config into a map
-  BugsnagConfiguration *config = [Bugsnag configuration];
-  return @{
-    @"apiKey": [config apiKey],
-    @"releaseStage": [config releaseStage],
-  };
+    // TODO: use this emitter to inform JS of changes to user, context and metadata
+    BugsnagReactNativeEmitter *emitter = [BugsnagReactNativeEmitter new];
+
+    // TODO: convert the entire config into a map
+    BugsnagConfiguration *config = [Bugsnag configuration];
+    return @{
+        @"apiKey": [config apiKey],
+        @"releaseStage": [config releaseStage],
+    };
 }
 
 RCT_EXPORT_METHOD(updateMetadata
@@ -35,39 +41,46 @@ RCT_EXPORT_METHOD(updateMetadata
   //TODO
 }
 
-RCT_EXPORT_METHOD(updateContext
-                  :(NSString *)context) {
+RCT_EXPORT_METHOD(updateContext:(NSString *)context) {
     [Bugsnag setContext:context];
 }
 
-RCT_EXPORT_METHOD(updateUser
-                  :(NSString *)userId
-         withEmail:(NSString *)email
-          withName:(NSString *)name) {
+RCT_EXPORT_METHOD(updateCodeBundleId:(NSString *)codeBundleId) {
+    // TODO
+}
+
+RCT_EXPORT_METHOD(updateUser:(NSString *)userId
+                   withEmail:(NSString *)email
+                    withName:(NSString *)name) {
     [Bugsnag setUser:userId withEmail:email andName:name];
 }
 
-RCT_EXPORT_METHOD(dispatch
-                  :(NSDictionary *)payload
-           resolve:(RCTPromiseResolveBlock)resolve
-            reject:(RCTPromiseRejectBlock)reject) {
-  resolve(@{});
+RCT_EXPORT_METHOD(dispatch:(NSDictionary *)payload
+                   resolve:(RCTPromiseResolveBlock)resolve
+                    reject:(RCTPromiseRejectBlock)reject) {
+    resolve(@{});
 }
 
-RCT_EXPORT_METHOD(leaveBreadcrumb
-                  :(NSDictionary *)options) {
+RCT_EXPORT_METHOD(leaveBreadcrumb:(NSDictionary *)options) {
   //TODO
 }
 
-RCT_EXPORT_METHOD(startSession) { [Bugsnag startSession]; }
-RCT_EXPORT_METHOD(pauseSession) { [Bugsnag pauseSession]; }
-RCT_EXPORT_METHOD(resumeSession) { [Bugsnag resumeSession]; }
+RCT_EXPORT_METHOD(startSession) {
+    [Bugsnag startSession];
+}
 
-RCT_EXPORT_METHOD(getPayloadInfo
-                  :(NSDictionary *)options
-           resolve:(RCTPromiseResolveBlock)resolve
-            reject:(RCTPromiseRejectBlock)reject) {
-  resolve(@{});
+RCT_EXPORT_METHOD(pauseSession) {
+    [Bugsnag pauseSession];
+}
+
+RCT_EXPORT_METHOD(resumeSession) {
+    [Bugsnag resumeSession];
+}
+
+RCT_EXPORT_METHOD(getPayloadInfo:(NSDictionary *)options
+                         resolve:(RCTPromiseResolveBlock)resolve
+                          reject:(RCTPromiseRejectBlock)reject) {
+    resolve(@{});
 }
 
 @end


### PR DESCRIPTION
## Goal
The methods on the React Bridge have changed slightly as part of the Android implementation. This changeset updates the signatures to match what the JS sends, and prevents the example app from crashing when loading React Native.

Note: this is based off #819 which has not yet been merged.

## Changeset

- Updated header file method signatures to match those expected by bugsnag-js
- Updated code formatting to match Cocoa conventions of 4-space indentation, and parameters aligned by colon position
- Implemented `configureAsync` method