### PR TITLE
Update ECR login script to work with AWS CLI v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:lint": "eslint --ext .ts,.js --report-unused-disable-directives --max-warnings=0 .",
     "test:unit": "jest && lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",
     "test:types": "tsc -p tsconfig.json && lerna run test:types",
-    "test:test-container-registry-login": "$(aws ecr get-login --profile=opensource --no-include-email)",
+    "test:test-container-registry-login": "aws ecr get-login-password | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com",
     "test:build-browser-container": "docker-compose up --build minimal-packager && docker-compose build --pull browser-maze-runner",
     "test:build-node-container": "docker-compose up --build minimal-packager && docker-compose build --pull node-maze-runner",
     "test:build-expo-android-container": "test/expo/scripts/build-android-locally.sh",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:lint": "eslint --ext .ts,.js --report-unused-disable-directives --max-warnings=0 .",
     "test:unit": "jest && lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",
     "test:types": "tsc -p tsconfig.json && lerna run test:types",
-    "test:test-container-registry-login": "aws ecr get-login-password | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com",
+    "test:test-container-registry-login": "aws ecr get-login-password --profile=opensource | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com",
     "test:build-browser-container": "docker-compose up --build minimal-packager && docker-compose build --pull browser-maze-runner",
     "test:build-node-container": "docker-compose up --build minimal-packager && docker-compose build --pull node-maze-runner",
     "test:build-expo-android-container": "test/expo/scripts/build-android-locally.sh",


### PR DESCRIPTION
The `get-login` command was removed in v2 of the AWS CLI so the `test:test-container-registry-login` NPM script doesn't work

The replacement `get-login-password` command was added in [v1.17.10 in February](https://github.com/aws/aws-cli/releases/tag/1.17.10)

See https://github.com/aws/containers-roadmap/issues/735 for more details