### PR TITLE
Respect sendThreads on RN cocoa for JS errors

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -9,7 +9,7 @@
 - (NSDictionary *)collectAppWithState;
 - (NSDictionary *)collectDeviceWithState;
 - (NSArray *)collectBreadcrumbs;
-- (NSArray *)collectThreads;
+- (NSArray *)collectThreads:(BOOL)unhandled;
 @property id notifier;
 @property id sessionTracker;
 @property BugsnagMetadata *metadata;
@@ -127,12 +127,14 @@ RCT_EXPORT_METHOD(resumeSession) {
 RCT_EXPORT_METHOD(getPayloadInfo:(NSDictionary *)options
                          resolve:(RCTPromiseResolveBlock)resolve
                           reject:(RCTPromiseRejectBlock)reject) {
+                              NSLog(@"payload info options: %@", options);
     BugsnagClient *client = [Bugsnag client];
     NSMutableDictionary *info = [NSMutableDictionary new];
     info[@"app"] = [client collectAppWithState];
     info[@"device"] = [client collectDeviceWithState];
     info[@"breadcrumbs"] = [client collectBreadcrumbs];
-    info[@"threads"] = [client collectThreads];
+    BOOL unhandled = [options[@"unhandled"] boolValue];
+    info[@"threads"] = [client collectThreads:unhandled];
     resolve(info);
 }
 


### PR DESCRIPTION
## Goal

For Cocoa changes see: https://github.com/bugsnag/bugsnag-cocoa/pull/766

Records thread information for unhandled JS errors. The thread information was not captured for unhandled JS errors when `BSGThreadSendPolicyUnhandledOnly` was set because the native layer used the presence of `BSG_KSCrashTypeUserReported` as the `crashType` to determine whether an error was unhandled instead.

This change adds an `unhandled` parameter which is passed down from the RN bridge and tells KSCrash whether the event was unhandled or not. If it was unhandled, all threads are captured, depending on the value of `sendThreads`.

## Tests
Covered by existing E2E test coverage, additionally verified in a React Native example app against handled + unhandled JS errors.