### PR TITLE
Revert "v7.3.0-alpha.2"

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.3.0-alpha.2"
+  "version": "7.3.0-alpha.1"
 }

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/react-native",
-	"version": "7.3.0-alpha.2",
+	"version": "7.3.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/react-native",
-  "version": "7.3.0-alpha.2",
+  "version": "7.3.0-alpha.1",
   "main": "src/notifier.js",
   "types": "types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for React Native applications",


### PR DESCRIPTION
This reverts commit 5116167b19e3370ccb7eeedbd4cc47cf9df487a9, which caused CI tests to start failing.