### PR TITLE
Add Bugsnag Integrity header to Expo delivery

### DIFF
--- a/packages/delivery-expo/package-lock.json
+++ b/packages/delivery-expo/package-lock.json
@@ -9,6 +9,11 @@
 			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.6.tgz",
 			"integrity": "sha512-cEkA1Apg8+VjnDdeDZRHI+2RqouiPKgYnewouRkvF4ettH9ZS4Cmi/nANQKIpIu2L+czboxM3fCZ44nc7IM9VQ=="
 		},
+		"expo-crypto": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-8.3.0.tgz",
+			"integrity": "sha512-PbfxihKJsAkAy5M6jfv5Eiv9pRHU1BjBa7jLcwKDH6aUiWiJNjUvfdwku/Odt/lpXDuNcyDASy4WrD/PZDHtLA=="
+		},
 		"expo-file-system": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-9.2.0.tgz",

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "dependencies": {
     "@react-native-community/netinfo": "5.9.6",
-    "expo-file-system": "~9.2"
+    "expo-file-system": "~9.2",
+    "expo-crypto": "~8.3.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.3.5"

--- a/packages/delivery-expo/test/delivery.test.ts
+++ b/packages/delivery-expo/test/delivery.test.ts
@@ -29,6 +29,17 @@ jest.mock('expo-file-system', () => ({
   createDownloadResumable: jest.fn(() => Promise.resolve())
 }))
 
+jest.mock('expo-crypto', () => ({
+  CryptoDigestAlgorithm: { SHA1: 'sha1' },
+  digestStringAsync: jest.fn((algorithm, input) => {
+    if (algorithm === 'sha1') {
+      return Promise.resolve(input)
+    }
+
+    return Promise.reject(new Error(`Invalid algorithm '${algorithm}'`))
+  })
+}))
+
 jest.mock('@react-native-community/netinfo', () => ({
   addEventListener: jest.fn(),
   fetch: () => new Promise(resolve => setTimeout(() => resolve({ isConnected: true }), 1))
@@ -100,6 +111,7 @@ describe('delivery: expo', () => {
         expect(requests[0].url).toMatch('/notify/')
         expect(requests[0].headers['content-type']).toEqual('application/json')
         expect(requests[0].headers['bugsnag-api-key']).toEqual('aaaaaaaa')
+        expect(requests[0].headers['bugsnag-integrity']).toEqual('sha1 {"events":[{"errors":[{"errorClass":"Error","errorMessage":"foo is not a function"}]}]}')
         expect(requests[0].headers['bugsnag-payload-version']).toEqual('4')
         expect(requests[0].headers['bugsnag-sent-at']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
         expect(requests[0].body).toBe(JSON.stringify(payload))
@@ -130,6 +142,7 @@ describe('delivery: expo', () => {
         expect(requests[0].url).toMatch('/sessions/')
         expect(requests[0].headers['content-type']).toEqual('application/json')
         expect(requests[0].headers['bugsnag-api-key']).toEqual('aaaaaaaa')
+        expect(requests[0].headers['bugsnag-integrity']).toEqual('sha1 {"events":[{"errors":[{"errorClass":"Error","errorMessage":"foo is not a function"}]}]}')
         expect(requests[0].headers['bugsnag-payload-version']).toEqual('1')
         expect(requests[0].headers['bugsnag-sent-at']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
         expect(requests[0].body).toBe(JSON.stringify(payload))
@@ -336,21 +349,17 @@ describe('delivery: expo', () => {
       endpoints: { notify: 'http://some-address.com' },
       redactedKeys: []
     }
-    let n = 0
-    const _done = () => {
-      n++
-      if (n === 2) done()
-    }
+
     const d = delivery({ _config: config, _logger: noopLogger } as unknown as Client, fetch)
     d.sendEvent(payload, (err) => {
       expect(err).not.toBeTruthy()
       expect(enqueueSpy).toHaveBeenCalledTimes(1)
-      _done()
-    })
-    d.sendSession(payload, (err) => {
-      expect(err).not.toBeTruthy()
-      expect(enqueueSpy).toHaveBeenCalledTimes(2)
-      _done()
+
+      d.sendSession(payload, (err) => {
+        expect(err).not.toBeTruthy()
+        expect(enqueueSpy).toHaveBeenCalledTimes(2)
+        done()
+      })
     })
   })
 })

--- a/packages/expo/CONTRIBUTING.md
+++ b/packages/expo/CONTRIBUTING.md
@@ -12,6 +12,7 @@ The following modules are currently used:
 - `expo-file-system`, `@react-native-community/netinfo` (`@bugsnag/delivery-expo`)
 - `expo-constants` (`@bugsnag/plugin-expo-app`)
 - `expo-device` (`@bugsnag/plugin-expo-device`)
+- `expo-crypto` (`@bugsnag/expo`, `@bugsnag/delivery-expo`)
 
 If you add a new dependency please add it to this list.
 

--- a/packages/expo/test/index.test.ts
+++ b/packages/expo/test/index.test.ts
@@ -24,6 +24,7 @@ jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
 }))
 
 jest.mock('@bugsnag/delivery-expo')
+jest.mock('../../delivery-expo/node_modules/expo-crypto', () => ({}))
 
 jest.mock('react-native', () => ({
   NativeModules: {

--- a/test/expo/features/app.feature
+++ b/test/expo/features/app.feature
@@ -13,6 +13,7 @@ Scenario: App data is included by default
   And the event "app.duration" is not null
   And the event "app.durationInForeground" is not null
   And the event "app.inForeground" is true
+  And the Bugsnag-Integrity header is valid
 
 Scenario: App data can be modified by a callback
   Given the element "enhancedAppButton" is present
@@ -23,4 +24,4 @@ Scenario: App data can be modified by a callback
   And the event "app.duration" is not null
   And the event "app.durationInForeground" is not null
   And the event "app.inForeground" is true
-
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/auto_breadcrumbs.feature
+++ b/test/expo/features/auto_breadcrumbs.feature
@@ -13,6 +13,7 @@ Scenario: App-state breadcrumbs are captured by default
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "defaultAppStateBreadcrumbsBehaviour"
   And the event has a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_5
 Scenario: App-state breadcrumbs can be disabled specifically
@@ -27,6 +28,7 @@ Scenario: App-state breadcrumbs can be disabled specifically
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAppStateBreadcrumbsBehaviour"
   And the event does not have a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_5
 Scenario: App-state breadcrumbs are disabled with other auto-breadcrumbs
@@ -41,6 +43,7 @@ Scenario: App-state breadcrumbs are disabled with other auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAllAppStateBreadcrumbsBehaviour"
   And the event does not have a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_5
 Scenario: App-state breadcrumbs overrides auto-breadcrumbs
@@ -55,6 +58,7 @@ Scenario: App-state breadcrumbs overrides auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "overrideAppStateBreadcrumbsBehaviour"
   And the event has a "state" breadcrumb named "App state changed"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs are captured by default
   Given the element "consoleBreadcrumbs" is present
@@ -65,6 +69,7 @@ Scenario: Console breadcrumbs are captured by default
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "defaultConsoleBreadcrumbsBehaviour"
   And the event has a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs can be disabled explicitly
   Given the element "consoleBreadcrumbs" is present
@@ -75,6 +80,7 @@ Scenario: Console breadcrumbs can be disabled explicitly
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledConsoleBreadcrumbsBehaviour"
   And the event does not have a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs are disabled with other auto-breadcrumbs
   Given the element "consoleBreadcrumbs" is present
@@ -85,6 +91,7 @@ Scenario: Console breadcrumbs are disabled with other auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAllConsoleBreadcrumbsBehaviour"
   And the event does not have a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Console breadcrumbs overrides auto-breadcrumbs
   Given the element "consoleBreadcrumbs" is present
@@ -95,6 +102,7 @@ Scenario: Console breadcrumbs overrides auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "overrideConsoleBreadcrumbsBehaviour"
   And the event has a "log" breadcrumb named "Console output"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs are captured by default
   Given the element "networkBreadcrumbs" is present
@@ -107,6 +115,7 @@ Scenario: Network breadcrumbs are captured by default
   And the event has a "request" breadcrumb named "XMLHttpRequest succeeded"
   And the event "breadcrumbs.1.metaData.status" equals 200
   And the event "breadcrumbs.1.metaData.request" equals "GET http://postman-echo.com/get"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs can be disabled explicitly
   Given the element "networkBreadcrumbs" is present
@@ -117,6 +126,7 @@ Scenario: Network breadcrumbs can be disabled explicitly
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledNetworkBreadcrumbsBehaviour"
   And the event does not have a "request" breadcrumb named "XMLHttpRequest succeeded"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs are disabled with other auto-breadcrumbs
   Given the element "networkBreadcrumbs" is present
@@ -127,6 +137,7 @@ Scenario: Network breadcrumbs are disabled with other auto-breadcrumbs
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "disabledAllNetworkBreadcrumbsBehaviour"
   And the event does not have a "request" breadcrumb named "XMLHttpRequest succeeded"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs overrides auto-breadcrumbs
   Given the element "networkBreadcrumbs" is present
@@ -139,3 +150,4 @@ Scenario: Network breadcrumbs overrides auto-breadcrumbs
   And the event has a "request" breadcrumb named "XMLHttpRequest succeeded"
   And the event "breadcrumbs.0.metaData.status" equals 200
   And the event "breadcrumbs.0.metaData.request" equals "GET http://postman-echo.com/get"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/device.feature
+++ b/test/expo/features/device.feature
@@ -24,6 +24,7 @@ Scenario: Device data is included by default
   And the event "device.totalMemory" is not null
   And the event "metaData.device.isDevice" is true
   And the event "metaData.device.appOwnership" equals "standalone"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Device data can be modified by a callback
   Given the element "deviceCallbackButton" is present
@@ -47,3 +48,4 @@ Scenario: Device data can be modified by a callback
   And the event "device.totalMemory" is not null
   And the event "metaData.device.isDevice" is true
   And the event "metaData.device.appOwnership" equals "standalone"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/error_boundary.feature
+++ b/test/expo/features/error_boundary.feature
@@ -11,6 +11,7 @@ Scenario: A render error is captured by an error boundary
   And the exception "errorClass" equals "Error"
   And the exception "message" starts with "An error has occurred in Buggy component!"
   And the event "metaData.react.componentStack" is not null
+  And the Bugsnag-Integrity header is valid
 
 @skip_android_7 @skip_android_8
 Scenario: When a render error occurs, a fallback is presented
@@ -19,3 +20,4 @@ Scenario: When a render error occurs, a fallback is presented
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the element "errorBoundaryFallback" is present
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/handled.feature
+++ b/test/expo/features/handled.feature
@@ -10,6 +10,7 @@ Scenario: Calling notify() with an Error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledError"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Calling notify() with a caught Error
   Given the element "handledCaughtErrorButton" is present
@@ -17,3 +18,4 @@ Scenario: Calling notify() with a caught Error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledCaughtError"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/manual_breadcrumbs.feature
+++ b/test/expo/features/manual_breadcrumbs.feature
@@ -12,3 +12,4 @@ Scenario: Manual breadcrumbs are enabled when automatic breadcrumbs are disabled
   And the exception "message" equals "ManualBreadcrumbError"
   And the event has a "manual" breadcrumb named "manualBreadcrumb"
   And the event "breadcrumbs.0.metaData.reason" equals "testing"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/metadata.feature
+++ b/test/expo/features/metadata.feature
@@ -11,6 +11,7 @@ Scenario: Meta data can be set via the client
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "MetadataClientError"
   And the event "metaData.extra.reason" equals "metadataClientName"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Meta data can be set via a callback
   Given the element "metadataCallbackButton" is present
@@ -19,3 +20,4 @@ Scenario: Meta data can be set via a callback
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "MetadataCallbackError"
   And the event "metaData.extra.reason" equals "metadataCallbackName"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/sessions.feature
+++ b/test/expo/features/sessions.feature
@@ -22,6 +22,7 @@ Scenario: Sessions can be automatically delivered
   And the payload field "app" is not null
   And the payload field "device" is not null
   And the payload has a valid sessions array
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Sessions can be manually delivered
   Given the element "manualSessionButton" is present
@@ -41,3 +42,4 @@ Scenario: Sessions can be manually delivered
   And the payload field "app" is not null
   And the payload field "device" is not null
   And the payload has a valid sessions array
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/unhandled.feature
+++ b/test/expo/features/unhandled.feature
@@ -10,6 +10,7 @@ Scenario: Catching an Unhandled error
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UnhandledError"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: Catching an Unhandled promise rejection
   Given the element "unhandledPromiseRejectionButton" is present
@@ -17,3 +18,4 @@ Scenario: Catching an Unhandled promise rejection
   Then I wait to receive a request
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UnhandledPromiseRejection"
+  And the Bugsnag-Integrity header is valid

--- a/test/expo/features/user.feature
+++ b/test/expo/features/user.feature
@@ -11,6 +11,7 @@ Scenario: User data can be set via the client
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UserClientError"
   And the event "user.name" equals "userClientName"
+  And the Bugsnag-Integrity header is valid
 
 Scenario: User data can be set via a callback
   Given the element "userCallbackButton" is present
@@ -19,3 +20,4 @@ Scenario: User data can be set via a callback
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UserCallbackError"
   And the event "user.name" equals "userCallbackName"
+  And the Bugsnag-Integrity header is valid


### PR DESCRIPTION
## Goal

Adds the Bugsnag-Integrity header to Expo delivery, using `expo-crypto` to calculate the sha1 hash of the payload