### PR TITLE
Release v7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - (plugin-express): Use import syntax that works without TypeScript's `esModuleInterop` compiler flag [#866](https://github.com/bugsnag/bugsnag-js/pull/866)
 - (expo-cli): Ensure version detection logic for @bugsnag/expo works after v7.0.0 [#865](https://github.com/bugsnag/bugsnag-js/pull/865)
-- (core): Ensure callbacks supplied in config permit no named arguments [#863](https://github.com/bugsnag/bugsnag-js/pull/863)
+- (core): Ensure callbacks supplied in config permit functions with no named arguments [#863](https://github.com/bugsnag/bugsnag-js/pull/863)
 
 
 ## 7.1.0 (2020-05-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+
+## 7.1.1 (2020-05-26)
+
+### Fixed
+
+- (plugin-express): Use import syntax that works without TypeScript's `esModuleInterop` compiler flag [#866](https://github.com/bugsnag/bugsnag-js/pull/866)
+- (expo-cli): Ensure version detection logic for @bugsnag/expo works after v7.0.0 [#865](https://github.com/bugsnag/bugsnag-js/pull/865)
+- (core): Ensure callbacks supplied in config permit no named arguments [#863](https://github.com/bugsnag/bugsnag-js/pull/863)
+
+
 ## 7.1.0 (2020-05-21)
 
 This update contains some substantial changes to plugin type definitions. If you are using TypeScript alongside a framework, you may need to make changes to your app. Please refer to the [upgrade guide](./UPGRADING.md).

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -138,9 +138,9 @@ class Client {
     if (config.logger) this._logger = config.logger
 
     // add callbacks
-    if (config.onError && config.onError.length) this._cbs.e = this._cbs.e.concat(config.onError)
-    if (config.onBreadcrumb && config.onBreadcrumb.length) this._cbs.b = this._cbs.b.concat(config.onBreadcrumb)
-    if (config.onSession && config.onSession.length) this._cbs.s = this._cbs.s.concat(config.onSession)
+    if (config.onError) this._cbs.e = this._cbs.e.concat(config.onError)
+    if (config.onBreadcrumb) this._cbs.b = this._cbs.b.concat(config.onBreadcrumb)
+    if (config.onSession) this._cbs.s = this._cbs.s.concat(config.onSession)
 
     // finally warn about any invalid config where we fell back to the default
     if (keys(errors).length) {

--- a/packages/expo-cli/lib/insert.js
+++ b/packages/expo-cli/lib/insert.js
@@ -35,7 +35,7 @@ Bugsnag.start();
 
 const getCode = async (projectRoot) => {
   const manifestRange = await detectInstalled(projectRoot)
-  const isPostV7 = !manifestRange || semver.satisfies('7.0.0', manifestRange)
+  const isPostV7 = !manifestRange || semver.ltr('6.99.99', manifestRange)
   return code[isPostV7 ? 'postV7' : 'preV7']
 }
 

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/App.js
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/App.js
@@ -1,0 +1,21 @@
+const React = require('react')
+const { StyleSheet, Text, View } = require('react-native')
+
+export default class App extends React.Component {
+  render () {
+    return (
+      <View style={styles.container}>
+        <Text>Hello Expo!</Text>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+})

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/app.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/app.json
@@ -1,0 +1,39 @@
+{
+  "expo": {
+    "name": "Bugsnag test fixture",
+    "slug": "bugsnag-test-fixture",
+    "privacy": "unlisted",
+    "sdkVersion": "32.0.0",
+    "platforms": [
+      "ios",
+      "android"
+    ],
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "extra": {
+      "bugsnag": {
+        "apiKey": "XoXoXoXoXoXo"
+      }
+    },
+    "hooks": {
+      "postPublish": [
+        {
+          "file": "@bugsnag/expo/hooks/post-publish.js",
+          "config": {}
+        }
+      ]
+    }
+  }
+}

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bugsnag-test-fixture-05",
+  "private": "true",
+  "version": "0.0.0",
+  "dependencies": {
+    "@bugsnag/expo": "^7.0.1"
+  }
+}

--- a/packages/expo-cli/lib/test/insert.test.js
+++ b/packages/expo-cli/lib/test/insert.test.js
@@ -58,4 +58,12 @@ describe('expo-cli: insert', () => {
     const appJs = await promisify(readFile)(`${projectRoot}/App.js`, 'utf8')
     expect(appJs).toMatch(/^import bugsnag from '@bugsnag\/expo';\sconst bugsnagClient = bugsnag\(\);\s/)
   })
+
+  it('inserts correct code for post v7.0.0 versions of Bugsnag', async () => {
+    const projectRoot = await prepareFixture('already-installed-01')
+    const msg = await insert(projectRoot)
+    expect(msg).toBe(undefined)
+    const appJs = await promisify(readFile)(`${projectRoot}/App.js`, 'utf8')
+    expect(appJs).toMatch(/^import Bugsnag from '@bugsnag\/expo';\sBugsnag\.start\(\);\s/)
+  })
 })

--- a/packages/plugin-express/types/bugsnag-express.d.ts
+++ b/packages/plugin-express/types/bugsnag-express.d.ts
@@ -1,5 +1,5 @@
 import { Plugin, Client } from '@bugsnag/core'
-import express from 'express'
+import * as express from 'express'
 
 declare const bugsnagPluginExpress: Plugin
 export default bugsnagPluginExpress


### PR DESCRIPTION
## 7.1.1 (2020-05-26)

### Fixed

- (plugin-express): Use import syntax that works without TypeScript's `esModuleInterop` compiler flag [#866](https://github.com/bugsnag/bugsnag-js/pull/866)
- (expo-cli): Ensure version detection logic for @bugsnag/expo works after v7.0.0 [#865](https://github.com/bugsnag/bugsnag-js/pull/865)
- (core): Ensure callbacks supplied in config permit functions with no named arguments [#863](https://github.com/bugsnag/bugsnag-js/pull/863)