### PR TITLE
Deserialize errors and thread stacktraces for Cocoa RN

### DIFF
--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagClient.m
@@ -107,6 +107,9 @@ static bool hasRecordedSessions;
 @property NSUInteger handledCount;
 @end
 
+@interface BugsnagThread ()
++ (NSMutableArray *)serializeThreads:(NSArray<BugsnagThread *> *)threads;
+@end
 
 @interface BugsnagAppWithState ()
 + (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
@@ -1551,7 +1554,8 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 - (NSArray *)collectThreads {
     int depth = (int)(BSGNotifierStackFrameCount);
     NSException *exc = [NSException exceptionWithName:@"Bugsnag" reason:@"" userInfo:nil];
-    return [[BSG_KSCrash sharedInstance] captureThreads:exc depth:depth];
+    NSArray<BugsnagThread *> *threads = [[BSG_KSCrash sharedInstance] captureThreads:exc depth:depth];
+    return [BugsnagThread serializeThreads:threads];
 }
 
 - (void)addRuntimeVersionInfo:(NSString *)info

--- a/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.m
+++ b/packages/react-native/ios/vendor/bugsnag-cocoa/Source/BugsnagEvent.m
@@ -752,8 +752,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             BSGArrayAddSafeObject(array, [error toDictionary]);
         }
         BSGDictSetSafeObject(event, array, BSGKeyExceptions);
-        BSGDictSetSafeObject(event, [BugsnagThread serializeThreads:self.threads], BSGKeyThreads);
     }
+    BSGDictSetSafeObject(event, [BugsnagThread serializeThreads:self.threads], BSGKeyThreads);
 
     // Build Event
     BSGDictSetSafeObject(event, BSGFormatSeverity(self.severity), BSGKeySeverity);


### PR DESCRIPTION
## Goal

Deserializes the error and thread objects sent in the `dispatch()` method, and ensure that they are sent as part of native reports. Tested by sending a handled JS exception in an example app and verifying the stacktrace and thread traces were populated correctly in the dashboard.

This changeset relies on vendored Cocoa code from https://github.com/bugsnag/bugsnag-cocoa/pull/611