### PR TITLE
test: improve jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -54,8 +54,6 @@ module.exports = {
         testsForPackage('plugin-react-native-session')
       ],
       setupFiles: [
-        require.resolve('react-native/Libraries/Core/setUpGlobals.js'),
-        require.resolve('react-native/Libraries/Core/setUpXHR.js'),
         '<rootDir>/packages/react-native/src/test/setup.js'
       ]
     },

--- a/packages/react-native/src/test/setup.js
+++ b/packages/react-native/src/test/setup.js
@@ -1,2 +1,6 @@
+if (global.window === undefined) {
+  global.window = global
+}
+
 // trick the notifier in thinking it's not running in the remote debugger
 global.nativeCallSyncHook = () => {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,10 +48,7 @@
     //   "node_modules/@types",
     //   "packages/core/types"
     // ],
-    "types": [                                /* Type declaration files to be included in compilation. */
-      "node",
-      "jest"
-    ],
+    // "types": []                                /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
## Goal

Simplify the jest testing configuration and fix the following warning in the test output:

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

      at get (node_modules/react-native/Libraries/Core/setUpXHR.js:28:30)
      at Object.getValue [as Blob] (node_modules/react-native/Libraries/Utilities/defineLazyObjectProperty.js:42:16)
          at Array.forEach (<anonymous>)
```

## Design

Remove unnecessary configuration. Specify own minimal test setup.

## Changeset

- Removal of `setUpGlobals.js` and `setUpXHR.js` test setup for react-native tests
- Define `window` in test setup, which is the only thing we used from `setUpGlobals.js`
- Remove unnecessary ts configuration

## Testing

Automated tests pass