### PR TITLE
Add Bugsnag-Integrity header to expo delivery

### DIFF
--- a/packages/delivery-expo/delivery.js
+++ b/packages/delivery-expo/delivery.js
@@ -1,3 +1,4 @@
+const bytesize = require('@bugsnag/bytesize')
 const payload = require('@bugsnag/core/lib/json-payload')
 const UndeliveredPayloadQueue = require('./queue')
 const NetworkStatus = require('./network-status')
@@ -45,6 +46,7 @@ module.exports = (client, fetch = global.fetch) => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'Bugsnag-Integrity': `simple ${bytesize(body)}`,
             'Bugsnag-Api-Key': event.apiKey || client._config.apiKey,
             'Bugsnag-Payload-Version': '4',
             'Bugsnag-Sent-At': (new Date()).toISOString()
@@ -75,6 +77,7 @@ module.exports = (client, fetch = global.fetch) => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'Bugsnag-Integrity': `simple ${bytesize(body)}`,
             'Bugsnag-Api-Key': client._config.apiKey,
             'Bugsnag-Payload-Version': '1',
             'Bugsnag-Sent-At': (new Date()).toISOString()

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -17,6 +17,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
+    "@bugsnag/bytesize": "^7.5.2",
     "@react-native-community/netinfo": "5.9.6",
     "expo-file-system": "~9.2"
   },

--- a/packages/delivery-expo/test/delivery.test.ts
+++ b/packages/delivery-expo/test/delivery.test.ts
@@ -100,6 +100,7 @@ describe('delivery: expo', () => {
         expect(requests[0].url).toMatch('/notify/')
         expect(requests[0].headers['content-type']).toEqual('application/json')
         expect(requests[0].headers['bugsnag-api-key']).toEqual('aaaaaaaa')
+        expect(requests[0].headers['bugsnag-integrity']).toEqual('simple 87')
         expect(requests[0].headers['bugsnag-payload-version']).toEqual('4')
         expect(requests[0].headers['bugsnag-sent-at']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
         expect(requests[0].body).toBe(JSON.stringify(payload))
@@ -116,7 +117,7 @@ describe('delivery: expo', () => {
       expect(err).toBeUndefined()
 
       const payload = {
-        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+        events: [{ errors: [{ errorClass: 'Error', errorMessage: 'undefined is not a function' }] }]
       } as unknown as EventDeliveryPayload
       const config = {
         apiKey: 'aaaaaaaa',
@@ -130,6 +131,7 @@ describe('delivery: expo', () => {
         expect(requests[0].url).toMatch('/sessions/')
         expect(requests[0].headers['content-type']).toEqual('application/json')
         expect(requests[0].headers['bugsnag-api-key']).toEqual('aaaaaaaa')
+        expect(requests[0].headers['bugsnag-integrity']).toEqual('simple 93')
         expect(requests[0].headers['bugsnag-payload-version']).toEqual('1')
         expect(requests[0].headers['bugsnag-sent-at']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
         expect(requests[0].body).toBe(JSON.stringify(payload))

--- a/test/expo/features/app.feature
+++ b/test/expo/features/app.feature
@@ -13,6 +13,7 @@ Scenario: App data is included by default
   And the event "app.duration" is not null
   And the event "app.durationInForeground" is not null
   And the event "app.inForeground" is true
+  And the Bugsnag-Integrity header is valid
 
 Scenario: App data can be modified by a callback
   Given the element "enhancedAppButton" is present
@@ -23,4 +24,4 @@ Scenario: App data can be modified by a callback
   And the event "app.duration" is not null
   And the event "app.durationInForeground" is not null
   And the event "app.inForeground" is true
-
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/auto_breadcrumbs.feature
+++ b/test/expo/features/auto_breadcrumbs.feature
@@ -13,6 +13,7 @@ Scenario: App-state breadcrumbs are captured by default
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "defaultAppStateBreadcrumbsBehaviour"
   And the event has a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_5
 Scenario: App-state breadcrumbs can be disabled specifically
@@ -27,6 +28,7 @@ Scenario: App-state breadcrumbs can be disabled specifically
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAppStateBreadcrumbsBehaviour"
   And the event does not have a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_5
 Scenario: App-state breadcrumbs are disabled with other auto-breadcrumbs
@@ -41,6 +43,7 @@ Scenario: App-state breadcrumbs are disabled with other auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAllAppStateBreadcrumbsBehaviour"
   And the event does not have a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_5
 Scenario: App-state breadcrumbs overrides auto-breadcrumbs
@@ -55,6 +58,7 @@ Scenario: App-state breadcrumbs overrides auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "overrideAppStateBreadcrumbsBehaviour"
   And the event has a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs are captured by default
   Given the element "consoleBreadcrumbs" is present
@@ -65,6 +69,7 @@ Scenario: Console breadcrumbs are captured by default
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "defaultConsoleBreadcrumbsBehaviour"
   And the event has a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs can be disabled explicitly
   Given the element "consoleBreadcrumbs" is present
@@ -75,6 +80,7 @@ Scenario: Console breadcrumbs can be disabled explicitly
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledConsoleBreadcrumbsBehaviour"
   And the event does not have a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs are disabled with other auto-breadcrumbs
   Given the element "consoleBreadcrumbs" is present
@@ -85,6 +91,7 @@ Scenario: Console breadcrumbs are disabled with other auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAllConsoleBreadcrumbsBehaviour"
   And the event does not have a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs overrides auto-breadcrumbs
   Given the element "consoleBreadcrumbs" is present
@@ -95,6 +102,7 @@ Scenario: Console breadcrumbs overrides auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "overrideConsoleBreadcrumbsBehaviour"
   And the event has a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs are captured by default
   Given the element "networkBreadcrumbs" is present
@@ -107,6 +115,7 @@ Scenario: Network breadcrumbs are captured by default
   And the event has a "request" breadcrumb named "XMLHttpRequest succeeded"
   And the event "breadcrumbs.1.metaData.status" equals 200
   And the event "breadcrumbs.1.metaData.request" equals "GET http://postman-echo.com/get"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs can be disabled explicitly
   Given the element "networkBreadcrumbs" is present
@@ -117,6 +126,7 @@ Scenario: Network breadcrumbs can be disabled explicitly
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledNetworkBreadcrumbsBehaviour"
   And the event does not have a "request" breadcrumb named "XMLHttpRequest succeeded"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs are disabled with other auto-breadcrumbs
   Given the element "networkBreadcrumbs" is present
@@ -127,6 +137,7 @@ Scenario: Network breadcrumbs are disabled with other auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAllNetworkBreadcrumbsBehaviour"
   And the event does not have a "request" breadcrumb named "XMLHttpRequest succeeded"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs overrides auto-breadcrumbs
   Given the element "networkBreadcrumbs" is present
@@ -139,3 +150,4 @@ Scenario: Network breadcrumbs overrides auto-breadcrumbs
   And the event has a "request" breadcrumb named "XMLHttpRequest succeeded"
   And the event "breadcrumbs.0.metaData.status" equals 200
   And the event "breadcrumbs.0.metaData.request" equals "GET http://postman-echo.com/get"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/device.feature
+++ b/test/expo/features/device.feature
@@ -24,6 +24,7 @@ Scenario: Device data is included by default
   And the event "device.totalMemory" is not null
   And the event "metaData.device.isDevice" is true
   And the event "metaData.device.appOwnership" equals "standalone"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Device data can be modified by a callback
   Given the element "deviceCallbackButton" is present
@@ -47,3 +48,4 @@ Scenario: Device data can be modified by a callback
   And the event "device.totalMemory" is not null
   And the event "metaData.device.isDevice" is true
   And the event "metaData.device.appOwnership" equals "standalone"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/error_boundary.feature
+++ b/test/expo/features/error_boundary.feature
@@ -11,6 +11,7 @@ Scenario: A render error is captured by an error boundary
   And the exception "errorClass" equals "Error"
   And the exception "message" starts with "An error has occurred in Buggy component!"
   And the event "metaData.react.componentStack" is not null
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_7 @skip_android_8
 Scenario: When a render error occurs, a fallback is presented
@@ -19,3 +20,4 @@ Scenario: When a render error occurs, a fallback is presented
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the element "errorBoundaryFallback" is present
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/handled.feature
+++ b/test/expo/features/handled.feature
@@ -10,6 +10,7 @@ Scenario: Calling notify() with an Error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledError"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Calling notify() with a caught Error
   Given the element "handledCaughtErrorButton" is present
@@ -17,3 +18,4 @@ Scenario: Calling notify() with a caught Error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledCaughtError"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/manual_breadcrumbs.feature
+++ b/test/expo/features/manual_breadcrumbs.feature
@@ -12,3 +12,4 @@ Scenario: Manual breadcrumbs are enabled when automatic breadcrumbs are disabled
   And the exception "message" equals "ManualBreadcrumbError"
   And the event has a "manual" breadcrumb named "manualBreadcrumb"
   And the event "breadcrumbs.0.metaData.reason" equals "testing"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/metadata.feature
+++ b/test/expo/features/metadata.feature
@@ -11,6 +11,7 @@ Scenario: Meta data can be set via the client
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "MetadataClientError"
   And the event "metaData.extra.reason" equals "metadataClientName"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Meta data can be set via a callback
   Given the element "metadataCallbackButton" is present
@@ -19,3 +20,4 @@ Scenario: Meta data can be set via a callback
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "MetadataCallbackError"
   And the event "metaData.extra.reason" equals "metadataCallbackName"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/sessions.feature
+++ b/test/expo/features/sessions.feature
@@ -22,6 +22,7 @@ Scenario: Sessions can be automatically delivered
   And the payload field "app" is not null
   And the payload field "device" is not null
   And the payload has a valid sessions array
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Sessions can be manually delivered
   Given the element "manualSessionButton" is present
@@ -41,3 +42,4 @@ Scenario: Sessions can be manually delivered
   And the payload field "app" is not null
   And the payload field "device" is not null
   And the payload has a valid sessions array
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/steps/browserstack_steps.rb
+++ b/test/expo/features/steps/browserstack_steps.rb
@@ -13,3 +13,12 @@ Then("the event does not have a {string} breadcrumb named {string}") do |type, n
   end
   fail("A breadcrumb was found matching: #{value}") if found
 end
+
+Then("the Bugsnag-Integrity header is valid") do
+  raw_request = Server.current_request[:request]
+
+  type, value = raw_request['Bugsnag-Integrity'].split(' ')
+
+  assert_equal('simple', type)
+  assert_equal(raw_request.body.bytesize, value.to_i)
+end

--- a/test/expo/features/unhandled.feature
+++ b/test/expo/features/unhandled.feature
@@ -10,6 +10,7 @@ Scenario: Catching an Unhandled error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UnhandledError"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Catching an Unhandled promise rejection
   Given the element "unhandledPromiseRejectionButton" is present
@@ -17,3 +18,4 @@ Scenario: Catching an Unhandled promise rejection
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UnhandledPromiseRejection"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/user.feature
+++ b/test/expo/features/user.feature
@@ -11,6 +11,7 @@ Scenario: User data can be set via the client
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UserClientError"
   And the event "user.name" equals "userClientName"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: User data can be set via a callback
   Given the element "userCallbackButton" is present
@@ -19,3 +20,4 @@ Scenario: User data can be set via a callback
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UserCallbackError"
   And the event "user.name" equals "userCallbackName"
+  And the Bugsnag-Integrity header is valid


### PR DESCRIPTION
## Goal

This PR adds the Bugsnag-Integrity header to the Expo's delivery

## Testing

- Unit tests check for the header being present
- the Maze Runner "the request is a valid browser payload for the x API" steps now also check for the new header, if the browser supports arbitrary headers