### PR TITLE
Allow overriding api key in RN iOS via event callback

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -85,6 +85,7 @@ BSGSeverity BSGParseSeverity(NSString *severity);
                                                     threads:[self deserializeThreads:payload[@"threads"]]
                                                     session:session];
     event.context = payload[@"context"];
+    event.apiKey = payload[@"apiKey"];
     event.groupingHash = payload[@"groupingHash"];
 
     NSDictionary *error = payload[@"errors"][0];

--- a/test/react-native/features/api-key-ios.feature
+++ b/test/react-native/features/api-key-ios.feature
@@ -1,0 +1,11 @@
+@ios_only
+Feature: iOS API key override
+
+Scenario: Handled JS error overrides API key
+  When I run "EventApiKeyOverrideScenario"
+  Then I wait to receive a request
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "EventApiKeyOverrideScenario"
+  And the exception "type" equals "reactnativejs"
+  And the event "unhandled" is false
+  And the payload field "apiKey" equals "abf0deabf0deabf0deabf0deabf0de12"

--- a/test/react-native/features/fixtures/app/Scenarios.js
+++ b/test/react-native/features/fixtures/app/Scenarios.js
@@ -8,6 +8,9 @@ export { UnhandledJsErrorScenario } from './scenarios/UnhandledJsErrorScenario'
 export { UnhandledJsErrorSeverityScenario } from './scenarios/UnhandledJsErrorSeverityScenario'
 export { UnhandledJsPromiseRejectionScenario } from './scenarios/UnhandledJsPromiseRejectionScenario'
 
+// api-key-ios.feature
+export { EventApiKeyOverrideScenario } from './scenarios/EventApiKeyOverrideScenario'
+
 // app.feature
 export { AppJsHandledScenario } from './scenarios/AppJsHandledScenario'
 export { AppJsUnhandledScenario } from './scenarios/AppJsUnhandledScenario'

--- a/test/react-native/features/fixtures/app/scenarios/EventApiKeyOverrideScenario.js
+++ b/test/react-native/features/fixtures/app/scenarios/EventApiKeyOverrideScenario.js
@@ -2,13 +2,8 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class EventApiKeyOverrideScenario extends Scenario {
-  constructor(configuration, extraData, jsConfig) {
-    super()
-  }
-
   run() {
     Bugsnag.notify(new Error('EventApiKeyOverrideScenario'), event => {
-      event.setUser('123', 'bug@sn.ag', 'Bug Snag')
       event.apiKey = 'abf0deabf0deabf0deabf0deabf0de12'
     })
   }

--- a/test/react-native/features/fixtures/app/scenarios/EventApiKeyOverrideScenario.js
+++ b/test/react-native/features/fixtures/app/scenarios/EventApiKeyOverrideScenario.js
@@ -1,0 +1,15 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+
+export class EventApiKeyOverrideScenario extends Scenario {
+  constructor(configuration, extraData, jsConfig) {
+    super()
+  }
+
+  run() {
+    Bugsnag.notify(new Error('EventApiKeyOverrideScenario'), event => {
+      event.setUser('123', 'bug@sn.ag', 'Bug Snag')
+      event.apiKey = 'abf0deabf0deabf0deabf0deabf0de12'
+    })
+  }
+}


### PR DESCRIPTION
## Goal

Allows overriding the API key in React Native iOS in an event callback by reading the value passed down from the JS layer. This only applies to the iOS layer for now.

Added an E2E scenario to cover the change.