### PR TITLE
Provide more resources for specific build steps

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -48,6 +48,8 @@ steps:
 
   - label:  ':docker: Publish expo app'
     timeout_in_minutes: 20
+    agents:
+      queue: "opensource-highpower"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
@@ -58,6 +60,8 @@ steps:
 
   - label:  ':docker: Build expo APK'
     timeout_in_minutes: 20
+    agents:
+      queue: "opensource-highpower"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk


### PR DESCRIPTION
This change provides a couple of specific build steps with access to the recently setup "highpower" build queue, which provides more CPU and memory resources for buildkite agents.  The selection of steps was made based on analysis of resource use for each build step across all of our notifier pipelines.