### PR TITLE
test(react-native): Add assertion for runtime version value

### DIFF
--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -18,7 +18,7 @@ Scenario: Handled JS error
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" equals "jsc"
   And the payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
   And the payload field "events.0.device.freeDisk" is greater than 0
@@ -44,7 +44,7 @@ Scenario: Unhandled JS error
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" equals "jsc"
   And the payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
   And the payload field "events.0.device.freeDisk" is greater than 0
@@ -69,7 +69,7 @@ Scenario: Handled native error
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" equals "jsc"
   And the payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
   And the payload field "events.0.device.freeDisk" is greater than 0
@@ -92,7 +92,7 @@ Scenario: Unhandled native error
   And the event "device.time" is a timestamp
   And the event "device.locale" is not null
   And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
-  And the event "device.runtimeVersions.reactNativeJsEngine" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" equals "jsc"
   And the event "device.runtimeVersions.osBuild" is not null
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
   And the payload field "events.0.device.freeMemory" is greater than 0


### PR DESCRIPTION
 I added these assertions when debugging the issue with the `reactNativeJsEngine` field. Seems more helpful than just asserting not null.