### PR TITLE
Fix RN 0.63 example app setup

### DIFF
--- a/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainApplication.java
+++ b/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainApplication.java
@@ -34,6 +34,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // packages.add(new MyReactNativePackage());
+          packages.add(new CrashyPackage());
           return packages;
         }
 


### PR DESCRIPTION
## Goal

The React Native 0.63 example app does not load the `CrashyPackage` class in the `getPackages()` method within `MainApplication`. This results in any call to the `NativeModules.CrashyCrashy` throwing an exception and terminating the process - clicking the "Send Handled Native Exception" button of the app is the most obvious way to reproduce this.

This adds the package to the list of created packages and ensure that all the example errors work as intended.

## Testing

Ran the Android example app.