### PR TITLE
Detect published packages

### DIFF
--- a/dockerfiles/Dockerfile.publisher
+++ b/dockerfiles/Dockerfile.publisher
@@ -14,16 +14,9 @@ RUN echo "always-auth=true" >> ~/.npmrc
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
-
 COPY . .
-
-RUN npm run bootstrap
-RUN npm run build
-
-RUN git checkout .
-
 COPY scripts/ scripts/
+
 ARG PUBLISH_URL
 ARG BUILDKITE
 ARG BRANCH_NAME

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -2,7 +2,8 @@ const lerna = require('../lerna.json')
 const { execSync } = require('child_process')
 
 module.exports = {
-  run: function run (command) {
+  run: function run (command, log = true) {
+    if (log) console.log(command)
     return execSync(command).toString().trim()
   },
   getCommitId: function getCommitId () {

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -9,6 +9,11 @@ function publish (publishUrl) {
   const myVersions = allVersions.filter(function (str) { return str.indexOf(version) !== -1; })
   if (myVersions.length === 0) {
     console.log(`Publishing as '${version}'`)
+
+    common.run('npm install')
+    common.run('npm run bootstrap')
+    common.run('npm run build')
+    common.run('git checkout .')
     common.run(`./node_modules/.bin/lerna publish ${version} --dist-tag ${distTag} --yes --force-publish --no-push --no-git-tag-version --registry ${publishUrl}`)
   } else {
     console.log(`Version '${version}' already found in registry - skipping publishing`)

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,8 +3,16 @@ const common = require('./common')
 function publish (publishUrl) {
   const version = common.determineVersion()
   const distTag = common.getCommitId()
-  console.log(`Publishing as: ${version}`)
-  common.run(`./node_modules/.bin/lerna publish ${version} --dist-tag ${distTag} --yes --force-publish --no-push --no-git-tag-version --registry ${publishUrl}`)
+
+  // Check for existing published packages
+  const allVersions = JSON.parse(common.run(`npm view @bugsnag/js versions --registry ${publishUrl} --json`).toString())
+  const myVersions = allVersions.filter(function (str) { return str.indexOf(version) !== -1; })
+  if (myVersions.length === 0) {
+    console.log(`Publishing as '${version}'`)
+    common.run(`./node_modules/.bin/lerna publish ${version} --dist-tag ${distTag} --yes --force-publish --no-push --no-git-tag-version --registry ${publishUrl}`)
+  } else {
+    console.log(`Version '${version}' already found in registry - skipping publishing`)
+  }
 }
 
 if (process.argv.length !== 3) {


### PR DESCRIPTION
This change improves the robustness of the build a little my detecting if the JavaScript packages for the branch/commit have already been published.  If they have, the build and publish step will be skipped.

This changes still isn't perfect though.  Some limitations:
- It won't help with partially published package sets (i.e. some but not all packages are published).  In this case existing packages either need to be manually removed from the registry, or a new commit artificially created.
- The script blissfully assume that `'npm install` etc will all be successful.  Some extra error checking could be useful.