### PR TITLE
test(plugin-react-native-global-error-handler, plugin-react-native-session): convert tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -48,7 +48,9 @@ module.exports = {
         testsForPackage('plugin-react-native-unhandled-rejection'),
         testsForPackage('plugin-react-native-hermes'),
         testsForPackage('plugin-react-native-client-sync'),
-        testsForPackage('plugin-react-native-event-sync')
+        testsForPackage('plugin-react-native-global-error-handler'),
+        testsForPackage('plugin-react-native-event-sync'),
+        testsForPackage('plugin-react-native-session')
       ],
       setupFiles: [
         require.resolve('react-native/Libraries/Core/setUpGlobals.js'),

--- a/packages/plugin-react-native-global-error-handler/package.json
+++ b/packages/plugin-react-native-global-error-handler/package.json
@@ -14,15 +14,10 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5",
-    "jasmine": "3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.3.5"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -14,15 +14,10 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5",
-    "jasmine": "3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.3.5"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/packages/plugin-react-native-session/test/session.test.ts
+++ b/packages/plugin-react-native-session/test/session.test.ts
@@ -1,7 +1,5 @@
-const { describe, it, expect, spyOn } = global
-
-const plugin = require('../')
-const Client = require('@bugsnag/core/client')
+import plugin from '../'
+import Client from '@bugsnag/core/client'
 
 describe('plugin: react native session', () => {
   it('adds missing methods and forwards calls to native client', () => {
@@ -11,9 +9,9 @@ describe('plugin: react native session', () => {
       resumeSession: () => {}
     }
 
-    const startSpy = spyOn(NativeClient, 'startSession')
-    const pauseSpy = spyOn(NativeClient, 'pauseSession')
-    const resumeSpy = spyOn(NativeClient, 'resumeSession')
+    const startSpy = jest.spyOn(NativeClient, 'startSession')
+    const pauseSpy = jest.spyOn(NativeClient, 'pauseSession')
+    const resumeSpy = jest.spyOn(NativeClient, 'resumeSession')
 
     const c = new Client({ apiKey: 'api_key', plugins: [plugin(NativeClient)] })
     c.startSession()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,8 @@
     "packages/plugin-react-native-hermes",
     "packages/plugin-react-native-client-sync",
     "packages/plugin-react-native-event-sync",
+    "packages/plugin-react-native-global-error-handler",
+    "packages/plugin-react-native-session",
     "packages/plugin-server-session",
     "packages/plugin-react",
     "packages/plugin-vue",


### PR DESCRIPTION
## Goal

Conversion of tests from jasmine to jest and TypeScript for consistency and performance and improved type checking.

## Design

See previous discussions

## Changeset

Converted `plugin-react-native-global-error-handler`, and `plugin-react-native-session` tests from jasmine to jest.

## Testing

Automated tests pass. Changes to test files, internal types and configuration only.