### PR TITLE
V7 React-native: Add additional user scenario

### DIFF
--- a/test/react-native/features/fixtures/app/Scenarios.js
+++ b/test/react-native/features/fixtures/app/Scenarios.js
@@ -39,6 +39,7 @@ export { UserJsClientScenario } from './scenarios/UserJsClientScenario'
 export { UserJsConfigScenario } from './scenarios/UserJsConfigScenario'
 export { UserJsEventScenario } from './scenarios/UserJsEventScenario'
 export { UserNativeClientScenario } from './scenarios/UserNativeClientScenario'
+export { UserJsNativeScenario } from './scenarios/UserJsNativeScenario'
 
 // metadata.feature
 export { MetadataJsScenario } from './scenarios/MetadataJsScenario'

--- a/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
+++ b/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
@@ -1,0 +1,11 @@
+import Scenario from './Scenario'
+import { NativeModules } from 'react-native'
+
+export class UserJsNativeScenario extends Scenario {
+  run() {
+    Bugsnag.setUser('123', 'bug@sn.ag', 'Bug Snag')
+    setTimeout(() => {
+      NativeModules.BugsnagTestInterface.runScenario('UnhandledNativeErrorScenario', () => {})
+    }, 500)
+  }
+}

--- a/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
+++ b/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
@@ -1,4 +1,5 @@
 import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
 import { NativeModules } from 'react-native'
 
 export class UserJsNativeScenario extends Scenario {

--- a/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
+++ b/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
@@ -4,8 +4,6 @@ import { NativeModules } from 'react-native'
 export class UserJsNativeScenario extends Scenario {
   run() {
     Bugsnag.setUser('123', 'bug@sn.ag', 'Bug Snag')
-    setTimeout(() => {
-      NativeModules.BugsnagTestInterface.runScenario('UnhandledNativeErrorScenario', () => {})
-    }, 500)
+    NativeModules.BugsnagTestInterface.runScenario('UnhandledNativeErrorScenario', () => {})
   }
 }

--- a/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
+++ b/test/react-native/features/fixtures/app/scenarios/UserJsNativeScenario.js
@@ -5,6 +5,8 @@ import { NativeModules } from 'react-native'
 export class UserJsNativeScenario extends Scenario {
   run() {
     Bugsnag.setUser('123', 'bug@sn.ag', 'Bug Snag')
-    NativeModules.BugsnagTestInterface.runScenario('UnhandledNativeErrorScenario', () => {})
+    setTimeout(() => {
+      NativeModules.BugsnagTestInterface.runScenario('UnhandledNativeErrorScenario', () => {})
+    }, 1000)
   }
 }

--- a/test/react-native/features/user.feature
+++ b/test/react-native/features/user.feature
@@ -40,10 +40,7 @@ Scenario: Setting user in native via client
   And the event "user.id" equals "123"
 
 Scenario: Setting user in JS via client and sending Native error
-  When I run "UserJsNativeScenario"
-  And I wait for 3 seconds
-  And I clear any error dialogue
-  And I relaunch the app
+  When I run "UserJsNativeScenario" and relaunch the app
   And I configure Bugsnag for "UserJsNativeScenario"
   Then I wait to receive a request
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/react-native/features/user.feature
+++ b/test/react-native/features/user.feature
@@ -40,7 +40,10 @@ Scenario: Setting user in native via client
   And the event "user.id" equals "123"
 
 Scenario: Setting user in JS via client and sending Native error
-  When I run "UserJsNativeScenario" and relaunch the app
+  When I run "UserJsNativeScenario"
+  And I wait for 3 seconds
+  And I clear any error dialogue
+  And I relaunch the app
   And I configure Bugsnag for "UserJsNativeScenario"
   Then I wait to receive a request
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/react-native/features/user.feature
+++ b/test/react-native/features/user.feature
@@ -38,3 +38,19 @@ Scenario: Setting user in native via client
   And the event "user.email" equals "bug@sn.ag"
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"
+
+Scenario: Setting user in JS via client and sending Native error
+  When I run "UserJsNativeScenario" and relaunch the app
+  And I configure Bugsnag for "UserJsNativeScenario"
+  Then I wait to receive a request
+  And the event "exceptions.0.errorClass" equals the platform-dependent string:
+  | android | java.lang.RuntimeException |
+  | ios     | NSException                |
+  And the event "exceptions.0.type" equals the platform-dependent string:
+  | android | android |
+  | ios     | cocoa   |
+  And the event "unhandled" is true
+  And the exception "message" equals "UnhandledNativeErrorScenario"
+  And the event "user.email" equals "bug@sn.ag"
+  And the event "user.name" equals "Bug Snag"
+  And the event "user.id" equals "123"


### PR DESCRIPTION
Adds a scenario where the User is set from the JS layer and an unhandled native error scenario is triggered to ensure the user in synchronised between layers correctly.