### PR TITLE
docs(readme): add top-level license file and make links consistent

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ See [contributing](CONTRIBUTING.md) for more information.
 
 ## License
 
-All packages in this repository are released under the MIT License.
+All packages in this repository are released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -3,4 +3,5 @@
 This package contains the browser implementation of the Bugsnag notifier for JavaScript. The normal use case is to install this package via `@bugsnag/js`, but you can install it directly if you want to.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,4 +13,5 @@ This package contains the core classes and utilities common to the Bugsnag notif
 Unless you are writing your own notifier, it is unlikely that you want to install this module – for the universal error reporting client, see [@bugsnag/js](../js).
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/delivery-expo/README.md
+++ b/packages/delivery-expo/README.md
@@ -3,4 +3,5 @@
 This delivery mechanism uses [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to send events and sessions to Bugsnag's API. If a payload fails to deliver due to a network error, it is cached on disk and retried later.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/delivery-node/README.md
+++ b/packages/delivery-node/README.md
@@ -3,4 +3,5 @@
 This delivery mechanism uses [request](https://github.com/request/request) to send events and sessions to Bugsnag's API. It is included in the node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/delivery-react-native/README.md
+++ b/packages/delivery-react-native/README.md
@@ -3,4 +3,5 @@
 This delivery mechanism defers to the native platform to send events. It is included in the React Native notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/delivery-x-domain-request/README.md
+++ b/packages/delivery-x-domain-request/README.md
@@ -3,4 +3,5 @@
 This delivery mechanism uses old IE browsers' built-in `XDomainRequest` to send events and sessions to Bugsnag's API (because they do not allow cross-domain requests with the `XMLHttpRequest` object). It is included in the browser notifier and is used by IE8, 9 and 10.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/delivery-xml-http-request/README.md
+++ b/packages/delivery-xml-http-request/README.md
@@ -3,4 +3,5 @@
 This delivery mechanism uses the browser's built-in `XMLHttpRequest` to send events and sessions to Bugsnag's API. It is included in the browser notifier and is used by every browser except IE8, 9 and 10.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/expo-cli/README.md
+++ b/packages/expo-cli/README.md
@@ -24,4 +24,5 @@ options
 
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -5,4 +5,5 @@ Error reporting for [Expo](https://expo.io/) apps.
 This notifier is for Expo apps that only have JS – no native code. For [ejected](https://docs.expo.io/versions/v32.0.0/workflow/glossary-of-terms/#eject) Expo apps and non-Expo React Native apps, you'll need to use the [`bugsnag-react-native`](https://github.com/bugsnag/bugsnag-react-native) notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -21,4 +21,5 @@ In various bundlers, importing `'@bugsnag/js'` will provide the [`@bugsnag/brows
 **Note**: by using this browser-specific entrypoint, none of the node-specific code will be included in your bundle.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -3,4 +3,5 @@
 This package contains the Node.js implementation of the Bugsnag notifier for JavaScript. The normal use case is to install this package via `@bugsnag/js`, but you can install it directly if you want to.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-angular/README.md
+++ b/packages/plugin-angular/README.md
@@ -49,4 +49,4 @@ import { ErrorHandler, NgModule } from '@angular/core'
 
 ## License
 
-The Bugsnag JS library and official plugins are free software released under the MIT License. See [LICENSE.txt](LICENSE.txt) for details.
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-app-duration/README.md
+++ b/packages/plugin-app-duration/README.md
@@ -3,4 +3,5 @@
 This plugin adds the duration an application has been running for to the `app` section of each event. It is included in the browser and node notifiers.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-browser-context/README.md
+++ b/packages/plugin-browser-context/README.md
@@ -3,4 +3,5 @@
 This plugin adds `window.location.pathname` as the `context` to each event. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-browser-device/README.md
+++ b/packages/plugin-browser-device/README.md
@@ -3,4 +3,5 @@
 This plugin adds the device time, locale, user agent and screen orientation to the `device` section of each event, and adds the locale, user agent and screen orientation to session payloads. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-browser-request/README.md
+++ b/packages/plugin-browser-request/README.md
@@ -3,4 +3,5 @@
 This plugin adds `window.location.href` to the `request.url` section of each event. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-browser-session/README.md
+++ b/packages/plugin-browser-session/README.md
@@ -3,4 +3,5 @@
 This plugin provides a session implementation for the browser notifier. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-client-ip/README.md
+++ b/packages/plugin-client-ip/README.md
@@ -3,4 +3,5 @@
 This plugin defines a configuration option `collectUserIp` which defaults to `true`. If set to `false` it will prevent the IP address of the client from being recorded. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-console-breadcrumbs/README.md
+++ b/packages/plugin-console-breadcrumbs/README.md
@@ -5,4 +5,5 @@ This plugin adds the ability to record console method calls as breadcrumbs by mo
 **Note:** enabling this plugin means that the line/col origin of console logs appear to come from within Bugsnag's code, so it is not recommended for use in dev environments.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-contextualize/README.md
+++ b/packages/plugin-contextualize/README.md
@@ -3,4 +3,5 @@
 This plugin provides a means of attaching context to a callback which gets included in an event in the case of an unhandled error. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-expo-app/README.md
+++ b/packages/plugin-expo-app/README.md
@@ -3,4 +3,5 @@
 A plugin to provide information about an Expo app, including version, bundle id and how long the app spent in the foreground.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-expo-device/README.md
+++ b/packages/plugin-expo-device/README.md
@@ -3,4 +3,5 @@
 This plugin fetches device information and adds it to the payload.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-express/README.md
+++ b/packages/plugin-express/README.md
@@ -3,4 +3,5 @@
 A [@bugsnag/js](https://github.com/bugsnag/bugsnag-js) plugin for capturing errors in Express (and Connect) web applications.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-inline-script-content/README.md
+++ b/packages/plugin-inline-script-content/README.md
@@ -3,4 +3,5 @@
 This plugin detects when an error originated in an inline `<script>` tag, and if so adds the content of the script to the event. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-interaction-breadcrumbs/README.md
+++ b/packages/plugin-interaction-breadcrumbs/README.md
@@ -3,4 +3,5 @@
 This plugin adds the ability to record click events as breadcrumbs by listening to events on the `window`, with the selector and text of the target element (if available) added to the breadcrumb as metadata. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-koa/README.md
+++ b/packages/plugin-koa/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/plugin-koa
+
+A [@bugsnag/js](https://github.com/bugsnag/bugsnag-js) plugin for capturing errors in Koa web applications.
+
+## License
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-navigation-breadcrumbs/README.md
+++ b/packages/plugin-navigation-breadcrumbs/README.md
@@ -3,4 +3,5 @@
 This plugin adds the ability to record browser navigation as breadcrumbs by listening to events on the `window` and monkey-patching `pushState`/`replaceState` history methods. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-network-breadcrumbs/README.md
+++ b/packages/plugin-network-breadcrumbs/README.md
@@ -3,4 +3,5 @@
 This plugin adds the ability to record browser requests as breadcrumbs by monkey-patching `window.XMLHttpRequest` and `window.fetch`, including HTTP status codes where available. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-node-device/README.md
+++ b/packages/plugin-node-device/README.md
@@ -3,4 +3,5 @@
 This plugin adds information about the device, including the time, hostname, memory usage and Node & OS versions to the `device` section of each event. It is included in the node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-node-in-project/README.md
+++ b/packages/plugin-node-in-project/README.md
@@ -3,4 +3,5 @@
 This plugin detects whether a stackframe is "in project" – i.e. whether it is a descendent of the project root and node within a `node_modules` directory. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-node-surrounding-code/README.md
+++ b/packages/plugin-node-surrounding-code/README.md
@@ -3,4 +3,5 @@
 This plugin loads the surrounding code for each stackframe in an event, if it is available. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-node-uncaught-exception/README.md
+++ b/packages/plugin-node-uncaught-exception/README.md
@@ -3,4 +3,5 @@
 This plugin hooks in to Node's `process#uncaughtException` event to provide reporting for unhandled errors. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-node-unhandled-rejection/README.md
+++ b/packages/plugin-node-unhandled-rejection/README.md
@@ -3,4 +3,5 @@
 This plugin hooks in to Node's `process#unhandledRejection` event to provide unhandled exception reporting for Promises. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-app-state-breadcrumbs/README.md
+++ b/packages/plugin-react-native-app-state-breadcrumbs/README.md
@@ -3,4 +3,5 @@
 This plugin adds the ability to record changes in network state. It is included in the Expo notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-client-sync/README.md
+++ b/packages/plugin-react-native-client-sync/README.md
@@ -3,4 +3,5 @@
 This plugin maintains client state between the JS client and the native client in React Native. It is included in the React Native notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-connectivity-breadcrumbs/README.md
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/README.md
@@ -3,4 +3,5 @@
 This plugin adds the ability to record changes in network state. It is included in the Expo notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-event-sync/README.md
+++ b/packages/plugin-react-native-event-sync/README.md
@@ -3,4 +3,5 @@
 This plugin retrieves native event information so that it is available in JS `onError` callbacks. It is included in the React Native notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-global-error-handler/README.md
+++ b/packages/plugin-react-native-global-error-handler/README.md
@@ -3,4 +3,5 @@
 This plugin hooks in to React Native's `ErrorUtils.globalHandler` to provide unhandled exception reporting.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-hermes/README.md
+++ b/packages/plugin-react-native-hermes/README.md
@@ -3,4 +3,5 @@
 Adds support for the Hermes JS engine.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-navigation/README.md
+++ b/packages/plugin-react-native-navigation/README.md
@@ -4,4 +4,4 @@ This plugin hooks in to React Native Navigation, updating the `context` with the
 
 ## License
 
-MIT
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-orientation-breadcrumbs/README.md
+++ b/packages/plugin-react-native-orientation-breadcrumbs/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/plugin-react-native-orientation-breadcrumbs
+
+This plugin adds the ability to record changes in the device's orientation. It is included in the React Native notifier.
+
+## License
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-session/README.md
+++ b/packages/plugin-react-native-session/README.md
@@ -3,4 +3,5 @@
 This plugin implements a session delegate which defers all session management to the underlying native platform. It is included in the React Native notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-native-unhandled-rejection/README.md
+++ b/packages/plugin-react-native-unhandled-rejection/README.md
@@ -3,4 +3,5 @@
 This plugin hooks in to React Native's promise rejection tracking to provide unhandled exception reporting for Promises. It is included in the Expo notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react-navigation/README.md
+++ b/packages/plugin-react-navigation/README.md
@@ -3,4 +3,5 @@
 Integrates with the [React Navigation](https://reactnavigation.org/) library to provide better error context and navigation breadcrumbs.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -51,4 +51,4 @@ ReactDOM.render(
 
 ## License
 
-The Bugsnag JS library and official plugins are free software released under the MIT License. See [LICENSE.txt](LICENSE.txt) for details.
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-restify/README.md
+++ b/packages/plugin-restify/README.md
@@ -3,4 +3,5 @@
 A [@bugsnag/js](https://github.com/bugsnag/bugsnag-js) plugin for capturing errors in Restify web applications.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-server-session/README.md
+++ b/packages/plugin-server-session/README.md
@@ -3,4 +3,5 @@
 This plugin provides a session implementation server applications. Rather than sending a session every time one is received like the browser session tracking does, it keeps a log of sessions started and sends a summary every minute. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-simple-throttle/README.md
+++ b/packages/plugin-simple-throttle/README.md
@@ -5,4 +5,5 @@ This plugin adds a safety mechanism to prevent too many events being sent to Bug
 **Note:** to support long-lived browser applications, this plugin defines a `resetEventCount()` method on the client which gets called when the URL of the page changes. This resets the count, allowing new events to be sent.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-strip-project-root/README.md
+++ b/packages/plugin-strip-project-root/README.md
@@ -3,4 +3,5 @@
 This plugin strips the project root from stacktraces. It is included in the Node notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-strip-query-string/README.md
+++ b/packages/plugin-strip-query-string/README.md
@@ -3,4 +3,5 @@
 This plugin removes query strings and document fragments from stackframe URLs. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -35,4 +35,4 @@ Bugsnag.use(bugsnagVue, Vue)
 
 ## License
 
-The Bugsnag JS library and official plugins are free software released under the MIT License. See [LICENSE.txt](LICENSE.txt) for details.
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-window-onerror/README.md
+++ b/packages/plugin-window-onerror/README.md
@@ -3,4 +3,5 @@
 This plugin hooks in to the browser's global `onerror` callback to provide unhandled exception reporting. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-window-unhandled-rejection/README.md
+++ b/packages/plugin-window-unhandled-rejection/README.md
@@ -3,4 +3,5 @@
 This plugin hooks in to the browser's global `unhandledRejection`/`onunhandledrejection` callbacks to provide unhandled exception reporting for Promises. It is included in the browser notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -5,4 +5,5 @@ Error reporting for [React Native](https://facebook.github.io/react-native/) app
 This notifier is for React Native apps that have JS and native code. For [non-ejected](https://docs.expo.io/versions/v32.0.0/workflow/glossary-of-terms/#eject) Expo apps, you'll need to use the [`@bugsnag/expo`](../expo) notifier.
 
 ## License
-MIT
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.


### PR DESCRIPTION
## Goal

Adds a LICENSE.txt file at the top-level so that the license link is shown on the Github homepage for this repo.

Also added a link from the README.md at the top-level and made the links for each of the packages consistent.

(A couple of package README's were missing so I've added these.)