### PR TITLE
feat: allow enhancing runtimeVersions info

### DIFF
--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/Bugsnag.m
@@ -58,6 +58,8 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 - (void)addBreadcrumbWithBlock:(void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
 - (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BugsnagOnErrorBlock)block;
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key;
 @property (nonatomic) NSString *codeBundleId;
 @end
 
@@ -233,6 +235,13 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
       formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     });
     return formatter;
+}
+
++ (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key {
+    if ([self bugsnagStarted]) {
+        [self.client addRuntimeVersionInfo:info withKey:key];
+    }
 }
 
 // =============================================================================

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagDevice.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagDevice.m
@@ -68,4 +68,11 @@
     BSGDictInsertIfNotNil(dict, self.totalMemory, @"totalMemory");
     return dict;
 }
+
+- (void)appendRuntimeInfo:(NSDictionary *)info {
+    NSMutableDictionary *versions = [self.runtimeVersions mutableCopy];
+    [versions addEntriesFromDictionary:info];
+    self.runtimeVersions = versions;
+}
+
 @end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.h
@@ -88,4 +88,7 @@ extern NSString *const BSGSessionUpdateNotification;
  */
 @property (nonatomic, strong, readonly) BugsnagSession *runningSession;
 
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key;
+
 @end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.m
@@ -14,6 +14,7 @@
 #import "BugsnagLogger.h"
 #import "BugsnagSessionInternal.h"
 #import "BSG_KSSystemInfo.h"
+#import "BugsnagCollections.h"
 
 /**
  Number of seconds in background required to make a new session
@@ -45,6 +46,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
 @interface BugsnagDevice ()
 + (BugsnagDevice *)deviceWithDictionary:(NSDictionary *)event;
+- (void)appendRuntimeInfo:(NSDictionary *)info;
 @end
 
 @interface BugsnagSessionTrackingApiClient ()
@@ -63,6 +65,8 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
  * Called when a session is altered
  */
 @property (nonatomic, strong, readonly) SessionTrackerCallback callback;
+
+@property NSMutableDictionary *extraRuntimeInfo;
 @end
 
 @implementation BugsnagSessionTracker
@@ -79,6 +83,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
             BSG_KSLOG_ERROR(@"Failed to initialize session store.");
         }
         _sessionStore = [BugsnagSessionFileStore storeWithPath:storePath];
+        _extraRuntimeInfo = [NSMutableDictionary new];
     }
     return self;
 }
@@ -141,6 +146,8 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo} config:self.config codeBundleId:self.codeBundleId];
     BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:@{@"system": systemInfo}];
+    [device appendRuntimeInfo:self.extraRuntimeInfo];
+
     BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                           startDate:[NSDate date]
                                                                user:self.config.user
@@ -162,6 +169,13 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     [self postUpdateNotice];
 
     [self.apiClient deliverSessionsInStore:self.sessionStore];
+}
+
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key {
+    if (info != nil && key != nil) {
+        self.extraRuntimeInfo[key] = info;
+    }
 }
 
 - (void)registerExistingSession:(NSString *)sessionId


### PR DESCRIPTION
## Goal

Allows setting extra runtime version information recorded for events and sessions. This changeset largely mirrors the Android implementation and relies on https://github.com/bugsnag/bugsnag-cocoa/pull/578

## Changeset

- `BugsnagReactNative.m` now reads the `reactNativeVersion` and `engine` values when `configure()` is called, and passes these onto the native layer
- Updated vendored code to use https://github.com/bugsnag/bugsnag-cocoa/pull/578
- Whenever a new session/error is captured, the extra runtime version info is added in the native layer

## Tests
Verified with a debugger that the object passed to an onSession/onError block contains the appropriate runtime version information.

Note that there is a known issue with the Cocoa implementation where the Event is not fully populated/persisted, so runtimeVersions information will not be sent in the actual payload. This will be addressed by a separate internal ticket.