### PR TITLE
[PLAT-3907] Use the `latest-v2-cli` branch and `reset_with_timeout` method

### DIFF
--- a/bin/local-test-util
+++ b/bin/local-test-util
@@ -247,6 +247,6 @@ async function runTests (args) {
     `-v`, `${process.cwd()}/test/browser/:/app/test/browser`,
     `-w`, `/app/test/browser`,
     `-p`, `9020:9020`,
-    `855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli`
+    `855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli`
   ].concat(args || []))
 }

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -45,7 +45,7 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 RUN rm -fr **/*/node_modules/
 
 # The maze-runner browser tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli as browser-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as browser-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev
 ENV GLIBC_VERSION 2.23-r3
 

--- a/dockerfiles/Dockerfile.expo
+++ b/dockerfiles/Dockerfile.expo
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli as expo-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as expo-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 COPY /test/expo /app/test/expo
 WORKDIR /app/test/expo

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node test/node

--- a/dockerfiles/Dockerfile.react-native
+++ b/dockerfiles/Dockerfile.react-native
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:typed-platform-checks-ci
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 COPY /test/react-native /app/test/react-native
 WORKDIR /app/test/react-native

--- a/test/expo/features/support/env.rb
+++ b/test/expo/features/support/env.rb
@@ -32,7 +32,7 @@ Before('@skip_ios_12') do |scenario|
 end
 
 After do |_scenario|
-  $driver.reset
+  $driver.reset_with_timeout
 end
 
 AfterConfiguration do |config|

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -40,7 +40,7 @@ Before('@ios_only') do |scenario|
 end
 
 After do |_scenario|
-  $driver.reset
+  $driver.reset_with_timeout
 end
 
 AfterConfiguration do |config|


### PR DESCRIPTION
## Goal
- Uses the `latest-v2-cli` release of Maze-runner to ensure future breaking changes do not effect the tests here
- Replaces `reset` with `reset_with_timeout` to add resilience against report duplication.