### PR TITLE
Prevent duplicate RCTFatalException in Cocoa React Native

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -5,11 +5,29 @@
 #import "BugsnagEventDeserializer.h"
 
 @interface Bugsnag ()
++ (BugsnagClient *)client;
 + (BOOL)bugsnagStarted;
 + (BugsnagConfiguration *)configuration;
 + (void)updateCodeBundleId:(NSString *)codeBundleId;
 + (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BOOL (^_Nonnull)(BugsnagEvent *_Nonnull))block;
+@end
+
+@interface BugsnagClient()
+@property id sessionTracker;
+@property BugsnagMetadata *metadata;
+@end
+
+@interface BugsnagMetadata ()
+@end
+
+@interface BugsnagEvent ()
+- (instancetype _Nonnull)initWithErrorName:(NSString *_Nonnull)name
+                              errorMessage:(NSString *_Nonnull)message
+                             configuration:(BugsnagConfiguration *_Nonnull)config
+                                  metadata:(BugsnagMetadata *_Nullable)metadata
+                              handledState:(BugsnagHandledState *_Nonnull)handledState
+                                   session:(BugsnagSession *_Nullable)session;
 @end
 
 @interface BugsnagReactNative ()
@@ -68,6 +86,7 @@ RCT_EXPORT_METHOD(dispatch:(NSDictionary *)payload
                     reject:(RCTPromiseRejectBlock)reject) {
     BugsnagEventDeserializer *deserializer = [BugsnagEventDeserializer new];
     BugsnagEvent *event = [deserializer deserializeEvent:payload];
+
     [Bugsnag notifyInternal:event block:^BOOL(BugsnagEvent * _Nonnull event) {
         NSLog(@"Sending event from JS: %@", event);
         return true;

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -51,6 +51,17 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
         return nil;
     }
 
+    [Bugsnag addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
+        BugsnagError *error;
+
+        if ([event.errors count] > 0) {
+            error = event.errors[0];
+        }
+        return error != nil
+                && ![error.errorClass hasPrefix:@"RCTFatalException"]
+                && ![error.errorMessage hasPrefix:@"Unhandled JS Exception"];
+    }];
+
     // TODO: use this emitter to inform JS of changes to user, context and metadata
     BugsnagReactNativeEmitter *emitter = [BugsnagReactNativeEmitter new];
 


### PR DESCRIPTION
## Goal

When an unhandled JS error occurs the JS layer captures it, but the Cocoa exception handler also catches it and reports it. This change discards any `NSException` with the name `RCTFatalException` and the error message that indicates it is an unhandled JS error. Tested in an example app and confirms that it works for the 'Trigger JS Exception' scenario.

Relies on #830 which has not yet been merged