### PR TITLE
[PLAT-5240] Add missing type definition for trackInlineScripts option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (browser): Added missing type definition for `trackInlineScripts` option [#1102](https://github.com/bugsnag/bugsnag-js/pull/1102) / [#1097](https://github.com/bugsnag/bugsnag-js/pull/1097)
+
 ## 7.5.0 (2020-10-08)
 
 ### Added

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -132,7 +132,8 @@ describe('browser notifier', () => {
       redactedKeys: ['foo', /bar/],
       collectUserIp: true,
       maxEvents: 10,
-      generateAnonymousId: false
+      generateAnonymousId: false,
+      trackInlineScripts: true
     })
 
     Bugsnag.notify(new Error('123'), (event) => {

--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -4,6 +4,7 @@ interface BrowserConfig extends Config {
   maxEvents?: number
   collectUserIp?: boolean
   generateAnonymousId?: boolean
+  trackInlineScripts?: boolean
 }
 
 interface BrowserBugsnagStatic extends BugsnagStatic {


### PR DESCRIPTION
## Goal

Add missing type definition.

## Testing

Add option to existing tests.