### PR TITLE
[PLAT-4872] Swap to a peer dependency on bugsnag/core in plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - (plugin-angular): Update bundles and package entrypoints to support the Ivy renderer. [#994](https://github.com/bugsnag/bugsnag-js/pull/994)
 - (react-native): Add `codeBundleId` to config type definition. [#1011](https://github.com/bugsnag/bugsnag-js/pull/1011)
+- Use a peer dependency on @bugsnag/core in plugins [#1012](https://github.com/bugsnag/bugsnag-js/pull/1012)
 
 ## 7.3.2 (2020-08-17)
 

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -20,12 +20,15 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "^7.3.0",
     "@react-native-community/netinfo": "5.9.2",
     "expo-file-system": "^6.0.2"
   },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -16,7 +16,10 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/delivery-react-native/package.json
+++ b/packages/delivery-react-native/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -16,7 +16,10 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -39,5 +39,8 @@
     "rxjs": "^5.5.8",
     "typescript": "^3.2.4",
     "zone.js": "^0.8.26"
+  },
+  "peerDependencies": {
+    "@bugsnag/js": "^7.0.0"
   }
 }

--- a/packages/plugin-app-duration/package.json
+++ b/packages/plugin-app-duration/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-browser-context/package.json
+++ b/packages/plugin-browser-context/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-browser-device/package.json
+++ b/packages/plugin-browser-device/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-browser-request/package.json
+++ b/packages/plugin-browser-request/package.json
@@ -21,5 +21,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-browser-session/package.json
+++ b/packages/plugin-browser-session/package.json
@@ -16,7 +16,10 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-client-ip/package.json
+++ b/packages/plugin-client-ip/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-console-breadcrumbs/package.json
+++ b/packages/plugin-console-breadcrumbs/package.json
@@ -16,7 +16,10 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-contextualize/package.json
+++ b/packages/plugin-contextualize/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -26,5 +26,8 @@
   },
   "dependencies": {
     "expo-constants": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "expo-constants": "^6.0.0",
     "expo-device": "^2.1.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -26,15 +26,15 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/js": "*"
+    "@bugsnag/core": "^7.0.0"
   },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "@types/express": "^4.17.6",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
   },
   "dependencies": {
-    "@bugsnag/core": "^7.3.0",
     "iserror": "^0.0.2"
   }
 }

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -17,11 +17,12 @@
   "scripts": {},
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-interaction-breadcrumbs/package.json
+++ b/packages/plugin-interaction-breadcrumbs/package.json
@@ -21,5 +21,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-intercept/package.json
+++ b/packages/plugin-intercept/package.json
@@ -17,11 +17,12 @@
   "scripts": {},
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -26,15 +26,15 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/js": "*"
+    "@bugsnag/core": "^7.0.0"
   },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "@types/koa": "^2.11.3",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
   },
   "dependencies": {
-    "@bugsnag/core": "^7.3.0",
     "iserror": "^0.0.2"
   }
 }

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -21,5 +21,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-node-in-project/package.json
+++ b/packages/plugin-node-in-project/package.json
@@ -21,5 +21,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -25,5 +25,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-node-uncaught-exception/package.json
+++ b/packages/plugin-node-uncaught-exception/package.json
@@ -21,5 +21,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-node-unhandled-rejection/package.json
+++ b/packages/plugin-node-unhandled-rejection/package.json
@@ -21,5 +21,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-app-state-breadcrumbs/package.json
+++ b/packages/plugin-react-native-app-state-breadcrumbs/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -20,11 +20,14 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "^7.3.0",
     "proxyquire": "^2.1.0"
   },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -26,5 +26,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-event-sync/package.json
+++ b/packages/plugin-react-native-event-sync/package.json
@@ -16,7 +16,10 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-global-error-handler/package.json
+++ b/packages/plugin-react-native-global-error-handler/package.json
@@ -23,5 +23,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -19,5 +19,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -23,5 +23,8 @@
     "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -19,11 +19,12 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react-native-unhandled-rejection/package.json
+++ b/packages/plugin-react-native-unhandled-rejection/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "@bugsnag/core": "^7.3.0",
     "promise": "^8.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -24,7 +24,10 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -26,15 +26,15 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/js": "*"
+    "@bugsnag/core": "^7.0.0"
   },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "@types/restify": "^8.4.2",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
   },
   "dependencies": {
-    "@bugsnag/core": "^7.3.0",
     "iserror": "^0.0.2"
   }
 }

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -17,7 +17,12 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/core": "^7.3.0",
     "backo": "^1.1.0"
+  },
+  "devDependencies": {
+    "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-simple-throttle/package.json
+++ b/packages/plugin-simple-throttle/package.json
@@ -17,11 +17,12 @@
   "scripts": {},
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "jasmine": "^3.1.0",
     "nyc": "^12.0.2"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-strip-project-root/package.json
+++ b/packages/plugin-strip-project-root/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-strip-query-string/package.json
+++ b/packages/plugin-strip-query-string/package.json
@@ -16,7 +16,10 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -24,13 +24,11 @@
   },
   "author": "Bugsnag",
   "license": "MIT",
-  "peerDependencies": {
-    "@bugsnag/js": "*"
-  },
   "devDependencies": {
+    "@bugsnag/core": "^7.3.0",
     "vue": "^2.5.8"
   },
-  "dependencies": {
-    "@bugsnag/core": "^7.3.0"
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-window-onerror/package.json
+++ b/packages/plugin-window-onerror/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-window-unhandled-rejection/package.json
+++ b/packages/plugin-window-unhandled-rejection/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Goal

Currently our plugins have a hard dependency on `@bugsnag/core`. This can lead to issues when a plugin is updated separately to `@bugsnag/core`, because NPM will dutifully install multiple copies of `@bugsnag/core` — the original version will remain and the plugin will get a newer version of its own. Typically this shouldn't be a problem because changes will be backwards compatible, but it can cause issues for type declarations as a newer `@bugsnag/core` may be incompatible with an old `@bugsnag/core`

To prevent having multiple copies of `@bugsnag/core`, we can use `peerDependencies` instead of a hard dependency. This should mean that there is only ever one top-level version installed, which will be pulled in by `@bugsnag/js`, `@bugsnag/expo` or `@bugsnag/react-native`

## Design

I went with a version constraint of `^7.0.0` to be as compatible as possible, but I think this could be `^7.3.0` (or even the version this is released in (`^7.4.0` ?)) because there shouldn't be a scenario where a new plugin version is installed with an old version of core — not 100% sure this is a good idea though!

## Changeset

- All `delivery-` and `plugin-` packages no longer have a hard dependency on `@bugsnag/core`
- All `delivery-` and `plugin-` packages have a dev dependency on `@bugsnag/core`
- All `delivery-` and `plugin-` packages have a peer dependency on `@bugsnag/core`

## Testing

This should be covered by existing tests