### PR TITLE
[PLAT-4930] Add bugsnag-react-native-cli package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -60,6 +60,13 @@ module.exports = {
       ]
     },
     {
+      displayName: 'react native cli',
+      testEnvironment: 'node',
+      testMatch: [
+        testsForPackage('react-native-cli')
+      ]
+    },
+    {
       displayName: 'expo',
       testMatch: [
         testsForPackage('delivery-expo'),

--- a/packages/react-native-cli/LICENSE.txt
+++ b/packages/react-native-cli/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/react-native-cli/README.md
+++ b/packages/react-native-cli/README.md
@@ -1,0 +1,6 @@
+# bugsnag-expo-cli
+
+A tool to help integrate Bugsnag with a React Native app.
+
+## License
+MIT

--- a/packages/react-native-cli/bin/cli
+++ b/packages/react-native-cli/bin/cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../dist/bin/cli.js').default(process.argv)

--- a/packages/react-native-cli/package-lock.json
+++ b/packages/react-native-cli/package-lock.json
@@ -1,0 +1,180 @@
+{
+	"name": "bugsnag-react-native-cli",
+	"version": "7.4.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/command-line-args": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+			"integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+			"dev": true
+		},
+		"@types/command-line-usage": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+			"integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"array-back": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"command-line-args": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+			"requires": {
+				"array-back": "^3.0.1",
+				"find-replace": "^3.0.0",
+				"lodash.camelcase": "^4.3.0",
+				"typical": "^4.0.0"
+			}
+		},
+		"command-line-usage": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+			"integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+			"requires": {
+				"array-back": "^4.0.0",
+				"chalk": "^2.4.2",
+				"table-layout": "^1.0.0",
+				"typical": "^5.2.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
+		"consola": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"find-replace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+			"requires": {
+				"array-back": "^3.0.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"reduce-flatten": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"table-layout": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+			"requires": {
+				"array-back": "^4.0.1",
+				"deep-extend": "~0.6.0",
+				"typical": "^5.2.0",
+				"wordwrapjs": "^4.0.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
+		"typical": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+		},
+		"wordwrapjs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+			"requires": {
+				"reduce-flatten": "^2.0.0",
+				"typical": "^5.0.0"
+			},
+			"dependencies": {
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		}
+	}
+}

--- a/packages/react-native-cli/package.json
+++ b/packages/react-native-cli/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "bugsnag-react-native-cli",
+  "version": "7.4.0",
+  "description": "A tool to help integrate Bugsnag with a React Native app",
+  "bin": "bin/cli",
+  "scripts": {
+    "clean": "rm -fr dist",
+    "build": "npm run clean && tsc -p tsconfig.build.json",
+    "preversion": "npm run build"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "LICENSE.txt"
+  ],
+  "author": "Bugsnag",
+  "license": "MIT",
+  "dependencies": {
+    "command-line-args": "^5.1.1",
+    "command-line-usage": "^6.1.0",
+    "consola": "^2.15.0"
+  },
+  "devDependencies": {
+    "@types/command-line-args": "^5.0.0",
+    "@types/command-line-usage": "^5.0.1"
+  }
+}

--- a/packages/react-native-cli/src/Logger.ts
+++ b/packages/react-native-cli/src/Logger.ts
@@ -1,0 +1,26 @@
+import consolaGlobalInstance, { LogLevel } from 'consola'
+
+export default consolaGlobalInstance
+consolaGlobalInstance.level = LogLevel.Debug
+
+export interface Logger {
+  trace: (...args: unknown[]) => void
+  debug: (...args: unknown[]) => void
+  info: (...args: unknown[]) => void
+  success: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+  error: (...args: unknown[]) => void
+  fatal: (...args: unknown[]) => void
+  level: LogLevel
+}
+
+export const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  success: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  level: -1
+}

--- a/packages/react-native-cli/src/bin/__test__/cli.test.ts
+++ b/packages/react-native-cli/src/bin/__test__/cli.test.ts
@@ -1,0 +1,32 @@
+import run from '../cli'
+import logger from '../../Logger'
+
+jest.mock('../../Logger')
+
+beforeEach(() => {
+  process.exitCode = 0
+})
+
+test('cli: prints help', async () => {
+  const logSpy = jest.spyOn(global.console, 'log').mockImplementation(jest.fn())
+  await run(['--help'])
+  expect(logSpy).toHaveBeenCalled()
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-react-native-cli <command>'))
+})
+
+test('cli: version', async () => {
+  const logSpy = jest.spyOn(global.console, 'log').mockImplementation(jest.fn())
+  await run(['--version'])
+  expect(logSpy).toHaveBeenCalled()
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-react-native-cli v'))
+})
+
+test('cli: duplicate option', async () => {
+  await run(['--help', '--help'])
+  expect(logger.error).toHaveBeenCalledWith('Invalid options. Singular option already set [help=true]')
+})
+
+test('cli: unrecognised command', async () => {
+  await run(['xyz'])
+  expect(logger.error).toHaveBeenCalledWith('Unrecognized command "xyz".')
+})

--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -1,0 +1,87 @@
+import commandLineArgs from 'command-line-args'
+import commandLineUsage from 'command-line-usage'
+import logger from '../Logger'
+
+const topLevelDefs = [
+  {
+    name: 'command',
+    defaultOption: true
+  },
+  {
+    name: 'help',
+    alias: 'h',
+    type: Boolean,
+    description: 'show this message'
+  },
+  {
+    name: 'version',
+    type: Boolean,
+    description: 'output the version of the CLI module'
+  }
+]
+
+export default async function run (argv: string[]): Promise<void> {
+  try {
+    const opts = commandLineArgs(topLevelDefs, { argv, stopAtFirstUnknown: true })
+
+    if (opts.version) {
+      return console.log(
+        `bugsnag-react-native-cli v${require('../../package.json').version}`
+      )
+    }
+
+    switch (opts.command) {
+      case 'init':
+      case 'install':
+      case 'insert':
+      case 'configure':
+      case 'automate-symbolication':
+        logger.info(`TODO ${opts.command}`)
+        break
+      default:
+        if (opts.help) return usage()
+        if (opts.command) {
+          logger.error(`Unrecognized command "${opts.command}".`)
+        } else {
+          logger.error('Command expected, nothing provided.')
+        }
+        usage()
+    }
+  } catch (e) {
+    logger.error(`Invalid options. ${e.message}`)
+    process.exitCode = 1
+  }
+}
+
+function usage (): void {
+  console.log(
+    commandLineUsage([
+      { content: 'bugsnag-react-native-cli <command>' },
+      { header: 'Available commands', content: commandList },
+      { header: 'Options', optionList: topLevelDefs, hide: ['command'] }
+    ])
+  )
+}
+
+const commandList = [
+  {
+    name: 'init',
+    summary: 'integrates Bugsnag with a React Native project (this command runs all of the other commands)'
+  },
+  {
+    name: 'install',
+    summary: 'installs @bugsnag/react-native'
+  },
+  {
+    name: 'insert',
+    summary: 'inserts Bugsnag initialisation into the JS, Android and iOS parts of the codebase'
+  },
+  {
+    name: 'configure',
+    summary: 'prompts for necessary configuration and outputs them to the relevant manifests'
+  },
+  {
+    name: 'automate-symbolication',
+    summary: 'configures the Xcode and Gradle builds to automatically upload source maps, dsyms and mappings to Bugsnag'
+  }
+]

--- a/packages/react-native-cli/tsconfig.build.json
+++ b/packages/react-native-cli/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}

--- a/packages/react-native-cli/tsconfig.json
+++ b/packages/react-native-cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Goal

Add a new package to house RN CLI commands.

## Design

For consistency, used exactly the same setup as [`@bugsnag/source-maps`](https://github.com/bugsnag/bugsnag-source-maps/).

## Changeset

Added a new package to the monorepo.

## Testing

Unit tests have been added, which are run by the top-level Jest invocation.

![image](https://user-images.githubusercontent.com/609579/98273249-f49f6700-1f89-11eb-97e2-3f7186681e5c.png)
