### PR TITLE
test(plugin-navigation-breadcrumbs): convert tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
         testsForPackage('plugin-browser-device'),
         testsForPackage('plugin-browser-request'),
         testsForPackage('plugin-client-ip'),
+        testsForPackage('plugin-navigation-breadcrumbs'),
         testsForPackage('plugin-network-breadcrumbs'),
         testsForPackage('plugin-window-unhandled-rejection'),
         testsForPackage('plugin-window-onerror'),

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -14,15 +14,10 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5",
-    "jasmine": "^3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.3.5"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,7 @@
     "packages/plugin-browser-context",
     "packages/plugin-browser-device",
     "packages/plugin-contextualize",
+    "packages/plugin-navigation-breadcrumbs",
     "packages/plugin-network-breadcrumbs",
     "packages/plugin-react-native-app-state-breadcrumbs",
     "packages/plugin-react-native-orientation-breadcrumbs",


### PR DESCRIPTION
## Goal

Conversion of tests from jasmine to jest and TypeScript for consistency and performance and improved type checking.

## Design

See previous discussions

## Changeset

Converted `plugin-navigation-breadcrumbs` tests from jasmine to jest.

## Testing

Automated tests pass. Changes to test files, internal types and configuration only.