### PR TITLE
Call methods for fetching payload info for RN Cocoa

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -1,10 +1,19 @@
 #import "Bugsnag.h"
+#import "BugsnagClient.h"
 #import "BugsnagReactNative.h"
 #import "BugsnagReactNativeEmitter.h"
 #import "BugsnagConfigSerializer.h"
 #import "BugsnagEventDeserializer.h"
 
+@interface BugsnagClient ()
+- (NSDictionary *)collectAppWithState;
+- (NSDictionary *)collectDeviceWithState;
+- (NSArray *)collectBreadcrumbs;
+- (NSArray *)collectThreads;
+@end
+
 @interface Bugsnag ()
++ (BugsnagClient *)client;
 + (BOOL)bugsnagStarted;
 + (BugsnagConfiguration *)configuration;
 + (void)updateCodeBundleId:(NSString *)codeBundleId;
@@ -101,7 +110,13 @@ RCT_EXPORT_METHOD(resumeSession) {
 RCT_EXPORT_METHOD(getPayloadInfo:(NSDictionary *)options
                          resolve:(RCTPromiseResolveBlock)resolve
                           reject:(RCTPromiseRejectBlock)reject) {
-    resolve(@{});
+    BugsnagClient *client = [Bugsnag client];
+    NSMutableDictionary *info = [NSMutableDictionary new];
+    info[@"app"] = [client collectAppWithState];
+    info[@"device"] = [client collectDeviceWithState];
+    info[@"breadcrumbs"] = [client collectBreadcrumbs];
+    info[@"threads"] = [client collectThreads];
+    resolve(info);
 }
 
 - (BSGBreadcrumbType)breadcrumbTypeFromString:(NSString *)value {

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
@@ -336,6 +336,10 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 + (NSDateFormatter *_Nonnull)payloadDateFormatter;
 @end
 
+@interface BugsnagBreadcrumbs ()
+@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
+@end
+
 // =============================================================================
 // MARK: - BugsnagClient
 // =============================================================================
@@ -1433,9 +1437,19 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (NSArray *)collectBreadcrumbs {
-    return @[
-        // TODO implement
-    ];
+    NSMutableArray *crumbs = self.configuration.breadcrumbs.breadcrumbs;
+    NSMutableArray *data = [NSMutableArray new];
+
+    for (BugsnagBreadcrumb *crumb in crumbs) {
+        NSMutableDictionary *crumbData = [[crumb objectValue] mutableCopy];
+        // JSON is serialized as 'name', we want as 'message' when passing to RN
+        crumbData[@"message"] = crumbData[@"name"];
+        crumbData[@"name"] = nil;
+        crumbData[@"metadata"] = crumbData[@"metaData"];
+        crumbData[@"metaData"] = nil;
+        [data addObject: crumbData];
+    }
+    return data;
 }
 
 - (NSArray *)collectThreads {


### PR DESCRIPTION
## Goal

Calls methods in bugsnag-cocoa for obtaining payload info, and serializes it in `getPayloadInfo`.

## Changeset

- Updates vendored cocoa to the latest from https://github.com/bugsnag/bugsnag-cocoa/pull/575
- Updates example app to use `startWithConfiguration` rather than removed method
- Modified `BugsnagReactNative` to use data collection methods added onto `BugsnagClient`, and serialize them in the `getPayloadInfo` method

Note that the Thread information has not been added in this changeset. This is not easy to collect in bugsnag-cocoa so will be addressed separately.
