### PR TITLE
Implement dispatch method for Cocoa RN

### DIFF
--- a/examples/reactnative/ios/reactnative/AppDelegate.m
+++ b/examples/reactnative/ios/reactnative/AppDelegate.m
@@ -20,7 +20,7 @@
 {
   BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc]
                                          initWithApiKey:@"0abcdef000000abcdef000000abcdef0"];
-  [Bugsnag startBugsnagWithConfiguration:configuration];
+  [Bugsnag startWithConfiguration:configuration];
   
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge

--- a/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		E7819C5C2459C7A100A7EBDD /* BugsnagConfigSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */; };
 		E7819C5D2459C7A500A7EBDD /* BugsnagConfigSerializer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */; };
 		E7A8E9D624602C9800CCBBD1 /* BugsnagEventDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A8E9D524602C9800CCBBD1 /* BugsnagEventDeserializer.m */; };
+		E7A8EA3E2461679B00CCBBD1 /* BugsnagEventDeserializer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7A8E9D424602C9800CCBBD1 /* BugsnagEventDeserializer.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -171,6 +172,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				E7A8EA3E2461679B00CCBBD1 /* BugsnagEventDeserializer.h in CopyFiles */,
 				E7819C5D2459C7A500A7EBDD /* BugsnagConfigSerializer.h in CopyFiles */,
 				E72AE2B9241AA1BB00ED8972 /* BugsnagReactNativeEmitter.h in CopyFiles */,
 				65ED539B23D86A77006E3DC2 /* BugsnagReactNativePlugin.h in CopyFiles */,

--- a/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/BugsnagReactNative.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		E7397E5B1F83BD7D0034242A /* libBugsnagStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E7397E5A1F83BD750034242A /* libBugsnagStatic.a */; };
 		E7819C5C2459C7A100A7EBDD /* BugsnagConfigSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */; };
 		E7819C5D2459C7A500A7EBDD /* BugsnagConfigSerializer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */; };
+		E7A8E9D624602C9800CCBBD1 /* BugsnagEventDeserializer.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A8E9D524602C9800CCBBD1 /* BugsnagEventDeserializer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -196,6 +197,8 @@
 		E7397E721F83BF940034242A /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagConfigSerializer.h; sourceTree = "<group>"; };
 		E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagConfigSerializer.m; sourceTree = "<group>"; };
+		E7A8E9D424602C9800CCBBD1 /* BugsnagEventDeserializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagEventDeserializer.h; sourceTree = "<group>"; };
+		E7A8E9D524602C9800CCBBD1 /* BugsnagEventDeserializer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagEventDeserializer.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -263,6 +266,8 @@
 			children = (
 				E7819C572459C7A100A7EBDD /* BugsnagConfigSerializer.h */,
 				E7819C5B2459C7A100A7EBDD /* BugsnagConfigSerializer.m */,
+				E7A8E9D424602C9800CCBBD1 /* BugsnagEventDeserializer.h */,
+				E7A8E9D524602C9800CCBBD1 /* BugsnagEventDeserializer.m */,
 				65AE6AA823D89BDC00301CC1 /* BugsnagReactNativeEmitter.h */,
 				65AE6AA423D89BDC00301CC1 /* BugsnagReactNativeEmitter.m */,
 				65ED539923D86A45006E3DC2 /* BugsnagReactNativePlugin.h */,
@@ -550,6 +555,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7A8E9D624602C9800CCBBD1 /* BugsnagEventDeserializer.m in Sources */,
 				65AE6AA923D89BDD00301CC1 /* BugsnagReactNativeEmitter.m in Sources */,
 				8AD256191D6DE5F600C7D842 /* BugsnagReactNative.m in Sources */,
 				65ED539A23D86A45006E3DC2 /* BugsnagReactNativePlugin.m in Sources */,

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.h
@@ -1,0 +1,21 @@
+//
+//  BugsnagEventDeserializer.h
+//  BugsnagReactNative
+//
+//  Created by Jamie Lynch on 04/05/2020.
+//  Copyright © 2020 Bugsnag, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Bugsnag.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagEventDeserializer : NSObject
+
+- (BugsnagEvent *)deserializeEvent:(NSDictionary *)payload;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -1,0 +1,52 @@
+//
+//  BugsnagEventDeserializer.m
+//  BugsnagReactNative
+//
+//  Created by Jamie Lynch on 04/05/2020.
+//  Copyright © 2020 Bugsnag, Inc. All rights reserved.
+//
+
+#import "BugsnagEventDeserializer.h"
+
+@interface Bugsnag ()
++ (id)client;
++ (BugsnagConfiguration *)configuration;
+@end
+
+@interface BugsnagClient()
+@property id sessionTracker;
+@property BugsnagMetadata *metadata;
+@end
+
+@interface BugsnagMetadata ()
+@end
+
+@interface BugsnagEvent ()
+- (instancetype _Nonnull)initWithErrorName:(NSString *_Nonnull)name
+                              errorMessage:(NSString *_Nonnull)message
+                             configuration:(BugsnagConfiguration *_Nonnull)config
+                                  metadata:(BugsnagMetadata *_Nullable)metadata
+                              handledState:(BugsnagHandledState *_Nonnull)handledState
+                                   session:(BugsnagSession *_Nullable)session;
+@end
+
+@implementation BugsnagEventDeserializer
+
+- (BugsnagEvent *)deserializeEvent:(NSDictionary *)payload {
+    NSLog(@"Received JS payload dispatch: %@", payload);
+
+    BugsnagClient *client = [Bugsnag client];
+    BugsnagSession *session = [client.sessionTracker valueForKey:@"runningSession"];
+    BugsnagMetadata *metadata = client.metadata;
+
+    NSDictionary *error = payload[@"errors"][0];
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithErrorName:error[@"errorClass"]
+                              errorMessage:error[@"errorMessage"]
+                             configuration:[Bugsnag configuration]
+                                  metadata:metadata
+                              handledState:nil
+                                   session:session];
+    return event;
+}
+
+@end

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -2,12 +2,14 @@
 #import "BugsnagReactNative.h"
 #import "BugsnagReactNativeEmitter.h"
 #import "BugsnagConfigSerializer.h"
+#import "BugsnagEventDeserializer.h"
 
 @interface Bugsnag ()
-+ (id)client;
 + (BOOL)bugsnagStarted;
 + (BugsnagConfiguration *)configuration;
 + (void)updateCodeBundleId:(NSString *)codeBundleId;
++ (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BOOL (^_Nonnull)(BugsnagEvent *_Nonnull))block;
 @end
 
 @interface BugsnagReactNative ()
@@ -26,7 +28,7 @@ RCT_EXPORT_METHOD(configureAsync:(NSDictionary *)readableMap
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
     self.configSerializer = [BugsnagConfigSerializer new];
-    
+
     if (![Bugsnag bugsnagStarted]) {
         return nil;
     }
@@ -64,6 +66,12 @@ RCT_EXPORT_METHOD(updateUser:(NSString *)userId
 RCT_EXPORT_METHOD(dispatch:(NSDictionary *)payload
                    resolve:(RCTPromiseResolveBlock)resolve
                     reject:(RCTPromiseRejectBlock)reject) {
+    BugsnagEventDeserializer *deserializer = [BugsnagEventDeserializer new];
+    BugsnagEvent *event = [deserializer deserializeEvent:payload];
+    [Bugsnag notifyInternal:event block:^BOOL(BugsnagEvent * _Nonnull event) {
+        NSLog(@"Sending event from JS: %@", event);
+        return true;
+    }];
     resolve(@{});
 }
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.m
@@ -56,9 +56,8 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 @interface BugsnagClient ()
 - (void)startListeningForStateChangeNotification:(NSString *_Nonnull)notificationName;
 - (void)addBreadcrumbWithBlock:(void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
-- (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block;
+- (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock)block;
 @property (nonatomic) NSString *codeBundleId;
 @end
 
@@ -156,13 +155,11 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
  * Intended for use by other clients (React Native/Unity). Calling this method
  * directly from iOS is not supported.
  */
-+ (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block {
++ (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagStarted]) {
-        [self.client internalClientNotify:exception
-                                   withData:metadata
-                                      block:block];
+        [self.client notifyInternal:event
+                              block:block];
     }
 }
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
@@ -59,7 +59,7 @@ NSString *const BSTabCrash = @"crash";
 NSString *const BSAttributeDepth = @"depth";
 NSString *const BSEventLowMemoryWarning = @"lowMemoryWarning";
 
-static NSInteger const BSGNotifierStackFrameCount = 5;
+static NSInteger const BSGNotifierStackFrameCount = 6;
 
 struct bugsnag_data_t {
     // Contains the state of the event (handled/unhandled)
@@ -101,6 +101,19 @@ static bool hasRecordedSessions;
 @interface BugsnagSession ()
 @property NSUInteger unhandledCount;
 @property NSUInteger handledCount;
+@end
+
+
+@interface BugsnagAppWithState ()
++ (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
+                                    config:(BugsnagConfiguration *)config
+                              codeBundleId:(NSString *)codeBundleId;
+- (NSDictionary *)toDict;
+@end
+
+@interface BugsnagDeviceWithState ()
++ (BugsnagDeviceWithState *)deviceWithDictionary:(NSDictionary *)event;
+- (NSDictionary *)toDictionary;
 @end
 
 /**
@@ -828,35 +841,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self notify:exception handledState:state block:block];
 }
 
-/**
- *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
- *
- *  @param exception the exception
- *  @param metadata  the metadata
- *  @param block     Configuration block for adding additional report
- * information
- */
-- (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block
-{
-    BSGSeverity severity = BSGParseSeverity(metadata[BSGKeySeverity]);
-    NSString *severityReason = metadata[BSGKeySeverityReason];
-    BOOL unhandled = [metadata[BSGKeyUnhandled] boolValue];
-    NSString *logLevel = metadata[BSGKeyLogLevel];
-    NSParameterAssert(severityReason.length > 0);
-
-    SeverityReasonType severityReasonType =
-        [BugsnagHandledState severityReasonFromString:severityReason];
-
-    BugsnagHandledState *state = [[BugsnagHandledState alloc] initWithSeverityReason:severityReasonType
-                                                                            severity:severity
-                                                                           unhandled:unhandled
-                                                                           attrValue:logLevel];
-
-    [self notify:exception handledState:state block:block];
-}
-
 - (void)notifyOutOfMemoryEvent {
     static NSString *const BSGOutOfMemoryErrorClass = @"Out Of Memory";
     static NSString *const BSGOutOfMemoryMessageFormat = @"The app was likely terminated by the operating system while in the %@";
@@ -902,11 +886,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 {
     NSString *exceptionName = exception.name ?: NSStringFromClass([exception class]);
     NSString *message = exception.reason;
-    if (handledState.unhandled) {
-        [self.sessionTracker handleUnhandledErrorEvent];
-    } else {
-        [self.sessionTracker handleHandledErrorEvent];
-    }
 
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithErrorName:exceptionName
                                                      errorMessage:message
@@ -915,12 +894,29 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                                                      handledState:handledState
                                                           session:self.sessionTracker.runningSession];
     event.originalError = exception;
-    
+    [self notifyInternal:event block:block];
+}
+
+/**
+ *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
+ *
+ *  @param event    the event
+ *  @param block     Configuration block for adding additional report information
+ */
+- (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock)block
+{
     if (block != nil && !block(event)) { // skip notifying if callback false
         return;
     }
-    
-    //    We discard 5 stack frames (including this one) by default,
+
+    if (event.handledState.unhandled) {
+        [self.sessionTracker handleUnhandledErrorEvent];
+    } else {
+        [self.sessionTracker handleHandledErrorEvent];
+    }
+
+    //    We discard 6 stack frames (including this one) by default,
     //    and sum that with the number specified by report.depth:
     //
     //    0 bsg_kscrashsentry_reportUserException
@@ -928,35 +924,42 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     //    2 -[BSG_KSCrash
     //    reportUserException:reason:language:lineOfCode:stackTrace:terminateProgram:]
     //    3 -[BugsnagCrashSentry reportUserException:reason:]
-    //    4 -[BugsnagClient notify:message:block:]
+    //    4 -[BugsnagClient notifyInternal:block:]
+    //    5 -[BugsnagClient notify:message:block:]
 
     int depth = (int)(BSGNotifierStackFrameCount + event.depth);
 
     NSString *eventErrorClass = event.errors[0].errorClass ?: NSStringFromClass([NSException class]);
     NSString *eventMessage = event.errors[0].errorMessage ?: @"";
 
+    NSException *exc = nil;
+
+    if ([event.originalError isKindOfClass:[NSException class]]) {
+        exc = event.originalError;
+    }
+
     [self.crashSentry reportUserException:eventErrorClass
                                    reason:eventMessage
-                        originalException:exception
-                             handledState:[handledState toJson]
+                        originalException:exc
+                             handledState:[event.handledState toJson]
                                  appState:[self.state toDictionary]
                         callbackOverrides:event.overrides
                                  metadata:[event.metadata toDictionary]
                                    config:[self.configuration.config toDictionary]
                              discardDepth:depth];
-    
+
     // A basic set of event metadata
     NSMutableDictionary *metadata = [@{
-        BSGKeyErrorClass : eventErrorClass,
-        BSGKeyUnhandled : [[event handledState] unhandled] ? @YES : @NO,
-        BSGKeySeverity : BSGFormatSeverity(event.severity)
+            BSGKeyErrorClass : eventErrorClass,
+            BSGKeyUnhandled : [[event handledState] unhandled] ? @YES : @NO,
+            BSGKeySeverity : BSGFormatSeverity(event.severity)
     } mutableCopy];
-    
+
     // Only include the eventMessage if it contains something
     if (eventMessage && [eventMessage length] > 0) {
         [metadata setValue:eventMessage forKey:BSGKeyName];
     }
-    
+
     [self addAutoBreadcrumbOfType:BSGBreadcrumbTypeError
                       withMessage:eventErrorClass
                       andMetadata:metadata];
@@ -1411,6 +1414,34 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                        withKey:(NSString *_Nonnull)key
 {
     [self.metadata clearMetadataFromSection:sectionName withKey:key];
+}
+
+// MARK: - methods used by React Native for collecting payload data
+
+- (NSDictionary *)collectAppWithState {
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:@{@"system": systemInfo}
+                                                               config:self.configuration
+                                                         codeBundleId:self.codeBundleId];
+    return [app toDict];
+}
+
+- (NSDictionary *)collectDeviceWithState {
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:@{@"system": systemInfo}];
+    return [device toDictionary];
+}
+
+- (NSArray *)collectBreadcrumbs {
+    return @[
+        // TODO implement
+    ];
+}
+
+- (NSArray *)collectThreads {
+    return @[
+        // TODO implement
+    ];
 }
 
 @end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagDeviceWithState.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagDeviceWithState.m
@@ -90,7 +90,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
     [self populateFields:device dictionary:event];
     device.orientation = [event valueForKeyPath:@"user.state.deviceState.orientation"];
-    device.freeMemory = [event valueForKeyPath:@"system.memory.free"];
+    device.freeMemory = [event valueForKeyPath:@"system.memory.free"] ?: [event valueForKeyPath:@"system.memory.usable"];
     device.freeDisk = BSGDeviceFreeSpace(NSCachesDirectory);
 
     NSString *val = [event valueForKeyPath:@"report.timestamp"];

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.m
@@ -480,7 +480,13 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         }
         self.breadcrumbs = [crumbs copy];
 
-        _handledState = handledState;
+        if (handledState == nil) { // initialise a sensible default to avoid crashing
+            _handledState = [BugsnagHandledState handledStateWithSeverityReason:HandledException
+                                                                       severity:BSGSeverityWarning
+                                                                      attrValue:nil];
+        } else {
+            _handledState = handledState;
+        }
         _severity = handledState.currentSeverity;
         _session = session;
         _threads = [NSMutableArray new];
@@ -813,6 +819,10 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                        withKey:(NSString *_Nonnull)key
 {
     [self.metadata clearMetadataFromSection:sectionName withKey:key];
+}
+
+- (void)updateUnhandled:(BOOL)val {
+    self.handledState.unhandled = val;
 }
 
 @end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagHandledState.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagHandledState.h
@@ -42,7 +42,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 
 @interface BugsnagHandledState : NSObject
 
-@property(nonatomic, readonly) BOOL unhandled;
+@property(nonatomic) BOOL unhandled;
 @property(nonatomic, readonly) SeverityReasonType severityReasonType;
 @property(nonatomic, readonly) BSGSeverity originalSeverity;
 @property(nonatomic) BSGSeverity currentSeverity;

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		E79148281FD828E6003EFEBF /* BugsnagSessionTrackingPayload.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */; };
 		E79148291FD828E6003EFEBF /* BugsnagUser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; };
 		E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
+		E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A9E56B2436363900D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */; };
 		E7AB4B9C2423E16C004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */; };
 		E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */; };
@@ -718,6 +719,7 @@
 		E790C49A2434C8C8006FFB26 /* BugsnagAppTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagAppTest.m; path = ../../Tests/BugsnagAppTest.m; sourceTree = "<group>"; };
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportConverter_Tests.m; path = ../Tests/KSCrash/KSCrashReportConverter_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -880,6 +882,7 @@
 				8A2C8F8B1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m */,
 				0089B70224221EDE00D5A7F2 /* BugsnagClientTests.m */,
 				E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */,
+				E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
 				4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
 				4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */,
@@ -1553,6 +1556,7 @@
 				E722105C243B69F00083CF15 /* BugsnagStackframeTest.m in Sources */,
 				8A2C8F911C6BBFDD00846019 /* BugsnagSinkTests.m in Sources */,
 				E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
+				E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */,
 				E784D2551FD70B3B004B01E1 /* KSCrashState_Tests.m in Sources */,
 				00D7ACAD23E9C63000FBE4A7 /* BugsnagTests.m in Sources */,
 				8A2C8F901C6BBFDD00846019 /* BugsnagEventTests.m in Sources */,


### PR DESCRIPTION
## Goal

Implements the `dispatch()` method for the Cocoa layer of React Native. Errors from the JS layer are now delivered to Bugsnag's API. Population of all the JS payload on the `BugsnagEvent` will take place in future changesets for ease of review.

## Changeset

- Vendored the changes from the corresponding Cocoa PR: https://github.com/bugsnag/bugsnag-cocoa/pull/576
- Constructed a `BugsnagEvent` by accessing internal Cocoa constructors, and passed it through to `[Bugsnag notifyInternal]`
- Create `BugsnagEventDeserializer` for deserializing events
- Set the `errorClass` + `errorMessage` on the error

## Tests
Confirmed that the app sends an error with the correct message/name to the Bugsnag dashboard with a handled JS error