### PR TITLE
Deserialize severityReason.type correctly for iOS RN

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -121,7 +121,8 @@ BSGSeverity BSGParseSeverity(NSString *severity);
         attrVal = [attrs allValues][0];
     }
 
-    NSUInteger reason = [BugsnagHandledState severityReasonFromString:payload[@"severityReason"]];
+    NSString *severityType = [payload valueForKeyPath:@"severityReason.type"];
+    NSUInteger reason = [BugsnagHandledState severityReasonFromString:severityType];
 
     BSGSeverity severity = BSGParseSeverity(payload[@"severity"]);
     BOOL unhandled = [payload[@"unhandled"] boolValue];


### PR DESCRIPTION
## Goal

Deserializes the `severityReason.type` correctly for iOS RN. This was not deserialized correctly so the reason was set to `UnhandledException` for all JS errors.

Verified that the `type` is set correctly when running in a debugger.