### PR TITLE
V7 RN: Add exception.type test assertions

### DIFF
--- a/test/react-native/features/handled.feature
+++ b/test/react-native/features/handled.feature
@@ -5,6 +5,7 @@ Scenario: Calling notify() with a caught Error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledJsErrorScenario"
+  And the exception "type" equals "reactnativejs"
   And the event "unhandled" is false
 
 Scenario: Native notify() with a caught Error
@@ -13,5 +14,8 @@ Scenario: Native notify() with a caught Error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
   | android | java.lang.RuntimeException |
   | ios     | NSException                |
+  And the event "exceptions.0.type" equals the platform-dependent string:
+  | android | android |
+  | ios     | cocoa   |
   And the exception "message" equals "HandledNativeErrorScenario"
   And the event "unhandled" is false

--- a/test/react-native/features/unhandled.feature
+++ b/test/react-native/features/unhandled.feature
@@ -5,6 +5,7 @@ Scenario: Catching an Unhandled error
   And I configure Bugsnag for "UnhandledJsErrorScenario"
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
+  And the exception "type" equals "reactnativejs"
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledJsErrorScenario"
 
@@ -13,6 +14,7 @@ Scenario: Catching an Unhandled promise rejection
   And I configure Bugsnag for "UnhandledJsPromiseRejectionScenario"
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
+  And the exception "type" equals "reactnativejs"
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledJsPromiseRejectionScenario"
 
@@ -23,5 +25,8 @@ Scenario: Catching an Unhandled Native error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
   | android | java.lang.RuntimeException |
   | ios     | NSException                |
+  And the event "exceptions.0.type" equals the platform-dependent string:
+  | android | android |
+  | ios     | cocoa   |
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledNativeErrorScenario"


### PR DESCRIPTION
##Goal
Add additional assertions for `exception.type` in handled/unhandled JS/native errors.