### PR TITLE
test(rn): relax check on device.locale

### DIFF
--- a/test/react-native/features/device-android.feature
+++ b/test/react-native/features/device-android.feature
@@ -10,7 +10,7 @@ Scenario: Handled JS error
 
   And the event "device.id" is not null
   And the event "device.jailbroken" is false
-  And the event "device.locale" equals "en_US"
+  And the event "device.locale" matches "^en_[A-Z]{2}$"
   And the event "device.manufacturer" is not null
   And the event "device.model" is not null
   And the event "device.osName" equals "android"
@@ -34,7 +34,7 @@ Scenario: Unhandled JS error
 
   And the event "device.id" is not null
   And the event "device.jailbroken" is false
-  And the event "device.locale" equals "en_US"
+  And the event "device.locale" matches "^en_[A-Z]{2}$"
   And the event "device.manufacturer" is not null
   And the event "device.model" is not null
   And the event "device.osName" equals "android"
@@ -58,7 +58,7 @@ Scenario: Handled native error
 
   And the event "device.id" is not null
   And the event "device.jailbroken" is false
-  And the event "device.locale" equals "en_US"
+  And the event "device.locale" matches "^en_[A-Z]{2}$"
   And the event "device.manufacturer" is not null
   And the event "device.model" is not null
   And the event "device.osName" equals "android"
@@ -82,7 +82,7 @@ Scenario: Unhandled native error
 
   And the event "device.id" is not null
   And the event "device.jailbroken" is false
-  And the event "device.locale" equals "en_US"
+  And the event "device.locale" matches "^en_[A-Z]{2}$"
   And the event "device.manufacturer" is not null
   And the event "device.model" is not null
   And the event "device.osName" equals "android"


### PR DESCRIPTION
## Goal

Allows the device locale to be something other than en_US (but still something English).

## Design

Technically this allows invalid locales to be present, but the risk of that seems very low (noting that in most other tests we only assert that it is non-null anyway).

## Changeset

e2e feature file.

## Testing

Covered by the CI passing.