### PR TITLE
React-native Fix: Add a reset after driver starts to ensure UI is present

### DIFF
--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -38,6 +38,7 @@ end
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, device_type, app_location, :accessibility_id)
   $driver.start_driver
+  $driver.reset
 end
 
 # Ensure the browserstack instance is stopped


### PR DESCRIPTION
There is currently an issue when running the react-native 0.55 test fixture where the UI isn't present when the run starts.  This causes a failure on the first scenario due to appium not being able to configure the application.

This fix forces an application reset immediately after starting in order to get the app into a state when appium can correctly find the UI and execute scenarios.

This is a temporary fix as it doesn't address the root of the problem, why the UI isn't showing up on the first run. A ticket will be created in order to address this at a later date, but this fix should allow CI and local testing to continue during the current development.