### PR TITLE
Add @bugsnag/bytesize package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     {
       displayName: 'shared plugins',
       testMatch: [
+        testsForPackage('bytesize'),
         testsForPackage('plugin-app-duration')
       ]
     },

--- a/packages/bytesize/LICENSE.txt
+++ b/packages/bytesize/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/bytesize/README.md
+++ b/packages/bytesize/README.md
@@ -1,0 +1,13 @@
+# @bugsnag/bytesize
+
+A helper module to calculate the number of bytes in a JavaScript string, when converted to UTF-8
+
+```js
+bytesize('abc') == 3
+bytesize('$£€') == 6
+bytesize('😀😃😄😁') == 16
+````
+
+## License
+
+MIT

--- a/packages/bytesize/bytesize.d.ts
+++ b/packages/bytesize/bytesize.d.ts
@@ -1,0 +1,3 @@
+declare const bytesize: (string: string) => number
+
+export default bytesize

--- a/packages/bytesize/bytesize.js
+++ b/packages/bytesize/bytesize.js
@@ -1,8 +1,4 @@
 export default function bytesize (string) {
-  if (typeof string !== 'string') {
-    throw new Error('Invalid type given, expected string but got ' + typeof string)
-  }
-
   let bytes = 0
 
   for (let i = 0; i < string.length; ++i) {

--- a/packages/bytesize/bytesize.js
+++ b/packages/bytesize/bytesize.js
@@ -1,4 +1,4 @@
-export default function bytesize (string) {
+module.exports = function bytesize (string) {
   let bytes = 0
 
   for (let i = 0; i < string.length; ++i) {

--- a/packages/bytesize/bytesize.js
+++ b/packages/bytesize/bytesize.js
@@ -1,0 +1,28 @@
+export default function bytesize (string) {
+  if (typeof string !== 'string') {
+    throw new Error('Invalid type given, expected string but got ' + typeof string)
+  }
+
+  let bytes = 0
+
+  for (let i = 0; i < string.length; ++i) {
+    const code = string.charCodeAt(i)
+
+    if (code <= 0x007f) {
+      bytes += 1
+    } else if (code <= 0x07ff || (code >= 0xd800 && code <= 0xdfff)) {
+      // special handling for surrogate pairs (code points between 0xd800-0xdfff)
+      // each part of the pair should be 2 bytes (so 4 bytes for the character)
+      // see https://www.unicode.org/faq/utf_bom.html#utf16-2
+      bytes += 2
+    } else {
+      bytes += 3
+    }
+
+    // 4 bytes isn't possible because 'charCodeAt' returns at most 65536 (0xffff).
+    // Code points above this are represented by a surrogate pair of "characters",
+    // which are 2 bytes each
+  }
+
+  return bytes
+}

--- a/packages/bytesize/package.json
+++ b/packages/bytesize/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bugsnag/bytesize",
+  "version": "7.5.2",
+  "description": "Calculate the size of a string in bytes",
+  "author": "Bugsnag",
+  "homepage": "https://www.bugsnag.com/",
+  "license": "MIT",
+  "main": "bytesize.js",
+  "files": [
+    "*.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/bytesize/test/bytesize.test.ts
+++ b/packages/bytesize/test/bytesize.test.ts
@@ -33,20 +33,3 @@ test.each([
 ])('it calculates the size of a string in bytes (%#)', (string, expected) => {
   expect(bytesize(string)).toBe(expected)
 })
-
-test.each([
-  [123, 'number'],
-  [123.456, 'number'],
-  [true, 'boolean'],
-  [[1, 'a', 2, 'b'], 'object'],
-  [{ a: 1, b: 2 }, 'object'],
-  [null, 'object'],
-  [undefined, 'undefined'],
-  [Symbol('abc'), 'symbol'],
-  [2n ** 64n, 'bigint'],
-  [() => {}, 'function']
-])('it throws when given an invalid type: %p', (input, expectedType) => {
-  const expected = new Error(`Invalid type given, expected string but got ${expectedType}`)
-
-  expect(() => bytesize(input)).toThrow(expected)
-})

--- a/packages/bytesize/test/bytesize.test.ts
+++ b/packages/bytesize/test/bytesize.test.ts
@@ -1,0 +1,52 @@
+import bytesize from '../'
+
+test.each([
+  ['', 0],
+  ['abc', 3],
+  ['aaaaaaaaa', 9],
+  ['abcdefghijklmnopqrstuvwxyz', 26],
+  // $ = 1 byte, £ = 2, € = 3
+  ['$£€', 6],
+  // each of these cyrillic characters are 2 bytes + 1 byte for the space
+  ['обичам те', 17],
+  // these emoji are 4 bytes each
+  ['😀😃😄😁', 16],
+  // the woman running emoji with a skin tone is made up of several combining characters
+  ['🏃🏽‍♀️', 17],
+  // this is the same woman running emoji but encoded
+  ['\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f', 17],
+  // these families are several separate emojis + combining characters
+  ['👩‍👩‍👧‍👧👨‍👨‍👦‍👦', 50],
+  ['1234567890'.repeat(1024), 10240],
+  ['обичам те'.repeat(1024), 17408],
+  // big strings to stress test performance — these are ~1mb & ~5mb
+  ['a'.repeat(1_000_000), 1_000_000],
+  ['👩‍👩‍👧‍👧👨‍👨‍👦‍👦'.repeat(100_000), 5_000_000],
+  // this is 'ññ' but the first 'ñ' is made up of 'n' and a combining tilde, so
+  // is counted as 3 bytes instead of 2
+  ['\u006E\u0303\u00F1', 5],
+  ['\uD834\uDF06', 4],
+  // stacking a bunch of combining characters to ensure they are each counted correctly
+  ['h\u0336\u0340\u0307\u0342\u030C\u033E\u035B\u0360\u0310\u0308\u0308\u030D\u0305\u0328\u0320\u0356\u031F\u031D\u0348\u035A\u0329\u0347e\u0336\u030A\u0329\u0345\u032B\u0319\u032F\u0339\u0339\u0317l\u0337\u0344\u034C\u0350\u035A\u0330\u031D\u0318\u0320\u0356\u0332\u0332\u033A\u033Bl\u0335\u0346\u0308\u0346\u035A\u0327\u0339\u032E\u0339\u0356o\u0336\u0352\u030C\u031B\u0351\u030D\u034B\u031A\u030A\u0342\u030A\u0304\u031B\u030E\u033F\u0323\u0329\u0349\u033B\u031E\u0330\u0323\u033C\u0348\u0347\u0359\u031F\u0359\u0355\u0347\u032E', 179],
+  ['\u{1FA00}\u{1003FF}', 8],
+  ['\u{1F701}\u{1F702}\u{1F703}\u{1F704}', 16]
+])('it calculates the size of a string in bytes (%#)', (string, expected) => {
+  expect(bytesize(string)).toBe(expected)
+})
+
+test.each([
+  [123, 'number'],
+  [123.456, 'number'],
+  [true, 'boolean'],
+  [[1, 'a', 2, 'b'], 'object'],
+  [{ a: 1, b: 2 }, 'object'],
+  [null, 'object'],
+  [undefined, 'undefined'],
+  [Symbol('abc'), 'symbol'],
+  [2n ** 64n, 'bigint'],
+  [() => {}, 'function']
+])('it throws when given an invalid type: %p', (input, expectedType) => {
+  const expected = new Error(`Invalid type given, expected string but got ${expectedType}`)
+
+  expect(() => bytesize(input)).toThrow(expected)
+})


### PR DESCRIPTION
## Goal

This PR adds a new package, `@bugsnag/bytesize`, which isn't used yet — upcoming PRs will start consuming it

## Design

This is a separate package so that it can be used in multiple other packages

Existing NPM packages for this are either:

- exclusively for node
- much more code than we need
- solve _slightly_ different problems, e.g. returning an array of bytes — this technically works for us as we can use the array length but it wastes a bunch of memory

I named this "bytesize" after the [Ruby string method](https://ruby-doc.org/core-2.7.2/String.html), but it can easily be renamed if it's unclear

## Testing

This is only tested with unit tests at the moment; when this is used in other packages then MR tests will be added