### PR TITLE
fix(types): Ensure start method is named correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD (2020-05-12)
+
+### Fixed
+
+- (types): Correct `init` static method name to `start` [#847](https://github.com/bugsnag/bugsnag-js/pull/847)
+
 ## 7.0.1 (2020-04-27)
 
 ### Fixed

--- a/packages/js/types.d.ts
+++ b/packages/js/types.d.ts
@@ -2,7 +2,7 @@ import { Client, BrowserConfig, BugsnagStatic } from '@bugsnag/browser'
 import { NodeConfig } from '@bugsnag/node'
 
 interface UniversalBugsnagStatic extends BugsnagStatic {
-  init(apiKeyOrOpts: string | BrowserConfig | NodeConfig): Client
+  start(apiKeyOrOpts: string | BrowserConfig | NodeConfig): Client
   createClient(apiKeyOrOpts: string | BrowserConfig | NodeConfig): Client
 }
 


### PR DESCRIPTION
Fixes #844.

The `start` method was named `init` for a while during the V7 implementation. This rename was missed.