### PR TITLE
Check if CDN uploads are successful

### DIFF
--- a/packages/browser/bin/cdn-upload
+++ b/packages/browser/bin/cdn-upload
@@ -25,9 +25,20 @@ const headers = {
   'x-amz-acl': 'public-read'
 }
 
-const upload = (localPath, remotePath) => {
-  console.log(`uploading ${relative('..', localPath)} -> ${remotePath}`)
-  return promisify(s3Client.putFile.bind(s3Client))(localPath, remotePath, headers)
+const putFile = promisify(s3Client.putFile.bind(s3Client))
+
+const upload = async (localPath, remotePath) => {
+  const relativePath = relative('..', localPath)
+  console.log(`uploading ${relativePath} -> ${remotePath}`)
+
+  const response = await putFile(localPath, remotePath, headers)
+
+  // Knox doesn't error if the request fails, so we need to check if this was a successful upload
+  if (response.statusCode >= 400) {
+    throw new Error(`Failed to upload ${relativePath}: ${response.statusCode} ${response.statusMessage}`)
+  }
+
+  return response
 }
 
 const invalidate = (paths) => {


### PR DESCRIPTION
## Goal

Knox doesn't error if the request is unsuccessful, so we need to check the status code ourselves

Ultimately we may want to move to a maintained library but, with this check, debugging should be less of a problem in future

## Testing

Manually tested by attempting to upload with invalid credentials — before the change the script silently does nothing; now it fails with an error