### PR TITLE
fix(delivery-react-native): Support sending apiKey to the native layer

### DIFF
--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -13,7 +13,8 @@ module.exports = (client, NativeClient) => ({
       context: event.context,
       user: event._user,
       metadata: event._metadata,
-      groupingHash: event.groupingHash
+      groupingHash: event.groupingHash,
+      apiKey: event.apiKey
     }).then(() => cb()).catch(cb)
   },
   sendSession: () => {

--- a/packages/delivery-react-native/test/delivery.test.js
+++ b/packages/delivery-react-native/test/delivery.test.js
@@ -19,6 +19,7 @@ describe('delivery: react native', () => {
     c.setUser('123')
     c.notify(new Error('oh no'), (e) => {
       e.groupingHash = 'ER_GRP_098'
+      e.apiKey = 'abcdef123456abcdef123456abcdef123456'
     }, (err, event) => {
       expect(err).not.toBeTruthy()
       expect(sent.length).toBe(1)
@@ -28,14 +29,14 @@ describe('delivery: react native', () => {
       expect(sent[0].unhandled).toBe(false)
       expect(sent[0].app).toEqual({ releaseStage: 'production', version: undefined, type: undefined })
       expect(sent[0].device).toEqual({})
-      // TODO enable once event.threads exists
-      // expect(sent[0].threads).toEqual({})
+      expect(sent[0].threads).toEqual([])
       expect(sent[0].breadcrumbs.length).toBe(1)
       expect(sent[0].breadcrumbs[0].message).toBe('hi')
       expect(sent[0].context).toBe('test screen')
       expect(sent[0].user).toEqual({ id: '123', email: undefined, name: undefined })
       expect(sent[0].metadata).toEqual({})
       expect(sent[0].groupingHash).toEqual('ER_GRP_098')
+      expect(sent[0].apiKey).toBe('abcdef123456abcdef123456abcdef123456')
       done()
     })
   })


### PR DESCRIPTION
Include `apiKey` in the payload sent to the native layer. Comes with a unit test.