### PR TITLE
feat: Upgrade TypeScript to 3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19923,9 +19923,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-test-renderer": "^16.13.1",
     "rimraf": "^3.0.0",
     "timekeeper": "^2.2.0",
-    "typescript": "^3.7.5",
+    "typescript": "^3.9.2",
     "uglify-js": "^3.4.9"
   },
   "scripts": {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -6,6 +6,7 @@ describe('@bugsnag/core/config', () => {
       Object.keys(config.schema).forEach(k => {
         const key = k as unknown as keyof typeof config.schema
         config.schema[key].defaultValue(undefined)
+        // @ts-expect-error
         config.schema[key].validate()
         config.schema[key].validate(-1)
         config.schema[key].validate('stringy stringerson')


### PR DESCRIPTION
Upgrades the TypeScript compiler to the latest version, which is more strict about its input. Fixes the one location where the current codebase does not compile.