### PR TITLE
Specify local maven repository in gradle for RN example/fixtures

### DIFF
--- a/examples/reactnative/android/build.gradle
+++ b/examples/reactnative/android/build.gradle
@@ -22,16 +22,14 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { // bugsnag AAR dependencies are installed from npm
+            url "$rootDir/../node_modules/@bugsnag/react-native/android"
+        }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-        mavenLocal()
         jcenter()
         google()
-
-        maven { // add this to use snapshots
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
     }
 }

--- a/test/react-native/features/fixtures/rn0.55/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.55/android/build.gradle
@@ -19,16 +19,14 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { // bugsnag AAR dependencies are installed from npm
+            url "$rootDir/../node_modules/@bugsnag/react-native/android"
+        }
         google()
-        mavenLocal()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
-        maven { url 'https://maven.google.com' }
     }
 }

--- a/test/react-native/features/fixtures/rn0.60/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.60/android/build.gradle
@@ -24,7 +24,9 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
+        maven { // bugsnag AAR dependencies are installed from npm
+            url "$rootDir/../node_modules/@bugsnag/react-native/android"
+        }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -32,12 +34,6 @@ allprojects {
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
-        }
-        maven {
-            url("http://maven.google.com")
-        }
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
 
         google()


### PR DESCRIPTION
## Goal

Fixes the React Native example app + test fixtures by specifying the maven repository location in the correct gradle script. This failure was originally obscured by `mavenLocal` containing a copy of the necessary dependency.

As an additional part of this changeset, `mavenLocal` and other unused repositories have been removed from the example app/fixtures to prevent similar future bugs.