### PR TITLE
test(plugin-react-native-connectivity-breadcrumbs): convert tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -44,6 +44,7 @@ module.exports = {
         testsForPackage('react-native'),
         testsForPackage('delivery-react-native'),
         testsForPackage('plugin-react-native-app-state-breadcrumbs'),
+        testsForPackage('plugin-react-native-connectivity-breadcrumbs'),
         testsForPackage('plugin-react-native-orientation-breadcrumbs'),
         testsForPackage('plugin-react-native-unhandled-rejection'),
         testsForPackage('plugin-react-native-hermes'),

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -14,18 +14,13 @@
   "files": [
     "*.js"
   ],
-  "scripts": {
-    "test": "nyc --reporter=lcov -- jasmine '!(node_modules)/**/*.test.js'"
-  },
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
     "@react-native-community/netinfo": "5.9.2"
   },
   "devDependencies": {
-    "@bugsnag/core": "^7.3.5",
-    "jasmine": "3.1.0",
-    "nyc": "^12.0.2"
+    "@bugsnag/core": "^7.3.5"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -75,6 +75,7 @@
     "packages/plugin-navigation-breadcrumbs",
     "packages/plugin-network-breadcrumbs",
     "packages/plugin-react-native-app-state-breadcrumbs",
+    "packages/plugin-react-native-connectivity-breadcrumbs",
     "packages/plugin-react-native-orientation-breadcrumbs",
     "packages/plugin-react-native-unhandled-rejection",
     "packages/plugin-react-native-hermes",


### PR DESCRIPTION
## Goal

Conversion of tests from jasmine to jest and TypeScript for consistency and performance and improved type checking.

## Design

See previous discussions

## Changeset

Converted `plugin-react-native-connectivity-breadcrumbs` tests from jasmine to jest.

## Testing

Automated tests pass. Changes to test files, internal types and configuration only.