### PR TITLE
[PLAT-5332]: Refine CONTRIBUTING.md and include native notifier update instructions

### DIFF
--- a/packages/react-native/CONTRIBUTING.md
+++ b/packages/react-native/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To update the version of the bundled artefacts:
 To update the version of the bundled notifier source:
 
 - Ensure `bugsnag-js` (this repo) is cloned in a sibling directory alongside `bugsnag-cocoa`
-- Checkout the tag of the release version to be vendored in `bugsnag-android` (e.g. `git checkout v5.2.2`)
+- Checkout the tag of the release version to be vendored in `bugsnag-cocoa` (e.g. `git checkout v5.2.2`)
 - From within the React Native package directory in this repo (`cd packages/react-native`), run the `./update-ios.sh` script. This will copy the Cocoa sources and headers into the correct locations.
 - Update the changelog according to the [contributing guide](../../CONTRIBUTING.md), creating a new `TBD` section if one doesn't exist. Under the section `### Changed` add a new entry: `- (react-native): Update bugsnag-cocoa to v{VERSION}`, indenting one level and including the entire changelog for the version that has been updated. If multiple releases have been made since the version bump, the changelog entries for the interim should be aggregated into one.
 

--- a/packages/react-native/CONTRIBUTING.md
+++ b/packages/react-native/CONTRIBUTING.md
@@ -1,30 +1,66 @@
-# @bugsnag/react-native: contributing guide
+# @bugsnag/react-native contributing guide
 
-This is a WIP.
+## Upgrading native notifier dependencies
 
-## Installing the development notifier in a React Native app
+Both [`bugsnag-android`](https://github.com/bugnsag/bugsnag-android) and [`bugsnag-cocoa`](https://github.com/bugnsag/bugsnag-cocoa) are vendored into this repository as part of the `@bugsnag/react-native` package. When updates to those notifiers are released, a PR should be make to this repository to vendor the new version.
 
-### Problem
+### Android
+
+[bugsnag-android](https://github.com/bugnsag/bugsnag-android) AAR artefacts are located in `packages/react-native/android/com/bugsnag`
+
+To update the version of the bundled artefacts:
+
+- Ensure `bugsnag-js` (this repo) is cloned in a sibling directory alongside `bugsnag-android`
+- Checkout the tag of the release version to be vendored in `bugsnag-android` (e.g. `git checkout v5.2.2`)
+- From within the React Native package directory in this repo (`cd packages/react-native`), run the `./update-android.sh` script. This will build the Android notifier and copy the files in.
+- Update the version in `packages/react-native/android/build.gradle` to match the version that was included
+    ```
+    dependencies {
+      api "com.bugsnag:bugsnag-android:{VERSION}-react-native"
+      api "com.bugsnag:bugsnag-plugin-react-native:{VERSION}-react-native"
+      ...
+    }
+    ```
+    N.B. The version name included the string `-react-native`. It is necessary to build artefacts in this way to ensure the version name is distinct, and cannot clash with any value released on mavenCentral/jcenter.
+- Update the changelog according to the [contributing guide](../../CONTRIBUTING.md), creating a new `TBD` section if one doesn't exist. Under the section `### Changed` add a new entry: `- (react-native): Update bugsnag-android to v{VERSION}`, indenting one level and including the entire changelog for the version that has been updated. If multiple releases have been made since the version bump, the changelog entries for the interim should be aggregated into one.
+
+#### iOS
+
+[bugsnag-cocoa](https://github.com/bugnsag/bugsnag-cocoa) source is vendored in `packages/react-native/ios/vendor/bugsnag-cocoa`.
+
+To update the version of the bundled notifier source:
+
+- Ensure `bugsnag-js` (this repo) is cloned in a sibling directory alongside `bugsnag-cocoa`
+- Checkout the tag of the release version to be vendored in `bugsnag-android` (e.g. `git checkout v5.2.2`)
+- From within the React Native package directory in this repo (`cd packages/react-native`), run the `./update-ios.sh` script. This will copy the Cocoa sources and headers into the correct locations.
+- Update the changelog according to the [contributing guide](../../CONTRIBUTING.md), creating a new `TBD` section if one doesn't exist. Under the section `### Changed` add a new entry: `- (react-native): Update bugsnag-cocoa to v{VERSION}`, indenting one level and including the entire changelog for the version that has been updated. If multiple releases have been made since the version bump, the changelog entries for the interim should be aggregated into one.
+
+## Development
+
+### Installing the development notifier in a React Native app
+
+#### Problem
 
 To install a single development npm package, you can simply use `npm pack` to create the tarball that would be added to the registry.
 
 Since the React Native notifier is larger that a single package – for the purpose of this discussion it's a directed graph of dependencies in this monorepo – you can't do that. You can pack the `@bugsnag/react-native` package, but any unpublished changes to any other local package in the monorepo will not be included. If you have added a new package which does not exist on the registry yet it will also not include that.
 
-To solve this problem we publish to a local npm proxy which can forward on install requests to npm.
+To solve this problem we publish to a local npm clone, which proxies requests for unknown modules onto the public registry. This means we can push local working copies to it, and consume them as if they were on the public registry.
 
-### Prerequisites
+#### Prerequisites
 
 The proxy of choice is [verdaccio](https://verdaccio.org/):
 
 ```sh
-# install it
+# install it globally on your system
 npm i -g verdaccio
 
-# starts verdaccio on the default port
+# starts the  on the default port
 verdaccio
 
 # log in to the registry
-# (you can enter nonsense credentials – it will accept anything)
+# (you can enter anything, just be sure to remember them when
+# your session times out and you need to "sign in" again)
 npm adduser --registry http://localhost:4873
 ```
 
@@ -34,28 +70,15 @@ On the project you want to install the development notifier, create an a `.npmrc
 registry=http://localhost:4873
 ```
 
-#### Android
+Alternatively you can just supply the `--registry=http://localhost:4873` to each npm/yarn command you issue.
 
-Currently this branch relies on a snapshotted version of bugsnag-android, which should _just work_.
-
-The tests can be run with by running `./gradlew test -Pbugsnagdev=true` from the `android` directory.
-
-The AAR artefacts can be updated by running `./update-android.sh` from the `packages/react-native` directory.
-__Please ensure that you are building from a tagged release of bugsnag-android if releasing!__ It is necessary to build artefacts in this way to ensure the version name is distinct, and cannot clash with any value released on mavenCentral/jcenter.
-
-#### iOS
-
-The cocoa notifier is vendored in to this repo so nothing special is required there.
-
-### Installing the development notifier on a React Native project
+#### Installing the development notifier on a React Native project
 
 1. Make changes.
-2. Commit your changes (you can't publish changes with Lerna with a dirty working tree).
-  _N.B. if you are making a lot of changes you can `git commit --amend` to prevent a noisy commit trail._
-3. Run the following command to publish to the local registry:
+2. Run the following command to publish to the local registry:
 
     ```
-    lerna publish v99.99.99-canary.`git rev-parse HEAD` --no-push --no-git-tag-version --registry http://localhost:4873/
+    npx lerna publish v99.99.99-canary.`git rev-parse HEAD` --no-push --exact --no-git-tag-version --registry http://localhost:4873/
     ```
 
     This should prompt you for each module that has changed since the last proper publish.


### PR DESCRIPTION
## Goal

Enable `bugsnag-cocoa` and `bugsnag-android` engineers to PR native notifier updates so that maintainers of this repo can review.

## Design

Outline the process in documentation

## Changeset

Also tidied up the rest of the RN contributing guide since that file was being modified.

## Testing

Manual testing only for this docs change.