### PR TITLE
Update Notifier payload information in React Native Cocoa

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -10,6 +10,7 @@
 - (NSDictionary *)collectDeviceWithState;
 - (NSArray *)collectBreadcrumbs;
 - (NSArray *)collectThreads;
+@property id notifier;
 @end
 
 @interface Bugsnag ()
@@ -69,6 +70,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
                 && ![error.errorClass hasPrefix:@"RCTFatalException"]
                 && ![error.errorMessage hasPrefix:@"Unhandled JS Exception"];
     }];
+    [self updateNotifierInfo:readableMap];
 
     // TODO: use this emitter to inform JS of changes to user, context and metadata
     BugsnagReactNativeEmitter *emitter = [BugsnagReactNativeEmitter new];
@@ -168,6 +170,17 @@ RCT_EXPORT_METHOD(getPayloadInfo:(NSDictionary *)options
     } else {
         return BSGBreadcrumbTypeManual; // return placeholder value
     }
+}
+
+- (void)updateNotifierInfo:(NSDictionary *)info {
+    NSString *jsVersion = info[@"notifierVersion"];
+    id notifier = [Bugsnag client].notifier;
+    [notifier setValue:jsVersion forKey:@"version"];
+    [notifier setValue:@"Bugsnag React Native" forKey:@"name"];
+    [notifier setValue: @"https://github.com/bugsnag/bugsnag-js" forKey:@"url"];
+    
+    NSMutableArray *deps = [NSMutableArray arrayWithObject:[NSClassFromString(@"BugsnagNotifier") new]];
+    [notifier setValue:deps forKey:@"dependencies"];
 }
 
 @end


### PR DESCRIPTION
## Goal

Updates the payload information sent in the notifier object of the JSON payload to include a dependencies section, which contains information about the Cocoa notifier. The JS notifier replaces the top-level information typically used by bugsnag-cocoa. Additionally, the vendored Cocoa has been updated to the latest on the v6 branch.

This object is global to session/event payloads in the Cocoa notifier. This has been tested by setting a custom endpoint and sending a session + event after the React Native layer has been initialised.
