### PR TITLE
Move Browser and Node tests to MazeRunner v3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,8 +135,6 @@ steps:
       BROWSER: "chrome_latest"
     concurrency: 5
     concurrency_group: 'browserstack'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':ie: v8 Browser tests'
     depends_on: "browser-maze-runner-image"
@@ -255,8 +253,6 @@ steps:
       BROWSER: "safari_13"
     concurrency: 5
     concurrency_group: 'browserstack'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':desktop_computer: Opera v12 Browser tests'
     depends_on: "browser-maze-runner-image"
@@ -336,8 +332,6 @@ steps:
       BROWSER: "firefox_latest"
     concurrency: 5
     concurrency_group: 'browserstack'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':node: Node 4'
     depends_on: "node-maze-runner-image"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,6 +135,8 @@ steps:
       BROWSER: "chrome_latest"
     concurrency: 5
     concurrency_group: 'browserstack'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':ie: v8 Browser tests'
     depends_on: "browser-maze-runner-image"
@@ -253,6 +255,8 @@ steps:
       BROWSER: "safari_13"
     concurrency: 5
     concurrency_group: 'browserstack'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':desktop_computer: Opera v12 Browser tests'
     depends_on: "browser-maze-runner-image"
@@ -332,6 +336,8 @@ steps:
       BROWSER: "firefox_latest"
     concurrency: 5
     concurrency_group: 'browserstack'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':node: Node 4'
     depends_on: "node-maze-runner-image"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,7 +19,7 @@ steps:
   - label: ':docker: Prepare package.json'
     timeout_in_minutes: 3
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           run: minimal-packager
     artifact_paths: min_packages.tar
 
@@ -30,14 +30,14 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
@@ -47,21 +47,21 @@ steps:
   - label: 'Lint'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: ci
     command: 'npm run test:lint'
 
   - label: 'Unit tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: ci
     command: 'npm run test:unit'
 
   - label: 'Type checks/tests'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: ci
     command: 'npm run test:types'
 
@@ -71,7 +71,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build:
             - browser-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
@@ -87,7 +87,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build:
             - node-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
@@ -101,7 +101,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -114,7 +114,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -127,7 +127,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -140,7 +140,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -153,7 +153,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -166,7 +166,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -180,7 +180,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -193,7 +193,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -206,7 +206,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -219,7 +219,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -232,7 +232,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -245,7 +245,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -259,7 +259,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -272,7 +272,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -285,7 +285,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: browser-maze-runner
         use-aliases: true
         verbose: true
@@ -298,7 +298,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -310,7 +310,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -322,7 +322,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -333,7 +333,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -344,7 +344,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,6 +123,19 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack'
 
+  - label: ':chrome: latest Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "chrome_latest"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
   - label: ':ie: v8 Browser tests'
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
@@ -228,6 +241,19 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack'
 
+  - label: ':safari: v13 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "safari_13"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
   - label: ':desktop_computer: Opera v12 Browser tests'
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
@@ -294,6 +320,19 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack'
 
+  - label: ':firefox: latest Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "firefox_latest"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
   - label: ':node: Node 4'
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
@@ -350,3 +389,14 @@ steps:
         verbose: true
     env:
       NODE_VERSION: "12"
+
+  - label: ':node: Node 14'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      NODE_VERSION: "14"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,6 +77,9 @@ steps:
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
+      - docker-compose#v3.7.0:
+          push:
+            - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
 
   - label:  ':docker: Build node maze runner image'
     key: "node-maze-runner-image"
@@ -89,6 +92,9 @@ steps:
             - node-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
+            - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
+      - docker-compose#v3.7.0:
+          push:
             - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
 
   - label: ':chrome: v43 Browser tests'

--- a/bin/local-test-util
+++ b/bin/local-test-util
@@ -247,6 +247,6 @@ async function runTests (args) {
     `-v`, `${process.cwd()}/test/browser/:/app/test/browser`,
     `-w`, `/app/test/browser`,
     `-p`, `9020:9020`,
-    `855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli`
+    `855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli`
   ].concat(args || []))
 }

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -45,24 +45,7 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 RUN rm -fr **/*/node_modules/
 
 # The maze-runner browser tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as browser-maze-runner
-RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev
-ENV GLIBC_VERSION 2.23-r3
-
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-  && wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
-  && apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
-  && rm "glibc-$GLIBC_VERSION.apk" \
-  && wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk" \
-  && apk --no-cache add "glibc-bin-$GLIBC_VERSION.apk" \
-  && rm "glibc-bin-$GLIBC_VERSION.apk" \
-  && wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-i18n-$GLIBC_VERSION.apk" \
-  && apk --no-cache add "glibc-i18n-$GLIBC_VERSION.apk" \
-  && rm "glibc-i18n-$GLIBC_VERSION.apk"
-
-RUN wget -q https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip \
-  && unzip BrowserStackLocal-linux-x64.zip \
-  && rm BrowserStackLocal-linux-x64.zip
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as browser-maze-runner
 
 COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
 WORKDIR /app/test/browser

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node test/node

--- a/test/browser/features/browsers.yml
+++ b/test/browser/features/browsers.yml
@@ -48,6 +48,12 @@ safari_10:
   os: "OS X"
   os_version: "sierra"
 
+safari_13:
+  browser: "Safari"
+  browser_version: "13.0"
+  os: "OS X"
+  os_version: "Catalina"
+
 opera_12:
   browser: "opera"
   browser_version: "12.16"
@@ -80,6 +86,13 @@ firefox_56:
   os: "windows"
   os_version: "10"
 
+firefox_latest:
+  browser: "firefox"
+  browser_version: "latest"
+  os: "windows"
+  os_version: "10"
+  selenium_version: "3.10.0"
+
 chrome_43:
   browser: "chrome"
   browser_version: "43.0"
@@ -91,3 +104,10 @@ chrome_61:
   browser_version: "61.0"
   os: "windows"
   os_version: "10"
+
+chrome_latest:
+  browser: "chrome"
+  browser_version: "latest"
+  os: "windows"
+  os_version: "10"
+  selenium_version: "3.14.0"

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -375,7 +375,7 @@ firefox_latest:
     errorClass: 'URIError'
     errorMessage: malformed URI sequence
     lineNumber: 17
-    columnNumber: 7
+    columnNumber: 25
 
 chrome_43:
   handled:

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -203,6 +203,32 @@ safari_10:
     lineNumber: 17
     columnNumber: 25
 
+safari_13:
+  handled:
+    errorClass: 'ReferenceError'
+    errorMessage: "Can't find variable: foo"
+  unhandled_syntax:
+    errorClass: 'SyntaxError'
+    errorMessage: "Unexpected token '!'. Parse error."
+    lineNumber: 17
+    columnNumber: 0
+    file: '/unhandled/script/a.html'
+  unhandled_thrown:
+    errorClass: 'Error'
+    errorMessage: "bad things"
+    lineNumber: 17
+    columnNumber: 22
+  unhandled_undefined_function:
+    errorClass: 'ReferenceError'
+    errorMessage: "Can't find variable: nevergoingtoexist_notinamillionyears"
+    lineNumber: 17
+    columnNumber: 43
+  unhandled_malformed_uri:
+    errorClass: 'URIError'
+    errorMessage: URI error
+    lineNumber: 17
+    columnNumber: 25
+
 opera_12:
   handled:
     errorClass: 'ReferenceError'
@@ -325,6 +351,32 @@ firefox_56:
     lineNumber: 17
     columnNumber: 7
 
+firefox_latest:
+  handled:
+    errorClass: 'ReferenceError'
+    errorMessage: 'foo is not defined'
+  unhandled_syntax:
+    errorClass: 'SyntaxError'
+    errorMessage: "unexpected token: '!'"
+    lineNumber: 17
+    columnNumber: 12
+    file: '/unhandled/script/a.html'
+  unhandled_thrown:
+    errorClass: 'Error'
+    errorMessage: "bad things"
+    lineNumber: 17
+    columnNumber: 13
+  unhandled_undefined_function:
+    errorClass: 'ReferenceError'
+    errorMessage: nevergoingtoexist_notinamillionyears is not defined
+    lineNumber: 17
+    columnNumber: 7
+  unhandled_malformed_uri:
+    errorClass: 'URIError'
+    errorMessage: malformed URI sequence
+    lineNumber: 17
+    columnNumber: 7
+
 chrome_43:
   handled:
     errorClass: 'ReferenceError'
@@ -358,6 +410,32 @@ chrome_61:
   unhandled_syntax:
     errorClass: 'SyntaxError'
     errorMessage: "Unexpected token !"
+    lineNumber: 17
+    columnNumber: 13
+    file: '/unhandled/script/a.html'
+  unhandled_thrown:
+    errorClass: 'Error'
+    errorMessage: "bad things"
+    lineNumber: 17
+    columnNumber: 13
+  unhandled_undefined_function:
+    errorClass: 'ReferenceError'
+    errorMessage: nevergoingtoexist_notinamillionyears is not defined
+    lineNumber: 17
+    columnNumber: 7
+  unhandled_malformed_uri:
+    errorClass: 'URIError'
+    errorMessage: URI malformed
+    lineNumber: 17
+    columnNumber: 7
+
+chrome_latest:
+  handled:
+    errorClass: 'ReferenceError'
+    errorMessage: 'foo is not defined'
+  unhandled_syntax:
+    errorClass: 'SyntaxError'
+    errorMessage: "Unexpected token '!'"
     lineNumber: 17
     columnNumber: 13
     file: '/unhandled/script/a.html'

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -25,8 +25,12 @@ def get_test_url path
   "http://#{ENV['HOST']}:#{FIXTURES_SERVER_PORT}#{path}?ENDPOINT=#{URI::encode("http://#{ENV['API_HOST']}:#{MOCK_API_PORT}")}&API_KEY=#{URI::encode($api_key)}"
 end
 
+
 def get_error_message id
-  ERRORS[ENV['BROWSER']][id]
+  browser = ENV['BROWSER']
+  raise "The browser '#{browser}' does not exist in 'browser_errors.yml'" unless ERRORS.has_key?(browser)
+
+  ERRORS[browser][id]
 end
 
 # check if Selenium supports running javascript in the current browser


### PR DESCRIPTION
## Goal

Update the main pipeline to use MazeRunner v3.

## Design

The MazeRunner Docker image is based on Ubuntu rather than Alpine, which seems to provide greater stability for the BrowserStackLocal binary (which does not directly support Alpine).  It also removes the need for copying in various glibc artefacts.

## Changeset

In addition to the move to MazeRuner v3, I've also taken the opportunity to review the platform version coverages.  One of the scenarios is failing on the later version of Chrome, Firefox and Safari, so I have put a soft fail on these pending further investigation.

## Testing

Basic move to v3 is covered by CI.  As noted above, there is a scenario failing on the newer browsers that requires further investigation.