### PR TITLE
Improve test resilience

### DIFF
--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -1,7 +1,7 @@
 When("I run {string}") do |event_type|
   steps %Q{
-    Given the element "scenarioInput" is present
-    When I send the keys "#{event_type}" to the element "scenarioInput"
+    Given the element "scenarioInput" is present within 60 seconds
+    When I clear and send the keys "#{event_type}" to the element "scenarioInput"
     And I click the element "startScenarioButton"
   }
 end
@@ -31,8 +31,8 @@ end
 
 When("I configure Bugsnag for {string}") do |event_type|
   steps %Q{
-    Given the element "scenarioInput" is present
-    When I send the keys "#{event_type}" to the element "scenarioInput"
+    Given the element "scenarioInput" is present within 60 seconds
+    When I clear and send the keys "#{event_type}" to the element "scenarioInput"
     And I click the element "startBugsnagButton"
   }
 end
@@ -40,7 +40,7 @@ end
 When("I configure the app to run in the {string} state") do |event_metadata|
   steps %Q{
     Given the element "scenarioMetaDataInput" is present
-    And I send the keys "#{event_metadata}" to the element "scenarioMetaDataInput"
+    And I clear and send the keys "#{event_metadata}" to the element "scenarioMetaDataInput"
   }
 end
 


### PR DESCRIPTION
1. Clear text fields before sending keys.  
2. Be prepared to wait longer (60s from default of 15s) before trying to enter text into the first field.