### PR TITLE
V7 React-native: Fix publishing hash to 10 characters

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -7,7 +7,7 @@ module.exports = {
     return execSync(command).toString().trim()
   },
   getCommitId: function getCommitId () {
-    return this.run('git rev-parse --short HEAD').substring(0, 8)
+    return this.run('git rev-parse --short=10 HEAD')
   },
   determineVersion: function determineVersion () {
     // Form version string - branch name and commit id

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -7,7 +7,7 @@ module.exports = {
     return execSync(command).toString().trim()
   },
   getCommitId: function getCommitId () {
-    return this.run('git rev-parse --short HEAD')
+    return this.run('git rev-parse --short HEAD').substring(0, 8)
   },
   determineVersion: function determineVersion () {
     // Form version string - branch name and commit id


### PR DESCRIPTION
Fixing the hash length fixes an issue where different versions of git/node determine different hash lengths during the build process.

For an example of this issue, compare the published package version [here](https://buildkite.com/bugsnag/at-bugsnag-react-native/builds/233#06fdee5c-2ea9-4645-8670-c4268d36ce8a/93-1299) to the requested package version [here](https://buildkite.com/bugsnag/at-bugsnag-react-native/builds/233#24c2f487-d587-447e-a4f6-8162a42eaf06/44-77).