### PR TITLE
[plugin-express] use proper TypeScript namespace importing for express

### DIFF
--- a/packages/plugin-express/types/bugsnag-express.d.ts
+++ b/packages/plugin-express/types/bugsnag-express.d.ts
@@ -1,5 +1,5 @@
 import { Plugin, Client } from '@bugsnag/core'
-import express from 'express'
+import * as express from 'express'
 
 declare const bugsnagPluginExpress: Plugin
 export default bugsnagPluginExpress


### PR DESCRIPTION
My project is using express and bugsnag and I've been upgrading my typescript, express, bugsnag, and other dependencies. After making the necessary changes to my code, I get the following error from `plugin-express/types/bugsnag-express.d.ts`:
```
node_modules/@bugsnag/plugin-express/types/bugsnag-express.d.ts:2:8 - error TS1259: Module '"<path to project>/node_modules/@types/express/index"' can only be default-imported using the 'esModuleInterop' flag

2 import express from 'express'
         ~~~~~~~

  node_modules/@types/express/index.d.ts:116:1
    116 export = e;
        ~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```

Using the `esModuleInterop` config option breaks several other of my dependencies, but changing the import to a proper typescript namespace import fixes my issues and I'm able to build again. I don't believe this would be a breaking change for any setup.