### PR TITLE
Separate pipelines for Browser, Node, Expo and RN

### DIFF
--- a/.buildkite/browsers-pipeline.yml
+++ b/.buildkite/browsers-pipeline.yml
@@ -1,0 +1,254 @@
+steps:
+
+  - label:  ':docker: Build browser maze runner image'
+    key: "browser-maze-runner-image"
+    timeout_in_minutes: 20
+    plugins:
+      - artifacts#v1.3.0:
+          download: min_packages.tar
+          build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
+      - docker-compose#v3.7.0:
+          build:
+            - browser-maze-runner
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+          cache-from:
+            - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
+      - docker-compose#v3.7.0:
+          push:
+            - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
+
+  - label: ':chrome: v43 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "chrome_43"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':chrome: v61 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "chrome_61"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':chrome: latest Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "chrome_latest"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':ie: v8 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "ie_8"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':ie: v9 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "ie_9"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':ie: v10 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "ie_10"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':ie: v11 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "ie_11"
+      HOST: 'localhost' # IE11 needs the host set to localhost for some reason!ß
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':edge: v14 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "edge_14"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':edge: v15 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "edge_15"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':safari: v6 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "safari_6"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':safari: v10 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "safari_10"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':safari: v13 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "safari_13"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':desktop_computer: Opera v12 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "opera_12"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':iphone: iOS 10.3 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 20
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "iphone_7"
+      HOST: "bs-local.com"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':android: Samsung Galaxy S8 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "android_s8"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':firefox: v30 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "firefox_30"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':firefox: v56 Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "firefox_56"
+    concurrency: 5
+    concurrency_group: 'browserstack'
+
+  - label: ':firefox: latest Browser tests'
+    depends_on: "browser-maze-runner-image"
+    timeout_in_minutes: 10
+    plugins:
+      docker-compose#v3.7.0:
+        run: browser-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      BROWSER: "firefox_latest"
+    concurrency: 5
+    concurrency_group: 'browserstack'

--- a/.buildkite/node-pipeline.yml
+++ b/.buildkite/node-pipeline.yml
@@ -1,0 +1,86 @@
+steps:
+
+  - label:  ':docker: Build node maze runner image'
+    key: "node-maze-runner-image"
+    timeout_in_minutes: 20
+    plugins:
+      - artifacts#v1.3.0:
+          download: min_packages.tar
+          build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
+      - docker-compose#v3.7.0:
+          build:
+            - node-maze-runner
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+          cache-from:
+            - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
+      - docker-compose#v3.7.0:
+          push:
+            - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
+
+  - label: ':node: Node 4'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "webpack.feature"]
+    env:
+      NODE_VERSION: "4"
+
+  - label: ':node: Node 6'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature"]
+    env:
+      NODE_VERSION: "6"
+
+  - label: ':node: Node 8'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      NODE_VERSION: "8"
+
+  - label: ':node: Node 10'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      NODE_VERSION: "10"
+
+  - label: ':node: Node 12'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      NODE_VERSION: "12"
+
+  - label: ':node: Node 14'
+    depends_on: "node-maze-runner-image"
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.7.0:
+        run: node-maze-runner
+        use-aliases: true
+        verbose: true
+    env:
+      NODE_VERSION: "14"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,8 +42,7 @@ steps:
 
   - label: 'Trigger Expo pipeline'
     depends_on: "publish-js"
-    # TODO: Rename to bugsnag-js-expo
-    trigger: 'at-bugsnag-expo'
+    trigger: 'bugsnag-js-expo'
     build:
       branch: '${BUILDKITE_BRANCH}'
       commit: '${BUILDKITE_COMMIT}'
@@ -52,8 +51,7 @@ steps:
 
   - label: 'Trigger React Native pipeline'
     depends_on: "publish-js"
-    # TODO: Rename to bugsnag-js-react-native
-    trigger: 'at-bugsnag-react-native'
+    trigger: 'bugsnag-js-react-native'
     build:
       branch: '${BUILDKITE_BRANCH}'
       commit: '${BUILDKITE_COMMIT}'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,16 @@
 steps:
 
   #
-  # Publish notifier
+  # Publish/package notifier
   #
+  - label: ':docker: Prepare package.json'
+    key: "package-js"
+    timeout_in_minutes: 3
+    plugins:
+      - docker-compose#v3.7.0:
+          run: minimal-packager
+    artifact_paths: min_packages.tar
+
   - label: ':docker: Build and publish JS packages'
     key: "publish-js"
     timeout_in_minutes: 30
@@ -11,12 +19,30 @@ steps:
           build: publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
 
-  - wait
-
   #
   # Trigger individual pipelines
   #
+  - label: 'Trigger Browser pipeline'
+    depends_on: "package-js"
+    trigger: 'bugsnag-js-browsers'
+    build:
+      branch: '${BUILDKITE_BRANCH}'
+      commit: '${BUILDKITE_COMMIT}'
+      message: '${BUILDKITE_MESSAGE}'
+    async: true
+
+  - label: 'Trigger Node pipeline'
+    depends_on: "package-js"
+    trigger: 'bugsnag-js-node'
+    build:
+      branch: '${BUILDKITE_BRANCH}'
+      commit: '${BUILDKITE_COMMIT}'
+      message: '${BUILDKITE_MESSAGE}'
+    async: true
+
   - label: 'Trigger Expo pipeline'
+    depends_on: "publish-js"
+    # TODO: Rename to bugsnag-js-expo
     trigger: 'at-bugsnag-expo'
     build:
       branch: '${BUILDKITE_BRANCH}'
@@ -24,7 +50,9 @@ steps:
       message: '${BUILDKITE_MESSAGE}'
     async: true
 
-  - label: 'Trigger React-native pipeline'
+  - label: 'Trigger React Native pipeline'
+    depends_on: "publish-js"
+    # TODO: Rename to bugsnag-js-react-native
     trigger: 'at-bugsnag-react-native'
     build:
       branch: '${BUILDKITE_BRANCH}'
@@ -32,16 +60,13 @@ steps:
       message: '${BUILDKITE_MESSAGE}'
     async: true
 
-  - label: ':docker: Prepare package.json'
-    timeout_in_minutes: 3
-    plugins:
-      - docker-compose#v3.7.0:
-          run: minimal-packager
-    artifact_paths: min_packages.tar
-
-  - wait
+  #
+  # Core tests and checks
+  #
 
   - label: ':docker: Build CI image'
+    key: "ci-image"
+    depends_on: "package-js"
     timeout_in_minutes: 20
     plugins:
       - artifacts#v1.2.0:
@@ -58,9 +83,8 @@ steps:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
 
-  - wait
-
   - label: 'Lint'
+    depends_on: "ci-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.7.0:
@@ -68,6 +92,7 @@ steps:
     command: 'npm run test:lint'
 
   - label: 'Unit tests'
+    depends_on: "ci-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.7.0:
@@ -75,344 +100,9 @@ steps:
     command: 'npm run test:unit'
 
   - label: 'Type checks/tests'
+    depends_on: "ci-image"
     timeout_in_minutes: 10
     plugins:
       docker-compose#v3.7.0:
         run: ci
     command: 'npm run test:types'
-
-  - label:  ':docker: Build browser maze runner image'
-    key: "browser-maze-runner-image"
-    timeout_in_minutes: 20
-    plugins:
-      - artifacts#v1.2.0:
-          download: min_packages.tar
-      - docker-compose#v3.7.0:
-          build:
-            - browser-maze-runner
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-          cache-from:
-            - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
-          push:
-            - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-
-  - label:  ':docker: Build node maze runner image'
-    key: "node-maze-runner-image"
-    timeout_in_minutes: 20
-    plugins:
-      - artifacts#v1.2.0:
-          download: min_packages.tar
-      - docker-compose#v3.7.0:
-          build:
-            - node-maze-runner
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-          cache-from:
-            - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
-          push:
-            - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
-
-  - label: ':chrome: v43 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "chrome_43"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':chrome: v61 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "chrome_61"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':chrome: latest Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "chrome_latest"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':ie: v8 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "ie_8"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':ie: v9 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "ie_9"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':ie: v10 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "ie_10"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':ie: v11 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "ie_11"
-      HOST: 'localhost' # IE11 needs the host set to localhost for some reason!ß
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':edge: v14 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "edge_14"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':edge: v15 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "edge_15"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':safari: v6 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "safari_6"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':safari: v10 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "safari_10"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':safari: v13 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "safari_13"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':desktop_computer: Opera v12 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "opera_12"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':iphone: iOS 10.3 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 20
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "iphone_7"
-      HOST: "bs-local.com"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':android: Samsung Galaxy S8 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "android_s8"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':firefox: v30 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "firefox_30"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':firefox: v56 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "firefox_56"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':firefox: latest Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "firefox_latest"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
-  - label: ':node: Node 4'
-    depends_on: "node-maze-runner-image"
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.7.0:
-        run: node-maze-runner
-        use-aliases: true
-        verbose: true
-        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "webpack.feature"]
-    env:
-      NODE_VERSION: "4"
-
-  - label: ':node: Node 6'
-    depends_on: "node-maze-runner-image"
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.7.0:
-        run: node-maze-runner
-        use-aliases: true
-        verbose: true
-        command: ["-e", "koa.feature", "-e", "koa-1x.feature"]
-    env:
-      NODE_VERSION: "6"
-
-  - label: ':node: Node 8'
-    depends_on: "node-maze-runner-image"
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.7.0:
-        run: node-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      NODE_VERSION: "8"
-
-  - label: ':node: Node 10'
-    depends_on: "node-maze-runner-image"
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.7.0:
-        run: node-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      NODE_VERSION: "10"
-
-  - label: ':node: Node 12'
-    depends_on: "node-maze-runner-image"
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.7.0:
-        run: node-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      NODE_VERSION: "12"
-
-  - label: ':node: Node 14'
-    depends_on: "node-maze-runner-image"
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.7.0:
-        run: node-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      NODE_VERSION: "14"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,21 @@
 steps:
 
+  #
+  # Publish notifier
+  #
+  - label: ':docker: Build and publish JS packages'
+    key: "publish-js"
+    timeout_in_minutes: 30
+    plugins:
+      - docker-compose#v3.3.0:
+          build: publisher
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+
+  - wait
+
+  #
+  # Trigger individual pipelines
+  #
   - label: 'Trigger Expo pipeline'
     trigger: 'at-bugsnag-expo'
     build:

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -33,7 +33,6 @@ steps:
     key: "rn-0-60-apk"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.60"
@@ -47,7 +46,6 @@ steps:
     key: "rn-0-60-ipa"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     agents:
       queue: "opensource-mac-rn"
@@ -61,7 +59,6 @@ steps:
     key: "rn-0-63-apk"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.63"
@@ -75,7 +72,6 @@ steps:
     key: "rn-0-63-ipa"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     agents:
       queue: "opensource-mac-rn"
@@ -89,7 +85,6 @@ steps:
     key: "react-navigation-0-60-apk"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.60"
@@ -105,8 +100,6 @@ steps:
   - label: ':ios: Build react-navigation 0.60 ipa'
     skip: "See PLAT-5173"
     key: "react-navigation-0-60-ipa"
-    depends_on:
-      - "publish-js"
     timeout_in_minutes: 60
     agents:
       queue: "opensource-mac-rn"
@@ -122,7 +115,6 @@ steps:
     key: "react-navigation-0-63-apk"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.63"
@@ -138,8 +130,6 @@ steps:
   - label: ':ios: Build react-navigation 0.63 ipa'
     skip: "See PLAT-5173"
     key: "react-navigation-0-63-ipa"
-    depends_on:
-      - "publish-js"
     timeout_in_minutes: 60
     agents:
       queue: "opensource-mac-rn"
@@ -155,7 +145,6 @@ steps:
     key: "react-native-navigation-0-60-apk"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.60"
@@ -171,8 +160,6 @@ steps:
   - label: ':ios: Build react-native-navigation 0.60 ipa'
     skip: "See PLAT-5173"
     key: "react-native-navigation-0-60-ipa"
-    depends_on:
-      - "publish-js"
     timeout_in_minutes: 60
     agents:
       queue: "opensource-mac-rn"
@@ -188,7 +175,6 @@ steps:
     key: "react-native-navigation-0-63-apk"
     depends_on:
       - "android-builder-image"
-      - "publish-js"
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.63"
@@ -204,8 +190,6 @@ steps:
   - label: ':ios: Build react-native-navigation 0.63 ipa'
     skip: "See PLAT-5173"
     key: "react-native-navigation-0-63-ipa"
-    depends_on:
-      - "publish-js"
     timeout_in_minutes: 60
     agents:
       queue: "opensource-mac-rn"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -1,17 +1,6 @@
 steps:
 
   #
-  # Publish notifier
-  #
-  - label: ':docker: Build and publish JS packages'
-    key: "publish-js"
-    timeout_in_minutes: 30
-    plugins:
-      - docker-compose#v3.3.0:
-          build: publisher
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-
-  #
   # Android builder images
   #
   - label: ':docker: Build Android Builder base image'


### PR DESCRIPTION
## Goal

Spilt the JS build into separate pipelines for Browsers, Node, Expo and React Native.  

## Design

A new pipeline for the React Native CLI will slot in next to these and the main pipeline contains "general" steps such as package/publishing and unit tests.  The package step may eventually disappear if Node/Browsers are switched over to using the NPM published artifacts.

## Changeset

As usual with changes like this the diffs look far worse than the real changes.  It was almost copy/paste other than:
- Moving the what was RN-specific publish step to the main pipeline.
- Adding the `build` attribute on artifact download steps
- Step dependencies reviewed

## Testing

Covered by CI passing, combined with a sanity check that no build steps have been lost as part of the refactor.  The browser tests currently fail, as an update to our S3 secrets bucket is needed in order to access the required BrowserStack credentials.