### PR TITLE
Correct app id mismatch

### DIFF
--- a/test/react-native/features/app.feature
+++ b/test/react-native/features/app.feature
@@ -15,7 +15,7 @@ Scenario: Handled JS error
   And the event "app.codeBundleId" equals "1.2.3-r00110011"
 
   # Android
-  # And the event "app.id" equals "com.reactnative"
+  And the event "app.id" equals "com.reactnative"
   And the event "app.type" equals "android"
   # iOS
   # And the event "app.id" equals "org.reactjs.native.example.reactnative"
@@ -38,7 +38,7 @@ Scenario: Unhandled JS error
   And the event "app.codeBundleId" equals "1.2.3-r00110011"
 
   # Android
-  # And the event "app.id" equals "com.reactnative"
+  And the event "app.id" equals "com.reactnative"
   And the event "app.type" equals "android"
   # iOS
   # And the event "app.id" equals "org.reactjs.native.example.reactnative"
@@ -60,7 +60,7 @@ Scenario: Handled native error
   And the event "app.codeBundleId" equals "1.2.3-r00110011"
 
   # Android
-  # And the event "app.id" equals "com.reactnative"
+  And the event "app.id" equals "com.reactnative"
   And the event "app.type" equals "android"
   # iOS
   # And the event "app.id" equals "org.reactjs.native.example.reactnative"
@@ -82,7 +82,7 @@ Scenario: Unhandled native error
   And the event "app.codeBundleId" equals "1.2.3-r00110011"
 
   # Android
-  # And the event "app.id" equals "com.reactnative"
+  And the event "app.id" equals "com.reactnative"
   And the event "app.type" equals "android"
   # iOS
   # And the event "app.id" equals "org.reactjs.native.example.reactnative"

--- a/test/react-native/features/fixtures/rn0.55/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.55/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        applicationId "com.rn055"
+        applicationId "com.reactnative"
         minSdkVersion 16
         targetSdkVersion 22
         versionCode 1


### PR DESCRIPTION
Makes the applicationId consistent across the two React Native test fixtures, allowing a test step to be written that will pass on both versions.