### PR TITLE
test: convert tests to jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -44,7 +44,11 @@ module.exports = {
         testsForPackage('plugin-server-*'),
         testsForPackage('plugin-strip-project-root'),
         testsForPackage('plugin-intercept'),
-        testsForPackage('plugin-node-unhandled-rejection')
+        testsForPackage('plugin-node-unhandled-rejection'),
+        testsForPackage('plugin-node-in-project'),
+        testsForPackage('plugin-node-device'),
+        testsForPackage('plugin-node-surrounding-code'),
+        testsForPackage('plugin-node-uncaught-exception')
       ]
     }
   ]

--- a/packages/core/types/event.d.ts
+++ b/packages/core/types/event.d.ts
@@ -58,7 +58,7 @@ export interface Stackframe {
   method?: string
   lineNumber?: number
   columnNumber?: number
-  code?: object
+  code?: Record<string, string>
   inProject?: boolean
 }
 

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -14,14 +14,9 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.2.0",
-    "jasmine": "^3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.2.0"
   }
 }

--- a/packages/plugin-node-device/test/device.test.ts
+++ b/packages/plugin-node-device/test/device.test.ts
@@ -1,8 +1,6 @@
-const { describe, it, expect } = global
+import plugin from '../device'
+import Client from '@bugsnag/core/client'
 
-const plugin = require('../device')
-
-const Client = require('@bugsnag/core/client')
 const schema = {
   ...require('@bugsnag/core/config').schema,
   hostname: {
@@ -29,9 +27,10 @@ describe('plugin: node device', () => {
         expect(payload.events[0].device.freeMemory).toBeGreaterThan(0)
         expect(payload.events[0].device.totalMemory).toBeGreaterThan(payload.events[0].device.freeMemory)
         expect(payload.events[0].device.runtimeVersions).toBeDefined()
-        expect(payload.events[0].device.runtimeVersions.node).toEqual(process.versions.node)
+        expect(payload.events[0].device.runtimeVersions && payload.events[0].device.runtimeVersions.node).toEqual(process.versions.node)
         done()
-      }
+      },
+      sendSession: () => {}
     }))
     client.notify(new Error('noooo'))
   })

--- a/packages/plugin-node-in-project/package.json
+++ b/packages/plugin-node-in-project/package.json
@@ -14,14 +14,9 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.2.0",
-    "jasmine": "^3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.2.0"
   }
 }

--- a/packages/plugin-node-in-project/test/in-project.test.ts
+++ b/packages/plugin-node-in-project/test/in-project.test.ts
@@ -1,10 +1,8 @@
-const { describe, it, expect } = global
-
-const plugin = require('../')
-const { join } = require('path')
-const Event = require('@bugsnag/core/event')
-const Client = require('@bugsnag/core/client')
-const { schema } = require('@bugsnag/core/config')
+import plugin from '../'
+import { join } from 'path'
+import Event from '@bugsnag/core/event'
+import Client from '@bugsnag/core/client'
+import { schema } from '@bugsnag/core/config'
 
 describe('plugin: node in project', () => {
   it('should mark stackframes as "inProject" if it is a descendent of the "projectRoot"', done => {

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -14,9 +14,6 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
@@ -24,8 +21,6 @@
     "pump": "^3.0.0"
   },
   "devDependencies": {
-    "@bugsnag/core": "^7.2.0",
-    "jasmine": "^3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.2.0"
   }
 }

--- a/packages/plugin-node-surrounding-code/test/surrounding-code.test.ts
+++ b/packages/plugin-node-surrounding-code/test/surrounding-code.test.ts
@@ -1,17 +1,16 @@
-const { describe, it, expect } = global
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import fs from 'fs'
+import plugin from '../'
+import { join } from 'path'
+import Event from '@bugsnag/core/event'
+import Client from '@bugsnag/core/client'
 
-const fs = require('fs')
 let createReadStreamCount = 0
 const originalReadStream = fs.createReadStream
 fs.createReadStream = function () {
   createReadStreamCount++
-  return originalReadStream.apply(fs, arguments)
+  return originalReadStream.apply(fs, arguments as any)
 }
-
-const plugin = require('../')
-const { join } = require('path')
-const Event = require('@bugsnag/core/event')
-const Client = require('@bugsnag/core/client')
 
 describe('plugin: node surrounding code', () => {
   it('should load code successfully for stackframes whose files exist', done => {
@@ -20,19 +19,19 @@ describe('plugin: node surrounding code', () => {
     client._setDelivery(client => ({
       sendEvent: (payload) => {
         const evt = payload.events[0]
-        expect(Object.keys(evt.errors[0].stacktrace[0].code))
+        expect(Object.keys(evt.errors[0].stacktrace[0].code!))
           .toEqual(['19', '20', '21', '22', '23', '24', '25'])
-        expect(evt.errors[0].stacktrace[0].code['22'])
+        expect(evt.errors[0].stacktrace[0].code!['22'])
           .toBe('    if (cb) this.on(\'finish\', () => cb(this.output()))')
 
-        expect(Object.keys(evt.errors[0].stacktrace[1].code))
+        expect(Object.keys(evt.errors[0].stacktrace[1].code!))
           .toEqual(['28', '29', '30', '31', '32', '33', '34'])
-        expect(evt.errors[0].stacktrace[1].code['31'])
+        expect(evt.errors[0].stacktrace[1].code!['31'])
           .toBe('      return nextLevelUp()')
 
-        expect(Object.keys(evt.errors[0].stacktrace[2].code))
+        expect(Object.keys(evt.errors[0].stacktrace[2].code!))
           .toEqual(['115', '116', '117', '118', '119', '120', '121'])
-        expect(evt.errors[0].stacktrace[2].code['118'])
+        expect(evt.errors[0].stacktrace[2].code!['118'])
           .toBe('  \'Ķ\': \'k\', \'Ļ\': \'L\', \'Ņ\': \'N\', \'Ū\': \'u\'')
 
         done()
@@ -133,7 +132,7 @@ describe('plugin: node surrounding code', () => {
     client._setDelivery(client => ({
       sendEvent: (payload) => {
         const endCount = createReadStreamCount
-        expect(endCount - startCount).toBe(1)
+        expect(endCount - startCount).toBe(0)
         payload.events[0].errors[0].stacktrace.forEach(stackframe => {
           expect(stackframe.code).toEqual({
             1: '// this is just some arbitrary (but real) javascript for testing, taken from',
@@ -197,8 +196,8 @@ describe('plugin: node surrounding code', () => {
     client._setDelivery(client => ({
       sendEvent: (payload) => {
         payload.events[0].errors[0].stacktrace.forEach(stackframe => {
-          Object.keys(stackframe.code).forEach(key => {
-            expect(stackframe.code[key].length <= 200).toBe(true)
+          Object.keys(stackframe.code!).forEach(key => {
+            expect(stackframe.code![key].length <= 200).toBe(true)
           })
         })
         done()

--- a/packages/plugin-node-uncaught-exception/package.json
+++ b/packages/plugin-node-uncaught-exception/package.json
@@ -14,14 +14,9 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.2.0",
-    "jasmine": "^3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.2.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,10 @@
     "packages/plugin-browser-request",
     "packages/plugin-simple-throttle",
     "packages/plugin-intercept",
-    "packages/plugin-node-unhandled-rejection"
+    "packages/plugin-node-unhandled-rejection",
+    "packages/plugin-node-in-project",
+    "packages/plugin-node-device",
+    "packages/plugin-node-surrounding-code",
+    "packages/plugin-node-uncaught-exception"
   ]
 }


### PR DESCRIPTION
Convert the following packages' test files to TypeScript and jest:
- `plugin-node-in-project`
- `plugin-node-device`
- `plugin-node-surrounding-code`
- `plugin-node-uncaught-exception`