### PR TITLE
Remove repetitive logging from React Native test fixtures

### DIFF
--- a/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
@@ -23,7 +23,6 @@ export default class AppScreen extends Component {
       sessionsEndpoint: 'http://bs-local.com:9339',
       scenario: null
     }
-    console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
   }
 
   getConfiguration = () => {

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -27,7 +27,6 @@ export default class App extends Component {
       sessionsEndpoint: 'http://bs-local.com:9339',
       scenario: null
     }
-    console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
   }
 
   getConfiguration = () => {

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -20,7 +20,6 @@ export default class App extends Component {
       notifyEndpoint: 'http://bs-local.com:9339',
       sessionsEndpoint: 'http://bs-local.com:9339'
     }
-    console.log(`Available scenarios:\n  ${Object.keys(Scenarios).join('\n  ')}`)
   }
 
   getConfiguration = () => {


### PR DESCRIPTION
## Goal

Removes repetitive logging that only makes it harder to find the relevant part of a device log when a test scenario fails.

## Design

This appears to be a hangover from the original test development phase and doesn't seem to serve a positive purpose anymore.

## Changeset

Logging removed from React Native test fixtures.

## Testing

Covered by standard CI.