### PR TITLE
[PLAT-4932] feat(react-native-cli): Add install command

### DIFF
--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -1,7 +1,9 @@
 import commandLineArgs from 'command-line-args'
 import commandLineUsage from 'command-line-usage'
 import logger from '../Logger'
+
 import automateSymbolication from '../commands/AutomateSymbolicationCommand'
+import install from '../commands/InstallCommand'
 
 const topLevelDefs = [
   {
@@ -31,15 +33,18 @@ export default async function run (argv: string[]): Promise<void> {
       )
     }
 
+    const remainingOpts = opts._unknown || []
     switch (opts.command) {
       case 'init':
-      case 'install':
       case 'insert':
       case 'configure':
         logger.info(`TODO ${opts.command}`)
         break
+      case 'install':
+        await install(remainingOpts, opts)
+        break
       case 'automate-symbolication':
-        await automateSymbolication(opts._unknown || [], opts)
+        await automateSymbolication(remainingOpts, opts)
         break
       default:
         if (opts.help) return usage()

--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -1,0 +1,41 @@
+import prompts from 'prompts'
+import logger from '../Logger'
+import { install as npmInstall, detectInstalled, guessPackageManager } from '../lib/Npm'
+import { install as podInstall } from '../lib/Pod'
+import onCancel from '../lib/OnCancel'
+
+export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
+  const projectRoot = process.cwd()
+
+  try {
+    const alreadyInstalled = await detectInstalled('@bugsnag/react-native', projectRoot)
+    if (alreadyInstalled) {
+      logger.warn('@bugsnag/react-native is already installed, skipping')
+    } else {
+      logger.info('Adding @bugsnag/react-native dependency')
+      const { packageManager } = await prompts({
+        type: 'select',
+        name: 'packageManager',
+        message: 'Using yarn or npm?',
+        choices: [
+          { title: 'npm', value: 'npm' },
+          { title: 'yarn', value: 'yarn' }
+        ],
+        initial: await guessPackageManager(projectRoot) === 'npm' ? 0 : 1
+      })
+
+      const { version } = await prompts({
+        type: 'text',
+        name: 'version',
+        message: 'If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want',
+        initial: 'latest'
+      }, { onCancel })
+
+      await npmInstall(packageManager, '@bugsnag/react-native', version, false, projectRoot)
+      logger.info('Installing cocoapods')
+      await podInstall(projectRoot, logger)
+    }
+  } catch (e) {
+    logger.error(e)
+  }
+}

--- a/packages/react-native-cli/src/lib/Pod.ts
+++ b/packages/react-native-cli/src/lib/Pod.ts
@@ -1,0 +1,34 @@
+import { spawn } from 'child_process'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { Logger } from '../Logger'
+
+export async function install (projectRoot: string, logger: Logger): Promise<void> {
+  try {
+    const iosDirList = await fs.readdir(join(projectRoot, 'ios'))
+    if (!iosDirList.includes('Podfile')) {
+      logger.warn('No Podfile found in ios directory, skipping')
+      return
+    }
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      logger.warn('No ios directory found in project, skipping')
+      return
+    }
+    throw e
+  }
+  return new Promise((resolve, reject) => {
+    const proc = spawn('pod', ['install'], { cwd: join(projectRoot, 'ios'), stdio: 'inherit' })
+
+    proc.on('error', err => reject(err))
+
+    proc.on('close', code => {
+      if (code === 0) return resolve()
+      reject(
+        new Error(
+          `Command exited with non-zero exit code (${code}) "pod install"`
+        )
+      )
+    })
+  })
+}

--- a/packages/react-native-cli/src/lib/__test__/Pod.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Pod.test.ts
@@ -1,0 +1,88 @@
+import { install } from '../Pod'
+import path from 'path'
+import { promises as fs } from 'fs'
+import { spawn, ChildProcess } from 'child_process'
+import { EventEmitter } from 'events'
+import logger from '../../Logger'
+
+async function generateNotFoundError () {
+  try {
+    await jest.requireActual('fs').promises.readdir(path.join(__dirname, 'does-not-exist'))
+  } catch (e) {
+    return e
+  }
+}
+
+jest.mock('fs', () => {
+  return { promises: { readFile: jest.fn(), writeFile: jest.fn(), readdir: jest.fn() } }
+})
+jest.mock('child_process')
+jest.mock('../../Logger')
+
+afterEach(() => jest.resetAllMocks())
+
+test('install(): success', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj', 'Podfile'])
+
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+
+  await install('/example/dir', logger)
+  expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
+})
+
+test('install(): no podfile', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj'])
+
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+
+  await install('/example/dir', logger)
+  expect(spawnMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith('No Podfile found in ios directory, skipping')
+})
+
+test('install(): no ios dir', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockRejectedValue(await generateNotFoundError())
+
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 0))
+    return ee
+  })
+
+  await install('/example/dir', logger)
+  expect(spawnMock).not.toHaveBeenCalled()
+  expect(logger.warn).toHaveBeenCalledWith('No ios directory found in project, skipping')
+})
+
+test('install(): bad exit code', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj', 'Podfile'])
+
+  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  spawnMock.mockImplementation(() => {
+    const ee = new EventEmitter() as ChildProcess
+    process.nextTick(() => ee.emit('close', 1))
+    return ee
+  })
+
+  await expect(install('/example/dir', logger)).rejects.toThrow('Command exited with non-zero exit code (1) "pod install"')
+  expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
+})


### PR DESCRIPTION
Adds `bugsnag-react-native-cli install` command.

Unit tests included for relevant parts. Interactive CLI aspects will be test via maze runner at a later point.

To test this out, use the following steps:

- `git fetch && git checkout feature/rn-cli-install-cmd`
- `npm i`
- `npm run bootstrap`
- `npm run build`
- `cd packages/react-native-cli`
- `npm link` (this symlinks the local cli package to your global npm modules)

On a React Native project:

- check that the command is linked up correctly `bugsnag-react-native-cli --help`
- run `bugsnag-react-native-cli install`
- verify that Bugsnag is installed (note that it will be integrated in another command `insert` so won't actually do anything until then)