### PR TITLE
Add installVueErrorHandler

### DIFF
--- a/examples/js/vue/src/main.js
+++ b/examples/js/vue/src/main.js
@@ -8,6 +8,8 @@ Bugsnag.start({
   plugins: [new BugsnagPluginVue(Vue)]
 })
 
+Bugsnag.getPlugin('vue').installVueErrorHandler(Vue)
+
 Vue.config.productionTip = false
 
 new Vue({


### PR DESCRIPTION
According to [docs](https://docs.bugsnag.com/platforms/javascript/vue/#basic-configuration) it's necessary to call installVueErrorHandler