### PR TITLE
[PLAT-4935] Add automate-symbolication command (Android)

### DIFF
--- a/packages/react-native-cli/package-lock.json
+++ b/packages/react-native-cli/package-lock.json
@@ -16,6 +16,21 @@
 			"integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
 			"dev": true
 		},
+		"@types/node": {
+			"version": "14.14.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+			"integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+			"dev": true
+		},
+		"@types/prompts": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
+			"integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -114,15 +129,34 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
+		"prompts": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+			"requires": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			}
+		},
 		"reduce-flatten": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
 			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+		},
+		"sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/packages/react-native-cli/package.json
+++ b/packages/react-native-cli/package.json
@@ -18,10 +18,12 @@
   "dependencies": {
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",
-    "consola": "^2.15.0"
+    "consola": "^2.15.0",
+    "prompts": "^2.4.0"
   },
   "devDependencies": {
     "@types/command-line-args": "^5.0.0",
-    "@types/command-line-usage": "^5.0.1"
+    "@types/command-line-usage": "^5.0.1",
+    "@types/prompts": "^2.0.9"
   }
 }

--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -1,6 +1,7 @@
 import commandLineArgs from 'command-line-args'
 import commandLineUsage from 'command-line-usage'
 import logger from '../Logger'
+import automateSymbolication from '../commands/AutomateSymbolicationCommand'
 
 const topLevelDefs = [
   {
@@ -35,8 +36,10 @@ export default async function run (argv: string[]): Promise<void> {
       case 'install':
       case 'insert':
       case 'configure':
-      case 'automate-symbolication':
         logger.info(`TODO ${opts.command}`)
+        break
+      case 'automate-symbolication':
+        await automateSymbolication(opts._unknown || [], opts)
         break
       default:
         if (opts.help) return usage()

--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -1,0 +1,66 @@
+import prompts from 'prompts'
+import logger from '../Logger'
+import { modifyRootBuildGradle, modifyAppBuildGradle } from '../lib/Gradle'
+import { install, detectInstalled, guessPackageManager } from '../lib/Npm'
+import onCancel from '../lib/OnCancel'
+
+export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
+  const projectRoot = process.cwd()
+
+  try {
+    const { iosIntegration } = await prompts({
+      type: 'confirm',
+      name: 'iosIntegration',
+      message: 'Do you want to automatically upload source maps as part of the Xcode build?',
+      initial: true
+    }, { onCancel })
+
+    if (iosIntegration) {
+      logger.info('TODO lookup xcode project and mutate it')
+    }
+
+    const { androidIntegration } = await prompts({
+      type: 'confirm',
+      name: 'androidIntegration',
+      message: 'Do you want to automatically upload source maps as part of the gradle build?',
+      initial: true
+    }, { onCancel })
+
+    if (androidIntegration) {
+      logger.info('Adding Bugsnag Gradle build')
+      await modifyRootBuildGradle(projectRoot, logger)
+      await modifyAppBuildGradle(projectRoot, logger)
+    }
+
+    if (androidIntegration || iosIntegration) {
+      const alreadyInstalled = await detectInstalled('@bugsnag/source-maps', projectRoot)
+      if (alreadyInstalled) {
+        logger.warn('@bugsnag/source-maps is already installed, skipping')
+      } else {
+        logger.info('Adding @bugsnag/source-maps dependency')
+        const { packageManager } = await prompts({
+          type: 'select',
+          name: 'packageManager',
+          message: 'Using yarn or npm?',
+          choices: [
+            { title: 'npm', value: 'npm' },
+            { title: 'yarn', value: 'yarn' }
+          ],
+          initial: await guessPackageManager(projectRoot) === 'npm' ? 0 : 1
+        })
+
+        const { version } = await prompts({
+          type: 'text',
+          name: 'version',
+          message: 'If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want',
+          initial: 'latest'
+        }, { onCancel })
+
+        await install(packageManager, '@bugsnag/source-maps', version, true, projectRoot)
+      }
+      logger.success('@bugsnag/source-maps dependency is installed')
+    }
+  } catch (e) {
+    logger.error(e)
+  }
+}

--- a/packages/react-native-cli/src/lib/Gradle.ts
+++ b/packages/react-native-cli/src/lib/Gradle.ts
@@ -13,7 +13,7 @@ export async function modifyRootBuildGradle (projectRoot: string, logger: Logger
   try {
     await insertValueAfterPattern(
       topLevelBuildGradlePath,
-      /[\r\n]\s*classpath\("com.android.tools.build:gradle:\d+\.\d+\.\d+"\)/,
+      /[\r\n]\s*classpath\(["']com.android.tools.build:gradle:.+["']\)/,
       GRADLE_PLUGIN_IMPORT,
       logger
     )
@@ -48,7 +48,7 @@ export async function modifyAppBuildGradle (projectRoot: string, logger: Logger)
   try {
     await insertValueAfterPattern(
       appBuildGradlePath,
-      /apply plugin: "com\.android\.application"/,
+      /apply plugin: ["']com\.android\.application["']/,
       GRADLE_PLUGIN_APPLY,
       logger
     )

--- a/packages/react-native-cli/src/lib/Gradle.ts
+++ b/packages/react-native-cli/src/lib/Gradle.ts
@@ -1,0 +1,100 @@
+import { Logger } from '../Logger'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const GRADLE_PLUGIN_IMPORT = 'classpath("com.bugsnag:bugsnag-android-gradle-plugin:5.+")'
+const GRADLE_PLUGIN_APPLY = 'apply plugin: "com.bugsnag.android.gradle"'
+const DOCS_LINK = 'https://docs.bugsnag.com/build-integrations/gradle/#installation'
+
+export async function modifyRootBuildGradle (projectRoot: string, logger: Logger): Promise<void> {
+  logger.debug('Looking for android/build.gradle')
+  const topLevelBuildGradlePath = path.join(projectRoot, 'android', 'build.gradle')
+  logger.debug('Importing com.bugsnag:bugsnag-android-gradle-plugin')
+  try {
+    await insertValueAfterPattern(
+      topLevelBuildGradlePath,
+      /[\r\n]\s*classpath\("com.android.tools.build:gradle:\d+\.\d+\.\d+"\)/,
+      GRADLE_PLUGIN_IMPORT,
+      logger
+    )
+  } catch (e) {
+    if (e.message === 'Pattern not found') {
+      logger.warn(
+        `The gradle file was in an unexpected format and so couldn't be updated automatically.
+
+Add '${GRADLE_PLUGIN_IMPORT}' to the 'buildscript.dependencies section of android/build.gradle
+
+See ${DOCS_LINK} for more information`
+      )
+    } else if (e.code === 'ENOENT') {
+      logger.warn(
+        `A gradle file was not found at the expected location and so couldn't be updated automatically.
+
+Add '${GRADLE_PLUGIN_IMPORT}' to the 'buildscript.dependencies section of your project's build.gradle
+
+See ${DOCS_LINK} for more information`
+      )
+    } else {
+      throw e
+    }
+  }
+  logger.success('Finished modifying android/build.gradle')
+}
+
+export async function modifyAppBuildGradle (projectRoot: string, logger: Logger): Promise<void> {
+  logger.debug('Looking for android/app/build.gradle')
+  const appBuildGradlePath = path.join(projectRoot, 'android', 'app', 'build.gradle')
+  logger.debug('Applying com.bugsnag.android.gradle plugin')
+  try {
+    await insertValueAfterPattern(
+      appBuildGradlePath,
+      /apply plugin: "com\.android\.application"/,
+      GRADLE_PLUGIN_APPLY,
+      logger
+    )
+  } catch (e) {
+    if (e.message === 'Pattern not found') {
+      logger.warn(
+        `The gradle file was in an unexpected format and so couldn't be updated automatically.
+
+Add '${GRADLE_PLUGIN_APPLY}' to android/app/build.gradle
+
+See ${DOCS_LINK} for more information`
+      )
+    } else if (e.code === 'ENOENT') {
+      logger.warn(
+        `A gradle file was not found at the expected location and so couldn't be updated automatically.
+
+Add '${GRADLE_PLUGIN_APPLY}' to your app module's build.gradle
+
+See ${DOCS_LINK} for more information`
+      )
+    } else {
+      throw e
+    }
+  }
+  logger.success('Finished modifying android/app/build.gradle')
+}
+
+async function insertValueAfterPattern (file: string, pattern: RegExp, value: string, logger: Logger): Promise<void> {
+  const fileContents = await fs.readFile(file, 'utf8')
+
+  if (fileContents.includes(value)) {
+    logger.warn('Value already found in file, skipping.')
+    return
+  }
+
+  const match = fileContents.match(pattern)
+  if (!match || match.index === undefined || !match.input) {
+    throw new Error('Pattern not found')
+  }
+
+  const splitLocation = match.index + match[0].length
+  const [indent] = match[0].match(/[\r\n]\s*/) || ['\n']
+  const firstChunk = fileContents.substr(0, splitLocation)
+  const lastChunk = fileContents.substring(splitLocation)
+
+  const output = `${firstChunk}${indent}${value}${lastChunk}`
+
+  await fs.writeFile(file, output, 'utf8')
+}

--- a/packages/react-native-cli/src/lib/Gradle.ts
+++ b/packages/react-native-cli/src/lib/Gradle.ts
@@ -9,7 +9,7 @@ const DOCS_LINK = 'https://docs.bugsnag.com/build-integrations/gradle/#installat
 export async function modifyRootBuildGradle (projectRoot: string, logger: Logger): Promise<void> {
   logger.debug('Looking for android/build.gradle')
   const topLevelBuildGradlePath = path.join(projectRoot, 'android', 'build.gradle')
-  logger.debug('Importing com.bugsnag:bugsnag-android-gradle-plugin')
+  logger.debug('Adding \'bugsnag-android-gradle-plugin\' to the build script classpath')
   try {
     await insertValueAfterPattern(
       topLevelBuildGradlePath,

--- a/packages/react-native-cli/src/lib/Npm.ts
+++ b/packages/react-native-cli/src/lib/Npm.ts
@@ -1,0 +1,64 @@
+import { spawn } from 'child_process'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+export type PackageManager = 'npm' | 'yarn'
+
+export async function install (packageManager: PackageManager, module: string, version: string, dev: boolean, projectRoot: string): Promise<void> {
+  let cmd: Command
+
+  switch (packageManager) {
+    case 'yarn':
+      cmd = yarnCommand(module, version, dev)
+      break
+    case 'npm':
+      cmd = npmCommand(module, version, dev)
+      break
+    default:
+      throw new Error(`Don’t know what command to use for ${packageManager}`)
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd[0], cmd[1], { cwd: projectRoot, stdio: 'inherit' })
+
+    proc.on('error', err => reject(err))
+
+    proc.on('close', code => {
+      if (code === 0) return resolve()
+      reject(
+        new Error(
+          `Command exited with non-zero exit code (${code}) "${cmd[0]} ${cmd[1].join(' ')}"`
+        )
+      )
+    })
+  })
+}
+
+type Command = [ string, string[] ]
+const yarnCommand = (module: string, version: string, dev: boolean): Command => [
+  'yarn',
+  !dev ? ['add', `${module}@${version}`] : ['add', '--dev', `${module}@${version}`]
+]
+const npmCommand = (module: string, version: string, dev: boolean): Command => [
+  'npm',
+  !dev ? ['install', '--save', `${module}@${version}`] : ['install', '--save-dev', `${module}@${version}`]
+]
+
+export async function detectInstalled (module: string, projectRoot: string): Promise<boolean> {
+  try {
+    const pkg = JSON.parse(await fs.readFile(join(projectRoot, 'package.json'), 'utf8'))
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies }
+    return !!allDeps[module]
+  } catch (e) {
+    throw new Error('Could not load package.json. Is this the project root?')
+  }
+}
+
+export async function guessPackageManager (projectRoot: string) {
+  try {
+    await fs.readFile(join(projectRoot, 'yarn.lock'))
+    return 'yarn'
+  } catch (e) {
+    return 'npm'
+  }
+}

--- a/packages/react-native-cli/src/lib/OnCancel.ts
+++ b/packages/react-native-cli/src/lib/OnCancel.ts
@@ -1,0 +1,3 @@
+export default function () {
+  process.exit()
+}

--- a/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
@@ -1,0 +1,153 @@
+import { modifyAppBuildGradle, modifyRootBuildGradle } from '../Gradle'
+import logger from '../../Logger'
+import path from 'path'
+import { promises as fs } from 'fs'
+
+async function loadFixture (fixture: string) {
+  return jest.requireActual('fs').promises.readFile(fixture, 'utf8')
+}
+
+async function generateNotFoundError () {
+  try {
+    await jest.requireActual('fs').promises.readFile(path.join(__dirname, 'does-not-exist.txt'))
+  } catch (e) {
+    return e
+  }
+}
+
+jest.mock('../../Logger')
+jest.mock('fs', () => {
+  return { promises: { readFile: jest.fn(), writeFile: jest.fn() } }
+})
+
+afterEach(() => jest.resetAllMocks())
+
+test('modifyRootBuildGradle(): success', async () => {
+  const rootBuildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'root-build-before.gradle'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(rootBuildGradle)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyRootBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/android/build.gradle',
+    await loadFixture(path.join(__dirname, 'fixtures', 'root-build-after.gradle')),
+    'utf8'
+  )
+})
+
+test('modifyRootBuildGradle(): tolerates errors', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('not a gradle file')
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyRootBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('The gradle file was in an unexpected format and so couldn\'t be updated automatically')
+  )
+})
+
+test('modifyRootBuildGradle(): skips when no changes are required', async () => {
+  const rootBuildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'root-build-after.gradle'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(rootBuildGradle)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyRootBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('Value already found in file, skipping.')
+  )
+})
+
+test('modifyRootBuildGradle(): tolerates missing gradle file', async () => {
+  const notFoundErr = await generateNotFoundError()
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(notFoundErr)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyRootBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('A gradle file was not found at the expected location and so couldn\'t be updated automatically.')
+  )
+})
+
+test('modifyRootBuildGradle(): passes on unknown errors', async () => {
+  const unknownErr = new Error('Unknown error')
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(unknownErr)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await expect(modifyRootBuildGradle('/random/path', logger)).rejects.toThrowError('Unknown error')
+})
+
+test('modifyAppBuildGradle(): success', async () => {
+  const appBuildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'app-build-before.gradle'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(appBuildGradle)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyAppBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/build.gradle',
+    await loadFixture(path.join(__dirname, 'fixtures', 'app-build-after.gradle')),
+    'utf8'
+  )
+})
+
+test('modifyAppBuildGradle(): tolerates gradle format errors', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('not a gradle file')
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyAppBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('The gradle file was in an unexpected format and so couldn\'t be updated automatically')
+  )
+})
+
+test('modifyAppBuildGradle(): skips when no changes are required', async () => {
+  const appBuildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'app-build-after.gradle'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(appBuildGradle)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyAppBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('Value already found in file, skipping.')
+  )
+})
+
+test('modifyAppBuildGradle(): tolerates missing gradle file', async () => {
+  const notFoundErr = await generateNotFoundError()
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(notFoundErr)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await modifyAppBuildGradle('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('A gradle file was not found at the expected location and so couldn\'t be updated automatically.')
+  )
+})
+
+test('modifyAppBuildGradle(): passes on unknown errors', async () => {
+  const unknownErr = new Error('Unknown error')
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(unknownErr)
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+  await expect(modifyAppBuildGradle('/random/path', logger)).rejects.toThrowError('Unknown error')
+})

--- a/packages/react-native-cli/src/lib/__test__/Npm.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Npm.test.ts
@@ -1,0 +1,135 @@
+import { install, detectInstalled, guessPackageManager, PackageManager } from '../Npm'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { spawn, ChildProcess } from 'child_process'
+import { EventEmitter } from 'events'
+
+async function generateNotFoundError () {
+  try {
+    await jest.requireActual('fs').promises.readFile(path.join(__dirname, 'does-not-exist.txt'))
+  } catch (e) {
+    return e
+  }
+}
+
+jest.mock('fs', () => {
+  return { promises: { readFile: jest.fn(), writeFile: jest.fn() } }
+})
+jest.mock('child_process')
+
+afterEach(() => jest.resetAllMocks())
+
+test('guessPackageManager(): yarn', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('<example yarn lock content>')
+  expect(await guessPackageManager('/example/dir')).toBe('yarn')
+  expect(readFileMock).toHaveBeenCalledWith('/example/dir/yarn.lock')
+})
+
+test('guessPackageManager(): npm', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(await generateNotFoundError())
+  expect(await guessPackageManager('/example/dir')).toBe('npm')
+  expect(readFileMock).toHaveBeenCalledWith('/example/dir/yarn.lock')
+})
+
+test('detectInstalled(): installed in deps', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('{"dependencies": { "@bugsnag/test-package": "~1.0.0"} }')
+  expect(await detectInstalled('@bugsnag/test-package', '/example/dir')).toBe(true)
+  expect(readFileMock).toHaveBeenCalledWith('/example/dir/package.json', 'utf8')
+})
+
+test('detectInstalled(): installed in dev deps', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('{"devDependencies": { "@bugsnag/test-package": "~1.0.0"} }')
+  expect(await detectInstalled('@bugsnag/test-package', '/example/dir')).toBe(true)
+  expect(readFileMock).toHaveBeenCalledWith('/example/dir/package.json', 'utf8')
+})
+
+test('detectInstalled(): not installed', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('{"dependencies": { "react-native": "~1.0.0"} }')
+  expect(await detectInstalled('@bugsnag/test-package', '/example/dir')).toBe(false)
+  expect(readFileMock).toHaveBeenCalledWith('/example/dir/package.json', 'utf8')
+})
+
+test('detectInstalled(): error reading JSON', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('not json')
+  await expect(detectInstalled('@bugsnag/test-package', '/example/dir'))
+    .rejects.toThrowError('Could not load package.json. Is this the project root?')
+  expect(readFileMock).toHaveBeenCalledWith('/example/dir/package.json', 'utf8')
+})
+
+test('install(): npm success', async () => {
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+  await install('npm', '@bugsnag/test-package', 'latest', false, '/example/dir')
+  expect(spawnMock).toHaveBeenCalledWith('npm', ['install', '--save', '@bugsnag/test-package@latest'], { cwd: '/example/dir', stdio: 'inherit' })
+})
+
+test('install(): npm error', async () => {
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 1))
+    return ee
+  })
+  await expect(install('npm', '@bugsnag/test-package', 'latest', false, '/example/dir')).rejects.toThrow('Command exited with non-zero exit code')
+  expect(spawnMock).toHaveBeenCalledWith('npm', ['install', '--save', '@bugsnag/test-package@latest'], { cwd: '/example/dir', stdio: 'inherit' })
+})
+
+test('install(): npm success - dev', async () => {
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+  await install('npm', '@bugsnag/test-package', 'latest', true, '/example/dir')
+  expect(spawnMock).toHaveBeenCalledWith('npm', ['install', '--save-dev', '@bugsnag/test-package@latest'], { cwd: '/example/dir', stdio: 'inherit' })
+})
+
+test('install(): yarn success', async () => {
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+  await install('yarn', '@bugsnag/test-package', 'latest', false, '/example/dir')
+  expect(spawnMock).toHaveBeenCalledWith('yarn', ['add', '@bugsnag/test-package@latest'], { cwd: '/example/dir', stdio: 'inherit' })
+})
+
+test('install(): yarn error', async () => {
+  const err = new Error('oh no')
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('error', err))
+    return ee
+  })
+  await expect(install('yarn', '@bugsnag/test-package', 'latest', false, '/example/dir')).rejects.toThrow(err)
+  expect(spawnMock).toHaveBeenCalledWith('yarn', ['add', '@bugsnag/test-package@latest'], { cwd: '/example/dir', stdio: 'inherit' })
+})
+
+test('install(): yarn success - dev', async () => {
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+  await install('yarn', '@bugsnag/test-package', 'latest', true, '/example/dir')
+  expect(spawnMock).toHaveBeenCalledWith('yarn', ['add', '--dev', '@bugsnag/test-package@latest'], { cwd: '/example/dir', stdio: 'inherit' })
+})
+
+test('install(): unknown package manager', async () => {
+  await expect(install('noopm' as PackageManager, '@bugsnag/test-package', '1.2.3', false, '/example/dir'))
+    .rejects.toThrowError('Don’t know what command to use for noopm')
+})

--- a/packages/react-native-cli/src/lib/__test__/fixtures/app-build-after.gradle
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/app-build-after.gradle
@@ -1,0 +1,220 @@
+apply plugin: "com.android.application"
+apply plugin: "com.bugsnag.android.gradle"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: true,  // clean and rebuild if changing
+]
+
+apply from: "../../node_modules/react-native/react.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = true
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.reactnativetest"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/react-native-cli/src/lib/__test__/fixtures/app-build-before.gradle
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/app-build-before.gradle
@@ -1,0 +1,219 @@
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: "index.android.js",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: "ram-bundle",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn${productFlavor}${buildType}'
+ *   //         'bundleIn${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: true,  // clean and rebuild if changing
+]
+
+apply from: "../../node_modules/react-native/react.gradle"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = true
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.reactnativetest"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/react-native-cli/src/lib/__test__/fixtures/root-build-after.gradle
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/root-build-after.gradle
@@ -1,0 +1,38 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "29.0.2"
+        minSdkVersion = 16
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.bugsnag:bugsnag-android-gradle-plugin:5.+")
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("$rootDir/../node_modules/react-native/android")
+        }
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}

--- a/packages/react-native-cli/src/lib/__test__/fixtures/root-build-before.gradle
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/root-build-before.gradle
@@ -1,0 +1,37 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "29.0.2"
+        minSdkVersion = 16
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:3.5.3")
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("$rootDir/../node_modules/react-native/android")
+        }
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}


### PR DESCRIPTION
Add a command to automate source map upload when a React Native build happens.

Unit tests included for relevant parts. Interactive CLI aspects will be test via maze runner at a later point.

To test this out, use the following steps:

- `git fetch && git checkout feature/rn-cli-automate-symbolication-cmd`
- `npm i`
- `npm run bootstrap`
- `npm run build`
- `cd packages/react-native-cli`
- `npm link` (this symlinks the local package to your global npm modules)

On a React Native project:

- check that the command is linked up correctly `bugsnag-react-native-cli --help` 
- run `bugsnag-react-native-cli automate-symbolication`