### PR TITLE
Include bugsnag-react-native.gradle in package.json

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -48,7 +48,8 @@
     "ios/vendor/bugsnag-cocoa/Framework/{Info.plist,module.modulemap}",
     "ios/vendor/bugsnag-cocoa/Bugsnag.podspec.json",
     "BugsnagReactNative.podspec",
-    "react-native.config.js"
+    "react-native.config.js",
+    "bugsnag-react-native.gradle"
   ],
   "scripts": {
     "test:types": "jasmine 'types/**/*.test.js'"


### PR DESCRIPTION
Fixes the newly added `bugsnag-react-native.gradle` not being included in the installed node_module.