### PR TITLE
test(plugin-react-native-orientation-breadcrumbs): convert tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -42,6 +42,7 @@ module.exports = {
         testsForPackage('react-native'),
         testsForPackage('delivery-react-native'),
         testsForPackage('plugin-react-native-app-state-breadcrumbs'),
+        testsForPackage('plugin-react-native-orientation-breadcrumbs'),
         testsForPackage('plugin-react-native-unhandled-rejection'),
         testsForPackage('plugin-react-native-hermes'),
         testsForPackage('plugin-react-native-client-sync'),

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -14,15 +14,10 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5",
-    "jasmine": "3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.3.5"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.ts
+++ b/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.ts
@@ -1,95 +1,71 @@
-const { describe, it, expect } = global
+import Client from '@bugsnag/core/client'
+import plugin from '..'
 
-const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
+// @types/react-native conflicts with lib dom so disable ts for
+// react-native imports until a better solution is found.
+// See DefinitelyTyped/DefinitelyTyped#33311
+// @ts-ignore
+import { Dimensions } from 'react-native'
 
-const Client = require('@bugsnag/core/client')
+jest.mock('react-native', () => ({
+  Dimensions: {
+    get: () => ({ height: 0, width: 0 }),
+    addEventListener: jest.fn()
+  }
+}))
+
+const MockDimensions: jest.Mocked<any> = Dimensions
 
 describe('plugin: react native orientation breadcrumbs', () => {
+  beforeEach(() => {
+    MockDimensions.addEventListener.mockReset()
+  })
+
   it('should create a breadcrumb when the Dimensions#change event happens', () => {
-    let _cb
-    let currentDimensions
-
-    const Dimensions = {
-      get: () => currentDimensions,
-      addEventListener: (type, fn) => { _cb = fn }
-    }
-
-    const plugin = proxyquire('../', {
-      'react-native': { Dimensions }
-    })
-
-    currentDimensions = { height: 100, width: 200 }
+    MockDimensions.get = () => ({ height: 100, width: 200 })
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin] })
 
-    expect(typeof _cb).toBe('function')
+    const cb = MockDimensions.addEventListener.mock.calls[0][1]
+    expect(MockDimensions.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
     expect(client._breadcrumbs.length).toBe(0)
 
-    currentDimensions = { height: 200, width: 100 }
-    _cb()
+    MockDimensions.get = () => ({ height: 200, width: 100 })
+    cb()
     expect(client._breadcrumbs.length).toBe(1)
     expect(client._breadcrumbs[0].message).toBe('Orientation changed')
     expect(client._breadcrumbs[0].metadata).toEqual({ from: 'landscape', to: 'portrait' })
 
-    currentDimensions = { height: 200, width: 100 }
-    _cb()
+    MockDimensions.get = () => ({ height: 200, width: 100 })
+    cb()
     expect(client._breadcrumbs.length).toBe(1)
 
-    currentDimensions = { height: 100, width: 200 }
-    _cb()
+    MockDimensions.get = () => ({ height: 100, width: 200 })
+    cb()
     expect(client._breadcrumbs.length).toBe(2)
     expect(client._breadcrumbs[1].message).toBe('Orientation changed')
     expect(client._breadcrumbs[1].metadata).toEqual({ from: 'portrait', to: 'landscape' })
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=null', () => {
-    let _cb
-    const Dimensions = {
-      addEventListener: (type, fn) => {
-        _cb = fn
-      }
-    }
-    const plugin = proxyquire('../', {
-      'react-native': { Dimensions }
-    })
-
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin] })
 
-    expect(_cb).toBe(undefined)
+    expect(MockDimensions.addEventListener).not.toHaveBeenCalled()
     expect(client).toBe(client)
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
-    let _cb
-    const Dimensions = {
-      addEventListener: (type, fn) => {
-        _cb = fn
-      }
-    }
-    const plugin = proxyquire('../', {
-      'react-native': { Dimensions }
-    })
-
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [], plugins: [plugin] })
 
-    expect(_cb).toBe(undefined)
+    expect(MockDimensions.addEventListener).not.toHaveBeenCalled()
     expect(client).toBe(client)
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["state"]', () => {
-    let _cb
-    const Dimensions = {
-      addEventListener: (type, fn) => {
-        _cb = fn
-      },
-      get: () => ({ height: 100, width: 200 })
-    }
-    const plugin = proxyquire('../', {
-      'react-native': { Dimensions }
-    })
+    MockDimensions.get = () => ({ height: 100, width: 200 })
 
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'], plugins: [plugin] })
 
-    expect(typeof _cb).toBe('function')
+    expect(MockDimensions.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
     expect(client).toBe(client)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -73,6 +73,7 @@
     "packages/plugin-browser-device",
     "packages/plugin-contextualize",
     "packages/plugin-react-native-app-state-breadcrumbs",
+    "packages/plugin-react-native-orientation-breadcrumbs",
     "packages/plugin-react-native-unhandled-rejection",
     "packages/plugin-react-native-hermes",
     "packages/plugin-react-native-client-sync",


### PR DESCRIPTION
## Goal

Conversion of tests from jasmine to jest and TypeScript for consistency and performance and improved type checking.

## Design

See previous discussions

## Changeset

Converted `plugin-react-native-orientation-breadcrumbs` tests from jasmine to jest.

## Testing

Automated tests pass. Changes to test files, internal types and configuration only.