### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/packages/react-native/BugsnagReactNative.podspec
+++ b/packages/react-native/BugsnagReactNative.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.public_header_files = "ios/vendor/bugsnag-cocoa/{#{bugsnag_cocoa_public_header_files.join(',')}}"
   s.header_dir = 'Bugsnag'
   s.requires_arc = true
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
## Goal

Latest Xcode 12 fails to build without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Testing

It's not easy to reproduce this, sometimes it might require to create a clean project.