### PR TITLE
Enable logging in Mazerunner Android

### DIFF
--- a/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
+++ b/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
@@ -4,9 +4,12 @@ package com.reactnative.module;
 import java.util.HashSet;
 import java.util.Set;
 
+import android.util.Log;
+
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.EndpointConfiguration;
+import com.bugsnag.android.Logger;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -43,6 +46,49 @@ public class BugsnagModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void startBugsnag(ReadableMap options, Callback readyCallback) {
     Configuration bugsnagConfig = createConfiguration(options);
+    bugsnagConfig.setLogger(new Logger() {
+      private static final String TAG = "Bugsnag";
+
+      @Override
+      public void e(String msg) {
+          Log.e(TAG, msg);
+      }
+
+      @Override
+      public void e(String msg, Throwable throwable) {
+          Log.e(TAG, msg, throwable);
+      }
+
+      @Override
+      public void w(String msg) {
+          Log.w(TAG, msg);
+      }
+
+      @Override
+      public void w(String msg, Throwable throwable) {
+          Log.w(TAG, msg, throwable);
+      }
+
+      @Override
+      public void i(String msg) {
+          Log.i(TAG, msg);
+      }
+
+      @Override
+      public void i(String msg, Throwable throwable) {
+          Log.i(TAG, msg, throwable);
+      }
+
+      @Override
+      public void d(String msg) {
+          Log.d(TAG, msg);
+      }
+
+      @Override
+      public void d(String msg, Throwable throwable) {
+          Log.d(TAG, msg, throwable);
+      }
+    });
     Bugsnag.start(reactContext, bugsnagConfig);
     readyCallback.invoke();
   }


### PR DESCRIPTION
## Goal

Enables debug logging in mazerunner. Logging is disabled by default in release mode - this alters configuration to log everything to logcat, which should aid debugging failing mazerunner scenarios.
