### PR TITLE
React Native: allow plugins to be set in JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (react-native): Allow plugins to be set in the JS layer. [#1064](https://github.com/bugsnag/bugsnag-js/pull/1064)
+
 ## 7.3.5 (2020-09-16)
 
 ### Fixed

--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -3,7 +3,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 const rnPackage = require('react-native/package.json')
 const iserror = require('iserror')
 
-const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId']
+const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins']
 const allowedErrorTypes = () => ({
   unhandledExceptions: true,
   unhandledRejections: true,


### PR DESCRIPTION
## Goal

To develop optional plugins for the React Native notifier, we need to allow the `plugins` option to be set from JS — it's currently not in the list of properties the JS layer is allowed to set

## Testing

I've tested with an in-progress plugin and it gets loaded as expected