### PR TITLE
Add clearer error message when Bugsnag.start() not present

### DIFF
--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
@@ -46,7 +46,7 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
         val client = try {
             Bugsnag.getClient()
         } catch (exc: IllegalStateException) {
-            throw IllegalStateException("Failed to initialise Android Client, please check you have " +
+            throw IllegalStateException("Failed to initialise the native Bugsnag Android client, please check you have " +
             "added Bugsnag.start() in the onCreate() method of your Application subclass")
         }
         return try {

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt
@@ -43,8 +43,13 @@ class BugsnagReactNative(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod(isBlockingSynchronousMethod = true)
     fun configure(env: ReadableMap): WritableMap {
+        val client = try {
+            Bugsnag.getClient()
+        } catch (exc: IllegalStateException) {
+            throw IllegalStateException("Failed to initialise Android Client, please check you have " +
+            "added Bugsnag.start() in the onCreate() method of your Application subclass")
+        }
         return try {
-            val client = Bugsnag.getClient()
             bridge = reactContext.getJSModule(RCTDeviceEventEmitter::class.java)
             logger = client.logger
             plugin = client.getPlugin(BugsnagReactNativePlugin::class.java)!!

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -56,7 +56,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
     self.configSerializer = [BugsnagConfigSerializer new];
 
     if (![Bugsnag bugsnagStarted]) {
-        [NSException raise:@"BugsnagException" format:@"Failed to initialise Cocoa Client, please check you have added Bugsnag.start() in the application:didFinishLaunchingWithOptions: method of your AppDelegate subclass"];
+        [NSException raise:@"BugsnagException" format:@"Failed to initialise the Bugsnag Cocoa client, please check you have added [Bugsnag start] in the application:didFinishLaunchingWithOptions: method of your AppDelegate subclass"];
     }
     [self updateNotifierInfo:readableMap];
     [self addRuntimeVersionInfo:readableMap];

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -56,7 +56,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
     self.configSerializer = [BugsnagConfigSerializer new];
 
     if (![Bugsnag bugsnagStarted]) {
-        return nil;
+        [NSException raise:@"BugsnagException" format:@"Failed to initialise Cocoa Client, please check you have added Bugsnag.start() in the application:didFinishLaunchingWithOptions: method of your AppDelegate subclass"];
     }
     [self updateNotifierInfo:readableMap];
     [self addRuntimeVersionInfo:readableMap];


### PR DESCRIPTION
Adds a clearer error message when `Bugsnag.start()` is not present for the iOS and Android clients. Currently if a user does not add `Bugsnag.start()` to the appropriate class or removes it, then the app crashes with a reasonably cryptic error message. As this is something that can be detected we can improve the error messaging to look like below instead:

<img width="508" alt="Screenshot 2020-05-22 at 10 11 21" src="https://user-images.githubusercontent.com/11800640/82651902-b3eaa600-9c14-11ea-8f1a-7d3034a99174.png">
