### PR TITLE
ci(react-native): increase java heap size for build test fixtures

### DIFF
--- a/test/react-native/features/fixtures/rn0.60/android/gradle.properties
+++ b/test/react-native/features/fixtures/rn0.60/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/test/react-native/features/fixtures/rn0.63/android/gradle.properties
+++ b/test/react-native/features/fixtures/rn0.63/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Goal

Attempts to avoid running out of Java heap space when building the RN Android test fixtures (having suffered such an issue in an earlier run).

## Testing

Standard CI run.