### PR TITLE
[PLAT-4718] RN: fix returning false in JS onBreadcrumb callbacks

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -215,8 +215,8 @@ class Client {
     this._cbs.s = filter(this._cbs.s, f => f !== fn)
   }
 
-  addOnBreadcrumb (fn) {
-    this._cbs.b.push(fn)
+  addOnBreadcrumb (fn, front = false) {
+    this._cbs.b[front ? 'unshift' : 'push'](fn)
   }
 
   removeOnBreadcrumb (fn) {

--- a/packages/plugin-react-native-client-sync/client-sync.js
+++ b/packages/plugin-react-native-client-sync/client-sync.js
@@ -8,7 +8,7 @@ module.exports = (NativeClient) => ({
       // bridge. This happens in the remote debugger and means the "message"
       // property is incorrectly named "name"
       NativeClient.leaveBreadcrumb({ ...breadcrumb })
-    })
+    }, true)
 
     const origSetUser = client.setUser
     client.setUser = function () {


### PR DESCRIPTION
Ensures the sync'ing callback runs after all the other callbacks.

This works because the synchronous callback runner pops off the end of the queue, so runs the first (zero'th) item last.