### PR TITLE
[PLAT-4377] correct casing of reactNativeJsEngine

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.m
@@ -142,7 +142,7 @@ RCT_EXPORT_METHOD(getPayloadInfo:(NSDictionary *)options
     NSString *reactNativeVersion = info[@"reactNativeVersion"];
     NSString *engine = info[@"engine"];
     [Bugsnag addRuntimeVersionInfo:reactNativeVersion withKey:@"reactNative"];
-    [Bugsnag addRuntimeVersionInfo:engine withKey:@"reactNativeJsengine"];
+    [Bugsnag addRuntimeVersionInfo:engine withKey:@"reactNativeJsEngine"];
 }
 
 - (BSGBreadcrumbType)breadcrumbTypeFromString:(NSString *)value {

--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -18,7 +18,7 @@ Scenario: Handled JS error
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the event "device.runtimeVersions.reactNativeJsengine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
   And the payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
   And the payload field "events.0.device.freeDisk" is greater than 0
@@ -44,7 +44,7 @@ Scenario: Unhandled JS error
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the event "device.runtimeVersions.reactNativeJsengine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
   And the payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
   And the payload field "events.0.device.freeDisk" is greater than 0
@@ -69,7 +69,7 @@ Scenario: Handled native error
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the event "device.runtimeVersions.reactNativeJsengine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
   And the payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
   And the payload field "events.0.device.freeDisk" is greater than 0
@@ -92,7 +92,7 @@ Scenario: Unhandled native error
   And the event "device.time" is a timestamp
   And the event "device.locale" is not null
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
-  And the event "device.runtimeVersions.reactNativeJsengine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
   And the payload field "events.0.device.freeMemory" is greater than 0


### PR DESCRIPTION
Corrects the casing of the reactNativeJsEngine runtimeVersionsInfo field, at the pipeline discards it if not matching.