### PR TITLE
Allow overriding unhandled state in callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - (react-native): Update bugsnag-cocoa to v6.2.5
   - Fixed a rare crash due to a race condition in BugsnagSystemState. [bugsnag-cocoa#893](https://github.com/bugsnag/bugsnag-cocoa/pull/893)
   - Out Of Memory errors are no longer reported if a device reboot was detected. [bugsnag-cocoa#822](https://github.com/bugsnag/bugsnag-cocoa/pull/882)
+- (core) The `event.unhandled` flag can now be changed in callbacks [#1148](https://github.com/bugsnag/bugsnag-js/pull/1148)
 
 ## v7.5.2 (2020-11-09)
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -273,18 +273,9 @@ class Client {
     event._user = assign({}, event._user, this._user)
     event.breadcrumbs = this._breadcrumbs.slice()
 
-    const trackSession = event => {
-      if (this._session) {
-        this._session._track(event)
-        event._session = this._session
-      }
-    }
-
     // exit early if events should not be sent on the current releaseStage
     if (this._config.enabledReleaseStages !== null && !includes(this._config.enabledReleaseStages, this._config.releaseStage)) {
       this._logger.warn('Event not sent due to releaseStage/enabledReleaseStages configuration')
-      trackSession(event)
-
       return cb(null, event)
     }
 
@@ -302,8 +293,6 @@ class Client {
 
       if (!shouldSend) {
         this._logger.debug('Event not sent due to onError callback')
-        trackSession(event)
-
         return cb(null, event)
       }
 
@@ -325,7 +314,10 @@ class Client {
         event._handledState.unhandled = event.unhandled
       }
 
-      trackSession(event)
+      if (this._session) {
+        this._session._track(event)
+        event._session = this._session
+      }
 
       this._delivery.sendEvent({
         apiKey: event.apiKey || this._config.apiKey,

--- a/packages/core/session.d.ts
+++ b/packages/core/session.d.ts
@@ -1,0 +1,24 @@
+import Session from './types/session'
+
+interface MinimalEvent {
+  _handledState: {
+    unhandled: boolean
+  }
+}
+
+interface SessionJson {
+  id: string
+  startedAt: Date
+  events: {
+    handled: number
+    unhandled: number
+  }
+}
+
+export default class SessionWithInternals extends Session {
+  _track(event: MinimalEvent): void
+  toJSON(): SessionJson
+
+  public _handled: number
+  public _unhandled: number
+}

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -446,9 +446,7 @@ describe('@bugsnag/core/client', () => {
         expect(err).toBe(null)
         expect(event).toBeTruthy()
         expect(event.errors[0].errorMessage).toBe('111')
-
-        expect((event as Event)._session).toBe(session)
-        expect(session.toJSON().events.handled).toBe(1)
+        expect((event as Event)._session).toBe(undefined)
         done()
       })
     })
@@ -469,9 +467,7 @@ describe('@bugsnag/core/client', () => {
         expect(err).toBe(null)
         expect(event).toBeTruthy()
         expect(event.errors[0].errorMessage).toBe('111')
-
-        expect((event as Event)._session).toBe(session)
-        expect(session.toJSON().events.handled).toBe(1)
+        expect((event as Event)._session).toBe(undefined)
         done()
       })
     })

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -1,6 +1,6 @@
 import Client from '../client'
 import Event from '../event'
-import { Session } from '..'
+import Session from '../session'
 
 describe('@bugsnag/core/client', () => {
   describe('constructor', () => {
@@ -158,6 +158,41 @@ describe('@bugsnag/core/client', () => {
         event.severity = 'info'
       })
     })
+
+    it('supports setting unhandled via callback', done => {
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
+
+      const session = new Session()
+      // @ts-ignore
+      client._session = session
+
+      client._setDelivery(client => ({
+        sendEvent: (payload) => {
+          expect(payload).toBeTruthy()
+          expect(Array.isArray(payload.events)).toBe(true)
+
+          const event = payload.events[0].toJSON()
+
+          expect(event.unhandled).toBe(true)
+          expect(event.severityReason).toEqual({
+            type: 'handledException',
+            unhandledOverridden: true
+          })
+
+          expect(event.session).toEqual(session)
+          expect((event.session as Session)._handled).toBe(0)
+          expect((event.session as Session)._unhandled).toBe(1)
+
+          done()
+        },
+        sendSession: () => {}
+      }))
+
+      client.notify(new Error('oh em gee'), event => {
+        event.unhandled = true
+      })
+    })
+
     // eslint-disable-next-line jest/expect-expect
     it('supports preventing send by returning false in onError callback', done => {
       const client = new Client({
@@ -177,6 +212,7 @@ describe('@bugsnag/core/client', () => {
       // give the event loop a tick to see if the event gets sent
       process.nextTick(() => done())
     })
+
     // eslint-disable-next-line jest/expect-expect
     it('supports preventing send by returning false in notify callback', done => {
       const client = new Client({ apiKey: 'API_KEY_YEAH' })
@@ -355,11 +391,18 @@ describe('@bugsnag/core/client', () => {
         sendSession: () => {},
         sendEvent: (payload, cb) => cb(null)
       }))
+
+      const session = new Session()
       // @ts-ignore
-      client.notify(new Error('111'), {}, (err, event) => {
+      client._session = session
+
+      client.notify(new Error('111'), () => {}, (err, event) => {
         expect(err).toBe(null)
         expect(event).toBeTruthy()
         expect(event.errors[0].errorMessage).toBe('111')
+
+        expect((event as Event)._session).toBe(session)
+        expect(session.toJSON().events.handled).toBe(1)
         done()
       })
     })
@@ -370,12 +413,19 @@ describe('@bugsnag/core/client', () => {
         sendSession: () => {},
         sendEvent: (payload, cb) => cb(new Error('flerp'))
       }))
+
+      const session = new Session()
       // @ts-ignore
-      client.notify(new Error('111'), {}, (err, event) => {
+      client._session = session
+
+      client.notify(new Error('111'), () => {}, (err, event) => {
         expect(err).toBeTruthy()
         expect(err.message).toBe('flerp')
         expect(event).toBeTruthy()
         expect(event.errors[0].errorMessage).toBe('111')
+
+        expect((event as Event)._session).toBe(session)
+        expect(session.toJSON().events.handled).toBe(1)
         done()
       })
     })
@@ -388,11 +438,17 @@ describe('@bugsnag/core/client', () => {
         sendEvent: () => { done('sendEvent() should not be called') }
       }))
 
+      const session = new Session()
       // @ts-ignore
-      client.notify(new Error('111'), {}, (err, event) => {
+      client._session = session
+
+      client.notify(new Error('111'), () => {}, (err, event) => {
         expect(err).toBe(null)
         expect(event).toBeTruthy()
         expect(event.errors[0].errorMessage).toBe('111')
+
+        expect((event as Event)._session).toBe(session)
+        expect(session.toJSON().events.handled).toBe(1)
         done()
       })
     })
@@ -405,11 +461,17 @@ describe('@bugsnag/core/client', () => {
         sendEvent: () => { done('sendEvent() should not be called') }
       }))
 
+      const session = new Session()
       // @ts-ignore
-      client.notify(new Error('111'), {}, (err, event) => {
+      client._session = session
+
+      client.notify(new Error('111'), () => {}, (err, event) => {
         expect(err).toBe(null)
         expect(event).toBeTruthy()
         expect(event.errors[0].errorMessage).toBe('111')
+
+        expect((event as Event)._session).toBe(session)
+        expect(session.toJSON().events.handled).toBe(1)
         done()
       })
     })

--- a/packages/core/types/event.d.ts
+++ b/packages/core/types/event.d.ts
@@ -30,7 +30,7 @@ declare class Event {
   public severity: 'info' | 'warning' | 'error'
 
   public readonly originalError: any
-  public readonly unhandled: boolean
+  public unhandled: boolean
 
   public apiKey?: string
   public context?: string

--- a/test/browser/features/fixtures/handled/script/h.html
+++ b/test/browser/features/fixtures/handled/script/h.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' },
+        onError: function (event) {
+          event.unhandled = false
+        }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      throw new Error('hello')
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/unhandled/script/h.html
+++ b/test/browser/features/fixtures/unhandled/script/h.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var ENDPOINT = decodeURIComponent(window.location.search.match(/ENDPOINT=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: ENDPOINT, sessions: '/noop' }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify(new Error('hello'), function(event) {
+        event.unhandled = true
+      })
+    </script>
+  </body>
+</html>

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -8,6 +8,7 @@ Scenario Outline: calling notify() with Error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "bad things"
   And the exception "type" equals "browserjs"
+  And event 0 is handled
 
   Examples:
     | type       |
@@ -24,6 +25,7 @@ Scenario Outline: calling notify() with Error within try/catch
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "handled" values for the current browser
   And the exception "type" equals "browserjs"
+  And event 0 is handled
 
   Examples:
     | type       |
@@ -42,6 +44,7 @@ Scenario Outline: calling notify() with Error within Promise catch
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "bad things"
   And the exception "type" equals "browserjs"
+  And event 0 is handled
 
   Examples:
     | type       |
@@ -62,6 +65,7 @@ Scenario: calling notify() with an object, getting a generated a stacktrace
 
   # this ensures the first generated stackframe doesn't come from bugsnag's source
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+  And event 0 is handled
 
 Scenario: calling notify() with a string, getting a generated stacktrace
   When I navigate to the URL "/handled/script/e.html"
@@ -73,6 +77,7 @@ Scenario: calling notify() with a string, getting a generated stacktrace
 
   # this ensures the first generated stackframe doesn't come from bugsnag's source
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+  And event 0 is handled
 
 Scenario: calling window.client.notify() with an object, getting a generated stacktrace
   When I navigate to the URL "/handled/script/f.html"
@@ -86,6 +91,7 @@ Scenario: calling window.client.notify() with an object, getting a generated sta
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
   And the payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
   And the payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
+  And event 0 is handled
 
 Scenario: calling window.client.notify() with a string, getting a generated stacktrace
   When I navigate to the URL "/handled/script/g.html"
@@ -99,3 +105,4 @@ Scenario: calling window.client.notify() with a string, getting a generated stac
   And the payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
   And the payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
   And the payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
+  And event 0 is handled

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -106,3 +106,11 @@ Scenario: calling window.client.notify() with a string, getting a generated stac
   And the payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
   And the payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
   And event 0 is handled
+
+Scenario: overridden handled state in a callback
+  When I navigate to the URL "/handled/script/h.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the exception "message" ends with "hello"
+  # The severity is "error" because only the handled-ness has been changed
+  And event 0 is handled with the severity "error"

--- a/test/browser/features/unhandled_errors.feature
+++ b/test/browser/features/unhandled_errors.feature
@@ -6,12 +6,14 @@ Scenario: syntax errors
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_syntax" values for the current browser
+  And event 0 is unhandled
 
 Scenario: thrown errors
   When I navigate to the URL "/unhandled/script/b.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_thrown" values for the current browser
+  And event 0 is unhandled
 
 Scenario: unhandled promise rejections
   When I navigate to the URL "/unhandled/script/c.html"
@@ -20,18 +22,21 @@ Scenario: unhandled promise rejections
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "broken promises"
+  And event 0 is unhandled
 
 Scenario: undefined function invocation
   When I navigate to the URL "/unhandled/script/d.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_undefined_function" values for the current browser
+  And event 0 is unhandled
 
 Scenario: decoding malformed URI component
   When I navigate to the URL "/unhandled/script/e.html"
   Then I wait to receive a request
   And the request is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_malformed_uri" values for the current browser
+  And event 0 is unhandled
 
 Scenario: detecting unhandled promise rejections with bluebird
   When I navigate to the URL "/unhandled/script/f.html"
@@ -39,6 +44,7 @@ Scenario: detecting unhandled promise rejections with bluebird
   And the request is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "broken bluebird promises"
+  And event 0 is unhandled
 
 Scenario: parsing stacks correctly with "@" in filename
   When I navigate to the URL "/unhandled/script/g.html"
@@ -46,3 +52,4 @@ Scenario: parsing stacks correctly with "@" in filename
   And the request is a valid browser payload for the error reporting API
   And the exception "message" ends with "at in filename"
   And the "file" of stack frame 0 ends with "unhandled/script/@dist/g.js"
+  And event 0 is unhandled

--- a/test/browser/features/unhandled_errors.feature
+++ b/test/browser/features/unhandled_errors.feature
@@ -53,3 +53,11 @@ Scenario: parsing stacks correctly with "@" in filename
   And the exception "message" ends with "at in filename"
   And the "file" of stack frame 0 ends with "unhandled/script/@dist/g.js"
   And event 0 is unhandled
+
+Scenario: overridden handled state in a callback
+  When I navigate to the URL "/unhandled/script/h.html"
+  Then I wait to receive a request
+  And the request is a valid browser payload for the error reporting API
+  And the exception "message" equals "hello"
+  # The severity is "warning" because only the handled-ness has been changed
+  And event 0 is unhandled with the severity "warning"

--- a/test/node/features/fixtures/handled/scenarios/modify-unhandled-callback.js
+++ b/test/node/features/fixtures/handled/scenarios/modify-unhandled-callback.js
@@ -1,0 +1,13 @@
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  onError: function (event) {
+    event.unhandled = false
+  }
+})
+
+throw new Error('hi from the abyss')

--- a/test/node/features/fixtures/unhandled/scenarios/modify-unhandled-callback.js
+++ b/test/node/features/fixtures/unhandled/scenarios/modify-unhandled-callback.js
@@ -1,0 +1,12 @@
+var Bugsnag = require('@bugsnag/node')
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  }
+})
+
+Bugsnag.notify(new Error('hi from the abyss'), function (event) {
+  event.unhandled = true
+})

--- a/test/node/features/handled_errors.feature
+++ b/test/node/features/handled_errors.feature
@@ -95,3 +95,12 @@ Scenario: calling an assigned client.notify with an object
   And the "method" of stack frame 0 equals "a"
   And the "method" of stack frame 1 equals "b"
   And the "method" of stack frame 2 equals "c"
+
+Scenario: overridden handled state in a callback
+  And I run the service "handled" with the command "node scenarios/modify-unhandled-callback"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  # The severity is "error" because only the handled-ness has been changed
+  And event 0 is handled with the severity "error"
+  And the "file" of stack frame 0 equals "scenarios/modify-unhandled-callback.js"
+  And the "lineNumber" of stack frame 0 equals 13

--- a/test/node/features/unhandled_errors.feature
+++ b/test/node/features/unhandled_errors.feature
@@ -68,3 +68,12 @@ Scenario: using contextualize to add context to an error
   And the "lineNumber" of stack frame 0 equals 12
   And the event "metaData.subsystem.name" equals "fs reader"
   And the event "metaData.subsystem.widgetsAdded" equals "cat,dog,mouse"
+
+Scenario: overridden handled state in a callback
+  And I run the service "unhandled" with the command "node scenarios/modify-unhandled-callback"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  # The severity is "warning" because only the handled-ness has been changed
+  And event 0 is unhandled with the severity "warning"
+  And the "file" of stack frame 0 equals "scenarios/modify-unhandled-callback.js"
+  And the "lineNumber" of stack frame 0 equals 10


### PR DESCRIPTION
## Goal

This PR allows callbacks to modify the handled-ness of an event. This propagates to the associated session (if one exists) so that its handled/unhandled count is incremented _after_ the handled-ness has been changed. We also send the `unhandledOverridden` flag to the API, so that it knows a callback has modified the handled-ness

## Testing

Unit tests and MR tests for browser & node