### PR TITLE
[PLAT-4934] Add configure command to RN CLI

### DIFF
--- a/packages/react-native-cli/package.json
+++ b/packages/react-native-cli/package.json
@@ -20,6 +20,7 @@
     "command-line-usage": "^6.1.0",
     "consola": "^2.15.0",
     "prompts": "^2.4.0",
+    "plist": "^3.0.1",
     "xcode": "^3.0.1"
   },
   "devDependencies": {

--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -4,6 +4,7 @@ import logger from '../Logger'
 
 import automateSymbolication from '../commands/AutomateSymbolicationCommand'
 import install from '../commands/InstallCommand'
+import configure from '../commands/ConfigureCommand'
 
 const topLevelDefs = [
   {
@@ -37,8 +38,10 @@ export default async function run (argv: string[]): Promise<void> {
     switch (opts.command) {
       case 'init':
       case 'insert':
-      case 'configure':
         logger.info(`TODO ${opts.command}`)
+        break
+      case 'configure':
+        await configure(remainingOpts, opts)
         break
       case 'install':
         await install(remainingOpts, opts)

--- a/packages/react-native-cli/src/commands/ConfigureCommand.ts
+++ b/packages/react-native-cli/src/commands/ConfigureCommand.ts
@@ -1,0 +1,30 @@
+import prompts from 'prompts'
+import logger from '../Logger'
+import onCancel from '../lib/OnCancel'
+import { addApiKey as addApiKeyAndroid } from '../lib/AndroidManifest'
+import { addApiKey as addApiKeyIos } from '../lib/InfoPlist'
+
+export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
+  const projectRoot = process.cwd()
+
+  try {
+    const { apiKey } = await prompts({
+      type: 'text',
+      name: 'apiKey',
+      message: 'What is your Bugsnag API key?',
+      validate: value => {
+        return value.length > 1
+          ? true
+          : 'API key is required. You can find it by going to https://app.bugsnag.com/settings/ > Projects'
+      }
+    }, { onCancel })
+
+    logger.info('Adding API key to AndroidManifest.xml')
+    await addApiKeyAndroid(projectRoot, apiKey, logger)
+
+    logger.info('Adding API key to Info.plist')
+    await addApiKeyIos(projectRoot, apiKey, logger)
+  } catch (e) {
+    logger.error(e)
+  }
+}

--- a/packages/react-native-cli/src/commands/ConfigureCommand.ts
+++ b/packages/react-native-cli/src/commands/ConfigureCommand.ts
@@ -13,7 +13,7 @@ export default async function run (argv: string[], opts: Record<string, unknown>
       name: 'apiKey',
       message: 'What is your Bugsnag API key?',
       validate: value => {
-        return value.length > 1
+        return /[A-Fa-f0-9]{32}/.test(value)
           ? true
           : 'API key is required. You can find it by going to https://app.bugsnag.com/settings/ > Projects'
       }

--- a/packages/react-native-cli/src/lib/AndroidManifest.ts
+++ b/packages/react-native-cli/src/lib/AndroidManifest.ts
@@ -1,0 +1,44 @@
+import path from 'path'
+import { Logger } from '../Logger'
+import { promises as fs } from 'fs'
+
+const DOCS_LINK = 'https://docs.bugsnag.com/platforms/react-native/react-native/#android'
+const UNLOCATED_PROJ_MSG = `The Android configuration was not in the expected location and so couldn't be updated automatically.
+
+Add your API key to the AndroidManifest.xml in your project.
+
+See ${DOCS_LINK} for more information`
+
+const MATCH_FAIL_MSG = `The project's AndroidManifest.xml couldn't be updated automatically as it was in an unexpected format.
+
+Add your API key to the AndroidManifest.xml in your project.
+
+See ${DOCS_LINK} for more information`
+
+const APP_END_REGEX = /\n\s*<\/application>/
+
+export async function addApiKey (projectRoot: string, apiKey: string, logger: Logger): Promise<void> {
+  const manifestPath = path.join(projectRoot, 'android', 'app', 'src', 'main', 'AndroidManifest.xml')
+  try {
+    const manifest = await fs.readFile(manifestPath, 'utf8')
+    const activityStartMatch = /(\s*)<activity/.exec(manifest)
+    const appEndMatch = APP_END_REGEX.exec(manifest)
+    if (manifest.includes('com.bugsnag.android.API_KEY')) {
+      logger.warn('API key is already present, skipping')
+      return
+    }
+    if (!activityStartMatch || !appEndMatch) {
+      logger.warn(MATCH_FAIL_MSG)
+      return
+    }
+    const activityStartIndent = activityStartMatch[1]
+    const updatedManifest = manifest.replace(
+      APP_END_REGEX,
+      `${activityStartIndent}<meta-data android:name="com.bugsnag.android.API_KEY" android:value="${apiKey}" />${appEndMatch}`
+    )
+    await fs.writeFile(manifestPath, updatedManifest, 'utf8')
+    logger.success('Updated AndroidManifest.xml')
+  } catch (e) {
+    logger.warn(UNLOCATED_PROJ_MSG)
+  }
+}

--- a/packages/react-native-cli/src/lib/InfoPlist.ts
+++ b/packages/react-native-cli/src/lib/InfoPlist.ts
@@ -1,0 +1,41 @@
+import { Logger } from '../Logger'
+import plist from 'plist'
+import path from 'path'
+import { promises as fs } from 'fs'
+
+const DOCS_LINK = 'https://docs.bugsnag.com/platforms/react-native/react-native/#ios'
+const UNLOCATED_PROJ_MSG = `The Xcode configuration was not in the expected location and so couldn't be updated automatically.
+
+Add your API key to the Info.plist in your project.
+
+See ${DOCS_LINK} for more information`
+
+const PLIST_FAIL_MSG = `The project's Info.plist couldn't be updated automatically. The plist file may not be valid XML.
+
+Add your API key to the Info.plist in your project manually.
+
+See ${DOCS_LINK} for more information`
+
+export async function addApiKey (projectRoot: string, apiKey: string, logger: Logger): Promise<void> {
+  const iosDir = path.join(projectRoot, 'ios')
+  let xcodeprojDir
+  try {
+    xcodeprojDir = (await fs.readdir(iosDir)).find(p => p.endsWith('.xcodeproj'))
+    if (!xcodeprojDir) {
+      logger.warn(UNLOCATED_PROJ_MSG)
+      return
+    }
+  } catch (e) {
+    logger.warn(UNLOCATED_PROJ_MSG)
+    return
+  }
+  const plistPath = path.join(iosDir, xcodeprojDir.replace(/\.xcodeproj$/, ''), 'Info.plist')
+  try {
+    const infoPlist = plist.parse(await fs.readFile(plistPath, 'utf8'))
+    infoPlist.bugsnag = { apiKey }
+    await fs.writeFile(plistPath, `${plist.build(infoPlist, { indent: '\t', indentSize: 1, offset: -1 })}\n`, 'utf8')
+    logger.success('Updating Info.plist')
+  } catch (e) {
+    logger.warn(PLIST_FAIL_MSG)
+  }
+}

--- a/packages/react-native-cli/src/lib/__test__/AndroidManifest.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/AndroidManifest.test.ts
@@ -1,0 +1,90 @@
+import { addApiKey } from '../AndroidManifest'
+import logger from '../../Logger'
+import path from 'path'
+import { promises as fs } from 'fs'
+
+async function loadFixture (fixture: string) {
+  return jest.requireActual('fs').promises.readFile(fixture, 'utf8')
+}
+
+async function generateNotFoundError () {
+  try {
+    await jest.requireActual('fs').promises.readFile(path.join(__dirname, 'does-not-exist.txt'))
+  } catch (e) {
+    return e
+  }
+}
+
+jest.mock('../../Logger')
+jest.mock('fs', () => {
+  return { promises: { readFile: jest.fn(), writeFile: jest.fn() } }
+})
+
+afterEach(() => jest.resetAllMocks())
+
+test('addApiKey(): success', async () => {
+  const androidManifest = await loadFixture(path.join(__dirname, 'fixtures', 'AndroidManifest-before.xml'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(androidManifest)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+
+  await addApiKey('/random/path', 'API_KEY_GOES_HERE', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/src/main/AndroidManifest.xml', 'utf8')
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/AndroidManifest.xml',
+    await loadFixture(path.join(__dirname, 'fixtures', 'AndroidManifest-after.xml')),
+    'utf8'
+  )
+})
+
+test('addApiKey(): already present', async () => {
+  const androidManifest = await loadFixture(path.join(__dirname, 'fixtures', 'AndroidManifest-after.xml'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(androidManifest)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+
+  await addApiKey('/random/path', 'API_KEY_GOES_HERE', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/src/main/AndroidManifest.xml', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith('API key is already present, skipping')
+})
+
+test('addApiKey(): self closing application tag', async () => {
+  const androidManifest =
+`<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.bugsnagreactnativeclitest">
+  <application/>
+</manifest>`
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(androidManifest)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await addApiKey('/random/path', 'API_KEY_GOES_HERE', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/src/main/AndroidManifest.xml', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('The project\'s AndroidManifest.xml couldn\'t be updated automatically as it was in an unexpected format.')
+  )
+})
+
+test('addApiKey(): missing file', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(await generateNotFoundError())
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await addApiKey('/random/path', 'API_KEY_GOES_HERE', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/src/main/AndroidManifest.xml', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining('The Android configuration was not in the expected location')
+  )
+})

--- a/packages/react-native-cli/src/lib/__test__/fixtures/AndroidManifest-after.xml
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/AndroidManifest-after.xml
@@ -1,0 +1,28 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.bugsnagreactnativeclitest">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="false"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <meta-data android:name="com.bugsnag.android.API_KEY" android:value="API_KEY_GOES_HERE" />
+    </application>
+
+</manifest>

--- a/packages/react-native-cli/src/lib/__test__/fixtures/AndroidManifest-before.xml
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/AndroidManifest-before.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.bugsnagreactnativeclitest">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="false"
+      android:theme="@style/AppTheme">
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+        android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+
+</manifest>

--- a/packages/react-native-cli/src/lib/__test__/fixtures/Info-after.plist
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/Info-after.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>BugsnagReactNativeCliTest</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	<key>bugsnag</key>
+	<dict>
+		<key>apiKey</key>
+		<string>API_KEY_GOES_HERE</string>
+	</dict>
+</dict>
+</plist>

--- a/packages/react-native-cli/src/lib/__test__/fixtures/Info-before.plist
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/Info-before.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>BugsnagReactNativeCliTest</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/react-native-cli/src/lib/lib-plist.d.ts
+++ b/packages/react-native-cli/src/lib/lib-plist.d.ts
@@ -1,0 +1,7 @@
+// Types for the module "plist", since it doesn't ship with them, nor are there any available on Definitely Typed.
+// These definitions are not complete, and only specify the parts of the library we interact with.
+
+declare module 'plist' {
+  export function parse (str: string): Record<string, unknown>
+  export function build (obj: Record<string, unknown>, opts?: { indent?: string, indentSize?: number, offset?: number }): string
+}


### PR DESCRIPTION
Adds `bugsnag-react-native-cli install` command.

Unit tests included for relevant parts. Interactive CLI aspects will be test via maze runner at a later point.

To test this out, use the following steps:

- `git fetch && git checkout feature/rn-cli-configure-cmd`
- `npm i`
- `npm run bootstrap`
- `npm run build`
- `cd packages/react-native-cli`
- `npm link` (this symlinks the local cli package to your global npm modules)

On a React Native project:

- check that the command is linked up correctly `bugsnag-react-native-cli --help`
- run `bugsnag-react-native-cli configure`
- verify that the Bugsnag API key that you were prompted for is added correctly to the Info.plist/AndroidManifest.xml