### PR TITLE
RN: Use proxy polyfill on older React Native versions

### DIFF
--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -1667,6 +1667,11 @@
 			"dev": true,
 			"optional": true
 		},
+		"iserror": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
+		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4306,6 +4311,11 @@
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true,
 			"optional": true
+		},
+		"proxy-polyfill": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/proxy-polyfill/-/proxy-polyfill-0.3.1.tgz",
+			"integrity": "sha512-jywE1NIksgIGqZc4uF0QLbXGz2RcHQobsCkAW+8F0nr/6agap+TWksEAKyLnIBafPD88HT9qZR2ec0oomHdjcQ=="
 		},
 		"readable-stream": {
 			"version": "2.3.6",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -78,6 +78,7 @@
     "@bugsnag/plugin-react-native-global-error-handler": "7.0.0",
     "@bugsnag/plugin-react-native-session": "7.0.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "7.0.0",
-    "iserror": "^0.0.2"
+    "iserror": "^0.0.2",
+    "proxy-polyfill": "^0.3.1"
   }
 }

--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -2,6 +2,7 @@ const { schema } = require('@bugsnag/core/config')
 const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 const rnPackage = require('react-native/package.json')
 const iserror = require('iserror')
+// const Proxy = require('./lib/proxy')
 
 const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId']
 const allowedErrorTypes = () => ({
@@ -88,23 +89,25 @@ const freeze = (opts, warn) => {
   // if we don't have any native options, something went wrong
   if (!opts) throw new Error('[bugsnag] Configuration could not be loaded from native client')
 
-  // save the original values to check for mutations (user, context and metadata can be supplied in JS)
-  Object.defineProperty(opts, '_originalValues', { value: { ...opts }, enumerable: false, writable: false })
-
-  return new Proxy(opts, {
-    set (obj, prop, value) {
-      if (!ALLOWED_IN_JS.includes(prop)) {
-        warn(`[bugsnag] Cannot set "${prop}" configuration option in JS. This must be set in the native layer.`)
-        return true
-      }
-      return Reflect.set(...arguments)
-    },
-    deleteProperty (target, prop) {
-      if (!ALLOWED_IN_JS.includes(prop)) {
-        warn(`[bugsnag] Cannot delete "${prop}" configuration option in JS. This must be set in the native layer.`)
-        return true
-      }
-      return Reflect.deleteProperty(...arguments)
-    }
+  const frozenOpts = {}
+  Object.keys(schema).forEach(k => {
+    let val = opts[k]
+    Object.defineProperty(frozenOpts, k, {
+      enumerable: true,
+      configurable: false,
+      set (newValue) {
+        if (!ALLOWED_IN_JS.includes(k)) {
+          warn(`[bugsnag] Cannot set "${k}" configuration option in JS. This must be set in the native layer.`)
+          return
+        }
+        val = newValue
+      },
+      get () { return val }
+    })
   })
+
+  // save the original values to check for mutations (user, context and metadata can be supplied in JS)
+  Object.defineProperty(frozenOpts, '_originalValues', { value: { ...opts }, enumerable: false, writable: false })
+
+  return frozenOpts
 }

--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -2,7 +2,6 @@ const { schema } = require('@bugsnag/core/config')
 const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 const rnPackage = require('react-native/package.json')
 const iserror = require('iserror')
-// const Proxy = require('./lib/proxy')
 
 const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId']
 const allowedErrorTypes = () => ({

--- a/packages/react-native/src/lib/proxy.js
+++ b/packages/react-native/src/lib/proxy.js
@@ -1,0 +1,1 @@
+module.exports = typeof Proxy !== 'undefined' ? Proxy : require('proxy-polyfill/src/proxy.js')

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -1,5 +1,6 @@
 const NativeModules = require('react-native').NativeModules
 const NativeClient = NativeModules.BugsnagReactNative
+const Proxy = require('./lib/proxy')
 
 const REMOTE_DEBUGGING_WARNING = `Bugsnag cannot initialize synchronously when running in the remote debugger.
 

--- a/packages/react-native/src/test/config.test.ts
+++ b/packages/react-native/src/test/config.test.ts
@@ -8,7 +8,7 @@ describe('react-native config: load()', () => {
       })
     }
     const config = load(mockNativeClient)
-    expect(config.apiKey).toBe('123')
+    expect((config as any).apiKey).toBe('123')
     expect(config._originalValues).toEqual({ apiKey: '123' })
   })
 
@@ -30,7 +30,7 @@ describe('react-native config: load()', () => {
       })
     }
 
-    const config = load(mockNativeClient, '1.1.1', 'test', '2.2.2', warnSpy)
+    const config: any = load(mockNativeClient, '1.1.1', 'test', '2.2.2', warnSpy)
 
     config.apiKey = '456'
     config.autoDetectErrors = false

--- a/test/react-native/features/handled.feature
+++ b/test/react-native/features/handled.feature
@@ -9,5 +9,5 @@ Scenario: Calling notify() with a caught Error
 Scenario: Native notify() with a caught Error
   When I run "HandledNativeErrorScenario"
   Then I wait to receive a request
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "HandledCaughtError"
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the exception "message" equals "HandledExceptionScenario"

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -38,6 +38,7 @@ end
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, device_type, app_location, :accessibility_id)
   $driver.start_driver
+  $driver.reset
 end
 
 # Ensure the browserstack instance is stopped

--- a/test/react-native/features/unhandled.feature
+++ b/test/react-native/features/unhandled.feature
@@ -17,5 +17,5 @@ Scenario: Catching an Unhandled Native error
   When I run "UnhandledNativeErrorScenario" and relaunch the app
   And I configure Bugsnag for "UnhandledNativeErrorScenario"
   Then I wait to receive a request
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "UnhandledError"
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the exception "message" equals "UnhandledExceptionScenario"


### PR DESCRIPTION
A feature we rely in JS is the `Proxy` global. This is unavailable in older versions of JSC bundled with RN0.55 and older. This pulls in the proxy (without adding it to the global scope) when it is not available.