### PR TITLE
Only test react-navigation on Android temporarily

### DIFF
--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -122,16 +122,17 @@ steps:
     artifact_paths:
       - build/r_navigation_0.60.apk
 
-  - label: ':ios: Build react-navigation 0.60 ipa'
-    agents:
-      queue: "opensource-mac-rn"
-    env:
-      REACT_NATIVE_VERSION: rn0.60
-      JS_SOURCE_DIR: "react_navigation_js"
-      ARTEFACT_NAME: "r_navigation_0.60"
-    artifact_paths: build/r_navigation_0.60.ipa
-    commands:
-      - npm run test:build-react-native-ios
+  # See: PLAT-5173
+  # - label: ':ios: Build react-navigation 0.60 ipa'
+  #   agents:
+  #     queue: "opensource-mac-rn"
+  #   env:
+  #     REACT_NATIVE_VERSION: rn0.60
+  #     JS_SOURCE_DIR: "react_navigation_js"
+  #     ARTEFACT_NAME: "r_navigation_0.60"
+  #   artifact_paths: build/r_navigation_0.60.ipa
+  #   commands:
+  #     - npm run test:build-react-native-ios
 
   - label: ':android: Build react-navigation 0.63 apk'
     env:
@@ -144,16 +145,17 @@ steps:
     artifact_paths:
       - build/r_navigation_0.63.apk
 
-  - label: ':ios: Build react-navigation 0.63 ipa'
-    agents:
-      queue: "opensource-mac-rn"
-    env:
-      REACT_NATIVE_VERSION: rn0.63
-      JS_SOURCE_DIR: "react_navigation_js"
-      ARTEFACT_NAME: "r_navigation_0.63"
-    artifact_paths: build/r_navigation_0.63.ipa
-    commands:
-      - npm run test:build-react-native-ios
+  # See: PLAT-5173
+  # - label: ':ios: Build react-navigation 0.63 ipa'
+  #   agents:
+  #     queue: "opensource-mac-rn"
+  #   env:
+  #     REACT_NATIVE_VERSION: rn0.63
+  #     JS_SOURCE_DIR: "react_navigation_js"
+  #     ARTEFACT_NAME: "r_navigation_0.63"
+  #   artifact_paths: build/r_navigation_0.63.ipa
+  #   commands:
+  #     - npm run test:build-react-native-ios
 
   - wait
 
@@ -172,20 +174,21 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: ':ios: React-navigation 0.60 iOS 12'
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/r_navigation_0.60.ipa"
-      docker-compose#v3.1.0:
-        run: react-native-maze-runner
-        use-aliases: true
-        command: ["features/navigation.feature"]
-    env:
-      DEVICE_TYPE: "IOS_12"
-      APP_LOCATION: "build/r_navigation_0.60.ipa"
-      RUN_NAVIGATION_SCENARIOS: "true"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
+  # See: PLAT-5173
+  # - label: ':ios: React-navigation 0.60 iOS 12'
+  #   plugins:
+  #     artifacts#v1.2.0:
+  #       download: "build/r_navigation_0.60.ipa"
+  #     docker-compose#v3.1.0:
+  #       run: react-native-maze-runner
+  #       use-aliases: true
+  #       command: ["features/navigation.feature"]
+  #   env:
+  #     DEVICE_TYPE: "IOS_12"
+  #     APP_LOCATION: "build/r_navigation_0.60.ipa"
+  #     RUN_NAVIGATION_SCENARIOS: "true"
+  #   concurrency: 10
+  #   concurrency_group: 'browserstack-app'
 
   - label: ':android: React-navigation 0.63 Android 9'
     plugins:
@@ -202,17 +205,18 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: ':ios: React-navigation 0.63 iOS 12'
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/r_navigation_0.63.ipa"
-      docker-compose#v3.1.0:
-        run: react-native-maze-runner
-        use-aliases: true
-        command: ["features/navigation.feature"]
-    env:
-      DEVICE_TYPE: "IOS_12"
-      APP_LOCATION: "build/r_navigation_0.63.ipa"
-      RUN_NAVIGATION_SCENARIOS: "true"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
+  # See: PLAT-5173
+  # - label: ':ios: React-navigation 0.63 iOS 12'
+  #   plugins:
+  #     artifacts#v1.2.0:
+  #       download: "build/r_navigation_0.63.ipa"
+  #     docker-compose#v3.1.0:
+  #       run: react-native-maze-runner
+  #       use-aliases: true
+  #       command: ["features/navigation.feature"]
+  #   env:
+  #     DEVICE_TYPE: "IOS_12"
+  #     APP_LOCATION: "build/r_navigation_0.63.ipa"
+  #     RUN_NAVIGATION_SCENARIOS: "true"
+  #   concurrency: 10
+  #   concurrency_group: 'browserstack-app'

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -66,11 +66,12 @@ export default class App extends Component {
     let jsConfig = defaultJsConfig()
     let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    NativeModules.BugsnagTestInterface.startBugsnag(configuration, () => {
-      Bugsnag.start(jsConfig)
-      this.setState({ scenario })
-      scenario.run()
-    })
+    NativeModules.BugsnagTestInterface.startBugsnag(configuration)
+      .then(() => {
+        Bugsnag.start(jsConfig)
+        this.setState({ scenario: scenario })
+        scenario.run()
+      })
   }
 
   startBugsnag = () => {

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -89,9 +89,10 @@ export default class App extends Component {
     let jsConfig = defaultJsConfig()
     let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    NativeModules.BugsnagTestInterface.startBugsnag(configuration, () => {
+    NativeModules.BugsnagTestInterface.startBugsnag(configuration)
+    .then(() => {
       Bugsnag.start(jsConfig)
-      this.setState({ scenario })
+      this.setState({ scenario: scenario })
     })
   }
 


### PR DESCRIPTION
## Goal
Until PLAT-5173 is resolved it will be necessary to only test react-navigation functionality on Android in an automated way, with iOS changes being covered manually.