### PR TITLE
Use v6 of safe-json-stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - (plugin-expo-device): Add total memory to error reports [#881](https://github.com/bugsnag/bugsnag-js/pull/881)
 - (plugin-node-device): Add OS name, OS version, total memory and free memory to error reports [#881](https://github.com/bugsnag/bugsnag-js/pull/881)
 
+### Changed
+
+- Update `@bugsnag/safe-json-stringify` to make `redactedKeys` case insensitive when using strings [#905](https://github.com/bugsnag/bugsnag-js/pull/905)
+
 ### Fixed
 - (plugin-express): Ensure `req.body` is always present in metadata by collecting it at the last possible moment [#872](https://github.com/bugsnag/bugsnag-js/pull/872)
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,9 +10,9 @@
 			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
 		},
 		"@bugsnag/safe-json-stringify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-5.0.0.tgz",
-			"integrity": "sha512-EdGnA7n2UmX9Z0e2tIU0biKz8tCgtjbY69KoyH3yiMzm7Q9sriIlN9bZjqhTOKzM0GdLSGrkyKWif08xWKyucA=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+			"integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
 		},
 		"error-stack-parser": {
 			"version": "2.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/cuid": "^3.0.0",
-    "@bugsnag/safe-json-stringify": "^5.0.0",
+    "@bugsnag/safe-json-stringify": "^6.0.0",
     "error-stack-parser": "^2.0.3",
     "iserror": "0.0.2",
     "stack-generator": "^2.0.3"


### PR DESCRIPTION
This makes `redactedKeys` case insensitive when using strings, to help prevent accidentally leaking data. For example, `redactedKeys = ['secret']` will now match 'SECRET', 'SeCrEt' etc&hellip; as well as 'secret'

See https://github.com/bugsnag/safe-json-stringify/compare/v5.0.0...v6.0.0