### PR TITLE
fix(lerna): replace non-semver characters  publishing

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -20,13 +20,14 @@ module.exports = {
   determineVersion: function determineVersion () {
     // Form version string - branch name and commit id
     const commitId = this.getCommitId()
+    const regex = /[^(a-zA-Z0-9.\-)]/g
     let branchName
     if (process.env.BRANCH_NAME) {
       console.log('Using BRANCH_NAME from the environment')
-      branchName = process.env.BRANCH_NAME
+      branchName = process.env.BRANCH_NAME.replace(regex, '-')
     } else {
       console.log('Using local Git repo to determine branch name (environment BRANCH_NAME may also be used)')
-      branchName = this.run('git rev-parse --abbrev-ref HEAD').replace(/\//g, '-')
+      branchName = this.run('git rev-parse --abbrev-ref HEAD').replace(regex, '-')
     }
 
     // Distinguish from local use


### PR DESCRIPTION
##  Goal

Avoid characters such a `_` in Git branch name breaking the build.

## Design

This is a slight improvement on the current situation, but still not infallible overall. For example, there are characters that can be used in branch names that are incompatible with Docker tag names - as used in the pipeline.  I have raised an internal ticket to conduct a review of such uses in a view to developing a foolproof scheme.

## Changeset

JS script responsible for determining the package version to use for the current CI run.

## Testing

In addition to the standard CI, I intentionally named this branch in a way that could break the build or lead to erroneous results (in particular `_`, `/` and upper case letters).