### PR TITLE
Add manual testing mode to RN fixture

### DIFF
--- a/test/react-native/features/fixtures/app/App.js
+++ b/test/react-native/features/fixtures/app/App.js
@@ -17,12 +17,23 @@ let getDefaultConfiguration = () => { return {
   }
 }
 
+let getManualModeConfiguration = (apiKey) => { return {
+  apiKey: apiKey,
+  endpoints: {
+    notify: 'https://notify.bugsnag.com',
+    sessions: 'https://sessions.bugsnag.com'
+  },
+  autoTrackSessions: false
+}
+}
+
 export default class App extends Component {
   constructor(props) {
     super(props)
     this.state = {
       currentScenario: '',
-      scenarioMetaData: ''
+      scenarioMetaData: '',
+      manualApiKey: null
     }
     console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
   }
@@ -33,6 +44,10 @@ export default class App extends Component {
 
   setScenarioMetaData = newScenarioMetaData => {
     this.setState(() => ({ scenarioMetaData: newScenarioMetaData }))
+  }
+
+  setManualApiKey = newApiKey => {
+    this.setState(() => ({ manualApiKey: newApiKey }))
   }
 
   startScenario = () => {
@@ -55,7 +70,13 @@ export default class App extends Component {
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     let scenarioName = this.state.currentScenario
     let scenarioMetaData = this.state.scenarioMetaData
-    let configuration = getDefaultConfiguration()
+    let configuration
+    if (this.state.manualApiKey) {
+      configuration = getManualModeConfiguration(this.state.manualApiKey)
+    }
+    else {
+      configuration = getDefaultConfiguration()
+    }
     let jsConfig = {}
     let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
@@ -70,19 +91,27 @@ export default class App extends Component {
         <View style={styles.child}>
           <Text>React-native end-to-end test app</Text>
           <TextInput style={styles.textInput}
-            accessibilityLabel='scenarioInput'
-            onChangeText={this.setScenario} />
+                     placeholder='Scenario Name'
+                     accessibilityLabel='scenarioInput'
+                     onChangeText={this.setScenario} />
           <TextInput style={styles.textInput}
-            accessibilityLabel='scenarioMetaDataInput'
-            onChangeText={this.setScenarioMetaData} />
+                     placeholder='Scenario Metadata'
+                     accessibilityLabel='scenarioMetaDataInput'
+                     onChangeText={this.setScenarioMetaData} />
+
           <Button style={styles.clickyButton}
-            accessibilityLabel='startScenarioButton'
-            title='Start scenario'
-            onPress={this.startScenario}/>
+                  accessibilityLabel='startScenarioButton'
+                  title='Start scenario'
+                  onPress={this.startScenario}/>
           <Button style={styles.clickyButton}
-            accessibilityLabel='startBugsnagButton'
-            title='Start Bugsnag'
-            onPress={this.startBugsnag}/>
+                  accessibilityLabel='startBugsnagButton'
+                  title='Start Bugsnag'
+                  onPress={this.startBugsnag}/>
+
+          <Text>Manual testing mode</Text>
+          <TextInput placeholder='API key'
+                     style={styles.textInput}
+                     onChangeText={this.setManualApiKey} />
         </View>
       </View>
     );

--- a/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
+++ b/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
@@ -95,38 +95,37 @@ public class BugsnagModule extends ReactContextBaseJavaModule {
 
   private Configuration createConfiguration(ReadableMap options) {
       Configuration config = new Configuration(options.getString("apiKey"));
-      config.setEndpoints(new EndpointConfiguration(options.getString("endpoint"), options.getString("endpoint")));
       config.setAutoTrackSessions(options.getBoolean("autoTrackSessions"));
 
-      try {
+      if (options.hasKey("endpoint")) {
+        config.setEndpoints(new EndpointConfiguration(options.getString("endpoint"), options.getString("endpoint")));
+      }
+      else if (options.hasKey("endpoints")) {
+          ReadableMap endpoints = options.getMap("endpoints");
+          config.setEndpoints(new EndpointConfiguration(endpoints.getString("notify"), endpoints.getString("sessions")));
+      }
+
+      if (options.hasKey("appVersion")) {
         String appVersion = null;
         appVersion = options.getString("appVersion");
         config.setAppVersion(appVersion);
-      } catch (NoSuchKeyException e) {
-        // ignore NoSuchKeyException
       }
 
-      try {
+      if (options.hasKey("appType")) {
         String appType = options.getString("appType");
         config.setAppType(appType);
-      } catch (NoSuchKeyException e) {
-        // ignore NoSuchKeyException
       }
 
-      try {
+      if (options.hasKey("releaseStage")) {
         String releaseStage = options.getString("releaseStage");
         config.setReleaseStage(releaseStage);
-      } catch (NoSuchKeyException e) {
-        // ignore NoSuchKeyException
       }
 
-      try {
+      if (options.hasKey("enabledReleaseStages")) {
         Set<String> enabledReleaseStages = new HashSet<String>();
         ReadableArray ar = options.getArray("enabledReleaseStages");
         for (int i = 0; i < ar.size(); i++) enabledReleaseStages.add(ar.getString(i));
         config.setEnabledReleaseStages(enabledReleaseStages);
-      } catch (NoSuchKeyException e) {
-        // ignore NoSuchKeyException
       }
 
       return config;


### PR DESCRIPTION
This changes adds an API key field to the test fixture UI.  If an API key is entered, reports will be sent to the real dashboard - useful for manually testing automated scenarios.

A further change that could be made here are persistence of the API key, to avoid having to re-enter it just to start Bugsnag after a crash.  

Additional UI fields could also be added to specify notify/session endpoints.  This would be useful for those of us with local mock servers when wanting to inspect the payloads in detail.