### PR TITLE
RN: CI Fix 0.63 fixture on Android

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -40,8 +40,8 @@ android {
 }
 
 dependencies {
-    api "com.bugsnag:bugsnag-android:+"
-    api "com.bugsnag:bugsnag-plugin-react-native:+"
+    api "com.bugsnag:bugsnag-android:5.0.1-react-native"
+    api "com.bugsnag:bugsnag-plugin-react-native:5.0.1-react-native"
     implementation 'com.facebook.react:react-native:+'
 
     testImplementation "junit:junit:4.12"

--- a/test/react-native/features/fixtures/rn0.60/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.60/android/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
+apply from: "../../node_modules/@bugsnag/react-native/bugsnag-react-native.gradle"
 
 import com.android.build.OutputFile
 

--- a/test/react-native/features/fixtures/rn0.63/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.63/android/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
+apply from: "../../node_modules/@bugsnag/react-native/bugsnag-react-native.gradle"
+
 
 import com.android.build.OutputFile
 

--- a/test/react-native/features/fixtures/rn0.63/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.63/android/build.gradle
@@ -23,9 +23,6 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { // bugsnag AAR dependencies are installed from npm
-            url "$rootDir/../node_modules/@bugsnag/react-native/android"
-        }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")


### PR DESCRIPTION
Fixes 0.63 Android fixture not building

- Update fixtures to use the recommended `apply from` gradle entry
- Update the version string so that the bundled bugnsnag-android modules are depended on 