### PR TITLE
test(plugin-network-breadcrumbs): convert tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
         testsForPackage('plugin-browser-device'),
         testsForPackage('plugin-browser-request'),
         testsForPackage('plugin-client-ip'),
+        testsForPackage('plugin-network-breadcrumbs'),
         testsForPackage('plugin-window-unhandled-rejection'),
         testsForPackage('plugin-window-onerror'),
         testsForPackage('plugin-strip-query-string'),

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -14,15 +14,10 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5",
-    "jasmine": "^3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.3.5"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -1,34 +1,42 @@
-const { describe, it, expect, jasmine, afterEach } = global
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import plugin from '../'
 
-const plugin = require('../')
-let p
+import Client from '@bugsnag/core/client'
+import { Config } from '@bugsnag/core'
 
-const Client = require('@bugsnag/core/client')
+class XMLHttpRequest {
+  _listeners: { load: () => void, error: () => void }
+  status: number | null;
 
-// mock XMLHttpRequest
-function XMLHttpRequest () {
-  this._listeners = { load: () => {}, error: () => {} }
-  this.status = null
-}
-XMLHttpRequest.prototype.open = function (method, url) {
-}
-XMLHttpRequest.prototype.send = function (fail, status) {
-  if (fail) {
-    this._listeners.error.call(this)
-  } else {
-    this.status = status
-    this._listeners.load.call(this)
+  constructor () {
+    this._listeners = { load: () => {}, error: () => {} }
+    this.status = null
   }
-}
-XMLHttpRequest.prototype.addEventListener = function (evt, listener) {
-  this._listeners[evt] = listener
-}
-XMLHttpRequest.prototype.removeEventListener = function (evt, listener) {
-  if (listener === this._listeners[evt]) delete this._listeners[evt]
+
+  open (method: string, url: string) {
+  }
+
+  send (fail: boolean, status: number | null = null) {
+    if (fail) {
+      this._listeners.error.call(this)
+    } else {
+      this.status = status
+      this._listeners.load.call(this)
+    }
+  }
+
+  addEventListener (evt: 'load'| 'error', listener: () => void) {
+    this._listeners[evt] = listener
+  }
+
+  removeEventListener (evt: 'load'| 'error', listener: () => void) {
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    if (listener === this._listeners[evt]) delete this._listeners[evt]
+  }
 }
 
 // mock fetch
-function fetch (url, options, fail, status) {
+function fetch (urlOrRequest: string | Request | null | undefined, options: {} | null, fail: boolean, status: number | null = null) {
   return new Promise((resolve, reject) => {
     if (fail) {
       reject(new Error('Fail'))
@@ -39,30 +47,36 @@ function fetch (url, options, fail, status) {
 }
 
 // mock (fetch) Request
-function Request (url, opts) {
-  this.url = url
-  this.method = (opts && opts.method) || 'GET'
+class Request {
+  url: string
+  method: string
+
+  constructor (url: string, opts?: { method: string }) {
+    this.url = url
+    this.method = (opts?.method) || 'GET'
+  }
 }
 
 describe('plugin: network breadcrumbs', () => {
+  let p: any
+
   afterEach(() => {
-    // undo the global side effects
     if (p) p.destroy()
   })
 
   it('should leave a breadcrumb when an XMLHTTPRequest resolves', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    const request = new window.XMLHttpRequest()
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
     request.open('GET', '/')
     // tell the mock request to succeed with status code 200
     request.send(false, 200)
 
     expect(client._breadcrumbs.length).toBe(1)
-    expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+    expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
       type: 'request',
       message: 'XMLHttpRequest succeeded',
       metadata: {
@@ -73,12 +87,12 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should not leave duplicate breadcrumbs if open() is called twice', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    const request = new window.XMLHttpRequest()
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
     request.open('GET', '/')
     request.open('GET', '/')
     request.send(false, 200)
@@ -86,17 +100,17 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should leave a breadcrumb when an XMLHTTPRequest has a failed response', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    const request = new window.XMLHttpRequest()
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
     request.open('GET', '/this-does-not-exist')
     request.send(false, 404)
 
     expect(client._breadcrumbs.length).toBe(1)
-    expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+    expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
       type: 'request',
       message: 'XMLHttpRequest failed',
       metadata: {
@@ -107,18 +121,18 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should leave a breadcrumb when an XMLHTTPRequest has a network error', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    const request = new window.XMLHttpRequest()
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
 
     request.open('GET', 'https://another-domain.xyz/')
     request.send(true)
 
     expect(client._breadcrumbs.length).toBe(1)
-    expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+    expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
       type: 'request',
       message: 'XMLHttpRequest error',
       metadata: {
@@ -128,39 +142,40 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should not leave a breadcrumb for request to bugsnag notify endpoint', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
-    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] } as unknown as Config)
 
-    const request = new window.XMLHttpRequest()
-    request.open('GET', client._config.endpoints.notify)
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
+    request.open('GET', client._config.endpoints!.notify)
     request.send(false, 200)
 
     expect(client._breadcrumbs.length).toBe(0)
   })
 
   it('should not leave a breadcrumb for session tracking requests', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
-    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] } as unknown as Config)
 
-    const request = new window.XMLHttpRequest()
-    request.open('GET', client._config.endpoints.sessions)
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
+    request.open('GET', client._config.endpoints!.sessions)
     request.send(false, 200)
     expect(client._breadcrumbs.length).toBe(0)
   })
 
   it('should leave a breadcrumb when a fetch() resolves', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch('/', {}, false, 200).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch('/', {}, false, 200).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -173,14 +188,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle a fetch(url, { method: null })', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch('/', { method: null }, false, 405).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch('/', { method: null }, false, 405).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -193,16 +209,17 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle a fetch() request supplied with a Request object', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
     const request = new Request('/')
 
-    window.fetch(request, {}, false, 200).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(request, {}, false, 200).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -215,16 +232,17 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle a fetch() request supplied with a Request object that has a method specified', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
     const request = new Request('/', { method: 'PUT' })
 
-    window.fetch(request, {}, false, 200).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(request, {}, false, 200).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -237,14 +255,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle fetch(null)', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch(null, {}, false, 404).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(null, {}, false, 404).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -257,14 +276,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle fetch(url, null)', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch('/', null, false, 200).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch('/', null, false, 200).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -277,14 +297,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle fetch(undefined)', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch(undefined, {}, false, 404).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(undefined, {}, false, 404).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -297,14 +318,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle a fetch(request, { method })', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch(new Request('/foo', { method: 'GET' }), { method: 'PUT' }, false, 200).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(new Request('/foo', { method: 'GET' }), { method: 'PUT' }, false, 200).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -317,14 +339,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle a fetch(request, { method: null })', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch(new Request('/foo'), { method: null }, false, 405).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(new Request('/foo'), { method: null }, false, 405).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -337,14 +360,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should handle a fetch(request, { method: undefined })', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch(new Request('/foo'), { method: undefined }, false, 200).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch(new Request('/foo'), { method: undefined }, false, 200).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() succeeded',
         metadata: {
@@ -357,14 +381,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should leave a breadcrumb when a fetch() has a failed response', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch('/does-not-exist', {}, false, 404).then(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch('/does-not-exist', {}, false, 404).then(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() failed',
         metadata: {
@@ -377,14 +402,15 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should leave a breadcrumb when a fetch() has a network error', (done) => {
-    const window = { XMLHttpRequest, fetch }
+    const window = { XMLHttpRequest, fetch } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [p] })
 
-    window.fetch('https://another-domain.xyz/foo/bar', {}, true).catch(() => {
+    const mockFetch = window.fetch as unknown as typeof fetch
+    mockFetch('https://another-domain.xyz/foo/bar', {}, true).catch(() => {
       expect(client._breadcrumbs.length).toBe(1)
-      expect(client._breadcrumbs[0]).toEqual(jasmine.objectContaining({
+      expect(client._breadcrumbs[0]).toEqual(expect.objectContaining({
         type: 'request',
         message: 'fetch() error',
         metadata: {
@@ -396,12 +422,12 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [], plugins: [p] })
 
-    const request = new window.XMLHttpRequest()
+    const request = new XMLHttpRequest()
     request.open('GET', '/')
     request.send(false, 200)
 
@@ -409,12 +435,12 @@ describe('plugin: network breadcrumbs', () => {
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["request"]', () => {
-    const window = { XMLHttpRequest }
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 
     p = plugin([], window)
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['request'], plugins: [p] })
 
-    const request = new window.XMLHttpRequest()
+    const request = new XMLHttpRequest()
     request.open('GET', '/')
     request.send(false, 200)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,7 @@
     "packages/plugin-browser-context",
     "packages/plugin-browser-device",
     "packages/plugin-contextualize",
+    "packages/plugin-network-breadcrumbs",
     "packages/plugin-react-native-app-state-breadcrumbs",
     "packages/plugin-react-native-orientation-breadcrumbs",
     "packages/plugin-react-native-unhandled-rejection",


### PR DESCRIPTION
## Goal

Conversion of tests from jasmine to jest and TypeScript for consistency and performance and improved type checking.

## Design

See previous discussions

## Changeset

Converted `plugin-network-breadcrumbs` tests from jasmine to jest.

## Testing

Automated tests pass. Changes to test files, internal types and configuration only.