### PR TITLE
chore(github): add CODEOWNERS file for automatic review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @bugsnag/platforms-test-automation


### PR DESCRIPTION
As an experimental process, we want to add the Test Automation team to all PRs for a test-based review.

[The CODEOWNERS file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) in this PR will add them to all PRs, but not require them to have approved before merging.