### PR TITLE
Deserialize severity reason information in RN Cocoa

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -8,6 +8,8 @@
 
 #import "BugsnagEventDeserializer.h"
 
+BSGSeverity BSGParseSeverity(NSString *severity);
+
 @interface Bugsnag ()
 + (id)client;
 + (BugsnagConfiguration *)configuration;
@@ -19,6 +21,14 @@
 @end
 
 @interface BugsnagMetadata ()
+@end
+
+@interface BugsnagHandledState: NSObject
+- (instancetype)initWithSeverityReason:(NSUInteger)severityReason
+                              severity:(BSGSeverity)severity
+                             unhandled:(BOOL)unhandled
+                             attrValue:(NSString *)attrValue;
++ (NSUInteger)severityReasonFromString:(NSString *)string;
 @end
 
 @interface BugsnagEvent ()
@@ -45,11 +55,13 @@
     BugsnagMetadata *metadata = client.metadata;
 
     NSDictionary *error = payload[@"errors"][0];
+    BugsnagHandledState *handledState = [self deserializeHandledState:payload];
+
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithErrorName:error[@"errorClass"]
                               errorMessage:error[@"errorMessage"]
                              configuration:[Bugsnag configuration]
                                   metadata:metadata
-                              handledState:nil
+                              handledState:handledState
                                    session:session];
     event.breadcrumbs = [self deserializeBreadcrumbs:payload[@"breadcrumbs"]];
     NSLog(@"Deserialized JS event: %@", [event toJson]);
@@ -69,6 +81,25 @@
         }
     }
     return array;
+}
+
+- (BugsnagHandledState *)deserializeHandledState:(NSDictionary *)payload {
+    NSDictionary *severityReason = payload[@"severityReason"];
+    NSDictionary *attrs = severityReason[@"attributes"];
+    NSString *attrVal;
+
+    if (attrs && [attrs count] > 0) {
+        attrVal = [attrs allValues][0];
+    }
+
+    NSUInteger reason = [BugsnagHandledState severityReasonFromString:payload[@"severityReason"]];
+
+    BSGSeverity severity = BSGParseSeverity(payload[@"severity"]);
+    BOOL unhandled = [payload[@"unhandled"] boolValue];
+    return [[BugsnagHandledState alloc] initWithSeverityReason:reason
+                                                      severity:severity
+                                                     unhandled:unhandled
+                                                     attrValue:attrVal];
 }
 
 @end


### PR DESCRIPTION
## Goal

Deserializes the severity information sent about JS events and passes it onto the native layer. Note that both the Android and Cocoa layers don't currently support all the possibly severity reasons such as `log` - a separate ticket has been raised to address this issue in the native repos.

Tested by confirming that the handled state which is logged out is accurate for handled/unhandled JS exceptions.