### PR TITLE
Add Bugsnag-Integrity header to browser XML HTTP delivery

### DIFF
--- a/packages/delivery-xml-http-request/delivery.js
+++ b/packages/delivery-xml-http-request/delivery.js
@@ -1,3 +1,4 @@
+const bytesize = require('@bugsnag/bytesize')
 const payload = require('@bugsnag/core/lib/json-payload')
 
 module.exports = (client, win = window) => ({
@@ -8,12 +9,17 @@ module.exports = (client, win = window) => ({
       req.onreadystatechange = function () {
         if (req.readyState === win.XMLHttpRequest.DONE) cb(null)
       }
+
+      const json = payload.event(event, client._config.redactedKeys)
+
       req.open('POST', url)
       req.setRequestHeader('Content-Type', 'application/json')
       req.setRequestHeader('Bugsnag-Api-Key', event.apiKey || client._config.apiKey)
+      req.setRequestHeader('Bugsnag-Integrity', 'simple ' + bytesize(json))
       req.setRequestHeader('Bugsnag-Payload-Version', '4')
       req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
-      req.send(payload.event(event, client._config.redactedKeys))
+
+      req.send(json)
     } catch (e) {
       client._logger.error(e)
     }
@@ -25,12 +31,17 @@ module.exports = (client, win = window) => ({
       req.onreadystatechange = function () {
         if (req.readyState === win.XMLHttpRequest.DONE) cb(null)
       }
+
+      const json = payload.session(session, client._config.redactedKeys)
+
       req.open('POST', url)
       req.setRequestHeader('Content-Type', 'application/json')
       req.setRequestHeader('Bugsnag-Api-Key', client._config.apiKey)
+      req.setRequestHeader('Bugsnag-Integrity', 'simple ' + bytesize(json))
       req.setRequestHeader('Bugsnag-Payload-Version', '1')
       req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
-      req.send(payload.session(session, client._config.redactedKeys))
+
+      req.send(json)
     } catch (e) {
       client._logger.error(e)
     }

--- a/packages/delivery-xml-http-request/delivery.js
+++ b/packages/delivery-xml-http-request/delivery.js
@@ -15,7 +15,7 @@ module.exports = (client, win = window) => ({
       req.open('POST', url)
       req.setRequestHeader('Content-Type', 'application/json')
       req.setRequestHeader('Bugsnag-Api-Key', event.apiKey || client._config.apiKey)
-      req.setRequestHeader('Bugsnag-Integrity', 'simple ' + bytesize(json))
+      req.setRequestHeader('Bugsnag-Integrity', `simple ${bytesize(json)}`)
       req.setRequestHeader('Bugsnag-Payload-Version', '4')
       req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
 
@@ -37,7 +37,7 @@ module.exports = (client, win = window) => ({
       req.open('POST', url)
       req.setRequestHeader('Content-Type', 'application/json')
       req.setRequestHeader('Bugsnag-Api-Key', client._config.apiKey)
-      req.setRequestHeader('Bugsnag-Integrity', 'simple ' + bytesize(json))
+      req.setRequestHeader('Bugsnag-Integrity', `simple ${bytesize(json)}`)
       req.setRequestHeader('Bugsnag-Payload-Version', '1')
       req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
 

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -16,6 +16,9 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
+  "dependencies": {
+    "@bugsnag/bytesize": "^7.5.2"
+  },
   "devDependencies": {
     "@bugsnag/core": "^7.3.5"
   },

--- a/packages/delivery-xml-http-request/test/delivery.test.ts
+++ b/packages/delivery-xml-http-request/test/delivery.test.ts
@@ -50,6 +50,7 @@ describe('delivery:XMLHttpRequest', () => {
       expect(requests[0].url).toMatch('/echo/')
       expect(requests[0].headers['Content-Type']).toEqual('application/json')
       expect(requests[0].headers['Bugsnag-Api-Key']).toEqual('aaaaaaaa')
+      expect(requests[0].headers['Bugsnag-Integrity']).toEqual('simple 20')
       expect(requests[0].headers['Bugsnag-Payload-Version']).toEqual('4')
       expect(requests[0].headers['Bugsnag-Sent-At']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
       expect(requests[0].data).toBe(JSON.stringify(payload))
@@ -83,7 +84,7 @@ describe('delivery:XMLHttpRequest', () => {
       this.onreadystatechange()
     }
 
-    const payload = { sample: 'payload' } as unknown as EventDeliveryPayload
+    const payload = { sample: 'session payload' } as unknown as EventDeliveryPayload
     const config = {
       apiKey: 'aaaaaaaa',
       endpoints: { notify: '/', sessions: '/echo/' },
@@ -96,6 +97,7 @@ describe('delivery:XMLHttpRequest', () => {
       expect(requests[0].url).toMatch('/echo/')
       expect(requests[0].headers['Content-Type']).toEqual('application/json')
       expect(requests[0].headers['Bugsnag-Api-Key']).toEqual('aaaaaaaa')
+      expect(requests[0].headers['Bugsnag-Integrity']).toEqual('simple 28')
       expect(requests[0].headers['Bugsnag-Payload-Version']).toEqual('1')
       expect(requests[0].headers['Bugsnag-Sent-At']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
       expect(requests[0].data).toBe(JSON.stringify(payload))

--- a/test/browser/features/bugsnag_integrity.feature
+++ b/test/browser/features/bugsnag_integrity.feature
@@ -1,0 +1,19 @@
+@bugsnag_integrity
+Feature: Bugsnag-Integrity header
+
+Scenario Outline: Bugsnag-Integrity header stress testing
+  When I navigate to the URL "/bugsnag_integrity/script/<file>.html"
+  And I wait to receive a request
+  Then the request is a valid browser payload for the error reporting API
+  And the Bugsnag-Integrity header is valid
+
+  Examples:
+    | file                   |
+    | cyrillic               |
+    | emoji_basic            |
+    | emoji_combined         |
+    | emoji_combined_encoded |
+    | emoji_large_string     |
+    | empty_string           |
+    | encoded                |
+    | large_string           |

--- a/test/browser/features/fixtures/bugsnag_integrity/script/cyrillic.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/cyrillic.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify('обичам те')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/emoji_basic.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/emoji_basic.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify('😀😃😄😁')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/emoji_combined.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/emoji_combined.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify('🏃🏽‍♀️')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/emoji_combined_encoded.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/emoji_combined_encoded.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify('\ud83c\udfc3\ud83c\udffd\u200d\u2640\ufe0f')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/emoji_large_string.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/emoji_large_string.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      var string = ''
+
+      for (var i = 0; i < 10000; ++i) {
+        string += '👩‍👩‍👧‍👧👨‍👨‍👦‍👦'
+      }
+
+      Bugsnag.notify(string)
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/empty_string.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/empty_string.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify('')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/encoded.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/encoded.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify('\u006E\u0303\u00F1')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/bugsnag_integrity/script/large_string.html
+++ b/test/browser/features/fixtures/bugsnag_integrity/script/large_string.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      var string = ''
+
+      for (var i = 0; i < 10000; ++i) {
+        string += '1234567890'
+      }
+
+      Bugsnag.notify(string)
+    </script>
+  </body>
+</html>

--- a/test/browser/features/steps/browser_steps.rb
+++ b/test/browser/features/steps/browser_steps.rb
@@ -47,6 +47,7 @@ Then(/^the request is a valid browser payload for the error reporting API$/) do
   if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
     steps %Q{
       Then the "Bugsnag-API-Key" header is not null
+      And the Bugsnag-Integrity header is valid
       And the "Content-Type" header equals one of:
         | application/json |
         | application/json; charset=UTF-8 |
@@ -60,6 +61,7 @@ Then(/^the request is a valid browser payload for the error reporting API$/) do
       And the "sentAt" query parameter is a timestamp
     }
   end
+
   steps %Q{
     And the payload field "notifier.name" is not null
     And the payload field "notifier.url" is not null
@@ -79,6 +81,7 @@ Then(/^the request is a valid browser payload for the session tracking API$/) do
   if !/^ie_(8|9|10)$/.match(ENV['BROWSER'])
     steps %Q{
       Then the "Bugsnag-API-Key" header is not null
+      And the Bugsnag-Integrity header is valid
       And the "Content-Type" header equals one of:
         | application/json |
         | application/json; charset=UTF-8 |
@@ -92,6 +95,7 @@ Then(/^the request is a valid browser payload for the session tracking API$/) do
       And the "sentAt" query parameter is a timestamp
     }
   end
+
   steps %Q{
     And the payload field "app" is not null
     And the payload field "device" is not null
@@ -118,4 +122,13 @@ Then("the event device ID is {string}") do |expected_id|
     $logger.info('Local storage is not supported in this browser, assuming device ID is null')
     step('the event "device.id" is null')
   end
+end
+
+Then("the Bugsnag-Integrity header is valid") do
+  raw_request = Server.current_request[:request]
+
+  type, value = raw_request['Bugsnag-Integrity'].split(' ')
+
+  assert_equal('simple', type)
+  assert_equal(raw_request.body.bytesize, value.to_i)
 end

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -58,6 +58,14 @@ Before('@skip_if_local_storage_is_unavailable') do |scenario|
   skip_this_scenario unless has_local_storage
 end
 
+# Skip tests for the Bugsnag-Integrity header on IE < 11 as those browsers do not
+# support arbitrary headers
+Before('@bugsnag_integrity') do
+  type, version = ENV['BROWSER'].split('_')
+
+  skip_this_scenario if type == 'ie' && version.to_i < 11
+end
+
 AfterConfiguration do
   # Necessary as Appium removes any existing $driver instance on load
   bs_local_start


### PR DESCRIPTION
## Goal

This PR adds the Bugsnag-Integrity header to the browser XML HTTP delivery

## Testing

- Unit tests check for the header being present
- the Maze Runner "the request is a valid browser payload for the _x_ API" steps now also check for the new header, if the browser supports arbitrary headers