### PR TITLE
revert(github): remove codeowners file for automatic Test Automation review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*  @bugsnag/platforms-test-automation


### PR DESCRIPTION
## Goal

After a trial run, it was decided that this automated mechanism generates excessive work. Dropping it in favour of a more targeted manual review request process.