### PR TITLE
Expo SDK 38 support

### DIFF
--- a/packages/delivery-expo/package-lock.json
+++ b/packages/delivery-expo/package-lock.json
@@ -114,9 +114,9 @@
 			}
 		},
 		"@react-native-community/netinfo": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.5.0.tgz",
-			"integrity": "sha512-9fdOk1dxR3Bt+T4OuQxhf7EjyfbI6qVbPcNfTvVjGgRrx798ixAbBcCC+k5wp3LloVChVicXkyblu+wXEGiCWw=="
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.2.tgz",
+			"integrity": "sha512-YPN6Qi9Sf64GlE3muLi4u4p4LaFP/65PTS0xssiGEaBAwSmZoUhzihhW1AptNe66ZQK9PxXfKIJDiLnYveK1aw=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/core": "^7.1.1",
-    "@react-native-community/netinfo": "5.5.0",
+    "@react-native-community/netinfo": "5.9.2",
     "expo-file-system": "^6.0.2"
   },
   "devDependencies": {

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -57,6 +57,7 @@ const selectVersion = async (dir) => {
     const isPre33 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '33.0.0'))
     const isPre36 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '36.0.0'))
     const isPre37 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '37.0.0'))
+    const isPre38 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '38.0.0'))
 
     if (isPre33) {
       throw new Error('Expo SDK <33 is no longer supported')
@@ -66,6 +67,9 @@ const selectVersion = async (dir) => {
     } else if (isPre37) {
       message = 'It looks like you’re using a version of Expo SDK <37. The last version of Bugsnag that supported your version of Expo is v6.5.3'
       defaultVersion = '6.5.3'
+    } else if (isPre38) {
+      message = 'It looks like you’re using a version of Expo SDK <38. The last version of Bugsnag that supported your version of Expo is v7.1.1'
+      defaultVersion = '7.1.1'
     }
 
     const { version } = await prompts({

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package-lock.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package-lock.json
@@ -114,9 +114,9 @@
 			}
 		},
 		"@react-native-community/netinfo": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.5.0.tgz",
-			"integrity": "sha512-9fdOk1dxR3Bt+T4OuQxhf7EjyfbI6qVbPcNfTvVjGgRrx798ixAbBcCC+k5wp3LloVChVicXkyblu+wXEGiCWw=="
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.2.tgz",
+			"integrity": "sha512-YPN6Qi9Sf64GlE3muLi4u4p4LaFP/65PTS0xssiGEaBAwSmZoUhzihhW1AptNe66ZQK9PxXfKIJDiLnYveK1aw=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -20,7 +20,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@react-native-community/netinfo": "5.5.0"
+    "@react-native-community/netinfo": "5.9.2"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.1.1",


### PR DESCRIPTION
Bumps the version of `@react-native-community/netinfo` as [depended on by the upcoming SDK 38](https://github.com/expo/expo/blob/master/CHANGELOG.md#3800--not-officially-out-yet) of Expo.

Adds another branch to `expo-cli` to install a compatible version.

Note that the changes are not catastrophic in the bump from 5.5.0 -> 5.9.2. When running the current version of @bugsnag/expo against SDK 38 I was unable to produce a problem. However, there may be subtle bugs introduced by running v5.5.0 in JS against v5.9.2 native code bundled in Expo, so best to upgrade anyway.