### PR TITLE
feat(expo): Upgrade to @bugsnag/source-maps module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (expo): Update the `postPublish` hook to use the new `@bugsnag/source-maps` library. [#1124]
+
 ## v7.5.4 (2020-12-10)
 
 ### Changed

--- a/packages/expo/hooks/lib/upload-source-maps.js
+++ b/packages/expo/hooks/lib/upload-source-maps.js
@@ -1,4 +1,5 @@
-const { upload } = require('bugsnag-sourcemaps')
+const sourceMaps = require('@bugsnag/source-maps').reactNative
+const logger = require('@bugsnag/source-maps/dist/Logger').default
 const { promisify } = require('util')
 const { tmpdir } = require('os')
 const { sep, join } = require('path')
@@ -34,26 +35,28 @@ module.exports = async (
   const opts = { apiKey }
   if (endpoint) opts.endpoint = endpoint
 
+  logger.info('Uploading source maps to Bugsnag')
+
   // android
-  console.log('Uploading Android source map')
-  await upload({
+  await sourceMaps.uploadOne({
+    ...opts,
     appVersion: androidManifest.version,
-    minifiedUrl: '*/cached-bundle-experience-*',
-    minifiedFile: androidBundlePath,
     codeBundleId: androidManifest.revisionId,
+    bundle: androidBundlePath,
     sourceMap: androidSourceMapPath,
-    ...opts
+    platform: 'android',
+    logger
   })
 
   // ios
-  console.log('Uploading iOS source map')
-  await upload({
+  await sourceMaps.uploadOne({
+    ...opts,
     appVersion: iosManifest.version,
-    minifiedUrl: iosManifest.bundleUrl,
-    minifiedFile: iosBundlePath,
     codeBundleId: iosManifest.revisionId,
+    bundle: iosBundlePath,
     sourceMap: iosSourceMapPath,
-    ...opts
+    platform: 'ios',
+    logger
   })
 }
 

--- a/packages/expo/package-lock.json
+++ b/packages/expo/package-lock.json
@@ -4,26 +4,65 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"ajv": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
-			"integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+		},
+		"@bugsnag/source-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@bugsnag/source-maps/-/source-maps-1.0.0.tgz",
+			"integrity": "sha512-PYO669msGRICyzxZtcTBWSB6zugnbtTao4TSAfdl30/vsoaVLICZyazB8Y3h+hzSQTp9mUCSNslRBXRJa4KeFA==",
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"command-line-args": "^5.1.1",
+				"command-line-usage": "^6.1.0",
+				"concat-stream": "^2.0.0",
+				"consola": "^2.15.0",
+				"form-data": "^3.0.0",
+				"glob": "^7.1.6",
+				"read-pkg-up": "^7.0.1"
+			},
+			"dependencies": {
+				"concat-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+					"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.0.2",
+						"typedarray": "^0.0.6"
+					}
+				},
+				"glob": {
+					"version": "7.1.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
-		"ansi-escapes": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -32,6 +71,11 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
+		},
+		"array-back": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
 		},
 		"array-find-index": {
 			"version": "1.0.2",
@@ -48,40 +92,23 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"buffer-from": {
@@ -235,38 +262,6 @@
 				}
 			}
 		},
-		"bugsnag-sourcemaps": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/bugsnag-sourcemaps/-/bugsnag-sourcemaps-1.1.0.tgz",
-			"integrity": "sha512-SJwKKTtC2N9c5g9/VRhyAKHl2wtM9PURnL1X/eyBNYMPlDfd+ODr6MzItwISpyuCXcCk2JJHW1NptsnLFDnNVA==",
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"listr": "^0.12.0",
-				"meow": "^3.7.0",
-				"rc": "^1.2.8",
-				"read-pkg-up": "^2.0.0",
-				"request": "^2.88.0"
-			}
-		},
-		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-		},
-		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
-			}
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -276,33 +271,6 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
-		},
-		"cli-cursor": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-			"requires": {
-				"restore-cursor": "^1.0.1"
-			}
-		},
-		"cli-spinners": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw="
-		},
-		"cli-truncate": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"requires": {
-				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
-			}
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -318,12 +286,51 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
+		},
+		"command-line-args": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+			"requires": {
+				"array-back": "^3.0.1",
+				"find-replace": "^3.0.0",
+				"lodash.camelcase": "^4.3.0",
+				"typical": "^4.0.0"
+			}
+		},
+		"command-line-usage": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+			"integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+			"requires": {
+				"array-back": "^4.0.1",
+				"chalk": "^2.4.2",
+				"table-layout": "^1.0.1",
+				"typical": "^5.2.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -335,6 +342,11 @@
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
 			}
+		},
+		"consola": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
 		},
 		"core-js": {
 			"version": "2.6.11",
@@ -353,19 +365,6 @@
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
-		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
 		},
 		"decamelize": {
 			"version": "1.2.0",
@@ -390,20 +389,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
-		"elegant-spinner": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -434,11 +419,6 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
-		"exit-hook": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-		},
 		"expo-constants": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.2.0.tgz",
@@ -448,30 +428,10 @@
 				"uuid": "^3.3.2"
 			}
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
-		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-		},
 		"fast-json-parse": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
 			"integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-safe-stringify": {
 			"version": "1.2.3",
@@ -498,27 +458,57 @@
 			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
 			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
-		"figures": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-			"requires": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
-			}
-		},
 		"find-nearest-file": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-nearest-file/-/find-nearest-file-1.1.0.tgz",
 			"integrity": "sha512-NMsS0ITOwpBPrHOyO7YUtDhaVEGUKS0kBJDVaWZPuCzO7JMW+uzFQQVts/gPyIV9ioyNWDb5LjhHWXVf1OnBDA=="
 		},
-		"find-up": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+		"find-replace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
 			"requires": {
-				"path-exists": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-back": "^3.0.1"
+			}
+		},
+		"find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"requires": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"dependencies": {
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				}
 			}
 		},
 		"flatstr": {
@@ -526,60 +516,25 @@
 			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.9.tgz",
 			"integrity": "sha512-qFlJnOBWDfIaunF54/lBqNKmXOI0HqNhu+mHkLmbaBXlS71PUd9OjFOdyevHt/aHoHB1+eW7eKHgRKOG5aHSpw=="
 		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+			"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
+				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
 			}
 		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -591,16 +546,6 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
 		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			}
-		},
 		"iconv-lite": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
@@ -609,12 +554,13 @@
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
 		},
-		"indent-string": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"repeating": "^2.0.0"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -622,56 +568,20 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
-		},
-		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -687,194 +597,25 @@
 				"whatwg-fetch": ">=0.10.0"
 			}
 		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"listr": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
-			"integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"figures": "^1.7.0",
-				"indent-string": "^2.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.2.0",
-				"listr-verbose-renderer": "^0.4.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"ora": "^0.2.3",
-				"p-map": "^1.1.1",
-				"rxjs": "^5.0.0-beta.11",
-				"stream-to-observable": "^0.1.0",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"listr-silent-renderer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
-		},
-		"listr-update-renderer": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
-			"integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"listr-verbose-renderer": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
-			}
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
 		},
 		"locate-path": {
 			"version": "2.0.0",
@@ -892,46 +633,10 @@
 				}
 			}
 		},
-		"log-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-			"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-			"requires": {
-				"chalk": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"log-update": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-			"requires": {
-				"ansi-escapes": "^1.0.0",
-				"cli-cursor": "^1.0.2"
-			}
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -955,50 +660,25 @@
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
-		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				}
-			}
-		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.44.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist-options": {
@@ -1030,16 +710,6 @@
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1051,46 +721,6 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"onetime": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-		},
-		"ora": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-			"requires": {
-				"chalk": "^1.1.1",
-				"cli-cursor": "^1.0.2",
-				"cli-spinners": "^0.1.2",
-				"object-assign": "^4.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
 			}
 		},
 		"p-limit": {
@@ -1109,69 +739,61 @@
 				"p-limit": "^1.1.0"
 			}
 		},
-		"p-map": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
-		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+			"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 			"requires": {
-				"error-ex": "^1.2.0"
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+				}
 			}
 		},
 		"path-exists": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"requires": {
-				"pinkie-promise": "^2.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			}
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "^2.0.0"
-			}
 		},
 		"pino": {
 			"version": "4.17.6",
@@ -1206,11 +828,6 @@
 				"asap": "~2.0.3"
 			}
 		},
-		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
-		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -1219,16 +836,6 @@
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
 			}
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"quick-format-unescaped": {
 			"version": "1.1.2",
@@ -1243,85 +850,32 @@
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+		"read-pkg": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
 			},
 			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				"type-fest": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
 				}
-			}
-		},
-		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
 			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"requires": {
-						"pify": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				}
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
 			}
 		},
 		"readable-stream": {
@@ -1338,49 +892,10 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
-			}
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
-		},
-		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
+		"reduce-flatten": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
 		},
 		"resolve": {
 			"version": "1.10.0",
@@ -1390,27 +905,10 @@
 				"path-parse": "^1.0.6"
 			}
 		},
-		"restore-cursor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-			"requires": {
-				"exit-hook": "^1.0.0",
-				"onetime": "^1.0.0"
-			}
-		},
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
 			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
-		},
-		"rxjs": {
-			"version": "5.5.12",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-			"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-			"requires": {
-				"symbol-observable": "1.0.1"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -1436,11 +934,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
-		"slice-ansi": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -1478,37 +971,6 @@
 				"through2": "^2.0.2"
 			}
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
-		"stream-to-observable": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
-			"integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4="
-		},
-		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
-			}
-		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1516,35 +978,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
-		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
-		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"requires": {
-				"is-utf8": "^0.2.0"
-			}
-		},
-		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"requires": {
-				"get-stdin": "^4.0.1"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -1554,10 +987,28 @@
 				"has-flag": "^3.0.0"
 			}
 		},
-		"symbol-observable": {
+		"table-layout": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+			"requires": {
+				"array-back": "^4.0.1",
+				"deep-extend": "~0.6.0",
+				"typical": "^5.2.0",
+				"wordwrapjs": "^4.0.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -1568,57 +1019,25 @@
 				"xtend": "~4.0.1"
 			}
 		},
-		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				}
-			}
-		},
-		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
+		"typical": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+		},
 		"ua-parser-js": {
 			"version": "0.7.22",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
 			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
-		},
-		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"requires": {
-				"punycode": "^2.1.0"
-			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -1639,20 +1058,26 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
-		},
 		"whatwg-fetch": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
 			"integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+		},
+		"wordwrapjs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+			"requires": {
+				"reduce-flatten": "^2.0.0",
+				"typical": "^5.0.0"
+			},
+			"dependencies": {
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -45,8 +45,8 @@
     "@bugsnag/plugin-react-native-global-error-handler": "^7.5.4",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.5.4",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.5.4",
+    "@bugsnag/source-maps": "^1.0.0",
     "bugsnag-build-reporter": "^1.0.1",
-    "bugsnag-sourcemaps": "^1.1.0",
     "expo-constants": "~9.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Goal

`bugsnag-sourcemaps` will soon be deprecated. This updates the source map upload hook in Expo to use the new `@bugsnag/source-maps` module.

## Design

The new module suports using the [React Native upload endpoint](https://docs.bugsnag.com/api/rn-source-map-upload/) so the upload is simplified somewhat (the `minifiedUrl` is no longer required, or used for version matching).

## Changeset

- Added dependency on the new module
- Removed dependency on the old module
- Updated module usage

## Testing

There are no automated tests for this feature. I have tested it manually on my Android device. ~It could do with testing on an iOS device too.~ Now tested on an iOS app too.