### PR TITLE
feat(plugin-react): export types

### DIFF
--- a/packages/plugin-react/types/bugsnag-plugin-react.d.ts
+++ b/packages/plugin-react/types/bugsnag-plugin-react.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, Client, OnErrorCallback } from '@bugsnag/core'
+import { Plugin, OnErrorCallback } from '@bugsnag/core'
 import React from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -8,7 +8,7 @@ declare class BugsnagPluginReact {
   constructor(react?: typeof React)
 }
 
-type BugsnagErrorBoundary = React.ComponentType<{
+export type BugsnagErrorBoundary = React.ComponentType<{
   onError?: OnErrorCallback
   FallbackComponent?: React.ComponentType<{
     error: Error
@@ -17,7 +17,7 @@ type BugsnagErrorBoundary = React.ComponentType<{
   }>
 }>
 
-interface BugsnagPluginReactResult {
+export interface BugsnagPluginReactResult {
   createErrorBoundary(react?: typeof React): BugsnagErrorBoundary
 }
 


### PR DESCRIPTION
- removed an unused import
- exports that will make it easier for strict TS users to initialize BugSnag asserting it won't be undefined

related to #868