### PR TITLE
Add plugin for React Native Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (browser): Attach an anonymous device ID to error reports and sessions when the new `generateAnonymousId` option is enabled. [#1072](https://github.com/bugsnag/bugsnag-js/pull/1072)
 
+### Added
+
+- (plugin-react-native-navigation): New plugin that integrates with React Native Navigation. [#1065](https://github.com/bugsnag/bugsnag-js/pull/1065)
+
 ### Changed
 
 - (react-native): Allow plugins to be set in the JS layer. [#1064](https://github.com/bugsnag/bugsnag-js/pull/1064)

--- a/jest.config.js
+++ b/jest.config.js
@@ -51,7 +51,8 @@ module.exports = {
         testsForPackage('plugin-react-native-client-sync'),
         testsForPackage('plugin-react-native-global-error-handler'),
         testsForPackage('plugin-react-native-event-sync'),
-        testsForPackage('plugin-react-native-session')
+        testsForPackage('plugin-react-native-session'),
+        testsForPackage('plugin-react-native-navigation')
       ],
       setupFiles: [
         require.resolve('react-native/Libraries/Core/setUpGlobals.js'),

--- a/packages/plugin-react-native-navigation/LICENSE.txt
+++ b/packages/plugin-react-native-navigation/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/plugin-react-native-navigation/README.md
+++ b/packages/plugin-react-native-navigation/README.md
@@ -1,6 +1,6 @@
 # @bugsnag/plugin-react-native-navigation
 
-This plugin hooks in to React Native Navigation, updating the `context` with the current component name.
+This plugin hooks in to React Native Navigation, updating the `context` with the current component name and leaving breadcrumbs for navigation changes.
 
 ## License
 

--- a/packages/plugin-react-native-navigation/README.md
+++ b/packages/plugin-react-native-navigation/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/plugin-react-native-navigation
+
+This plugin hooks in to React Native Navigation, updating the `context` with the current component name.
+
+## License
+
+MIT

--- a/packages/plugin-react-native-navigation/package-lock.json
+++ b/packages/plugin-react-native-navigation/package-lock.json
@@ -4,60 +4,114 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@bugsnag/core": {
-      "version": "7.3.5",
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.49",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+      "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
       "dev": true,
       "requires": {
-        "@bugsnag/cuid": "^3.0.0",
-        "@bugsnag/safe-json-stringify": "^6.0.0",
-        "error-stack-parser": "^2.0.3",
-        "iserror": "0.0.2",
-        "stack-generator": "^2.0.3"
-      },
-      "dependencies": {
-        "@bugsnag/cuid": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-          "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==",
-          "dev": true
-        },
-        "@bugsnag/safe-json-stringify": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
-          "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
-          "dev": true
-        },
-        "error-stack-parser": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.3.tgz",
-          "integrity": "sha512-vRC4rKv87twMZy92X4+TmUdv3iYMsmePbpG/YguHsfzmZ8bYJZYYep7yrXH09yFUaCEPKgNK5X79+Yq7hwLVOA==",
-          "dev": true,
-          "requires": {
-            "stackframe": "^1.0.4"
-          }
-        },
-        "iserror": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-          "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=",
-          "dev": true
-        },
-        "stack-generator": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-          "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
-          "dev": true,
-          "requires": {
-            "stackframe": "^1.0.4"
-          }
-        },
-        "stackframe": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-          "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
-          "dev": true
-        }
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
       }
+    },
+    "@types/react-native": {
+      "version": "0.63.20",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.20.tgz",
+      "integrity": "sha512-APnxRTDxbWw/IYjvwvXkhYJiz1gahyVA579pJqAVsEfZ+ZUwUHZpWKnexobyH5NmRJHuA/8LrThyps/BW3SYXA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "csstype": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+      "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "react-lifecycles-compat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-2.0.0.tgz",
+      "integrity": "sha512-txfpPCQYiazVdcbMRhatqWKcAxJweUu2wDXvts5/7Wyp6+Y9cHojqXHsLPEckzutfHlxZhG8Oiundbmp8Fd6eQ==",
+      "dev": true
+    },
+    "react-native-navigation": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-navigation/-/react-native-navigation-7.0.0.tgz",
+      "integrity": "sha512-6fcaHvGw0ALLa9ZcqPpCr3H4Ykbd1IsqjB3m9SeoQ4zKuf3r7DJTJsJnazcj6LZxjt5IiBDQr/GzhnZquGXjUA==",
+      "dev": true,
+      "requires": {
+        "hoist-non-react-statics": "3.x.x",
+        "lodash": "4.17.x",
+        "prop-types": "15.x.x",
+        "react-lifecycles-compat": "2.0.0",
+        "tslib": "1.9.3"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     }
   }
 }

--- a/packages/plugin-react-native-navigation/package-lock.json
+++ b/packages/plugin-react-native-navigation/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "@bugsnag/plugin-react-native-navigation",
+  "version": "7.3.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bugsnag/core": {
+      "version": "7.3.5",
+      "dev": true,
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      },
+      "dependencies": {
+        "@bugsnag/cuid": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+          "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==",
+          "dev": true
+        },
+        "@bugsnag/safe-json-stringify": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+          "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
+          "dev": true
+        },
+        "error-stack-parser": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.3.tgz",
+          "integrity": "sha512-vRC4rKv87twMZy92X4+TmUdv3iYMsmePbpG/YguHsfzmZ8bYJZYYep7yrXH09yFUaCEPKgNK5X79+Yq7hwLVOA==",
+          "dev": true,
+          "requires": {
+            "stackframe": "^1.0.4"
+          }
+        },
+        "iserror": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+          "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=",
+          "dev": true
+        },
+        "stack-generator": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
+          "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
+          "dev": true,
+          "requires": {
+            "stackframe": "^1.0.4"
+          }
+        },
+        "stackframe": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+          "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@bugsnag/plugin-react-native-navigation",
+  "version": "7.3.5",
+  "main": "react-native-navigation.js",
+  "description": "@bugsnag/react-native plugin for integration with react-native-navigation",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "*.js"
+  ],
+  "author": "Bugsnag",
+  "license": "MIT",
+  "devDependencies": {
+    "@bugsnag/core": "^7.3.5"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0",
+    "react-native-navigation": "^7.0.0"
+  }
+}

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -2,6 +2,7 @@
   "name": "@bugsnag/plugin-react-native-navigation",
   "version": "7.3.5",
   "main": "react-native-navigation.js",
+  "types": "types/react-native-navigation.d.ts",
   "description": "@bugsnag/react-native plugin for integration with react-native-navigation",
   "homepage": "https://www.bugsnag.com/",
   "repository": {
@@ -12,15 +13,21 @@
     "access": "public"
   },
   "files": [
-    "*.js"
+    "*.js",
+    "types"
   ],
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5"
+    "@bugsnag/core": "^7.3.5",
+    "@types/react-native": "^0.63.20",
+    "react-native-navigation": "^7.0.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
     "react-native-navigation": "2 - 7"
+  },
+  "scripts": {
+    "test:types": "tsc -p tsconfig.json"
   }
 }

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -21,6 +21,6 @@
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "react-native-navigation": "^7.0.0"
+    "react-native-navigation": "2 - 7"
   }
 }

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -1,5 +1,11 @@
 module.exports = class BugsnagPluginReactNativeNavigation {
   constructor (Navigation) {
+    if (!Navigation) {
+      throw new Error(
+        '@bugsnag/plugin-react-native-navigation reference to `Navigation` was undefined'
+      )
+    }
+
     this.Navigation = Navigation
   }
 

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -4,8 +4,20 @@ module.exports = class BugsnagPluginReactNativeNavigation {
   }
 
   load (client) {
+    let lastComponent
+
     this.Navigation.events().registerComponentDidAppearListener(event => {
       client.setContext(event.componentName)
+
+      if (lastComponent !== event.componentName) {
+        client.leaveBreadcrumb(
+          'React Native Navigation componentDidAppear',
+          { to: event.componentName, from: lastComponent },
+          'navigation'
+        )
+      }
+
+      lastComponent = event.componentName
     })
   }
 }

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -1,0 +1,11 @@
+module.exports = class BugsnagPluginReactNativeNavigation {
+  constructor (Navigation) {
+    this.Navigation = Navigation
+  }
+
+  load (client) {
+    this.Navigation.events().registerComponentDidAppearListener(event => {
+      client.setContext(event.componentName)
+    })
+  }
+}

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -9,7 +9,11 @@ module.exports = class BugsnagPluginReactNativeNavigation {
     this.Navigation.events().registerComponentDidAppearListener(event => {
       client.setContext(event.componentName)
 
-      if (lastComponent !== event.componentName) {
+      if (
+        client._config.enabledBreadcrumbTypes &&
+        client._config.enabledBreadcrumbTypes.includes('navigation') &&
+        lastComponent !== event.componentName
+      ) {
         client.leaveBreadcrumb(
           'React Native Navigation componentDidAppear',
           { to: event.componentName, from: lastComponent },

--- a/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
+++ b/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
@@ -1,6 +1,6 @@
 import Plugin from '../react-native-navigation'
-import Client from '@bugsnag/core/client'
 import { Breadcrumb } from '@bugsnag/core'
+import Client from '@bugsnag/core/client'
 
 interface Event {
   componentId: number

--- a/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
+++ b/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
@@ -1,0 +1,60 @@
+import Plugin from '../react-native-navigation'
+import Client from '@bugsnag/core/client'
+
+describe('plugin-react-native-navigation', () => {
+  it('adds an event listener on load', () => {
+    const spy = jest.fn()
+
+    const Navigation = {
+      events () {
+        return { registerComponentDidAppearListener: spy }
+      }
+    }
+
+    const plugin = new Plugin(Navigation)
+
+    expect(spy).not.toHaveBeenCalled()
+
+    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin] })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(client.getContext()).toBe(undefined)
+  })
+
+  it('updates the client context when the listener is triggered', () => {
+    interface Event {
+      componentId: number
+      componentName: string
+      passProps: object
+    }
+
+    // Setup a fake listener that should never be called - the plugin should
+    // replace this on load by calling 'registerComponentDidAppearListener'
+    let listener = (event: Event) => {
+      throw new Error(`This function was not supposed to be called! ${event.componentName}`)
+    }
+
+    const Navigation = {
+      events () {
+        return {
+          registerComponentDidAppearListener (callback: (event: Event) => never) {
+            listener = callback
+          }
+        }
+      }
+    }
+
+    const plugin = new Plugin(Navigation)
+    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin] })
+
+    expect(client.getContext()).toBe(undefined)
+
+    listener({ componentId: 1, componentName: 'abc xyz', passProps: {} })
+
+    expect(client.getContext()).toBe('abc xyz')
+
+    listener({ componentId: 2, componentName: 'xyz abc', passProps: {} })
+
+    expect(client.getContext()).toBe('xyz abc')
+  })
+})

--- a/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
+++ b/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
@@ -9,6 +9,12 @@ interface Event {
 }
 
 describe('plugin-react-native-navigation', () => {
+  it('should throw when Navigation is not passed', () => {
+    const message = '@bugsnag/plugin-react-native-navigation reference to `Navigation` was undefined'
+
+    expect(() => new Plugin()).toThrow(new Error(message))
+  })
+
   it('adds an event listener on load', () => {
     const spy = jest.fn()
 

--- a/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
+++ b/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
@@ -131,8 +131,56 @@ describe('plugin-react-native-navigation', () => {
 
     expect(breadcrumbs.length).toBe(1)
 
+    listener({ componentId: 1, componentName: 'xyz abc', passProps: {} })
+
+    expect(breadcrumbs.length).toBe(2)
+    expect(breadcrumbs[1].message).toBe('React Native Navigation componentDidAppear')
+    expect(breadcrumbs[1].metadata).toStrictEqual({ to: 'xyz abc', from: 'abc xyz' })
+    expect(breadcrumbs[1].type).toBe('navigation')
+
+    listener({ componentId: 1, componentName: 'xyz abc', passProps: {} })
+
+    expect(breadcrumbs.length).toBe(2)
+  })
+
+  it('does not leave a breadcrumb when the "navigation" breadcrumb type is disabled', () => {
+    let listener = (event: Event) => {
+      throw new Error(`This function was not supposed to be called! ${event.componentName}`)
+    }
+
+    const Navigation = {
+      events () {
+        return {
+          registerComponentDidAppearListener (callback: (event: Event) => never) {
+            listener = callback
+          }
+        }
+      }
+    }
+
+    const breadcrumbs: Breadcrumb[] = []
+
+    const plugin = new Plugin(Navigation)
+    const client = new Client({
+      apiKey: 'API_KEY_YEAH',
+      plugins: [plugin],
+      enabledBreadcrumbTypes: ['request', 'process', 'log', 'user', 'state', 'error', 'manual']
+    })
+
+    client.addOnBreadcrumb(breadcrumb => { breadcrumbs.push(breadcrumb) })
+
+    expect(breadcrumbs.length).toBe(0)
+
     listener({ componentId: 1, componentName: 'abc xyz', passProps: {} })
 
-    expect(breadcrumbs.length).toBe(1)
+    expect(breadcrumbs.length).toBe(0)
+
+    listener({ componentId: 1, componentName: 'abc xyz', passProps: {} })
+
+    expect(breadcrumbs.length).toBe(0)
+
+    listener({ componentId: 1, componentName: 'abc xyz', passProps: {} })
+
+    expect(breadcrumbs.length).toBe(0)
   })
 })

--- a/packages/plugin-react-native-navigation/tsconfig.json
+++ b/packages/plugin-react-native-navigation/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["."],
+    "compilerOptions": {
+        "lib": ["es2015"],
+        "types": ["jest"],
+    }
+}

--- a/packages/plugin-react-native-navigation/types/react-native-navigation.d.ts
+++ b/packages/plugin-react-native-navigation/types/react-native-navigation.d.ts
@@ -1,0 +1,10 @@
+import { Client, Plugin } from '@bugsnag/core'
+import { Navigation } from 'react-native-navigation'
+
+declare class BugsnagPluginReactNativeNavigation implements Plugin {
+  constructor(navigation: typeof Navigation)
+
+  load: (client: Client) => void
+}
+
+export default BugsnagPluginReactNativeNavigation

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -83,6 +83,7 @@
     "packages/plugin-react-native-event-sync",
     "packages/plugin-react-native-global-error-handler",
     "packages/plugin-react-native-session",
+    "packages/plugin-react-native-navigation",
     "packages/plugin-server-session",
     "packages/plugin-react",
     "packages/plugin-vue",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -83,7 +83,6 @@
     "packages/plugin-react-native-event-sync",
     "packages/plugin-react-native-global-error-handler",
     "packages/plugin-react-native-session",
-    "packages/plugin-react-native-navigation",
     "packages/plugin-server-session",
     "packages/plugin-react",
     "packages/plugin-vue",


### PR DESCRIPTION
## Goal

This PR adds a plugin for [React Native Navigation](https://wix.github.io/react-native-navigation). This plugin sets the [context](https://docs.bugsnag.com/platforms/react-native/react-native/customizing-error-reports/#setting-context) to the name of the currently rendered component and leaves a breadcrumb on each navigation change

Usage:

```js
import { Navigation } from 'react-native-navigation'
import Bugsnag from '@bugsnag/react-native'
import BugsnagPluginReactNativeNavigation from '@bugsnag/plugin-react-native-navigation'

Bugsnag.start({
  plugins: [new BugsnagPluginReactNativeNavigation(Navigation)]
})
```