### PR TITLE
fix(plugin-vue): Access the window object safely, in case it isn't defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (plugin-vue): Ensure the `window.Vue` fallback does not throw in environments where `window` is undefined. [#928](https://github.com/bugsnag/bugsnag-js/pull/928)
+
 ## 7.2.0 (2020-07-06)
 
 ### Added

--- a/packages/plugin-vue/src/index.js
+++ b/packages/plugin-vue/src/index.js
@@ -1,9 +1,13 @@
 module.exports = class BugsnagPluginVue {
   constructor (...args) {
+    // Fetch Vue from the window object, if it exists
+    const globalVue = typeof window !== 'undefined' && window.Vue
+
     this.name = 'vue'
-    this.lazy = args.length === 0 && !window.Vue
+    this.lazy = args.length === 0 && !globalVue
+
     if (!this.lazy) {
-      this.Vue = args[0] || window.Vue
+      this.Vue = args[0] || globalVue
       if (!this.Vue) throw new Error('@bugsnag/plugin-vue reference to `Vue` was undefined')
     }
   }

--- a/packages/plugin-vue/test/index.test.ts
+++ b/packages/plugin-vue/test/index.test.ts
@@ -45,4 +45,64 @@ describe('bugsnag vue', () => {
     expect(BugsnagVuePlugin.classify('foo_bar')).toBe('FooBar')
     expect(BugsnagVuePlugin.classify('foo-bar')).toBe('FooBar')
   })
+
+  describe('global Vue', () => {
+    // Workaround typescript getting upset at messing around with global
+    // by taking a reference as 'any' and modifying that instead
+    const globalReference: any = global
+    const actualWindow = globalReference.window
+
+    afterEach(() => {
+      globalReference.window = actualWindow
+      globalReference.window.Vue = undefined
+    })
+
+    it('can pull Vue out of the window object', done => {
+      globalReference.window.Vue = Vue
+
+      const client = new Client({ apiKey: 'API_KEYYY', plugins: [new BugsnagVuePlugin()] })
+
+      client._setDelivery(client => ({
+        sendEvent: (payload) => {
+          expect(payload.events[0].errors[0].errorClass).toBe('Error')
+          expect(payload.events[0].errors[0].errorMessage).toBe('oops')
+          expect(payload.events[0]._metadata.vue).toBeDefined()
+          done()
+        },
+        sendSession: () => {}
+      }))
+
+      expect(typeof Vue.config.errorHandler).toBe('function')
+
+      Vue.config.errorHandler(
+        new Error('oops'),
+        { $root: true, $options: {} } as unknown as Vue,
+        'callback for watcher "fooBarBaz"'
+      )
+    })
+
+    it('checks for window.Vue safely', done => {
+      // Delete the window object so that any unsafe check for 'window.Vue' will throw
+      delete globalReference.window
+
+      const client = new Client({ apiKey: 'API_KEYYY', plugins: [new BugsnagVuePlugin()] })
+
+      // eslint-disable-next-line
+      client.getPlugin('vue')!.installVueErrorHandler(Vue)
+
+      client._setDelivery(client => ({
+        sendEvent: (payload) => {
+          expect(payload.events[0].errors[0].errorClass).toBe('Error')
+          expect(payload.events[0].errors[0].errorMessage).toBe('oops')
+          expect(payload.events[0]._metadata.vue).toBeDefined()
+          done()
+        },
+        sendSession: () => {}
+      }))
+
+      expect(typeof Vue.config.errorHandler).toBe('function')
+
+      Vue.config.errorHandler(new Error('oops'), { $root: true, $options: {} } as unknown as Vue, 'callback for watcher "fooBarBaz"')
+    })
+  })
 })


### PR DESCRIPTION
This prevents errors when using SSR as `window` won't exist

The tests for this aren't particularly nice as we have to edit the `global` object to add/remove references to `window` and `window.Vue`; I'm not sure there's a nicer way to write them ?

Fixes #895