### PR TITLE
Depends on pipeline

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label:  ':docker: Build expo publisher'
+    key: "expo-publisher"
     timeout_in_minutes: 30
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
@@ -15,7 +16,20 @@ steps:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
 
+  - label:  ':docker: Publish expo app'
+    key: "publish-expo-app"
+    depends_on: "expo-publisher"
+    timeout_in_minutes: 20
+    agents:
+      queue: "opensource-highpower"
+    env:
+      EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
+    plugins:
+      - docker-compose#v3.1.0:
+          run: expo-publisher
+
   - label: ':docker: Build expo maze runner image'
+    key: "expo-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       - docker-compose#v3.1.0:
@@ -29,6 +43,7 @@ steps:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
 
   - label:  ':docker: Build expo APK builder'
+    key: "expo-android-builder"
     timeout_in_minutes: 40
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
@@ -44,21 +59,11 @@ steps:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
 
-  - wait
-
-  - label:  ':docker: Publish expo app'
-    timeout_in_minutes: 20
-    agents:
-      queue: "opensource-highpower"
-    env:
-      EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-    plugins:
-      - docker-compose#v3.1.0:
-          run: expo-publisher
-
-  - wait
-
   - label:  ':docker: Build expo APK'
+    key: "build-expo-apk"
+    depends_on:
+      - "publish-expo-app"
+      - "expo-android-builder"
     timeout_in_minutes: 20
     agents:
       queue: "opensource-highpower"
@@ -72,6 +77,9 @@ steps:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
 
   - label: ':docker: Build expo IPA'
+    key: "build-expo-ipa"
+    depends_on:
+      - "publish-expo-app"
     timeout_in_minutes: 20
     agents:
       queue: "opensource-mac-expo"
@@ -81,9 +89,10 @@ steps:
     commands:
       - test/expo/scripts/build-ios.sh
 
-  - wait
-
   - label: 'expo Android 9'
+    depends_on:
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -98,6 +107,9 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: 'expo iOS 12'
+    depends_on:
+      - "build-expo-ipa"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,7 @@ steps:
     command: 'npm run test:types'
 
   - label:  ':docker: Build browser maze runner image'
+    key: "browser-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
       - artifacts#v1.2.0:
@@ -77,6 +78,7 @@ steps:
             - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
 
   - label:  ':docker: Build node maze runner image'
+    key: "node-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
       - artifacts#v1.2.0:
@@ -88,9 +90,8 @@ steps:
           cache-from:
             - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
 
-  - wait
-
   - label: ':chrome: v43 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -103,6 +104,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':chrome: v61 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -115,6 +117,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v8 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -127,6 +130,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v9 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -139,6 +143,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v10 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -151,6 +156,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':ie: v11 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -164,6 +170,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':edge: v14 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -176,6 +183,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':edge: v15 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -188,6 +196,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':safari: v6 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -200,6 +209,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':safari: v10 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -212,6 +222,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':desktop_computer: Opera v12 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -224,6 +235,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':iphone: iOS 10.3 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
       docker-compose#v3.3.0:
@@ -237,6 +249,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':android: Samsung Galaxy S8 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -249,6 +262,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v30 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -261,6 +275,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v56 Browser tests'
+    depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.3.0:
@@ -273,6 +288,7 @@ steps:
     concurrency_group: 'browserstack'
 
   - label: ':node: Node 4'
+    depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.3.0:
@@ -284,6 +300,7 @@ steps:
       NODE_VERSION: "4"
 
   - label: ':node: Node 6'
+    depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.3.0:
@@ -295,6 +312,7 @@ steps:
       NODE_VERSION: "6"
 
   - label: ':node: Node 8'
+    depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.3.0:
@@ -305,6 +323,7 @@ steps:
       NODE_VERSION: "8"
 
   - label: ':node: Node 10'
+    depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.3.0:
@@ -315,6 +334,7 @@ steps:
       NODE_VERSION: "10"
 
   - label: ':node: Node 12'
+    depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.3.0:

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -8,6 +8,7 @@ steps:
   - wait
 
   - label: ':docker: Build RN Android Builder image'
+    key: "android-builder-image"
     timeout_in_minutes: 30
     plugins:
       - improbable-eng/metahook:
@@ -19,9 +20,9 @@ steps:
       - docker-compose#v3.3.0:
           push: react-native-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
-  - wait
-
   - label: ':android: Build RN 0.60 apk'
+    key: "rn-0-60-apk"
+    depends_on: "android-builder-image"
     env:
       REACT_NATIVE_VERSION: "rn0.60"
     plugins:
@@ -31,6 +32,7 @@ steps:
       - build/rn0.60.apk
 
   - label: ':ios: Build RN 0.60 ipa'
+    key: "rn-0-60-ipa"
     agents:
       queue: "opensource-mac-rn"
     env:
@@ -40,6 +42,8 @@ steps:
       - npm run test:build-react-native-ios
 
   - label: ':android: Build RN 0.63 apk'
+    key: "rn-0-63-apk"
+    depends_on: "android-builder-image"
     env:
       REACT_NATIVE_VERSION: "rn0.63"
     plugins:
@@ -49,6 +53,7 @@ steps:
       - build/rn0.63.apk
 
   - label: ':ios: Build RN 0.63 ipa'
+    key: "rn-0-63-ipa"
     agents:
       queue: "opensource-mac-rn"
     env:
@@ -57,9 +62,112 @@ steps:
     commands:
       - npm run test:build-react-native-ios
 
-  - wait
+  - label: ':android: Build react-navigation 0.60 apk'
+    key: "react-navigation-0-60-apk"
+    depends_on: "android-builder-image"
+    env:
+      REACT_NATIVE_VERSION: "rn0.60"
+      JS_SOURCE_DIR: "react_navigation_js"
+      ARTEFACT_NAME: "r_navigation_0.60"
+    plugins:
+      - docker-compose#v3.3.0:
+          run: react-native-android-builder
+    artifact_paths:
+      - build/r_navigation_0.60.apk
+
+  # See: PLAT-5173
+  # - label: ':ios: Build react-navigation 0.60 ipa'
+  #   key: "react-navigation-0-60-ipa"
+  #   agents:
+  #     queue: "opensource-mac-rn"
+  #   env:
+  #     REACT_NATIVE_VERSION: rn0.60
+  #     JS_SOURCE_DIR: "react_navigation_js"
+  #     ARTEFACT_NAME: "r_navigation_0.60"
+  #   artifact_paths: build/r_navigation_0.60.ipa
+  #   commands:
+  #     - npm run test:build-react-native-ios
+
+  - label: ':android: Build react-navigation 0.63 apk'
+    key: "react-navigation-0-63-apk"
+    depends_on: "android-builder-image"
+    env:
+      REACT_NATIVE_VERSION: "rn0.63"
+      JS_SOURCE_DIR: "react_navigation_js"
+      ARTEFACT_NAME: "r_navigation_0.63"
+    plugins:
+      - docker-compose#v3.3.0:
+          run: react-native-android-builder
+    artifact_paths:
+      - build/r_navigation_0.63.apk
+
+  # See: PLAT-5173
+  # - label: ':ios: Build react-navigation 0.63 ipa'
+  #   key: "react-navigation-0-63-ipa"
+  #   agents:
+  #     queue: "opensource-mac-rn"
+  #   env:
+  #     REACT_NATIVE_VERSION: rn0.63
+  #     JS_SOURCE_DIR: "react_navigation_js"
+  #     ARTEFACT_NAME: "r_navigation_0.63"
+  #   artifact_paths: build/r_navigation_0.63.ipa
+  #   commands:
+  #     - npm run test:build-react-native-ios
+
+  - label: ':android: Build react-native-navigation 0.60 apk'
+    key: "react-native-navigation-0-60-apk"
+    depends_on: "android-builder-image"
+    env:
+      REACT_NATIVE_VERSION: "rn0.60"
+      JS_SOURCE_DIR: "react_native_navigation_js"
+      ARTEFACT_NAME: "r_native_navigation_0.60"
+    plugins:
+      - docker-compose#v3.3.0:
+          run: react-native-android-builder
+    artifact_paths:
+      - build/r_native_navigation_0.60.apk
+
+  # See: PLAT-5173
+  # - label: ':ios: Build react-native-navigation 0.60 ipa'
+  #   key: "react-native-navigation-0-60-ipa"
+  #   agents:
+  #     queue: "opensource-mac-rn"
+  #   env:
+  #     REACT_NATIVE_VERSION: rn0.60
+  #     JS_SOURCE_DIR: "react_native_navigation_js"
+  #     ARTEFACT_NAME: "r_native_navigation_0.60"
+  #   artifact_paths: build/r_native_navigation_0.60.ipa
+  #   commands:
+  #     - npm run test:build-react-native-ios
+
+  - label: ':android: Build react-native-navigation 0.63 apk'
+    key: "react-native-navigation-0-63-apk"
+    depends_on: "android-builder-image"
+    env:
+      REACT_NATIVE_VERSION: "rn0.63"
+      JS_SOURCE_DIR: "react_native_navigation_js"
+      ARTEFACT_NAME: "r_native_navigation_0.63"
+    plugins:
+      - docker-compose#v3.3.0:
+          run: react-native-android-builder
+    artifact_paths:
+      - build/r_native_navigation_0.63.apk
+
+  # See: PLAT-5173
+  # - label: ':ios: Build react-native-navigation 0.63 ipa'
+  #   key: "react-native-navigation-0-63-ipa"
+  #   agents:
+  #     queue: "opensource-mac-rn"
+  #   env:
+  #     REACT_NATIVE_VERSION: rn0.63
+  #     JS_SOURCE_DIR: "react_native_navigation_js"
+  #     ARTEFACT_NAME: "r_native_navigation_0.63"
+  #   artifact_paths: build/r_native_navigation_0.63.ipa
+  #   commands:
+  #     - npm run test:build-react-native-ios
 
   - label: ':android: RN 0.60 Android 9 end-to-end tests'
+    depends_on: "rn-0-60-apk"
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.60.apk"
@@ -74,6 +182,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':ios: RN 0.60 iOS 12 end-to-end tests'
+    depends_on: "rn-0-60-ipa"
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.60.ipa"
@@ -88,6 +197,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: RN 0.63 Android 9 end-to-end tests'
+    depends_on: "rn-0-63-apk"
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.63.apk"
@@ -102,6 +212,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':ios: RN 0.63 iOS 12 end-to-end tests'
+    depends_on: "rn-0-63-ipa"
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.63.ipa"
@@ -115,101 +226,8 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Build react-navigation 0.60 apk'
-    env:
-      REACT_NATIVE_VERSION: "rn0.60"
-      JS_SOURCE_DIR: "react_navigation_js"
-      ARTEFACT_NAME: "r_navigation_0.60"
-    plugins:
-      - docker-compose#v3.3.0:
-          run: react-native-android-builder
-    artifact_paths:
-      - build/r_navigation_0.60.apk
-
-  # See: PLAT-5173
-  # - label: ':ios: Build react-navigation 0.60 ipa'
-  #   agents:
-  #     queue: "opensource-mac-rn"
-  #   env:
-  #     REACT_NATIVE_VERSION: rn0.60
-  #     JS_SOURCE_DIR: "react_navigation_js"
-  #     ARTEFACT_NAME: "r_navigation_0.60"
-  #   artifact_paths: build/r_navigation_0.60.ipa
-  #   commands:
-  #     - npm run test:build-react-native-ios
-
-  - label: ':android: Build react-navigation 0.63 apk'
-    env:
-      REACT_NATIVE_VERSION: "rn0.63"
-      JS_SOURCE_DIR: "react_navigation_js"
-      ARTEFACT_NAME: "r_navigation_0.63"
-    plugins:
-      - docker-compose#v3.3.0:
-          run: react-native-android-builder
-    artifact_paths:
-      - build/r_navigation_0.63.apk
-
-  # See: PLAT-5173
-  # - label: ':ios: Build react-navigation 0.63 ipa'
-  #   agents:
-  #     queue: "opensource-mac-rn"
-  #   env:
-  #     REACT_NATIVE_VERSION: rn0.63
-  #     JS_SOURCE_DIR: "react_navigation_js"
-  #     ARTEFACT_NAME: "r_navigation_0.63"
-  #   artifact_paths: build/r_navigation_0.63.ipa
-  #   commands:
-  #     - npm run test:build-react-native-ios
-
-  - label: ':android: Build react-native-navigation 0.60 apk'
-    env:
-      REACT_NATIVE_VERSION: "rn0.60"
-      JS_SOURCE_DIR: "react_native_navigation_js"
-      ARTEFACT_NAME: "r_native_navigation_0.60"
-    plugins:
-      - docker-compose#v3.3.0:
-          run: react-native-android-builder
-    artifact_paths:
-      - build/r_native_navigation_0.60.apk
-
-  # See: PLAT-5173
-  # - label: ':ios: Build react-native-navigation 0.60 ipa'
-  #   agents:
-  #     queue: "opensource-mac-rn"
-  #   env:
-  #     REACT_NATIVE_VERSION: rn0.60
-  #     JS_SOURCE_DIR: "react_native_navigation_js"
-  #     ARTEFACT_NAME: "r_native_navigation_0.60"
-  #   artifact_paths: build/r_native_navigation_0.60.ipa
-  #   commands:
-  #     - npm run test:build-react-native-ios
-
-  - label: ':android: Build react-native-navigation 0.63 apk'
-    env:
-      REACT_NATIVE_VERSION: "rn0.63"
-      JS_SOURCE_DIR: "react_native_navigation_js"
-      ARTEFACT_NAME: "r_native_navigation_0.63"
-    plugins:
-      - docker-compose#v3.3.0:
-          run: react-native-android-builder
-    artifact_paths:
-      - build/r_native_navigation_0.63.apk
-
-  # See: PLAT-5173
-  # - label: ':ios: Build react-native-navigation 0.63 ipa'
-  #   agents:
-  #     queue: "opensource-mac-rn"
-  #   env:
-  #     REACT_NATIVE_VERSION: rn0.63
-  #     JS_SOURCE_DIR: "react_native_navigation_js"
-  #     ARTEFACT_NAME: "r_native_navigation_0.63"
-  #   artifact_paths: build/r_native_navigation_0.63.ipa
-  #   commands:
-  #     - npm run test:build-react-native-ios
-
-  - wait
-
   - label: ':android: react-navigation 0.60 Android 9 end-to-end tests'
+    depends_on: "react-navigation-0-60-apk"
     plugins:
       artifacts#v1.2.0:
         download: "build/r_navigation_0.60.apk"
@@ -225,6 +243,7 @@ steps:
 
   # See: PLAT-5173
   # - label: ':ios: react-navigation 0.60 iOS 13 end-to-end tests'
+  #   depends_on: "react-navigation-0-60-ipa"
   #   plugins:
   #     artifacts#v1.2.0:
   #       download: "build/r_navigation_0.60.ipa"
@@ -239,6 +258,7 @@ steps:
   #   concurrency_group: 'browserstack-app'
 
   - label: ':android: react-navigation 0.63 Android 9 end-to-end tests'
+    depends_on: "react-navigation-0-63-apk"
     plugins:
       artifacts#v1.2.0:
         download: "build/r_navigation_0.63.apk"
@@ -254,6 +274,7 @@ steps:
 
   # See: PLAT-5173
   # - label: ':ios: react-navigation 0.63 iOS 13 end-to-end tests'
+  #   depends_on: "react-navigation-0-63-ipa"
   #   plugins:
   #     artifacts#v1.2.0:
   #       download: "build/r_navigation_0.63.ipa"
@@ -268,6 +289,7 @@ steps:
   #   concurrency_group: 'browserstack-app'
 
   - label: ':android: react-native-navigation 0.60 Android 9 end-to-end tests'
+    depends_on: "react-native-navigation-0-60-apk"
     plugins:
       artifacts#v1.2.0:
         download: "build/r_native_navigation_0.60.apk"
@@ -283,7 +305,8 @@ steps:
 
   # See: PLAT-5173
   # - label: ':ios: react-native-navigation 0.60 iOS 13 end-to-end tests'
-  #   plugins:
+  #   depends_on: "react-native-navigation-0-60-ipa"
+  #    plugins:
   #     artifacts#v1.2.0:
   #       download: "build/r_native_navigation_0.60.ipa"
   #     docker-compose#v3.1.0:
@@ -297,6 +320,7 @@ steps:
   #   concurrency_group: 'browserstack-app'
 
   - label: ':android: react-native-navigation 0.63 Android 9 end-to-end tests'
+    depends_on: "react-native-navigation-0-63-apk"
     plugins:
       artifacts#v1.2.0:
         download: "build/r_native_navigation_0.63.apk"
@@ -312,6 +336,7 @@ steps:
 
   # See: PLAT-5173
   # - label: ':ios: react-native-navigation 0.63 iOS 13 end-to-end tests'
+  #   depends_on: "react-native-navigation-0-63-ipa"
   #   plugins:
   #     artifacts#v1.2.0:
   #       download: "build/r_native_navigation_0.63.ipa"


### PR DESCRIPTION
## Goal

For each of the Buildkite pipelines, use the `depends_on` feature to form a dependency tree of build steps instead of running in a series of parallel steps.  This avoids steps needlessly waiting for steps in previous groups to complete if their dependency steps have already completed, potentially saving elapsed time on the overall build.  Indications are a time saving of 25% for React Native.

## Design

Pipeline step `key` and `depends_on` used as documented by Buildkite.

## Changeset

Pipelines ordering and utilization of step dependency mechanism only.

## Testing

Covered by standard CI.