### PR TITLE
Deserialize breadcrumbs in RN Cocoa dispatch()

### DIFF
--- a/packages/react-native/ios/Bugsnag/BugsnagConfiguration.h
+++ b/packages/react-native/ios/Bugsnag/BugsnagConfiguration.h
@@ -105,6 +105,14 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 
 @interface BugsnagConfiguration : NSObject <BugsnagMetadataStore>
 
+/**
+ * Create a new configuration from the main bundle's infoDictionary, using keys nested under
+ * the "bugsnag" key.
+ *
+ * @return a BugsnagConfiguration containing the options set in the plist file
+ */
++ (instancetype _Nonnull)loadConfig;
+
 // -----------------------------------------------------------------------------
 // MARK: - Properties
 // -----------------------------------------------------------------------------

--- a/packages/react-native/ios/Bugsnag/BugsnagEvent.h
+++ b/packages/react-native/ios/Bugsnag/BugsnagEvent.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
  * at least one error that represents the root cause, with subsequent elements populated
  * from the cause.
  */
-@property(readonly, nonnull) NSMutableArray<BugsnagError *> *errors;
+@property(readwrite, copy, nonnull) NSArray<BugsnagError *> *errors;
 
 /**
  *  Customized hash for grouping this report with other errors
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  *  Breadcrumbs from user events leading up to the error
  */
-@property(readwrite, copy, nullable) NSArray <BugsnagBreadcrumb *>*breadcrumbs;
+@property(readwrite, copy, nonnull) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
 
 /**
  * A per-event override for the apiKey.
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  * Thread traces for the error that occurred, if collection was enabled.
  */
-@property(readonly, nonnull) NSMutableArray<BugsnagThread *> *threads;
+@property(readwrite, copy, nonnull) NSArray<BugsnagThread *> *threads;
 
 /**
  * The original object that caused the error in your application. This value will only be populated for

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -28,6 +28,11 @@
                                   metadata:(BugsnagMetadata *_Nullable)metadata
                               handledState:(BugsnagHandledState *_Nonnull)handledState
                                    session:(BugsnagSession *_Nullable)session;
+- (NSDictionary *)toJson;
+@end
+
+@interface BugsnagBreadcrumb ()
++ (instancetype)breadcrumbFromDict:(NSDictionary *)dict;
 @end
 
 @implementation BugsnagEventDeserializer
@@ -46,7 +51,24 @@
                                   metadata:metadata
                               handledState:nil
                                    session:session];
+    event.breadcrumbs = [self deserializeBreadcrumbs:payload[@"breadcrumbs"]];
+    NSLog(@"Deserialized JS event: %@", [event toJson]);
     return event;
+}
+
+- (NSArray *)deserializeBreadcrumbs:(NSArray *)crumbs {
+    NSMutableArray *array = [NSMutableArray new];
+
+    if (crumbs != nil) {
+        for (NSDictionary *crumb in crumbs) {
+            BugsnagBreadcrumb *obj = [BugsnagBreadcrumb breadcrumbFromDict:crumb];
+            
+            if (obj != nil) {
+                [array addObject:obj];
+            }
+        }
+    }
+    return array;
 }
 
 @end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/CHANGELOG.md
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/CHANGELOG.md
@@ -8,6 +8,12 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Alter default session background timeout to 30s
+  [#581](https://github.com/bugsnag/bugsnag-cocoa/pull/581)
+
+* Support loading configuration from values in `Info.plist`.
+  [#582](https://github.com/bugsnag/bugsnag-cocoa/pull/582)
+
 * Add `unhandledRejections` to `BugsnagErrorTypes`
   [#567](https://github.com/bugsnag/bugsnag-cocoa/pull/567)
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BSGConfigurationBuilder.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BSGConfigurationBuilder.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+@class BugsnagConfiguration;
+
+@interface BSGConfigurationBuilder : NSObject
+
+/**
+ * Creates a configuration, applying supported options before returning the new
+ * config object.
+ *
+ * @return a new BugsnagConfiguration object or nil if the a valid object could
+ * not be created (including a non-empty API key)
+ */
++ (BugsnagConfiguration *_Nonnull)configurationFromOptions:(NSDictionary *_Nonnull)options;
+
+@end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BSGConfigurationBuilder.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BSGConfigurationBuilder.m
@@ -1,0 +1,115 @@
+#import "BSGConfigurationBuilder.h"
+#import "BugsnagConfiguration.h"
+#import "BugsnagEndpointConfiguration.h"
+
+NSString *const BSGKeyAppType = @"appType";
+NSString *const BSGKeyAppVersion = @"appVersion";
+NSString *const BSGKeyAutoDetectErrors = @"autoDetectErrors";
+NSString *const BSGKeyAutoTrackSessions = @"autoTrackSessions";
+NSString *const BSGKeyBundleVersion = @"bundleVersion";
+NSString *const BSGKeyPersistUser = @"persistUser";
+NSString *const BSGKeyReleaseStage = @"releaseStage";
+NSString *const BSGKeyEnabledReleaseStages = @"enabledReleaseStages";
+NSString *const BSGKeyRedactedKeys = @"redactedKeys";
+NSString *const BSGKeyEndpoints = @"endpoints";
+NSString *const BSGKeyNotifyEndpoint = @"notify";
+NSString *const BSGKeySessionsEndpoint = @"sessions";
+NSString *const BSGKeyMaxBreadcrumbs = @"maxBreadcrumbs";
+NSString *const BSGKeySendThreads = @"sendThreads";
+
+static BOOL BSGValueIsBoolean(id object) {
+    return object != nil && [object isKindOfClass:[NSNumber class]]
+            && CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID();
+}
+
+@interface BugsnagConfiguration ()
++ (BOOL)isValidApiKey:(NSString *)apiKey;
+@end
+
+@implementation BSGConfigurationBuilder
+
++ (BugsnagConfiguration *)configurationFromOptions:(NSDictionary *)options {
+    NSString *apiKey = options[@"apiKey"];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
+
+    if (![BugsnagConfiguration isValidApiKey:apiKey]) {
+        return config;
+    }
+
+    [self loadString:config options:options key:BSGKeyAppType];
+    [self loadString:config options:options key:BSGKeyAppVersion];
+    [self loadBoolean:config options:options key:BSGKeyAutoDetectErrors];
+    [self loadBoolean:config options:options key:BSGKeyAutoTrackSessions];
+    [self loadString:config options:options key:BSGKeyBundleVersion];
+    [self loadBoolean:config options:options key:BSGKeyPersistUser];
+    [self loadString:config options:options key:BSGKeyReleaseStage];
+
+    [self loadStringArray:config options:options key:BSGKeyEnabledReleaseStages];
+    [self loadStringArray:config options:options key:BSGKeyRedactedKeys];
+    [self loadEndpoints:config options:options];
+
+    [self loadMaxBreadcrumbs:config options:options];
+    [self loadSendThreads:config options:options];
+    return config;
+}
+
++ (void)loadBoolean:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+    if (BSGValueIsBoolean(options[key])) {
+        [config setValue:options[key] forKey:key];
+    }
+}
+
++ (void)loadString:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+    if (options[key] && [options[key] isKindOfClass:[NSString class]]) {
+        [config setValue:options[key] forKey:key];
+    }
+}
+
++ (void)loadStringArray:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+    if (options[key] && [options[key] isKindOfClass:[NSArray class]]) {
+        NSArray *val = options[key];
+
+        for (NSString *obj in val) {
+            if (![obj isKindOfClass:[NSString class]]) {
+                return;
+            }
+        }
+        [config setValue:val forKey:key];
+    }
+}
+
++ (void)loadEndpoints:(BugsnagConfiguration *)config options:(NSDictionary *)options {
+    if (options[BSGKeyEndpoints] && [options[BSGKeyEndpoints] isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *endpoints = options[BSGKeyEndpoints];
+
+        if ([endpoints[BSGKeyNotifyEndpoint] isKindOfClass:[NSString class]]) {
+            config.endpoints.notify = endpoints[BSGKeyNotifyEndpoint];
+        }
+        if ([endpoints[BSGKeySessionsEndpoint] isKindOfClass:[NSString class]]) {
+            config.endpoints.sessions = endpoints[BSGKeySessionsEndpoint];
+        }
+    }
+}
+
++ (void)loadMaxBreadcrumbs:(BugsnagConfiguration *)config options:(NSDictionary *)options {
+    if (options[BSGKeyMaxBreadcrumbs] && [options[BSGKeyMaxBreadcrumbs] isKindOfClass:[NSNumber class]]) {
+        NSNumber *num = options[BSGKeyMaxBreadcrumbs];
+        config.maxBreadcrumbs = [num unsignedIntValue];
+    }
+}
+
++ (void)loadSendThreads:(BugsnagConfiguration *)config options:(NSDictionary *)options {
+    if (options[BSGKeySendThreads] && [options[BSGKeySendThreads] isKindOfClass:[NSString class]]) {
+        NSString *sendThreads = [options[BSGKeySendThreads] lowercaseString];
+
+        if ([@"unhandledonly" isEqualToString:sendThreads]) {
+            config.sendThreads = BSGThreadSendPolicyUnhandledOnly;
+        } else if ([@"always" isEqualToString:sendThreads]) {
+            config.sendThreads = BSGThreadSendPolicyAlways;
+        } else if ([@"never" isEqualToString:sendThreads]) {
+            config.sendThreads = BSGThreadSendPolicyNever;
+        }
+    }
+}
+
+@end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagBreadcrumb.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagBreadcrumb.m
@@ -191,14 +191,17 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 + (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
     BOOL isValidCrumb = [dict[BSGKeyType] isKindOfClass:[NSString class]]
         && [dict[BSGKeyTimestamp] isKindOfClass:[NSString class]]
-        && [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
+        && (
+            [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
+            || [dict[@"metadata"] isKindOfClass:[NSDictionary class]] // react-native uses lowercase key
+            )
         // Accept legacy 'name' value if provided.
         && ([dict[BSGKeyMessage] isKindOfClass:[NSString class]]
             || [dict[BSGKeyName] isKindOfClass:[NSString class]]);
     if (isValidCrumb) {
         return [self breadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
             crumb.message = dict[BSGKeyMessage] ?: dict[BSGKeyName];
-            crumb.metadata = dict[BSGKeyMetadata];
+            crumb.metadata = dict[BSGKeyMetadata] ?: dict[@"metadata"];
             crumb.timestamp = [[Bugsnag payloadDateFormatter] dateFromString:dict[BSGKeyTimestamp]];
             crumb.type = BSGBreadcrumbTypeFromString(dict[BSGKeyType]);
         }];

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
@@ -46,6 +46,7 @@
 #import "BSGSerialization.h"
 #import "Bugsnag.h"
 #import "BugsnagErrorTypes.h"
+#import "BugsnagNotifier.h"
 
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -53,8 +54,6 @@
 #import <AppKit/AppKit.h>
 #endif
 
-NSString *const NOTIFIER_VERSION = @"5.23.0";
-NSString *const NOTIFIER_URL = @"https://github.com/bugsnag/bugsnag-cocoa";
 NSString *const BSTabCrash = @"crash";
 NSString *const BSAttributeDepth = @"depth";
 NSString *const BSEventLowMemoryWarning = @"lowMemoryWarning";
@@ -362,21 +361,7 @@ NSString *_lastOrientation = nil;
         // Take a shallow copy of the configuration
         self.configuration = [initConfiguration copy];
         self.state = [[BugsnagMetadata alloc] init];
-        NSString *notifierName =
-#if TARGET_OS_TV
-            @"tvOS Bugsnag Notifier";
-#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
-            @"iOS Bugsnag Notifier";
-#elif TARGET_OS_MAC
-            @"OSX Bugsnag Notifier";
-#else
-            @"Bugsnag Objective-C";
-#endif
-        self.details = [@{
-            BSGKeyName : notifierName,
-            BSGKeyVersion : NOTIFIER_VERSION,
-            BSGKeyUrl : NOTIFIER_URL
-        } mutableCopy];
+        self.notifier = [BugsnagNotifier new];
 
         NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(
                                 NSCachesDirectory, NSUserDomainMask, YES) firstObject];

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClientInternal.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClientInternal.h
@@ -14,12 +14,13 @@
 @class BugsnagSessionTracker;
 @class BugsnagConfiguration;
 @class BugsnagMetadata;
+@class BugsnagNotifier;
 
 @interface BugsnagClient ()
 
 @property(nonatomic, readwrite, retain) BugsnagConfiguration *_Nullable configuration;
 @property(nonatomic, readwrite, strong) BugsnagMetadata *_Nonnull state;
-@property(nonatomic, readwrite, strong) NSDictionary *_Nonnull details;
+@property(nonatomic, readwrite, strong) BugsnagNotifier *_Nonnull notifier;
 @property(nonatomic, readwrite, strong) NSLock *_Nonnull metadataLock;
 @property(nonatomic, readwrite, strong) BugsnagSessionTracker *_Nonnull sessionTracker;
 @property(readonly) BOOL started;

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagConfiguration.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagConfiguration.h
@@ -105,6 +105,14 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 
 @interface BugsnagConfiguration : NSObject <BugsnagMetadataStore>
 
+/**
+ * Create a new configuration from the main bundle's infoDictionary, using keys nested under
+ * the "bugsnag" key.
+ *
+ * @return a BugsnagConfiguration containing the options set in the plist file
+ */
++ (instancetype _Nonnull)loadConfig;
+
 // -----------------------------------------------------------------------------
 // MARK: - Properties
 // -----------------------------------------------------------------------------

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
  * at least one error that represents the root cause, with subsequent elements populated
  * from the cause.
  */
-@property(readonly, nonnull) NSMutableArray<BugsnagError *> *errors;
+@property(readwrite, copy, nonnull) NSArray<BugsnagError *> *errors;
 
 /**
  *  Customized hash for grouping this report with other errors
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  *  Breadcrumbs from user events leading up to the error
  */
-@property(readwrite, copy, nullable) NSArray <BugsnagBreadcrumb *>*breadcrumbs;
+@property(readwrite, copy, nonnull) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
 
 /**
  * A per-event override for the apiKey.
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  * Thread traces for the error that occurred, if collection was enabled.
  */
-@property(readonly, nonnull) NSMutableArray<BugsnagThread *> *threads;
+@property(readwrite, copy, nonnull) NSArray<BugsnagThread *> *threads;
 
 /**
  * The original object that caused the error in your application. This value will only be populated for

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.m
@@ -326,8 +326,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             _deviceAppHash = [report valueForKeyPath:@"user.state.oom.device.id"];
 
             // no threads or metadata captured for OOMs
-            _threads = [NSMutableArray new];
-            [_errors addObject:[[BugsnagError alloc] initWithEvent:report errorReportingThread:nil]];
+            _threads = @[];
+            _errors = @[[[BugsnagError alloc] initWithEvent:report errorReportingThread:nil]];
             self.metadata = [BugsnagMetadata new];
 
             NSDictionary *sessionData = [report valueForKeyPath:@"user.state.oom.session"];
@@ -394,7 +394,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                 }
             }
 
-            [_errors addObject:[[BugsnagError alloc] initWithEvent:report errorReportingThread:errorReportingThread]];
+            _errors = @[[[BugsnagError alloc] initWithEvent:report errorReportingThread:errorReportingThread]];
             _customException = BSGParseCustomException(report, [_errors[0].errorClass copy], [_errors[0].errorMessage copy]);
 
             if (!recordedState) { // the event was unhandled.
@@ -457,12 +457,11 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                                    session:(BugsnagSession *_Nullable)session
 {
     if (self = [super init]) {
-        _errors = [NSMutableArray new];
         BugsnagError *error = [BugsnagError new];
         error.errorClass = name;
         error.errorMessage = message;
         error.type = BSGErrorTypeCocoa;
-        [_errors addObject:error];
+        _errors = @[error];
 
         _overrides = [NSDictionary new];
         _device = [BugsnagDeviceWithState new];
@@ -489,7 +488,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         }
         _severity = handledState.currentSeverity;
         _session = session;
-        _threads = [NSMutableArray new];
+        _threads = @[];
     }
     return self;
 }

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagNotifier.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagNotifier.h
@@ -1,0 +1,22 @@
+//
+//  BugsnagNotifier.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 29/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagNotifier : NSObject
+
+@property NSString *name;
+@property NSString *version;
+@property NSString *url;
+@property NSMutableArray<BugsnagNotifier *> *dependencies;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagNotifier.m
@@ -1,0 +1,50 @@
+//
+//  BugsnagNotifier.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 29/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagNotifier.h"
+
+@implementation BugsnagNotifier
+
+- (instancetype)init {
+    if (self = [super init]) {
+
+        self.name =
+#if TARGET_OS_TV
+        @"tvOS Bugsnag Notifier";
+#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+        @"iOS Bugsnag Notifier";
+#elif TARGET_OS_MAC
+        @"OSX Bugsnag Notifier";
+#else
+        @"Bugsnag Objective-C";
+#endif
+        self.version = @"5.23.0";
+        self.url = @"https://github.com/bugsnag/bugsnag-cocoa";
+        self.dependencies = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (NSDictionary *)toDict {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[@"name"] = self.name;
+    dict[@"version"] = self.version;
+    dict[@"url"] = self.url;
+
+    if ([self.dependencies count] > 0) {
+        NSMutableArray *values = [NSMutableArray new];
+        dict[@"dependencies"] = values;
+
+        for (BugsnagNotifier *notifier in self.dependencies) {
+            [values addObject:[notifier toDict]];
+        }
+    }
+    return dict;
+}
+
+@end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTracker.m
@@ -18,7 +18,7 @@
 /**
  Number of seconds in background required to make a new session
  */
-NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
+NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 
 NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingPayload.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSessionTrackingPayload.m
@@ -12,10 +12,15 @@
 #import "BugsnagClientInternal.h"
 #import "Bugsnag.h"
 #import "BugsnagKeys.h"
+#import "BugsnagNotifier.h"
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagConfiguration.h"
 #import "Private.h"
 #import "BugsnagApp.h"
+
+@interface BugsnagNotifier ()
+- (NSDictionary *)toDict;
+@end
 
 @interface BugsnagSession ()
 - (NSDictionary *)toDictionary;
@@ -66,7 +71,7 @@
         [sessionData addObject:[session toDictionary]];
     }
     BSGDictInsertIfNotNil(dict, sessionData, @"sessions");
-    BSGDictSetSafeObject(dict, [Bugsnag client].details, BSGKeyNotifier);
+    BSGDictSetSafeObject(dict, [[Bugsnag client].notifier toDict], BSGKeyNotifier);
 
     // app/device data collection relies on KSCrash reports,
     // need to mimic the JSON structure here

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSink.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagSink.m
@@ -31,6 +31,7 @@
 #import "BugsnagClient.h"
 #import "BugsnagClientInternal.h"
 #import "BugsnagKeys.h"
+#import "BugsnagNotifier.h"
 #import "BSG_KSSystemInfo.h"
 #import "Private.h"
 
@@ -38,6 +39,10 @@
 // it here.
 @interface Bugsnag ()
 + (BugsnagClient *)client;
+@end
+
+@interface BugsnagNotifier ()
+- (NSDictionary *)toDict;
 @end
 
 @interface BugsnagClient ()
@@ -132,7 +137,7 @@
 // Generates the payload for notifying Bugsnag
 - (NSDictionary *)getBodyFromEvents:(NSArray *)events {
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
-    BSGDictSetSafeObject(data, [Bugsnag client].details, BSGKeyNotifier);
+    BSGDictSetSafeObject(data, [[Bugsnag client].notifier toDict], BSGKeyNotifier);
     BSGDictSetSafeObject(data, [Bugsnag client].configuration.apiKey, BSGKeyApiKey);
     BSGDictSetSafeObject(data, @"4.0", @"payloadVersion");
 

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
 		8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */; };
 		8A72A0392396590300328051 /* BugsnagPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A72A0352396535000328051 /* BugsnagPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A89F3F222D8B62B000D34D1 /* BSGConfigurationBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */; };
+		8A89F3F322D8B62B000D34D1 /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */; };
+		8A89F3F522D8B81F000D34D1 /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */; };
 		8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */; };
 		8AF1748E23070F0300902CC2 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
@@ -310,6 +313,11 @@
 		E77AFF0A244A18890082B8BB /* BugsnagEndpointConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */; };
 		E77AFF0B244A18890082B8BB /* BugsnagEndpointConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */; };
 		E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */; };
+		E7819BAA2459756700A7EBDD /* BugsnagNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = E7819BA82459756700A7EBDD /* BugsnagNotifier.h */; };
+		E7819BAB2459756700A7EBDD /* BugsnagNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BA92459756700A7EBDD /* BugsnagNotifier.m */; };
+		E7819BAC2459756700A7EBDD /* BugsnagNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BA92459756700A7EBDD /* BugsnagNotifier.m */; };
+		E7819BAD2459758300A7EBDD /* BugsnagNotifier.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7819BA82459756700A7EBDD /* BugsnagNotifier.h */; };
+		E7819BB7245979B800A7EBDD /* BugsnagNotifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BB6245979B800A7EBDD /* BugsnagNotifierTest.m */; };
 		E784D2551FD70B3B004B01E1 /* KSCrashState_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2511FD70AE6004B01E1 /* KSCrashState_Tests.m */; };
 		E784D2561FD70B3E004B01E1 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */; };
 		E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */; };
@@ -361,6 +369,9 @@
 		E79148291FD828E6003EFEBF /* BugsnagUser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; };
 		E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
 		E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
+		E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */; };
+		E7A8EA3B24606C6B00CCBBD1 /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */; };
+		E7A8EA612461813700CCBBD1 /* TestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A8EA602461813700CCBBD1 /* TestsInfo.plist */; };
 		E7A9E56B2436363900D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */; };
 		E7AB4B9C2423E16C004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */; };
 		E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */; };
@@ -407,6 +418,8 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E7819BAD2459758300A7EBDD /* BugsnagNotifier.h in CopyFiles */,
+				E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */,
 				E7565F7C245082580041768E /* BugsnagErrorTypes.h in CopyFiles */,
 				E77AFEF22448A13C0082B8BB /* BugsnagSessionInternal.h in CopyFiles */,
 				E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */,
@@ -522,7 +535,6 @@
 		8A2C8F181C6BBD2300846019 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A2C8F1D1C6BBD2300846019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		8A2C8F221C6BBD2300846019 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A2C8F291C6BBD2300846019 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		8A2C8F321C6BBD7200846019 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = SOURCE_ROOT; };
 		8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Bugsnag.h; path = ../Source/Bugsnag.h; sourceTree = SOURCE_ROOT; };
 		8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Bugsnag.m; path = ../Source/Bugsnag.m; sourceTree = SOURCE_ROOT; };
@@ -561,6 +573,9 @@
 		8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
 		8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		8A72A0352396535000328051 /* BugsnagPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagPlugin.h; path = ../Source/BugsnagPlugin.h; sourceTree = "<group>"; };
+		8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGConfigurationBuilder.h; path = ../Source/BSGConfigurationBuilder.h; sourceTree = "<group>"; };
+		8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilder.m; path = ../Source/BSGConfigurationBuilder.m; sourceTree = "<group>"; };
+		8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilderTests.m; path = ../../Tests/BSGConfigurationBuilderTests.m; sourceTree = "<group>"; };
 		8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivityTest.m; path = ../../Tests/BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AF2894923339CCA00E8EB27 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Configurations/Config.xcconfig; sourceTree = "<group>"; };
 		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
@@ -690,6 +705,9 @@
 		E77AFEEF2448A1030082B8BB /* BugsnagSessionInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagSessionInternal.h; path = ../Source/BugsnagSessionInternal.h; sourceTree = "<group>"; };
 		E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEndpointConfiguration.h; path = ../Source/BugsnagEndpointConfiguration.h; sourceTree = "<group>"; };
 		E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEndpointConfiguration.m; path = ../Source/BugsnagEndpointConfiguration.m; sourceTree = "<group>"; };
+		E7819BA82459756700A7EBDD /* BugsnagNotifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagNotifier.h; path = ../Source/BugsnagNotifier.h; sourceTree = "<group>"; };
+		E7819BA92459756700A7EBDD /* BugsnagNotifier.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagNotifier.m; path = ../Source/BugsnagNotifier.m; sourceTree = "<group>"; };
+		E7819BB6245979B800A7EBDD /* BugsnagNotifierTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagNotifierTest.m; path = ../../Tests/BugsnagNotifierTest.m; sourceTree = "<group>"; };
 		E784D2511FD70AE6004B01E1 /* KSCrashState_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashState_Tests.m; path = ../Tests/KSCrash/KSCrashState_Tests.m; sourceTree = SOURCE_ROOT; };
 		E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSMach_Tests.m; path = ../Tests/KSCrash/KSMach_Tests.m; sourceTree = SOURCE_ROOT; };
 		E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSJSONCodec_Tests.m; path = ../Tests/KSCrash/KSJSONCodec_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -720,6 +738,7 @@
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
+		E7A8EA602461813700CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportConverter_Tests.m; path = ../Tests/KSCrash/KSCrashReportConverter_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -841,6 +860,12 @@
 				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 				8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */,
 				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
+				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
+				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
+				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
+				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
+				8A2C8F3F1C6BBE3C00846019 /* BugsnagBreadcrumb.h */,
+				8A2C8F401C6BBE3C00846019 /* BugsnagBreadcrumb.m */,
 				8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */,
 				8A2C8F421C6BBE3C00846019 /* BugsnagCollections.m */,
 				E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */,
@@ -875,7 +900,6 @@
 			isa = PBXGroup;
 			children = (
 				8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */,
-				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				E790C49A2434C8C8006FFB26 /* BugsnagAppTest.m */,
 				009131BD23F5884E000810D9 /* BugsnagBaseUnitTest.m */,
 				009131BF23F58930000810D9 /* BugsnagBaseUnitTest.h */,
@@ -886,6 +910,7 @@
 				4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
 				4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */,
+				8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */,
 				8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */,
 				E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */,
 				E73D4439243E1912001686F5 /* BugsnagErrorTest.m */,
@@ -894,8 +919,10 @@
 				E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */,
 				E71DB9D024470F4100D0161E /* BugsnagMetadataRedactionTest.m */,
 				009131BB23F46279000810D9 /* BugsnagMetadataTests.m */,
+				E7819BB6245979B800A7EBDD /* BugsnagNotifierTest.m */,
 				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
 				E728378A2451843000EE2B7D /* BugsnagOnCrashTest.m */,
+				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 				E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */,
 				E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */,
@@ -913,10 +940,10 @@
 				E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */,
 				F42954B7D892334E7551F0F3 /* RegisterErrorDataTest.m */,
 				000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */,
-				8A2C8F291C6BBD2300846019 /* TestsInfo.plist */,
 				8A2C8F951C6BC08600846019 /* report.json */,
 				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				E70EE0891FD7047D00FA745C /* KSCrash */,
+				E7A8EA602461813700CCBBD1 /* TestsInfo.plist */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1115,6 +1142,8 @@
 		E7565F7B245082100041768E /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */,
+				8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */,
 				8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */,
 				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
 				E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */,
@@ -1128,8 +1157,6 @@
 		E7A9E587243B23FF00D99F8A /* Client */ = {
 			isa = PBXGroup;
 			children = (
-				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
-				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
 				8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */,
 				8A2C8F4C1C6BBE3C00846019 /* BugsnagClient.m */,
 				E790C424243354A8006FFB26 /* BugsnagClientInternal.h */,
@@ -1162,6 +1189,8 @@
 				E790C44D24349898006FFB26 /* BugsnagError.m */,
 				8A2C8F451C6BBE3C00846019 /* BugsnagEvent.h */,
 				8A2C8F461C6BBE3C00846019 /* BugsnagEvent.m */,
+				E7819BA82459756700A7EBDD /* BugsnagNotifier.h */,
+				E7819BA92459756700A7EBDD /* BugsnagNotifier.m */,
 				E72BF7781FC869F7004BE82F /* BugsnagSession.h */,
 				E72BF7791FC869F7004BE82F /* BugsnagSession.m */,
 				E77AFEEF2448A1030082B8BB /* BugsnagSessionInternal.h */,
@@ -1199,8 +1228,6 @@
 			children = (
 				E72352B41F55718E00436528 /* BSGConnectivity.h */,
 				E72352B51F55718E00436528 /* BSGConnectivity.m */,
-				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
-				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
 				E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */,
 				E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */,
 			);
@@ -1210,8 +1237,6 @@
 		E7A9E598243B246600D99F8A /* Breadcrumbs */ = {
 			isa = PBXGroup;
 			children = (
-				8A2C8F3F1C6BBE3C00846019 /* BugsnagBreadcrumb.h */,
-				8A2C8F401C6BBE3C00846019 /* BugsnagBreadcrumb.m */,
 				E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */,
 				E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */,
 			);
@@ -1255,6 +1280,7 @@
 				E7107C521F4C97F100BB3F98 /* BSG_KSCrashSentry_NSException.h in Headers */,
 				E7107C3E1F4C97F100BB3F98 /* BSG_KSCrashReportStore.h in Headers */,
 				E7107C791F4C97F100BB3F98 /* BSG_KSString.h in Headers */,
+				E7819BAA2459756700A7EBDD /* BugsnagNotifier.h in Headers */,
 				E7D2E66B243B8F48005A3041 /* BugsnagStacktrace.h in Headers */,
 				E7107C5B1F4C97F100BB3F98 /* BSG_KSBacktrace.h in Headers */,
 				E78C1EF61FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h in Headers */,
@@ -1287,6 +1313,7 @@
 				8A381D4B1EAA49A700AF8429 /* BugsnagLogger.h in Headers */,
 				E7107C771F4C97F100BB3F98 /* BSG_KSSingleton.h in Headers */,
 				E7107C861F4C97F100BB3F98 /* BSG_KSCrashReportFilter.h in Headers */,
+				8A89F3F222D8B62B000D34D1 /* BSGConfigurationBuilder.h in Headers */,
 				E72962D81F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h in Headers */,
 				E7107C5C1F4C97F100BB3F98 /* BSG_KSBacktrace_Private.h in Headers */,
 				E7107C371F4C97F100BB3F98 /* BSG_KSCrashC.h in Headers */,
@@ -1432,6 +1459,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7A8EA612461813700CCBBD1 /* TestsInfo.plist in Resources */,
 				8A2C8F961C6BC08600846019 /* report.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1475,11 +1503,13 @@
 				E790C4452434984B006FFB26 /* BugsnagDevice.m in Sources */,
 				E7107C681F4C97F100BB3F98 /* BSG_KSLogger.m in Sources */,
 				E78C1EF71FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */,
+				8A89F3F322D8B62B000D34D1 /* BSGConfigurationBuilder.m in Sources */,
 				E7107C751F4C97F100BB3F98 /* BSG_KSSignalInfo.c in Sources */,
 				E7107C6D1F4C97F100BB3F98 /* BSG_KSMach_x86_32.c in Sources */,
 				E72352B71F55718E00436528 /* BSGConnectivity.m in Sources */,
 				8A2C8F601C6BBE3C00846019 /* BugsnagSink.m in Sources */,
 				E790C45924349A28006FFB26 /* BugsnagThread.m in Sources */,
+				E7819BAB2459756700A7EBDD /* BugsnagNotifier.m in Sources */,
 				E7107C661F4C97F100BB3F98 /* BSG_KSJSONCodecObjC.m in Sources */,
 				E7529F8A243C8DA2006B4932 /* RegisterErrorData.m in Sources */,
 				8A2C8F5C1C6BBE3C00846019 /* BugsnagMetadata.m in Sources */,
@@ -1547,9 +1577,11 @@
 				E7A9E56B2436363900D99F8A /* BugsnagDeviceTest.m in Sources */,
 				E7D2E670243B8F8D005A3041 /* BugsnagStacktraceTest.m in Sources */,
 				E73D443A243E1912001686F5 /* BugsnagErrorTest.m in Sources */,
+				8A89F3F522D8B81F000D34D1 /* BSGConfigurationBuilderTests.m in Sources */,
 				E7B970311FD702DA00590C27 /* KSLogger_Tests.m in Sources */,
 				E7529F9C243CAE02006B4932 /* BugsnagThreadSerializationTest.m in Sources */,
 				8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */,
+				E7819BB7245979B800A7EBDD /* BugsnagNotifierTest.m in Sources */,
 				E70EE0921FD706C700FA745C /* KSDynamicLinker_Tests.m in Sources */,
 				E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */,
 				E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */,
@@ -1605,6 +1637,7 @@
 				E7397E3A1F83BC320034242A /* BSG_KSBacktrace.c in Sources */,
 				E7397E3B1F83BC320034242A /* BSG_KSDynamicLinker.c in Sources */,
 				E7397E3C1F83BC320034242A /* BSG_KSFileUtils.c in Sources */,
+				E7A8EA3B24606C6B00CCBBD1 /* BSGConfigurationBuilder.m in Sources */,
 				E7397E3D1F83BC320034242A /* BSG_KSJSONCodec.c in Sources */,
 				E790C44124349831006FFB26 /* BugsnagAppWithState.m in Sources */,
 				E77526BC242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */,
@@ -1617,6 +1650,7 @@
 				E7397E411F83BC320034242A /* BSG_KSMach_x86_32.c in Sources */,
 				E790C43C24349817006FFB26 /* BugsnagApp.m in Sources */,
 				E78C1EF81FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */,
+				E7819BAC2459756700A7EBDD /* BugsnagNotifier.m in Sources */,
 				E7397E421F83BC320034242A /* BSG_KSMach_x86_64.c in Sources */,
 				E7397E431F83BC320034242A /* BSG_KSObjC.c in Sources */,
 				E790C455243498BB006FFB26 /* BugsnagStackframe.m in Sources */,

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Info.plist
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
## Goal

Allows deserialization of breadcrumbs in the `dispatch()` method of the Cocoa RN implementation, and sets the value on the native event. This changeset relies on https://github.com/bugsnag/bugsnag-cocoa/pull/584, which updates quite a lot of the vendored code to match v6 of the implementation branch.

Tested by running an example app and confirming that the generated JSON for the event contains the breadcrumbs.