### PR TITLE
build: Stream CDN upload stdout/stderr for immediate feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ lerna publish from-git
 At this point it is sensible to perform some manual smoke tests to ensure the new version on npm works as expected. Only then publish to the CDN:
 
 ```
-lerna run cdn-upload
+npm run cdn-upload
 ```
 
 Finally:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
+    "cdn-upload": "lerna run cdn-upload --stream",
     "build": "lerna run build --scope '@bugsnag/node' --scope '@bugsnag/browser' --scope '@bugsnag/expo' && lerna run build --ignore '@bugsnag/node' --ignore '@bugsnag/browser' --ignore '@bugsnag/expo'",
     "test:lint": "eslint --ext .ts,.js --report-unused-disable-directives --max-warnings=0 .",
     "test:unit": "jest && lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",


### PR DESCRIPTION
This now outputs the stdout from the upload process as it is received, rather than buffering until finished:

```
$ » npm run cdn-upload

> @ cdn-upload /Users/bengourley/Development/bugsnag-js
> lerna run cdn-upload --stream

lerna notice cli v3.20.2
lerna info Executing command in 1 package: "npm run cdn-upload"
@bugsnag/browser: > @bugsnag/browser@7.2.0 cdn-upload /Users/bengourley/Development/bugsnag-js/packages/browser
@bugsnag/browser: > ./bin/cdn-upload
@bugsnag/browser: uploading browser/dist/bugsnag.js -> /v7.2.0/bugsnag.js
@bugsnag/browser: uploading browser/dist/bugsnag.js.map -> /v7.2.0/bugsnag.js.map
@bugsnag/browser: uploading browser/dist/bugsnag.min.js -> /v7.2.0/bugsnag.min.js
@bugsnag/browser: uploading browser/dist/bugsnag.min.js.map -> /v7.2.0/bugsnag.min.js.map
@bugsnag/browser: uploading browser/dist/bugsnag.js -> /v7/bugsnag.js
@bugsnag/browser: uploading browser/dist/bugsnag.js.map -> /v7/bugsnag.js.map
@bugsnag/browser: uploading browser/dist/bugsnag.min.js -> /v7/bugsnag.min.js
@bugsnag/browser: uploading browser/dist/bugsnag.min.js.map -> /v7/bugsnag.min.js.map
@bugsnag/browser: uploading browser/dist/bugsnag.js -> /v7.2/bugsnag.js
@bugsnag/browser: uploading browser/dist/bugsnag.js.map -> /v7.2/bugsnag.js.map
@bugsnag/browser: uploading browser/dist/bugsnag.min.js -> /v7.2/bugsnag.min.js
@bugsnag/browser: uploading browser/dist/bugsnag.min.js.map -> /v7.2/bugsnag.min.js.map
@bugsnag/browser: invaliding CloudFront cache for the following objects:
@bugsnag/browser: /v7.2.0/bugsnag.js
@bugsnag/browser: /v7.2.0/bugsnag.js.map
@bugsnag/browser: /v7.2.0/bugsnag.min.js
@bugsnag/browser: /v7.2.0/bugsnag.min.js.map
@bugsnag/browser: /v7/bugsnag.js
@bugsnag/browser: /v7/bugsnag.js.map
@bugsnag/browser: /v7/bugsnag.min.js
@bugsnag/browser: /v7/bugsnag.min.js.map
@bugsnag/browser: /v7.2/bugsnag.js
@bugsnag/browser: /v7.2/bugsnag.js.map
@bugsnag/browser: /v7.2/bugsnag.min.js
@bugsnag/browser: /v7.2/bugsnag.min.js.map
lerna success run Ran npm script 'cdn-upload' in 1 package in 31.9s:
lerna success - @bugsnag/browser
```