### PR TITLE
Handle empty NPM registry when building React Native test fixture

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -184,6 +184,7 @@ These should be set to the `REACT_NATIVE_VERSION` environment variable according
 | React native fixture | `REACT_NATIVE_VERSION` |
 |----------------------|------------------------|
 | 0.60                 | `rn0.60`               |
+| 0.63                 | `rn0.63`               |
 
 The following environment variables need to be set:
 

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -5,8 +5,15 @@ function publish (publishUrl) {
   const distTag = common.getCommitId()
 
   // Check for existing published packages
-  const allVersions = JSON.parse(common.run(`npm view @bugsnag/js versions --registry ${publishUrl} --json`).toString())
-  const myVersions = allVersions.filter(function (str) { return str.indexOf(version) !== -1 })
+  let myVersions = []
+  try {
+    const allVersions = JSON.parse(common.run(`npm view @bugsnag/js versions --registry ${publishUrl} --json`).toString())
+    myVersions = allVersions.filter(function (str) { return str.indexOf(version) !== -1 })
+  } catch (err) {
+    // Ignore any errors and assume we can just publish.  For example, the command will fail
+    // with a 404 when there are no @bugsnag/js at all, but that's fine here.
+  }
+
   if (myVersions.length === 0) {
     console.log(`Publishing as '${version}'`)
 


### PR DESCRIPTION
## Goal

After completely clearing out our local NPM registry, I found that the `publish.js` script failed due to `npm view versions` returning 404 when there are no `@bugsnag/js` artifacts at all.  This handles that special case, together with any other failure to detect existing versions.  If it fails for a different reason and it actually causes the publish to fail (failing to detect existing versions doesn't necessarily mean that the publish will fail), the script will simply error at a later stage and we can investigate and fix the underlying cause.

## Changeset

I also noticed that RN 0.63 was missing from the list of available testing options.

## Testing

Verified by the fact that the CI for this PR now runs.