### PR TITLE
ci(maze-runner): take maze-runner docker image from releases repo

### DIFF
--- a/bin/local-test-util
+++ b/bin/local-test-util
@@ -247,6 +247,6 @@ async function runTests (args) {
     `-v`, `${process.cwd()}/test/browser/:/app/test/browser`,
     `-w`, `/app/test/browser`,
     `-p`, `9020:9020`,
-    `855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli`
+    `855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli`
   ].concat(args || []))
 }

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -45,7 +45,7 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 RUN rm -fr **/*/node_modules/
 
 # The maze-runner browser tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as browser-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as browser-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev
 ENV GLIBC_VERSION 2.23-r3
 

--- a/dockerfiles/Dockerfile.expo
+++ b/dockerfiles/Dockerfile.expo
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as expo-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as expo-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 COPY /test/expo /app/test/expo
 WORKDIR /app/test/expo

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node test/node

--- a/dockerfiles/Dockerfile.react-native
+++ b/dockerfiles/Dockerfile.react-native
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 COPY /test/react-native /app/test/react-native
 WORKDIR /app/test/react-native


### PR DESCRIPTION
## Goal

Take the Maze Runner image from its releases repository.

## Design

maze-runner-releases is a new ECR repository of ours that is dedicated to releases and separate to images built for development branches.  It means that releases will not get swept away as part of our housekeeping policy.

## Changeset

Maze Runner docker file(s).

## Testing

Covered by standard CI.