### PR TITLE
docs(example): add missing pod install step for React Native example

### DIFF
--- a/examples/reactnative/rn063example/README.md
+++ b/examples/reactnative/rn063example/README.md
@@ -31,10 +31,10 @@ This project was bootstrapped with `react-native init`.
 
     The API key can be found in the Bugsnag settings for your project.
 
-1. For iOS only, install the project dependencies using: 
+1. For iOS only, install the project dependencies from the `ios/` directory using: 
 
 ```
-pod install --project-directory=ios
+pod install 
 ```
 
 1. Run the app on either Android or iOS:

--- a/examples/reactnative/rn063example/README.md
+++ b/examples/reactnative/rn063example/README.md
@@ -31,6 +31,12 @@ This project was bootstrapped with `react-native init`.
 
     The API key can be found in the Bugsnag settings for your project.
 
+1. For iOS only, install the project dependencies using: 
+
+```
+pod install --project-directory=ios
+```
+
 1. Run the app on either Android or iOS:
 
 ```


### PR DESCRIPTION
Details the required pod install step, which was previously missing having moved the example from RN 0.59.