### PR TITLE
test(expo): Pin expo publisher container to node 12

### DIFF
--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:12-alpine
 
 RUN apk add --update bash git python
 


### PR DESCRIPTION
The version of expo-cli we're using is not compatible with node 14 and the LTS container recently bumped to that version, causing CI to fail.

If CI passes for this PR it means the fix worked.