### PR TITLE
fix(expo-cli): Ensure version detection logic for @bugsnag/expo is correct

### DIFF
--- a/packages/expo-cli/lib/insert.js
+++ b/packages/expo-cli/lib/insert.js
@@ -35,7 +35,7 @@ Bugsnag.start();
 
 const getCode = async (projectRoot) => {
   const manifestRange = await detectInstalled(projectRoot)
-  const isPostV7 = !manifestRange || semver.satisfies('7.0.0', manifestRange)
+  const isPostV7 = !manifestRange || semver.ltr('6.99.99', manifestRange)
   return code[isPostV7 ? 'postV7' : 'preV7']
 }
 

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/App.js
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/App.js
@@ -1,0 +1,21 @@
+const React = require('react')
+const { StyleSheet, Text, View } = require('react-native')
+
+export default class App extends React.Component {
+  render () {
+    return (
+      <View style={styles.container}>
+        <Text>Hello Expo!</Text>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+})

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/app.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/app.json
@@ -1,0 +1,39 @@
+{
+  "expo": {
+    "name": "Bugsnag test fixture",
+    "slug": "bugsnag-test-fixture",
+    "privacy": "unlisted",
+    "sdkVersion": "32.0.0",
+    "platforms": [
+      "ios",
+      "android"
+    ],
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "extra": {
+      "bugsnag": {
+        "apiKey": "XoXoXoXoXoXo"
+      }
+    },
+    "hooks": {
+      "postPublish": [
+        {
+          "file": "@bugsnag/expo/hooks/post-publish.js",
+          "config": {}
+        }
+      ]
+    }
+  }
+}

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bugsnag-test-fixture-03",
+  "private": "true",
+  "version": "0.0.0",
+  "dependencies": {
+    "@bugsnag/expo": "^7.0.1"
+  }
+}

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bugsnag-test-fixture-03",
+  "name": "bugsnag-test-fixture-05",
   "private": "true",
   "version": "0.0.0",
   "dependencies": {

--- a/packages/expo-cli/lib/test/insert.test.js
+++ b/packages/expo-cli/lib/test/insert.test.js
@@ -58,4 +58,12 @@ describe('expo-cli: insert', () => {
     const appJs = await promisify(readFile)(`${projectRoot}/App.js`, 'utf8')
     expect(appJs).toMatch(/^import bugsnag from '@bugsnag\/expo';\sconst bugsnagClient = bugsnag\(\);\s/)
   })
+
+  it('inserts correct code for post v7.0.0 versions of Bugsnag', async () => {
+    const projectRoot = await prepareFixture('already-installed-01')
+    const msg = await insert(projectRoot)
+    expect(msg).toBe(undefined)
+    const appJs = await promisify(readFile)(`${projectRoot}/App.js`, 'utf8')
+    expect(appJs).toMatch(/^import Bugsnag from '@bugsnag\/expo';\sBugsnag\.start\(\);\s/)
+  })
 })


### PR DESCRIPTION
The existing logic to detect whether @bugsnag/expo v6 or v7 was used only worked for exactly v7.0.0, nothing higher.

This updates the logic to ensure the minimum version in the range is at least v7. I couldn't find a way to express "less than or equal to range", so I had to provide a high version of v6 that we will never conceivably publish, in order to be inclusive of v7.0.0 – if that makes sense.