### PR TITLE
Serialize cocoa config for React Native JS layer

### DIFF
--- a/packages/react-native/ios/Bugsnag/Bugsnag.h
+++ b/packages/react-native/ios/Bugsnag/Bugsnag.h
@@ -52,7 +52,7 @@
  *
  * @param apiKey  The API key from your Bugsnag dashboard.
  */
-+ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *_Nonnull)apiKey;
++ (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey;
 
 /** Start listening for crashes.
  *
@@ -63,7 +63,7 @@
  *
  * @param configuration  The configuration to use.
  */
-+ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
++ (BugsnagClient *_Nonnull)startWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed

--- a/packages/react-native/ios/Bugsnag/BugsnagErrorTypes.h
+++ b/packages/react-native/ios/Bugsnag/BugsnagErrorTypes.h
@@ -45,5 +45,12 @@
  */
 @property BOOL machExceptions;
 
+/**
+ * Sets whether Bugsnag should automatically capture and report unhandled promise rejections.
+ * This only applies to React Native apps.
+ * By default, this value is true.
+ */
+@property BOOL unhandledRejections;
+
 @end
 

--- a/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		E72B3254241FC57E005FB2CA /* libBugsnagReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD256131D6DE5F600C7D842 /* libBugsnagReactNative.a */; };
 		E72B325B241FC771005FB2CA /* BugsnagReactNativeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E72B325A241FC771005FB2CA /* BugsnagReactNativeTest.m */; };
 		E7397E5B1F83BD7D0034242A /* libBugsnagStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7397E5A1F83BD750034242A /* libBugsnagStatic.a */; };
+		E7819C5C2459C7A100A7EBDD /* BugsnagConfigSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */; };
+		E7819C5D2459C7A500A7EBDD /* BugsnagConfigSerializer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +170,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				E7819C5D2459C7A500A7EBDD /* BugsnagConfigSerializer.h in CopyFiles */,
 				E72AE2B9241AA1BB00ED8972 /* BugsnagReactNativeEmitter.h in CopyFiles */,
 				65ED539B23D86A77006E3DC2 /* BugsnagReactNativePlugin.h in CopyFiles */,
 				8AD256171D6DE5F600C7D842 /* BugsnagReactNative.h in CopyFiles */,
@@ -191,6 +194,8 @@
 		E72B325A241FC771005FB2CA /* BugsnagReactNativeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagReactNativeTest.m; sourceTree = "<group>"; };
 		E7397E6D1F83BF8F0034242A /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		E7397E721F83BF940034242A /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagConfigSerializer.h; sourceTree = "<group>"; };
+		E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagConfigSerializer.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +261,8 @@
 		8AD256151D6DE5F600C7D842 /* BugsnagReactNative */ = {
 			isa = PBXGroup;
 			children = (
+				E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */,
+				E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */,
 				65AE6AA823D89BDC00301CC1 /* BugsnagReactNativeEmitter.h */,
 				65AE6AA423D89BDC00301CC1 /* BugsnagReactNativeEmitter.m */,
 				65ED539923D86A45006E3DC2 /* BugsnagReactNativePlugin.h */,
@@ -546,6 +553,7 @@
 				65AE6AA923D89BDD00301CC1 /* BugsnagReactNativeEmitter.m in Sources */,
 				8AD256191D6DE5F600C7D842 /* BugsnagReactNative.m in Sources */,
 				65ED539A23D86A45006E3DC2 /* BugsnagReactNativePlugin.m in Sources */,
+				E7819C5C2459C7A100A7EBDD /* BugsnagConfigSerializer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.h
@@ -1,0 +1,21 @@
+//
+//  BugsnagConfigSerializer.h
+//  BugsnagReactNative
+//
+//  Created by Jamie Lynch on 16/03/2020.
+//  Copyright © 2020 Bugsnag, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Bugsnag.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagConfigSerializer : NSObject
+
+- (NSDictionary *)serialize:(BugsnagConfiguration *)config;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
@@ -19,7 +19,7 @@
     BSGDictInsertIfNotNil(dict, config.enabledReleaseStages, @"enabledReleaseStages");
     BSGDictInsertIfNotNil(dict, config.releaseStage, @"releaseStage");
     BSGDictInsertIfNotNil(dict, config.appVersion, @"appVersion");
-    BSGDictInsertIfNotNil(dict, config.appType, @"type");
+    BSGDictInsertIfNotNil(dict, config.appType, @"appType");
     BSGDictInsertIfNotNil(dict, @(config.persistUser), @"persistUser");
     BSGDictInsertIfNotNil(dict, @(config.maxBreadcrumbs), @"maxBreadcrumbs");
     

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
@@ -1,0 +1,90 @@
+//
+//  BugsnagConfigSerializer.m
+//  BugsnagReactNative
+//
+//  Created by Jamie Lynch on 16/03/2020.
+//  Copyright © 2020 Bugsnag, Inc. All rights reserved.
+//
+
+#import "BugsnagConfigSerializer.h"
+#import "BugsnagCollections.h"
+
+@implementation BugsnagConfigSerializer
+
+- (NSDictionary *)serialize:(BugsnagConfiguration *)config {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    BSGDictInsertIfNotNil(dict, config.apiKey, @"apiKey");
+    BSGDictInsertIfNotNil(dict, @(config.autoDetectErrors), @"autoDetectErrors");
+    BSGDictInsertIfNotNil(dict, @(config.autoTrackSessions), @"autoTrackSessions");
+    BSGDictInsertIfNotNil(dict, config.enabledReleaseStages, @"enabledReleaseStages");
+    BSGDictInsertIfNotNil(dict, config.releaseStage, @"releaseStage");
+    BSGDictInsertIfNotNil(dict, config.appVersion, @"appVersion");
+    BSGDictInsertIfNotNil(dict, config.appType, @"type");
+    BSGDictInsertIfNotNil(dict, @(config.persistUser), @"persistUser");
+    BSGDictInsertIfNotNil(dict, @(config.maxBreadcrumbs), @"maxBreadcrumbs");
+    
+    BSGDictInsertIfNotNil(dict, [self serializeThreadSendPolicy:config.sendThreads], @"sendThreads");
+    BSGDictInsertIfNotNil(dict, [self serializeBreadcrumbTypes:config], @"enabledBreadcrumbTypes");
+    BSGDictInsertIfNotNil(dict, [self serializeErrorTypes:config], @"enabledErrorTypes");
+    BSGDictInsertIfNotNil(dict, [self serializeEndpoints:config], @"endpoints");
+
+    return [NSDictionary dictionaryWithDictionary:dict];
+}
+
+- (NSDictionary *)serializeEndpoints:(BugsnagConfiguration *)config {
+    return @{
+        @"notify" : config.endpoints.notify,
+        @"sessions" : config.endpoints.sessions
+    };
+}
+
+- (NSDictionary *)serializeErrorTypes:(BugsnagConfiguration *)config {
+    return @{
+        @"unhandledExceptions" : @(config.enabledErrorTypes.unhandledExceptions),
+        @"unhandledRejections" : @(config.enabledErrorTypes.unhandledRejections)
+    };
+}
+
+- (NSString *)serializeThreadSendPolicy:(BSGThreadSendPolicy)policy {
+    switch (policy) {
+        case BSGThreadSendPolicyAlways:
+            return @"ALWAYS";
+        case BSGThreadSendPolicyUnhandledOnly:
+            return @"UNHANDLED_ONLY";
+        case BSGThreadSendPolicyNever:
+            return @"NEVER";
+        default:
+            return @"ALWAYS";
+    }
+}
+
+- (NSArray *)serializeBreadcrumbTypes:(BugsnagConfiguration *)config {
+    NSMutableArray *types = [NSMutableArray new];
+    [types addObject:@"manual"];
+    BSGEnabledBreadcrumbType enabled = config.enabledBreadcrumbTypes;
+    
+    if (enabled & BSGEnabledBreadcrumbTypeError) {
+        [types addObject:@"error"];
+    }
+    if (enabled & BSGEnabledBreadcrumbTypeLog) {
+        [types addObject:@"log"];
+    }
+    if (enabled & BSGEnabledBreadcrumbTypeNavigation) {
+        [types addObject:@"navigation"];
+    }
+    if (enabled & BSGEnabledBreadcrumbTypeProcess) {
+        [types addObject:@"process"];
+    }
+    if (enabled & BSGEnabledBreadcrumbTypeRequest) {
+        [types addObject:@"request"];
+    }
+    if (enabled & BSGEnabledBreadcrumbTypeState) {
+        [types addObject:@"state"];
+    }
+    if (enabled & BSGEnabledBreadcrumbTypeUser) {
+        [types addObject:@"user"];
+    }
+    return types;
+}
+
+@end

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -1,12 +1,17 @@
 #import "Bugsnag.h"
 #import "BugsnagReactNative.h"
 #import "BugsnagReactNativeEmitter.h"
+#import "BugsnagConfigSerializer.h"
 
 @interface Bugsnag ()
 + (id)client;
 + (BOOL)bugsnagStarted;
 + (BugsnagConfiguration *)configuration;
 + (void)updateCodeBundleId:(NSString *)codeBundleId;
+@end
+
+@interface BugsnagReactNative ()
+@property (nonatomic) BugsnagConfigSerializer *configSerializer;
 @end
 
 @implementation BugsnagReactNative
@@ -20,20 +25,17 @@ RCT_EXPORT_METHOD(configureAsync:(NSDictionary *)readableMap
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
+    self.configSerializer = [BugsnagConfigSerializer new];
+    
     if (![Bugsnag bugsnagStarted]) {
-        // TODO: fail loudly here
         return nil;
     }
 
     // TODO: use this emitter to inform JS of changes to user, context and metadata
     BugsnagReactNativeEmitter *emitter = [BugsnagReactNativeEmitter new];
 
-    // TODO: convert the entire config into a map
     BugsnagConfiguration *config = [Bugsnag configuration];
-    return @{
-        @"apiKey": [config apiKey],
-        @"releaseStage": [config releaseStage],
-    };
+    return [self.configSerializer serialize:config];
 }
 
 RCT_EXPORT_METHOD(updateMetadata:(NSString *)section

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/CHANGELOG.md
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/CHANGELOG.md
@@ -8,6 +8,12 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add `unhandledRejections` to `BugsnagErrorTypes`
+  [#567](https://github.com/bugsnag/bugsnag-cocoa/pull/567)
+
+* Rename `Bugsnag` start methods
+  [#566](https://github.com/bugsnag/bugsnag-cocoa/pull/566)
+
 * Rename `OnSend` to `OnSendError`
   [#562](https://github.com/bugsnag/bugsnag-cocoa/pull/562)
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.h
@@ -52,7 +52,7 @@
  *
  * @param apiKey  The API key from your Bugsnag dashboard.
  */
-+ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *_Nonnull)apiKey;
++ (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey;
 
 /** Start listening for crashes.
  *
@@ -63,7 +63,7 @@
  *
  * @param configuration  The configuration to use.
  */
-+ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
++ (BugsnagClient *_Nonnull)startWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.m
@@ -68,12 +68,12 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 @implementation Bugsnag
 
-+ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *)apiKey {
++ (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-    return [self startBugsnagWithConfiguration:configuration];
+    return [self startWithConfiguration:configuration];
 }
 
-+ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
++ (BugsnagClient *_Nonnull)startWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration {
     @synchronized(self) {
         bsg_g_bugsnag_client =
                 [[BugsnagClient alloc] initWithConfiguration:configuration];

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagErrorTypes.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagErrorTypes.h
@@ -45,5 +45,12 @@
  */
 @property BOOL machExceptions;
 
+/**
+ * Sets whether Bugsnag should automatically capture and report unhandled promise rejections.
+ * This only applies to React Native apps.
+ * By default, this value is true.
+ */
+@property BOOL unhandledRejections;
+
 @end
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagErrorTypes.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagErrorTypes.m
@@ -16,6 +16,7 @@
         _signals = true;
         _cppExceptions = true;
         _machExceptions = true;
+        _unhandledRejections = true;
 
 #if DEBUG
         _ooms = false;

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Private.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Private.h
@@ -25,8 +25,8 @@
 
 /** Get the current Bugsnag configuration.
  *
- * This method returns nil if called before +startBugsnagWithApiKey: or
- * +startBugsnagWithConfiguration:, and otherwise returns the current
+ * This method returns nil if called before +startWithApiKey: or
+ * +startWithConfiguration:, and otherwise returns the current
  * configuration for Bugsnag.
  *
  * @return The configuration, or nil.

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/UPGRADING.md
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/UPGRADING.md
@@ -129,12 +129,18 @@ Bugsnag.getMetadata("section" key:"key")
 [Bugsnag getMetadata:@"section" key:@"key"];
 ```
 
-`startBugsnagWithApiKey` and `startBugsnagWithConfiguration` now return a `BugsnagClient`.
+`startWithApiKey` and `startWithConfiguration` now return a `BugsnagClient`.
 
 #### Renames
 
 ```diff
 ObjC:
+
+- [Bugsnag startBugsnagWithApiKey]
++ [Bugsnag startWithApiKey]
+
+- [Bugsnag startBugsnagWithConfiguration]
++ [Bugsnag startWithConfiguration]
 
 - [Bugsnag configuration]
 + [Bugsnag setUser:withEmail:andName:]
@@ -155,6 +161,11 @@ ObjC:
 + [Bugsnag notify:block:]
 
 Swift:
+- Bugsnag.startBugsnagWith(:apiKey)
++ Bugsnag.startWith(:apiKey)
+
+- Bugsnag.startBugsnagWith(:configuration)
++ Bugsnag.startWith(:configuration)
 
 - Bugsnag.configuration()
 + Bugsnag.setUser(_:email:name:)

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -170,12 +170,6 @@
 		E72BF77F1FC86A7A004BE82F /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E72BF7801FC86A7A004BE82F /* BugsnagUser.m in Sources */ = {isa = PBXBuildFile; fileRef = E72BF77E1FC86A7A004BE82F /* BugsnagUser.m */; };
 		E72BF7811FC86A7A004BE82F /* BugsnagUser.m in Sources */ = {isa = PBXBuildFile; fileRef = E72BF77E1FC86A7A004BE82F /* BugsnagUser.m */; };
-		E732BAF52456F09100365780 /* BugsnagMetadataStore.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 009DF96824327FA2000A8363 /* BugsnagMetadataStore.h */; };
-		E732BAF62456F09100365780 /* BugsnagPluginClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */; };
-		E732BAF72456F09100365780 /* Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A3B5F252407EC6400CE4A3A /* Private.h */; };
-		E732BAF82456F09100365780 /* BSGOutOfMemoryWatchdog.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */; };
-		E732BAF92456F09100365780 /* BSG_SSKeychain.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0061D84624067AF80041C068 /* BSG_SSKeychain.h */; };
-		E732BAFA2456F09100365780 /* BSG_KSCrashIdentifier.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A530CBE22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.h */; };
 		E733A7681FD7091F003EAA29 /* KSCrashSentry_NSException_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E733A7641FD7091F003EAA29 /* KSCrashSentry_NSException_Tests.m */; };
 		E733A76A1FD7091F003EAA29 /* KSCrashSentry_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E733A7661FD7091F003EAA29 /* KSCrashSentry_Tests.m */; };
 		E733A76B1FD7091F003EAA29 /* KSCrashSentry_Signal_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E733A7671FD7091F003EAA29 /* KSCrashSentry_Signal_Tests.m */; };
@@ -412,12 +406,6 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
-				E732BAF52456F09100365780 /* BugsnagMetadataStore.h in CopyFiles */,
-				E732BAF62456F09100365780 /* BugsnagPluginClient.h in CopyFiles */,
-				E732BAF72456F09100365780 /* Private.h in CopyFiles */,
-				E732BAF82456F09100365780 /* BSGOutOfMemoryWatchdog.h in CopyFiles */,
-				E732BAF92456F09100365780 /* BSG_SSKeychain.h in CopyFiles */,
-				E732BAFA2456F09100365780 /* BSG_KSCrashIdentifier.h in CopyFiles */,
 				E7565F7C245082580041768E /* BugsnagErrorTypes.h in CopyFiles */,
 				E77AFEF22448A13C0082B8BB /* BugsnagSessionInternal.h in CopyFiles */,
 				E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */,

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
@@ -33,7 +33,7 @@
     config.autoDetectErrors = NO;
     config.releaseStage = @"MagicalTestingTime";
 
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
 }
 
 - (void)testNilPathDoesNotCreateWatchdog {


### PR DESCRIPTION
## Goal

Serializes the Configuration object into JSON for use by the JS layer on React Native.

## Changeset
- Updated vendored bugsnag-cocoa code to latest on `v6`
- Created `BugsnagConfigSerializer` which converts `BugsnagConfiguration` into an `NSDictionary`
- Serialized all the configuration options available in Cocoa v6
- Returned the serialized config in the `configure()` method

This has been tested by manually verifying that the example app runs and does not log any warnings about invalid configuration values.