### PR TITLE
[PLAT-4848] RN: Add type definitions to published package files

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.3.1"
+  "version": "7.3.2-alpha.0"
 }

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bugsnag/react-native",
-	"version": "7.3.1",
+	"version": "7.3.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/react-native",
-  "version": "7.3.1",
+  "version": "7.3.2-alpha.0",
   "main": "src/notifier.js",
   "types": "types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for React Native applications",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "src",
+    "types/bugsnag.d.ts",
     "android/build.gradle",
     "android/proguard-rules.pro",
     "android/src/main",


### PR DESCRIPTION
The type definitions were not inlude in the `files` list in the React Native package's manifest.