### PR TITLE
fix(plugin-react): Access the window object safely, in case it isn't defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (plugin-react): Ensure the `window.React` fallback does not throw in environments where `window` is undefined. [#930](https://github.com/bugsnag/bugsnag-js/pull/930)
+
 ## 7.2.0 (2020-07-06)
 
 ### Added

--- a/packages/plugin-react/src/index.js
+++ b/packages/plugin-react/src/index.js
@@ -1,9 +1,13 @@
 module.exports = class BugsnagPluginReact {
   constructor (...args) {
+    // Fetch React from the window object, if it exists
+    const globalReact = typeof window !== 'undefined' && window.React
+
     this.name = 'react'
-    this.lazy = args.length === 0 && !window.React
+    this.lazy = args.length === 0 && !globalReact
+
     if (!this.lazy) {
-      this.React = args[0] || window.React
+      this.React = args[0] || globalReact
       if (!this.React) throw new Error('@bugsnag/plugin-react reference to `React` was undefined')
     }
   }

--- a/packages/plugin-react/src/test/index.test.tsx
+++ b/packages/plugin-react/src/test/index.test.tsx
@@ -141,3 +141,38 @@ it('supports passing reference to React when the error boundary is created', () 
   const ErrorBoundary = client.getPlugin('react')!.createErrorBoundary(React)
   expect(ErrorBoundary).toBeTruthy()
 })
+
+describe('global React', () => {
+  // Workaround typescript getting upset at messing around with global
+  // by taking a reference as 'any' and modifying that instead
+  const globalReference: any = global
+  const actualWindow = globalReference.window
+
+  afterEach(() => {
+    globalReference.window = actualWindow
+    globalReference.window.React = undefined
+  })
+
+  it('can pull React out of the window object', () => {
+    globalReference.window.React = React
+
+    const client = new Client({ apiKey: 'API_KEYYY', plugins: [new BugsnagPluginReact()] })
+
+    // eslint-disable-next-line
+    const ErrorBoundary = client.getPlugin('react')!.createErrorBoundary()
+
+    expect(ErrorBoundary).toBeTruthy()
+  })
+
+  it('checks for window.React safely', () => {
+    // Delete the window object so that any unsafe check for 'window.React' will throw
+    delete globalReference.window
+
+    const client = new Client({ apiKey: 'API_KEYYY', plugins: [new BugsnagPluginReact()] })
+
+    // eslint-disable-next-line
+    const ErrorBoundary = client.getPlugin('react')!.createErrorBoundary(React)
+
+    expect(ErrorBoundary).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This prevents errors when using SSR as 'window' won't exist

Heavily based on #928 🙂