### PR TITLE
Inform JS layer of native state changes on Cocoa

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -72,9 +72,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
                 && ![error.errorMessage hasPrefix:@"Unhandled JS Exception"];
     }];
 
-    // TODO: use this emitter to inform JS of changes to user, context and metadata
-    BugsnagReactNativeEmitter *emitter = [BugsnagReactNativeEmitter new];
-
     BugsnagConfiguration *config = [Bugsnag configuration];
     return [self.configSerializer serialize:config];
 }

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativeEmitter.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativeEmitter.m
@@ -1,4 +1,30 @@
 #import "BugsnagReactNativeEmitter.h"
+#import "Bugsnag.h"
+#import "BugsnagClient.h"
+
+@interface BugsnagStateEvent: NSObject
+@property NSString *type;
+@property id data;
+@end
+
+typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
+
+@interface Bugsnag ()
++ (BugsnagClient *)client;
+@end
+
+@interface BugsnagClient ()
+- (void)addObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
+- (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
+@end
+
+@interface BugsnagMetadata ()
+- (NSDictionary *)toDictionary;
+@end
+
+@interface BugsnagReactNativeEmitter ()
+@property BugsnagObserverBlock observerBlock;
+@end
 
 @implementation BugsnagReactNativeEmitter
 
@@ -8,8 +34,42 @@ RCT_EXPORT_MODULE();
   return @[@"bugsnag::sync"];
 }
 
-- (void)onChange {
-  [self sendEventWithName:@"bugsnag::sync" body:@{@"type": @"TEST_UPDATE", @"data": @"TESTING_123"}];
+- (void)startObserving {
+    __weak __typeof__(self) weakSelf = self;
+    self.observerBlock = ^(BugsnagStateEvent * _Nonnull event) {
+        if (weakSelf) {
+            NSDictionary *data = [weakSelf serializeStateChangeData:event];
+            [weakSelf sendEventWithName:@"bugsnag::sync" body:data];
+        }
+    };
+    [[Bugsnag client] addObserverWithBlock:self.observerBlock];
+}
+
+- (void)stopObserving {
+    [[Bugsnag client] removeObserverWithBlock:self.observerBlock];
+}
+
+- (NSDictionary *)serializeStateChangeData:(BugsnagStateEvent *)event {
+    id obj;
+
+    if ([@"ContextUpdate" isEqualToString:event.type]) {
+        obj = event.data;
+    } else if ([@"UserUpdate" isEqualToString:event.type]) {
+        obj = event.data;
+    } else if ([@"MetadataUpdate" isEqualToString:event.type]) {
+        BugsnagMetadata *metadata = event.data;
+        obj = [metadata toDictionary];
+    }
+
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[@"type"] = event.type;
+
+    if (obj != nil) {
+        dict[@"data"] = obj;
+    } else {
+        dict[@"data"] = [NSNull null];
+    }
+    return dict;
 }
 
 @end

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
@@ -417,9 +417,13 @@ NSString *_lastOrientation = nil;
         // for the entire lifecycle of an application, and there is therefore
         // no need to check for strong self
         __weak __typeof__(self) weakSelf = self;
-        [self addObserverUsingBlock:^(BugsnagStateEvent *event) {
+        void (^observer)(BugsnagStateEvent *) = ^(BugsnagStateEvent *event) {
             [weakSelf metadataChanged:event.data];
-        }];
+        };
+        [self addObserverWithBlock:observer];
+        [self.configuration.metadata addObserverWithBlock:observer];
+        [self.configuration.config addObserverWithBlock:observer];
+        [self.state addObserverWithBlock:observer];
 
         self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins];
 
@@ -435,14 +439,18 @@ NSString *_lastOrientation = nil;
     return self;
 }
 
-- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)observer {
+- (void)addObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer {
     [self.stateEventBlocks addObject:[observer copy]];
 
     // additionally listen for metadata updates
-    [self.metadata addObserverUsingBlock:observer];
-    [self.configuration.metadata addObserverUsingBlock:observer];
-    [self.configuration.config addObserverUsingBlock:observer];
-    [self.state addObserverUsingBlock:observer];
+    [self.metadata addObserverWithBlock:observer];
+}
+
+- (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer {
+    [self.stateEventBlocks removeObject:observer];
+
+    // additionally listen for metadata updates
+    [self.metadata removeObserverWithBlock:observer];
 }
 
 - (void)notifyObservers:(BugsnagStateEvent *)event {

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagMetadata.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagMetadata.m
@@ -101,8 +101,12 @@
     }
 }
 
-- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)block {
+- (void)addObserverWithBlock:(BugsnagObserverBlock _Nonnull)block {
     [self.stateEventBlocks addObject:[block copy]];
+}
+
+- (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)block {
+    [self.stateEventBlocks removeObject:block];
 }
 
 // MARK: - <NSMutableCopying>

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagMetadataInternal.h
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagMetadataInternal.h
@@ -25,7 +25,9 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
 
 - (id)deepCopy;
 
-- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)block;
+- (void)addObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
+
+- (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
 
 @end
 


### PR DESCRIPTION
## Goal

When the native layer changes its context, user, or metadata, the JS layer should be informed of the change. This implements a mechanism by which the JS layer is informed of any alteration to the data.

## Changeset
The changeset relies on alterations made to the Cocoa notifier which have been vendored from this PR: https://github.com/bugsnag/bugsnag-cocoa/pull/610

- `BugsnagReactNativeEmitter` extends `RCTEventEmitter`, as suggested in FB's react-native docs: https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript
- Set a native callback for state changes on `[Bugsnag client]` by using `addObserverWithBlock`
- Serialized the state change event data into a format understood by the JS layer and send an event

## Tests
This has been tested by altering the context/user/metadata in the native layer, and sending a handled JS exception through to the dashboard.