### PR TITLE
Standardize React Native end-to-end test fixtures

### DIFF
--- a/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
@@ -1,139 +1,147 @@
-/**
- * @format
- */
-
-import {Navigation} from 'react-native-navigation';
-import HomeScreen from './screens/Home';
-import DetailsScreen from './screens/Details';
-import {NativeModules, View, Text, Button, TextInput, StyleSheet} from 'react-native';
-import * as React from 'react';
-import Bugsnag from '@bugsnag/react-native';
+import { Navigation } from 'react-native-navigation'
+import HomeScreen from './screens/Home'
+import DetailsScreen from './screens/Details'
+import { NativeModules, View, Text, Button, TextInput, StyleSheet } from 'react-native'
+import * as React from 'react'
+import Bugsnag from '@bugsnag/react-native'
 import * as Scenarios from './Scenarios'
-import BugsnagReactNativeNavigation from '@bugsnag/plugin-react-native-navigation';
-
-let getDefaultConfiguration = () => {
-  return {
-    apiKey: '12312312312312312312312312312312',
-    endpoint: 'http://bs-local.com:9339',
-    autoTrackSessions: false
-  }
-}
-
-let getManualModeConfiguration = (apiKey) => {
-  return {
-    apiKey: apiKey,
-    endpoints: {
-      notify: 'https://notify.bugsnag.com',
-      sessions: 'https://sessions.bugsnag.com'
-    },
-    autoTrackSessions: false
-  }
-}
+import BugsnagReactNativeNavigation from '@bugsnag/plugin-react-native-navigation'
+import { Component } from 'react'
 
 const defaultJsConfig = () => ({
   plugins: [new BugsnagReactNativeNavigation(Navigation)]
 })
 
-const AppScreen = () => {
-  state = {
-    currentScenario: '',
-    scenarioMetaData: '',
-    manualApiKey: null,
-    scenario: null
+export default class AppScreen extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      currentScenario: '',
+      scenarioMetaData: '',
+      apiKey: '12312312312312312312312312312312',
+      notifyEndpoint: 'http://bs-local.com:9339',
+      sessionsEndpoint: 'http://bs-local.com:9339',
+      scenario: null
+    }
+    console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
   }
-  console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
+
+  getConfiguration = () => {
+    return {
+      apiKey: this.state.apiKey,
+      endpoints: {
+        notify: this.state.notifyEndpoint,
+        sessions: this.state.sessionsEndpoint
+      },
+      autoTrackSessions: false
+    }
+  }
 
   setScenario = newScenario => {
-    state.currentScenario = newScenario
+    this.state.currentScenario = newScenario
   }
 
   setScenarioMetaData = newScenarioMetaData => {
-    state.scenarioMetaData = newScenarioMetaData
-  }
-
-  setManualApiKey = newApiKey => {
-    setState.manualApiKey = newApiKey
+    this.state.scenarioMetaData = newScenarioMetaData
   }
 
   startScenario = () => {
-    console.log(`Running scenario: ${state.currentScenario}`)
-    console.log(`  with MetaData: ${state.scenarioMetaData}`)
-    let scenarioName = state.currentScenario
-    let scenarioMetaData = state.scenarioMetaData
-    let configuration = getDefaultConfiguration()
-    let jsConfig = defaultJsConfig()
-    let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    console.log(`Running scenario: ${this.state.currentScenario}`)
+    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
+    const scenarioName = this.state.currentScenario
+    const scenarioMetaData = this.state.scenarioMetaData
+    const configuration = this.getConfiguration()
+    const jsConfig = defaultJsConfig()
+    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-    .then(() => {
-      Navigation.setRoot({
-        root: {
-          stack: {
-            children: [
-              {
-                component: {
-                  name: 'Home',
-                },
-              },
-            ],
-          },
-        }
+      .then(() => {
+        Navigation.setRoot({
+          root: {
+            stack: {
+              children: [
+                {
+                  component: {
+                    name: 'Home'
+                  }
+                }
+              ]
+            }
+          }
+        })
+        Bugsnag.start(jsConfig)
+        this.state.scenario = scenario
+        scenario.run()
       })
-      Bugsnag.start(jsConfig)
-      state.scenario = scenario
-      scenario.run()
-    })
   }
 
   startBugsnag = () => {
-    console.log(`Starting Bugsnag for scenario: ${state.currentScenario}`)
-    console.log(`  with MetaData: ${state.scenarioMetaData}`)
-    let scenarioName = state.currentScenario
-    let scenarioMetaData = state.scenarioMetaData
-    let configuration
-    if (state.manualApiKey) {
-      configuration = getManualModeConfiguration(state.manualApiKey)
-    } else {
-      configuration = getDefaultConfiguration()
-    }
-    let jsConfig = defaultJsConfig()
-    let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
+    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
+    const scenarioName = this.state.currentScenario
+    const scenarioMetaData = this.state.scenarioMetaData
+    const configuration = this.getConfiguration()
+    const jsConfig = defaultJsConfig()
+    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-    .then(() => {
-      Bugsnag.start(jsConfig)
-      state.scenario = scenario
-    })
+      .then(() => {
+        Bugsnag.start(jsConfig)
+        this.state.scenario = scenario
+      })
   }
 
-  return (
-    <View style={styles.container}>
-      <View style={styles.child}>
-        <Text>React-native end-to-end test app</Text>
-        <TextInput style={styles.textInput}
-          placeholder='Scenario Name'
-          accessibilityLabel='scenario_name'
-          onChangeText={this.setScenario} />
-        <TextInput style={styles.textInput}
-          placeholder='Scenario Metadata'
-          accessibilityLabel='scenarioMetaDataInput'
-          onChangeText={this.setScenarioMetaData} />
-        <Button style={styles.clickyButton}
-          accessibilityLabel='startScenarioButton'
-          title='Start scenario'
-          onPress={this.startScenario}/>
-        <Button style={styles.clickyButton}
-          accessibilityLabel='startBugsnagButton'
-          title='Start Bugsnag'
-          onPress={this.startBugsnag}/>
+  render () {
+    return (
+      <View style={styles.container}>
+        <View style={styles.child}>
+          <Text>React Native Navigation Test App</Text>
+          <TextInput style={styles.textInput}
+            placeholder='Scenario Name'
+            accessibilityLabel='scenario_name'
+            onChangeText={this.setScenario} />
+          <TextInput style={styles.textInput}
+            placeholder='Scenario Metadata'
+            accessibilityLabel='scenario_metadata'
+            onChangeText={this.setScenarioMetaData} />
+          <Button style={styles.clickyButton}
+            accessibilityLabel='start_bugsnag'
+            title='Start Bugsnag only'
+            onPress={this.startBugsnag}/>
+          <Button style={styles.clickyButton}
+            accessibilityLabel='run_scenario'
+            title='Start Bugsnag and run scenario'
+            onPress={this.startScenario}/>
+
+          <Text>Configuration</Text>
+          <TextInput placeholder='Notify endpoint'
+            style={styles.textInput}
+            accessibilityLabel='notify_endpoint'
+            value={this.state.notifyEndpoint}
+            onChangeText={this.setNotifyEndpoint} />
+          <TextInput placeholder='Sessions endpoint'
+            style={styles.textInput}
+            accessibilityLabel='sessions_endpoint'
+            value={this.state.sessionsEndpoint}
+            onChangeText={this.setSessionsEndpoint} />
+          <TextInput placeholder='API key'
+            style={styles.textInput}
+            accessibilityLabel='api_key'
+            value={this.state.apiKey}
+            onChangeText={this.setApiKey} />
+          <Button style={styles.clickyButton}
+            accessibilityLabel='use_dashboard_endpoints'
+            title='Use dashboard endpoints'
+            onPress={this.useRealEndpoints}/>
+        </View>
       </View>
-    </View>
-  )
+    )
+  }
 }
 
 Navigation.registerComponent('App', () => AppScreen)
-Navigation.registerComponent('Home', () => HomeScreen);
-Navigation.registerComponent('Details', () => DetailsScreen);
+Navigation.registerComponent('Home', () => HomeScreen)
+Navigation.registerComponent('Details', () => DetailsScreen)
 Navigation.events().registerAppLaunchedListener(async () => {
   Navigation.setRoot({
     root: {
@@ -141,12 +149,12 @@ Navigation.events().registerAppLaunchedListener(async () => {
         children: [
           {
             component: {
-              name: 'App',
-            },
-          },
-        ],
-      },
-    },
+              name: 'App'
+            }
+          }
+        ]
+      }
+    }
   })
 })
 

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
@@ -19,7 +19,7 @@ let getDefaultConfiguration = () => {
   }
 }
 
-let getManualModeConfiguration = (apiKey) => { 
+let getManualModeConfiguration = (apiKey) => {
   return {
     apiKey: apiKey,
     endpoints: {
@@ -112,7 +112,7 @@ const AppScreen = () => {
         <Text>React-native end-to-end test app</Text>
         <TextInput style={styles.textInput}
           placeholder='Scenario Name'
-          accessibilityLabel='scenarioInput'
+          accessibilityLabel='scenario_name'
           onChangeText={this.setScenario} />
         <TextInput style={styles.textInput}
           placeholder='Scenario Metadata'

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -103,7 +103,7 @@ export default class App extends Component {
           <Text>React-native end-to-end test app</Text>
           <TextInput style={styles.textInput}
             placeholder='Scenario Name'
-            accessibilityLabel='scenarioInput'
+            accessibilityLabel='scenario_name'
             onChangeText={this.setScenario} />
           <TextInput style={styles.textInput}
             placeholder='Scenario Metadata'

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -12,23 +12,6 @@ import {
   NativeModules
 } from 'react-native'
 
-let getDefaultConfiguration = () => { return {
-    apiKey: '12312312312312312312312312312312',
-    endpoint: 'http://bs-local.com:9339',
-    autoTrackSessions: false
-  }
-}
-
-let getManualModeConfiguration = (apiKey) => { return {
-  apiKey: apiKey,
-  endpoints: {
-    notify: 'https://notify.bugsnag.com',
-    sessions: 'https://sessions.bugsnag.com'
-  },
-  autoTrackSessions: false
-}
-}
-
 const defaultJsConfig = () => ({
   plugins: [new BugsnagPluginReactNavigation()]
 })
@@ -39,10 +22,23 @@ export default class App extends Component {
     this.state = {
       currentScenario: '',
       scenarioMetaData: '',
-      manualApiKey: null,
+      apiKey: '12312312312312312312312312312312',
+      notifyEndpoint: 'http://bs-local.com:9339',
+      sessionsEndpoint: 'http://bs-local.com:9339',
       scenario: null
     }
     console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
+  }
+
+  getConfiguration = () => {
+    return {
+      apiKey: this.state.apiKey,
+      endpoints: {
+        notify: this.state.notifyEndpoint,
+        sessions: this.state.sessionsEndpoint
+      },
+      autoTrackSessions: false
+    }
   }
 
   setScenario = newScenario => {
@@ -53,18 +49,31 @@ export default class App extends Component {
     this.setState(() => ({ scenarioMetaData: newScenarioMetaData }))
   }
 
-  setManualApiKey = newApiKey => {
-    this.setState(() => ({ manualApiKey: newApiKey }))
+  setApiKey = newApiKey => {
+    this.setState(() => ({ apiKey: newApiKey }))
+  }
+
+  setNotifyEndpoint = newNotifyEndpoint => {
+    this.setState(() => ({ notifyEndpoint: newNotifyEndpoint }))
+  }
+
+  setSessionsEndpoint = newSessionsEndpoint => {
+    this.setState(() => ({ sessionsEndpoint: newSessionsEndpoint }))
+  }
+
+  useRealEndpoints = () => {
+    this.setState({ notifyEndpoint: 'https://notify.bugsnag.com' })
+    this.setState({ sessionsEndpoint: 'https://sessions.bugsnag.com' })
   }
 
   startScenario = () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
-    let scenarioName = this.state.currentScenario
-    let scenarioMetaData = this.state.scenarioMetaData
-    let configuration = getDefaultConfiguration()
-    let jsConfig = defaultJsConfig()
-    let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    const scenarioName = this.state.currentScenario
+    const scenarioMetaData = this.state.scenarioMetaData
+    const configuration = this.getConfiguration()
+    const jsConfig = defaultJsConfig()
+    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
       .then(() => {
@@ -77,46 +86,62 @@ export default class App extends Component {
   startBugsnag = () => {
     console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
-    let scenarioName = this.state.currentScenario
-    let scenarioMetaData = this.state.scenarioMetaData
-    let configuration
-    if (this.state.manualApiKey) {
-      configuration = getManualModeConfiguration(this.state.manualApiKey)
-    }
-    else {
-      configuration = getDefaultConfiguration()
-    }
-    let jsConfig = defaultJsConfig()
-    let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    const scenarioName = this.state.currentScenario
+    const scenarioMetaData = this.state.scenarioMetaData
+    const configuration = this.getConfiguration()
+    const jsConfig = defaultJsConfig()
+    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-    .then(() => {
-      Bugsnag.start(jsConfig)
-      this.setState({ scenario: scenario })
-    })
+      .then(() => {
+        Bugsnag.start(jsConfig)
+        this.setState({ scenario: scenario })
+      })
   }
 
   waiting () {
     return (
       <View style={styles.container}>
         <View style={styles.child}>
-          <Text>React-native end-to-end test app</Text>
+          <Text>React Navigation Test App</Text>
           <TextInput style={styles.textInput}
             placeholder='Scenario Name'
             accessibilityLabel='scenario_name'
             onChangeText={this.setScenario} />
           <TextInput style={styles.textInput}
             placeholder='Scenario Metadata'
-            accessibilityLabel='scenarioMetaDataInput'
+            accessibilityLabel='scenario_metadata'
             onChangeText={this.setScenarioMetaData} />
+
           <Button style={styles.clickyButton}
-            accessibilityLabel='startScenarioButton'
-            title='Start scenario'
-            onPress={this.startScenario}/>
-          <Button style={styles.clickyButton}
-            accessibilityLabel='startBugsnagButton'
-            title='Start Bugsnag'
+            accessibilityLabel='start_bugsnag'
+            title='Start Bugsnag only'
             onPress={this.startBugsnag}/>
+          <Button style={styles.clickyButton}
+            accessibilityLabel='run_scenario'
+            title='Start Bugsnag and run scenario'
+            onPress={this.startScenario}/>
+
+          <Text>Configuration</Text>
+          <TextInput placeholder='Notify endpoint'
+            style={styles.textInput}
+            accessibilityLabel='notify_endpoint'
+            value={this.state.notifyEndpoint}
+            onChangeText={this.setNotifyEndpoint} />
+          <TextInput placeholder='Sessions endpoint'
+            style={styles.textInput}
+            accessibilityLabel='sessions_endpoint'
+            value={this.state.sessionsEndpoint}
+            onChangeText={this.setSessionsEndpoint} />
+          <TextInput placeholder='API key'
+            style={styles.textInput}
+            accessibilityLabel='api_key'
+            value={this.state.apiKey}
+            onChangeText={this.setApiKey} />
+          <Button style={styles.clickyButton}
+            accessibilityLabel='use_dashboard_endpoints'
+            title='Use dashboard endpoints'
+            onPress={this.useRealEndpoints}/>
         </View>
       </View>
     )

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -54,6 +54,11 @@ export default class App extends Component {
     this.setState(() => ({ sessionsEndpoint: newSessionsEndpoint }))
   }
 
+  useRealEndpoints = () => {
+    this.setState({ notifyEndpoint: 'https://notify.bugsnag.com' })
+    this.setState({ sessionsEndpoint: 'https://sessions.bugsnag.com' })
+  }
+
   startScenario = async () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
@@ -118,6 +123,10 @@ export default class App extends Component {
                      style={styles.textInput}
                      value={this.state.apiKey}
                      onChangeText={this.setApiKey} />
+          <Button style={styles.clickyButton}
+                  accessibilityLabel='sendToDashboardButton'
+                  title='Send to dashboard'
+                  onPress={this.useRealEndpoints}/>
         </View>
       </View>
     );

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -10,32 +10,28 @@ import {
   NativeModules
 } from 'react-native'
 
-let getDefaultConfiguration = () => { return {
-    apiKey: '12312312312312312312312312312312',
-    endpoint: 'http://bs-local.com:9339',
-    autoTrackSessions: false
-  }
-}
-
-let getManualModeConfiguration = (apiKey) => { return {
-  apiKey: apiKey,
-  endpoints: {
-    notify: 'https://notify.bugsnag.com',
-    sessions: 'https://sessions.bugsnag.com'
-  },
-  autoTrackSessions: false
-}
-}
-
 export default class App extends Component {
   constructor(props) {
     super(props)
     this.state = {
       currentScenario: '',
       scenarioMetaData: '',
-      manualApiKey: null
+      apiKey: '12312312312312312312312312312312',
+      notifyEndpoint: 'http://bs-local.com:9339',
+      sessionsEndpoint: 'http://bs-local.com:9339'
     }
     console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
+  }
+
+  getConfiguration = () => {
+    return {
+      apiKey: this.state.apiKey,
+      endpoints: {
+        notify: this.state.notifyEndpoint,
+        sessions: this.state.sessionsEndpoint
+      },
+      autoTrackSessions: false
+    }
   }
 
   setScenario = newScenario => {
@@ -46,8 +42,16 @@ export default class App extends Component {
     this.setState(() => ({ scenarioMetaData: newScenarioMetaData }))
   }
 
-  setManualApiKey = newApiKey => {
-    this.setState(() => ({ manualApiKey: newApiKey }))
+  setApiKey = newApiKey => {
+    this.setState(() => ({ apiKey: newApiKey }))
+  }
+
+  setNotifyEndpoint = newNotifyEndpoint => {
+    this.setState(() => ({ notifyEndpoint: newNotifyEndpoint }))
+  }
+
+  setSessionsEndpoint = newSessionsEndpoint => {
+    this.setState(() => ({ sessionsEndpoint: newSessionsEndpoint }))
   }
 
   startScenario = async () => {
@@ -55,7 +59,7 @@ export default class App extends Component {
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     let scenarioName = this.state.currentScenario
     let scenarioMetaData = this.state.scenarioMetaData
-    let configuration = getDefaultConfiguration()
+    let configuration = this.getConfiguration()
     let jsConfig = {}
     let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
@@ -69,15 +73,10 @@ export default class App extends Component {
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     let scenarioName = this.state.currentScenario
     let scenarioMetaData = this.state.scenarioMetaData
-    let configuration
-    if (this.state.manualApiKey) {
-      configuration = getManualModeConfiguration(this.state.manualApiKey)
-    }
-    else {
-      configuration = getDefaultConfiguration()
-    }
+    let configuration = this.getConfiguration()
+
     let jsConfig = {}
-    let scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     await NativeModules.BugsnagTestInterface.startBugsnag(configuration)
     Bugsnag.start(jsConfig)
@@ -98,18 +97,27 @@ export default class App extends Component {
                      onChangeText={this.setScenarioMetaData} />
 
           <Button style={styles.clickyButton}
-                  accessibilityLabel='startScenarioButton'
-                  title='Start scenario'
-                  onPress={this.startScenario}/>
-          <Button style={styles.clickyButton}
                   accessibilityLabel='startBugsnagButton'
-                  title='Start Bugsnag'
+                  title='Start Bugsnag only'
                   onPress={this.startBugsnag}/>
+          <Button style={styles.clickyButton}
+                  accessibilityLabel='startScenarioButton'
+                  title='Start Bugsnag and run scenario'
+                  onPress={this.startScenario}/>
 
-          <Text>Manual testing mode</Text>
+          <Text>Configuration</Text>
+          <TextInput placeholder='Notify endpoint'
+                     style={styles.textInput}
+                     value={this.state.notifyEndpoint}
+                     onChangeText={this.setNotifyEndpoint} />
+          <TextInput placeholder='Sessions endpoint'
+                     style={styles.textInput}
+                     value={this.state.sessionsEndpoint}
+                     onChangeText={this.setSessionsEndpoint} />
           <TextInput placeholder='API key'
                      style={styles.textInput}
-                     onChangeText={this.setManualApiKey} />
+                     value={this.state.apiKey}
+                     onChangeText={this.setApiKey} />
         </View>
       </View>
     );

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -94,37 +94,40 @@ export default class App extends Component {
           <Text>React-native end-to-end test app</Text>
           <TextInput style={styles.textInput}
                      placeholder='Scenario Name'
-                     accessibilityLabel='scenarioInput'
+                     accessibilityLabel='scenario_name'
                      onChangeText={this.setScenario} />
           <TextInput style={styles.textInput}
                      placeholder='Scenario Metadata'
-                     accessibilityLabel='scenarioMetaDataInput'
+                     accessibilityLabel='scenario_metadata'
                      onChangeText={this.setScenarioMetaData} />
 
           <Button style={styles.clickyButton}
-                  accessibilityLabel='startBugsnagButton'
+                  accessibilityLabel='start_bugsnag'
                   title='Start Bugsnag only'
                   onPress={this.startBugsnag}/>
           <Button style={styles.clickyButton}
-                  accessibilityLabel='startScenarioButton'
+                  accessibilityLabel='run_scenario'
                   title='Start Bugsnag and run scenario'
                   onPress={this.startScenario}/>
 
           <Text>Configuration</Text>
           <TextInput placeholder='Notify endpoint'
                      style={styles.textInput}
+                     accessibilityLabel='notify_endpoint'
                      value={this.state.notifyEndpoint}
                      onChangeText={this.setNotifyEndpoint} />
           <TextInput placeholder='Sessions endpoint'
                      style={styles.textInput}
+                     accessibilityLabel='sessions_endpoint'
                      value={this.state.sessionsEndpoint}
                      onChangeText={this.setSessionsEndpoint} />
           <TextInput placeholder='API key'
                      style={styles.textInput}
+                     accessibilityLabel='api_key'
                      value={this.state.apiKey}
                      onChangeText={this.setApiKey} />
           <Button style={styles.clickyButton}
-                  accessibilityLabel='useDashboardEndpointsButton'
+                  accessibilityLabel='use_dashboard_endpoints'
                   title='Use dashboard endpoints'
                   onPress={this.useRealEndpoints}/>
         </View>

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -124,8 +124,8 @@ export default class App extends Component {
                      value={this.state.apiKey}
                      onChangeText={this.setApiKey} />
           <Button style={styles.clickyButton}
-                  accessibilityLabel='sendToDashboardButton'
-                  title='Send to dashboard'
+                  accessibilityLabel='useDashboardEndpointsButton'
+                  title='Use dashboard endpoints'
                   onPress={this.useRealEndpoints}/>
         </View>
       </View>

--- a/test/react-native/features/fixtures/ios-module/BugsnagModule.m
+++ b/test/react-native/features/fixtures/ios-module/BugsnagModule.m
@@ -42,8 +42,10 @@ BugsnagConfiguration *createConfiguration(NSDictionary * options) {
       NSLog(@"key: %@, value: %@ \n", key, [options objectForKey:key]);
   }
   BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:options[@"apiKey"]];
-  NSString *endpoint = options[@"endpoint"];
-  BugsnagEndpointConfiguration *endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:endpoint sessions:endpoint];
+  NSDictionary *endpointsIn = options[@"endpoints"];
+  NSString *notifyEndpoint = endpointsIn[@"notify"];
+  NSString *sessionsEndpoint = endpointsIn[@"sessions"];
+  BugsnagEndpointConfiguration *endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:notifyEndpoint sessions:sessionsEndpoint];
   [config setEndpoints:endpoints];
   [config setAutoTrackSessions:[[options objectForKey:@"autoTrackSessions"]boolValue]];
   config.enabledErrorTypes.ooms = NO; // Set by default, will add an override as required

--- a/test/react-native/features/fixtures/rn0.60/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native/features/fixtures/rn0.60/android/app/src/main/AndroidManifest.xml
@@ -22,12 +22,6 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-      <meta-data android:name="com.bugsnag.android.API_KEY"
-          android:value="ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"/>
-      <meta-data android:name="com.bugsnag.android.ENDPOINT_NOTIFY"
-             android:value="http://bs-local.com:9339"/>
-      <meta-data android:name="com.bugsnag.android.ENDPOINT_SESSIONS"
-             android:value="http://bs-local.com:9339"/>
     </application>
 
 </manifest>

--- a/test/react-native/features/fixtures/rn0.60/build.sh
+++ b/test/react-native/features/fixtures/rn0.60/build.sh
@@ -1,3 +1,5 @@
+rm -rf reactnative.xcarchive
+
 cd ios && pod install
 xcrun xcodebuild \
   -scheme reactnative \
@@ -17,3 +19,5 @@ xcrun xcodebuild -exportArchive \
   -exportOptionsPlist exportOptions.plist
 
 mv output/reactnative.ipa output/output.ipa
+
+rm -rf reactnative.xcarchive

--- a/test/react-native/features/fixtures/rn0.60/ios/reactnative/Info.plist
+++ b/test/react-native/features/fixtures/rn0.60/ios/reactnative/Info.plist
@@ -58,7 +58,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>BugsnagAPIKey</key>
-	<string>ABCDEFGHIJKLMNOPQRSTUVWXYZ123456</string>
 </dict>
 </plist>

--- a/test/react-native/features/fixtures/rn0.63/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native/features/fixtures/rn0.63/android/app/src/main/AndroidManifest.xml
@@ -23,12 +23,6 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-      <meta-data android:name="com.bugsnag.android.API_KEY"
-          android:value="ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"/>
-      <meta-data android:name="com.bugsnag.android.ENDPOINT_NOTIFY"
-             android:value="http://bs-local.com:9339"/>
-      <meta-data android:name="com.bugsnag.android.ENDPOINT_SESSIONS"
-             android:value="http://bs-local.com:9339"/>
     </application>
 
 </manifest>

--- a/test/react-native/features/fixtures/rn0.63/build.sh
+++ b/test/react-native/features/fixtures/rn0.63/build.sh
@@ -1,4 +1,5 @@
-npm i
+rm -rf reactnative.xcarchive
+
 cd ios && pod install
 xcrun xcodebuild \
   -scheme reactnative \
@@ -18,3 +19,5 @@ xcrun xcodebuild -exportArchive \
   -exportOptionsPlist exportOptions.plist
 
 mv output/reactnative.ipa output/output.ipa
+
+rm -rf reactnative.xcarchive

--- a/test/react-native/features/fixtures/rn0.63/ios/reactnative/Info.plist
+++ b/test/react-native/features/fixtures/rn0.63/ios/reactnative/Info.plist
@@ -58,7 +58,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>BugsnagAPIKey</key>
-	<string>ABCDEFGHIJKLMNOPQRSTUVWXYZ123456</string>
 </dict>
 </plist>

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -1,8 +1,8 @@
 When("I run {string}") do |event_type|
   steps %Q{
-    Given the element "scenarioInput" is present within 60 seconds
-    When I clear and send the keys "#{event_type}" to the element "scenarioInput"
-    And I click the element "startScenarioButton"
+    Given the element "scenario_name" is present within 60 seconds
+    When I clear and send the keys "#{event_type}" to the element "scenario_name"
+    And I click the element "run_scenario"
   }
 end
 
@@ -31,16 +31,16 @@ end
 
 When("I configure Bugsnag for {string}") do |event_type|
   steps %Q{
-    Given the element "scenarioInput" is present within 60 seconds
-    When I clear and send the keys "#{event_type}" to the element "scenarioInput"
-    And I click the element "startBugsnagButton"
+    Given the element "scenario_name" is present within 60 seconds
+    When I clear and send the keys "#{event_type}" to the element "scenario_name"
+    And I click the element "start_bugsnag"
   }
 end
 
 When("I configure the app to run in the {string} state") do |event_metadata|
   steps %Q{
-    Given the element "scenarioMetaDataInput" is present
-    And I clear and send the keys "#{event_metadata}" to the element "scenarioMetaDataInput"
+    Given the element "scenario_metadata" is present
+    And I clear and send the keys "#{event_metadata}" to the element "scenario_metadata"
   }
 end
 


### PR DESCRIPTION
## Goal

Standardize the test fixtures for React Native to fall in line with recently formed internal guidelines.  This provides improved debugging features, such as being able to change the Bugsnag endpoints and API key whilst running test scenarios in a manual environment.

## Design

Implemented in line with internal guidance.

## Changeset

RN test fixtures and supporting build script.

## Testing

Covered by standard CI tests.