### PR TITLE
Update Expo pipeline to Maze Runner v3

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -5,13 +5,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           build: expo-publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           push:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
@@ -25,19 +25,19 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           run: expo-publisher
 
   - label: ':docker: Build expo maze runner image'
     key: "expo-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           build: expo-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           push:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
@@ -48,13 +48,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           build: expo-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           push:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -71,7 +71,7 @@ steps:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
     plugins:
-      - docker-compose#v3.1.0:
+      - docker-compose#v3.7.0:
           run: expo-android-builder
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -89,7 +89,7 @@ steps:
     commands:
       - test/expo/scripts/build-ios.sh
 
-  - label: 'expo Android 9'
+  - label: ':runner: expo Android 9'
     depends_on:
       - "build-expo-apk"
       - "expo-maze-runner-image"
@@ -97,16 +97,22 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "ANDROID_9_0"
-      APP_LOCATION: "build/output.apk"
+        command:
+          - --app=build/output.apk
+          - --farm=bs
+          - --device=ANDROID_9_0
+          - --a11y-locator
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'expo iOS 12'
+  - label: ':runner: expo iOS 12'
     depends_on:
       - "build-expo-ipa"
       - "expo-maze-runner-image"
@@ -114,97 +120,161 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "IOS_12"
-      APP_LOCATION: "build/output.ipa"
+        command:
+          - --app=build/output.ipa
+          - --farm=bs
+          - --device=IOS_12
+          - --a11y-locator
+          - --appium-version=1.16.0
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
   - block: "Trigger full test suite"
 
-  - label: 'expo Android 8'
+  - label: ':runner: expo Android 8'
+    depends_on:
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "ANDROID_8_1"
-      APP_LOCATION: "build/output.apk"
+        command:
+          - --app=build/output.apk
+          - --farm=bs
+          - --device=ANDROID_8_1
+          - --a11y-locator
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'expo Android 7'
+  - label: ':runner: expo Android 7'
+    depends_on:
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "ANDROID_7_1"
-      APP_LOCATION: "build/output.apk"
+        command:
+          - --app=build/output.apk
+          - --farm=bs
+          - --device=ANDROID_7_1
+          - --a11y-locator
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'expo Android 6'
+  - label: ':runner: expo Android 6'
+    depends_on:
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "ANDROID_6_0"
-      APP_LOCATION: "build/output.apk"
+        command:
+          - --app=build/output.apk
+          - --farm=bs
+          - --device=ANDROID_6_0
+          - --a11y-locator
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'expo Android 5'
+  - label: ':runner: expo Android 5'
+    depends_on:
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "ANDROID_5_0"
-      APP_LOCATION: "build/output.apk"
+        command:
+          - --app=build/output.apk
+          - --farm=bs
+          - --device=ANDROID_5_0
+          - --a11y-locator
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'expo iOS 10'
+  - label: ':runner: expo iOS 11'
+    depends_on:
+      - "build-expo-ipa"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "IOS_10"
-      APP_LOCATION: "build/output.ipa"
+        command:
+          - --app=build/output.ipa
+          - --farm=bs
+          - --device=IOS_11
+          - --a11y-locator
+          - --appium-version=1.16.0
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
+          - --resilient
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: 'expo iOS 11'
+  - label: ':runner: expo iOS 10'
+    depends_on:
+      - "build-expo-ipa"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v3.1.0:
+      docker-compose#v3.7.0:
         run: expo-maze-runner
         use-aliases: true
-    env:
-      DEVICE_TYPE: "IOS_11"
-      APP_LOCATION: "build/output.ipa"
+        command:
+          - --app=build/output.ipa
+          - --farm=bs
+          - --device=IOS_10
+          - --a11y-locator
+          - --username=$BROWSER_STACK_USERNAME
+          - --access-key=$BROWSER_STACK_ACCESS_KEY
+          - --fail-fast
+          - --retry=2
+          - --resilient
     concurrency: 10
     concurrency_group: 'browserstack-app'

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -139,9 +139,6 @@ steps:
   - block: "Trigger full test suite"
 
   - label: ':runner: expo Android 8'
-    depends_on:
-      - "build-expo-apk"
-      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -160,11 +157,10 @@ steps:
           - --retry=2
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':runner: expo Android 7'
-    depends_on:
-      - "build-expo-apk"
-      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -185,9 +181,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo Android 6'
-    depends_on:
-      - "build-expo-apk"
-      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -208,9 +201,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo Android 5'
-    depends_on:
-      - "build-expo-apk"
-      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -231,9 +221,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 11'
-    depends_on:
-      - "build-expo-ipa"
-      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -256,9 +243,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 10'
-    depends_on:
-      - "build-expo-ipa"
-      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:

--- a/TESTING.md
+++ b/TESTING.md
@@ -162,6 +162,7 @@ node ./scripts/publish.js http://localhost:4873
 This can also be overridden using the environment variable `NOTIFIER_VERSION`, which is useful during development when 
 making test, but not notifier, changes.
 
+
 If building against the current branch/commit, the packages must be published to a locally owned NPM repository 
 (! Not the official NPMJS repository !). This can be locally or remotely hosted, but should be versioned appropriately.  
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,15 +70,9 @@ services:
       dockerfile: dockerfiles/Dockerfile.expo
       args:
         - BUILDKITE_BUILD_NUMBER
-    command: --fail-fast --retry 2
     environment:
       VERBOSE:
       DEBUG:
-      BROWSER_STACK_USERNAME:
-      BROWSER_STACK_ACCESS_KEY:
-      BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
-      APP_LOCATION:
-      DEVICE_TYPE:
     networks:
       default:
         aliases:

--- a/dockerfiles/Dockerfile.expo
+++ b/dockerfiles/Dockerfile.expo
@@ -1,5 +1,4 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as expo-maze-runner
-RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as expo-maze-runner
 COPY /test/expo /app/test/expo
 WORKDIR /app/test/expo

--- a/test/expo/features/support/env.rb
+++ b/test/expo/features/support/env.rb
@@ -1,46 +1,35 @@
-bs_username = ENV['BROWSER_STACK_USERNAME']
-bs_access_key = ENV['BROWSER_STACK_ACCESS_KEY']
-bs_local_id = ENV['BROWSER_STACK_LOCAL_IDENTIFIER'] || 'mazzzzeee'
-app_location = ENV['APP_LOCATION']
-
-def device_type
-  ENV['DEVICE_TYPE']
-end
-
 Before('@skip_android_5') do |scenario|
-  skip_this_scenario("Skipping scenario") if device_type == 'ANDROID_5_0'
+  if MazeRunner.driver.capabilities['os'] == 'android' and MazeRunner.config.os_version.floor == 5
+    skip_this_scenario("Skipping Android 5")
+  end
 end
 
 Before('@skip_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if device_type == 'ANDROID_7_1'
+  if MazeRunner.driver.capabilities['os'] == 'android' and MazeRunner.config.os_version.floor == 7
+    skip_this_scenario("Skipping Android 7")
+  end
 end
 
 Before('@skip_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") if device_type == 'ANDROID_8_1'
+  if MazeRunner.driver.capabilities['os'] == 'android' and MazeRunner.config.os_version.floor == 8
+    skip_this_scenario("Skipping Android 8")
+  end
 end
 
 Before('@skip_ios_10') do |scenario|
-  skip_this_scenario("Skipping scenario") if device_type == 'IOS_10'
+  if MazeRunner.driver.capabilities['os'] == 'ios' and MazeRunner.config.os_version.floor == 10
+    skip_this_scenario("Skipping iOS 10")
+  end
 end
 
 Before('@skip_ios_11') do |scenario|
-  skip_this_scenario("Skipping scenario") if device_type == 'IOS_11'
+  if MazeRunner.driver.capabilities['os'] == 'ios' and MazeRunner.config.os_version.floor == 11
+    skip_this_scenario("Skipping iOS 11")
+  end
 end
 
 Before('@skip_ios_12') do |scenario|
-  skip_this_scenario("Skipping scenario") if device_type == 'IOS_12'
-end
-
-After do |_scenario|
-  $driver.reset_with_timeout
-end
-
-AfterConfiguration do |config|
-  AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, device_type, app_location, :accessibility_id)
-  $driver.start_driver
-end
-
-# Ensure the browserstack instance is stopped
-at_exit do
-  $driver.driver_quit if $driver
+  if MazeRunner.driver.capabilities['os'] == 'ios' and MazeRunner.config.os_version.floor == 12
+    skip_this_scenario("Skipping iOS 12")
+  end
 end


### PR DESCRIPTION
## Goal

Migrate the Expo pipeline to use Maze Runner v3.

Note that this PR is chained onto the v3 migration of React Native.

## Design

Follows the standard migration approach.

## Changeset

Maze Runner touch point - pipeline, `env.rb` and `docker-compose.yml`.

## Testing

Covered by standard CI.