### PR TITLE
[PLAT-4933] Add insert command to RN CLI

### DIFF
--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -5,6 +5,7 @@ import logger from '../Logger'
 import automateSymbolication from '../commands/AutomateSymbolicationCommand'
 import install from '../commands/InstallCommand'
 import configure from '../commands/ConfigureCommand'
+import insert from '../commands/InsertCommand'
 
 const topLevelDefs = [
   {
@@ -37,8 +38,10 @@ export default async function run (argv: string[]): Promise<void> {
     const remainingOpts = opts._unknown || []
     switch (opts.command) {
       case 'init':
-      case 'insert':
         logger.info(`TODO ${opts.command}`)
+        break
+      case 'insert':
+        await insert(remainingOpts, opts)
         break
       case 'configure':
         await configure(remainingOpts, opts)

--- a/packages/react-native-cli/src/commands/InsertCommand.ts
+++ b/packages/react-native-cli/src/commands/InsertCommand.ts
@@ -1,0 +1,14 @@
+import logger from '../Logger'
+import { insertJs, insertAndroid, insertIos } from '../lib/Insert'
+
+export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
+  const projectRoot = process.cwd()
+
+  try {
+    await insertJs(projectRoot, logger)
+    await insertIos(projectRoot, logger)
+    await insertAndroid(projectRoot, logger)
+  } catch (e) {
+    logger.error(e)
+  }
+}

--- a/packages/react-native-cli/src/lib/Insert.ts
+++ b/packages/react-native-cli/src/lib/Insert.ts
@@ -12,7 +12,7 @@ const COCOA_APP_LAUNCH_REGEX = /(-\s*\(BOOL\)\s*application:\s*\(UIApplication\s
 
 const BUGSNAG_JAVA_IMPORT = 'import com.bugsnag.android.Bugsnag;'
 const BUGSNAG_JAVA_INIT = 'Bugsnag.start();'
-const JAVA_APP_ON_CREATE_REGEX = /(public void onCreate\s*\(\)\s*\{[.\s]*super\.onCreate\([.\s]*\);(\s*))\S/
+const JAVA_APP_ON_CREATE_REGEX = /(public void onCreate\s*\(\)\s*\{[^]*super\.onCreate\(\);(\s*))\S/
 
 const DOCS_LINK = 'https://docs.bugsnag.com/platforms/react-native/react-native/#basic-configuration'
 const FAIL_MSG = (filename: string) =>

--- a/packages/react-native-cli/src/lib/Insert.ts
+++ b/packages/react-native-cli/src/lib/Insert.ts
@@ -1,0 +1,112 @@
+import { Logger } from '../Logger'
+import path from 'path'
+import { promises as fs } from 'fs'
+
+const BUGSNAG_JS_IMPORT_INIT =
+`import Bugsnag from "@bugsnag/react-native";
+Bugsnag.start();`
+
+const BUGSNAG_COCOA_IMPORT = '#import <Bugsnag/Bugsnag.h>'
+const BUGSNAG_COCOA_INIT = '[Bugsnag start];'
+const COCOA_APP_LAUNCH_REGEX = /(-\s*\(BOOL\)\s*application:\s*\(UIApplication\s\*\)\s*application\s+didFinishLaunchingWithOptions:\s*\(NSDictionary\s*\*\)launchOptions\s*\{\s*)\S/
+
+const BUGSNAG_JAVA_IMPORT = 'import com.bugsnag.android.Bugsnag;'
+const BUGSNAG_JAVA_INIT = 'Bugsnag.start();'
+const JAVA_APP_ON_CREATE_REGEX = /(public void onCreate\s*\(\)\s*\{[.\s]*super\.onCreate\([.\s]*\);(\s*))\S/
+
+const DOCS_LINK = 'https://docs.bugsnag.com/platforms/react-native/react-native/#basic-configuration'
+const FAIL_MSG = (filename: string) =>
+`Failed to update "${filename}" automatically. The file may not exist or it may be in an unexpected format or location.
+
+Bugsnag must be imported manually. See ${DOCS_LINK} for more information.`
+
+export async function insertJs (projectRoot: string, logger: Logger): Promise<void> {
+  logger.info('Adding Bugsnag to the JS layer')
+  const indexJsPath = path.join(projectRoot, 'index.js')
+  try {
+    const indexJs = await fs.readFile(indexJsPath, 'utf8')
+
+    if (indexJs.includes(BUGSNAG_JS_IMPORT_INIT)) {
+      logger.warn('Bugsnag is already included, skipping')
+      return
+    }
+
+    await fs.writeFile(indexJsPath, `${BUGSNAG_JS_IMPORT_INIT}\n\n${indexJs}`, 'utf8')
+    logger.success('Done')
+  } catch (e) {
+    logger.error(FAIL_MSG('index.js'))
+  }
+}
+
+export async function insertIos (projectRoot: string, logger: Logger): Promise<void> {
+  logger.info('Adding Bugsnag to the iOS layer')
+  const iosDir = path.join(projectRoot, 'ios')
+  let xcodeprojDir
+  try {
+    xcodeprojDir = (await fs.readdir(iosDir)).find(p => p.endsWith('.xcodeproj'))
+    if (!xcodeprojDir) {
+      logger.warn(FAIL_MSG('AppDelegate.m'))
+      return
+    }
+  } catch (e) {
+    logger.error(FAIL_MSG('AppDelegate.m'))
+    return
+  }
+  const appDelegatePath = path.join(iosDir, xcodeprojDir.replace(/\.xcodeproj$/, ''), 'AppDelegate.m')
+  try {
+    const appDelegate = await fs.readFile(appDelegatePath, 'utf8')
+
+    if (appDelegate.includes(BUGSNAG_COCOA_IMPORT) || appDelegate.includes(BUGSNAG_COCOA_INIT)) {
+      logger.warn('Bugsnag is already included, skipping')
+      return
+    }
+
+    const appDelegateWithImport = `${BUGSNAG_COCOA_IMPORT}\n${appDelegate}`
+    const appLaunchRes = COCOA_APP_LAUNCH_REGEX.exec(appDelegateWithImport)
+    if (!appLaunchRes) {
+      logger.warn(FAIL_MSG('AppDelegate.m'))
+      return
+    }
+    await fs.writeFile(appDelegatePath, appDelegateWithImport.replace(appLaunchRes[1], `${appLaunchRes[1]}  ${BUGSNAG_COCOA_INIT}\n\n`), 'utf8')
+    logger.success('Done')
+  } catch (e) {
+    logger.error(FAIL_MSG('AppDelegate.m'))
+  }
+}
+
+export async function insertAndroid (projectRoot: string, logger: Logger): Promise<void> {
+  logger.info('Adding Bugsnag to the Android layer')
+  const comDir = path.join(projectRoot, 'android', 'app', 'src', 'main', 'java', 'com')
+  let appPackagePath
+  try {
+    appPackagePath = (await fs.readdir(comDir))[0]
+    if (!appPackagePath) {
+      logger.warn(FAIL_MSG('MainApplication.java'))
+      return
+    }
+  } catch (e) {
+    logger.error(FAIL_MSG('MainApplication.java'))
+    return
+  }
+  try {
+    const mainApplicationPath = path.join(comDir, appPackagePath, 'MainApplication.java')
+    const mainApplication = await fs.readFile(mainApplicationPath, 'utf8')
+
+    if (mainApplication.includes(BUGSNAG_JAVA_IMPORT) || mainApplication.includes(BUGSNAG_JAVA_INIT)) {
+      logger.warn('Bugsnag is already included, skipping')
+      return
+    }
+
+    const mainApplicationWithImport = mainApplication.replace('import', `${BUGSNAG_JAVA_IMPORT}\nimport`)
+    const onCreateRes = JAVA_APP_ON_CREATE_REGEX.exec(mainApplicationWithImport)
+    if (!onCreateRes) {
+      logger.warn(FAIL_MSG('MainApplication.java'))
+      return
+    }
+
+    await fs.writeFile(mainApplicationPath, mainApplicationWithImport.replace(onCreateRes[1], `${onCreateRes[1]}${BUGSNAG_JAVA_INIT}${onCreateRes[2]}`), 'utf8')
+    logger.success('Done')
+  } catch (e) {
+    logger.error(FAIL_MSG('MainApplication.java'))
+  }
+}

--- a/packages/react-native-cli/src/lib/__test__/Insert.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Insert.test.ts
@@ -1,0 +1,283 @@
+import { insertJs, insertAndroid, insertIos } from '../Insert'
+import logger from '../../Logger'
+import path from 'path'
+import { promises as fs } from 'fs'
+
+async function loadFixture (fixture: string) {
+  return jest.requireActual('fs').promises.readFile(fixture, 'utf8')
+}
+
+async function generateNotFoundError () {
+  try {
+    await jest.requireActual('fs').promises.readFile(path.join(__dirname, 'does-not-exist.txt'))
+  } catch (e) {
+    return e
+  }
+}
+
+jest.mock('../../Logger')
+jest.mock('fs', () => {
+  return { promises: { readFile: jest.fn(), writeFile: jest.fn(), readdir: jest.fn() } }
+})
+
+afterEach(() => jest.resetAllMocks())
+
+test('insertJs(): success', async () => {
+  const indexJs = await loadFixture(path.join(__dirname, 'fixtures', 'index-before.js'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(indexJs)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+
+  await insertJs('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/index.js', 'utf8')
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/index.js',
+    await loadFixture(path.join(__dirname, 'fixtures', 'index-after.js')),
+    'utf8'
+  )
+})
+
+test('insertJs(): fail', async () => {
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(await generateNotFoundError())
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertJs('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/index.js', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "index.js" automatically.'))
+})
+
+test('insertJs(): already present', async () => {
+  const indexJs = await loadFixture(path.join(__dirname, 'fixtures', 'index-after.js'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(indexJs)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertJs('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/index.js', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith('Bugsnag is already included, skipping')
+})
+
+test('insertIos(): success', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  const appDelegate = await loadFixture(path.join(__dirname, 'fixtures', 'AppDelegate-before.m'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(appDelegate)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+
+  await insertIos('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m',
+    await loadFixture(path.join(__dirname, 'fixtures', 'AppDelegate-after.m')),
+    'utf8'
+  )
+})
+
+test('insertIos(): already present', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  const appDelegate = await loadFixture(path.join(__dirname, 'fixtures', 'AppDelegate-after.m'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(appDelegate)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+  writeFileMock.mockResolvedValue()
+
+  await insertIos('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith('Bugsnag is already included, skipping')
+})
+
+test('insertIos(): failure to locate file', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(await generateNotFoundError())
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertIos('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+})
+
+test('insertIos(): failure to locate project directory', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['nope'])
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertIos('/random/path', logger)
+  expect(readFileMock).not.toHaveBeenCalled()
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+})
+
+test('insertIos(): project directory error', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockRejectedValue(await generateNotFoundError())
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertIos('/random/path', logger)
+  expect(readFileMock).not.toHaveBeenCalled()
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+})
+
+test('insertIos(): no identifiable app launch method', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('not good objective c')
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertIos('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+})
+
+test('insertAndroid(): success', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['bugsnagreactnativeclitest'])
+
+  const mainApplication = await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-before.java'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(mainApplication)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    'utf8'
+  )
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-after.java')),
+    'utf8'
+  )
+})
+
+test('insertAndroid(): already present', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['bugsnagreactnativeclitest'])
+
+  const mainApplication = await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-after.java'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(mainApplication)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    'utf8'
+  )
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith('Bugsnag is already included, skipping')
+})
+
+test('insertAndroid(): failure to locate file', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['bugsnagreactnativeclitest'])
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockRejectedValue(await generateNotFoundError())
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    'utf8'
+  )
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "MainApplication.java" automatically.'))
+})
+
+test('insertAndroid(): failure to locate package directory', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue([])
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).not.toHaveBeenCalled()
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "MainApplication.java" automatically.'))
+})
+
+test('insertAndroid(): project directory error', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockRejectedValue(await generateNotFoundError())
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).not.toHaveBeenCalled()
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "MainApplication.java" automatically.'))
+})
+
+test('insertAndroid(): no identifiable onCreate method', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['bugsnagreactnativeclitest'])
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue('not good java')
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    'utf8'
+  )
+  expect(writeFileMock).not.toHaveBeenCalled()
+
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "MainApplication.java" automatically.'))
+})

--- a/packages/react-native-cli/src/lib/__test__/Insert.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Insert.test.ts
@@ -192,6 +192,29 @@ test('insertAndroid(): success', async () => {
   )
 })
 
+test('insertAndroid(): success, tolerates some differences in source', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['bugsnagreactnativeclitest'])
+
+  const mainApplication = await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-before-2.java'))
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValue(mainApplication)
+
+  const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
+
+  await insertAndroid('/random/path', logger)
+  expect(readFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    'utf8'
+  )
+  expect(writeFileMock).toHaveBeenCalledWith(
+    '/random/path/android/app/src/main/java/com/bugsnagreactnativeclitest/MainApplication.java',
+    await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-after-2.java')),
+    'utf8'
+  )
+})
+
 test('insertAndroid(): already present', async () => {
   type readdir = (path: string) => Promise<string[]>
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>

--- a/packages/react-native-cli/src/lib/__test__/fixtures/AppDelegate-after.m
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/AppDelegate-after.m
@@ -1,0 +1,60 @@
+#import <Bugsnag/Bugsnag.h>
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+#ifdef FB_SONARKIT_ENABLED
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  [Bugsnag start];
+
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                                   moduleName:@"BugsnagReactNativeCliTest"
+                                            initialProperties:nil];
+
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+@end

--- a/packages/react-native-cli/src/lib/__test__/fixtures/AppDelegate-before.m
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/AppDelegate-before.m
@@ -1,0 +1,57 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+
+#ifdef FB_SONARKIT_ENABLED
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#ifdef FB_SONARKIT_ENABLED
+  InitializeFlipper(application);
+#endif
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                                   moduleName:@"BugsnagReactNativeCliTest"
+                                            initialProperties:nil];
+
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+@end

--- a/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-after-2.java
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-after-2.java
@@ -1,0 +1,82 @@
+package com.bugsnagreactnativeclitest;
+
+import com.bugsnag.android.Bugsnag;
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override public void onCreate() {
+    // something between curly brace and super call
+    super.onCreate();
+    Bugsnag.start();
+    SoLoader.init(this, /* native exopackage */ false);
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+  private static void initializeFlipper(
+      Context context, ReactInstanceManager reactInstanceManager) {
+    if (BuildConfig.DEBUG) {
+      try {
+        /*
+         We use reflection here to pick up the class that initializes Flipper,
+        since Flipper library is not available in release mode
+        */
+        Class<?> aClass = Class.forName("com.bugsnagreactnativeclitest.ReactNativeFlipper");
+        aClass
+            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+            .invoke(null, context, reactInstanceManager);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      } catch (NoSuchMethodException e) {
+        e.printStackTrace();
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-after.java
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-after.java
@@ -1,0 +1,82 @@
+package com.bugsnagreactnativeclitest;
+
+import com.bugsnag.android.Bugsnag;
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    Bugsnag.start();
+    SoLoader.init(this, /* native exopackage */ false);
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+  private static void initializeFlipper(
+      Context context, ReactInstanceManager reactInstanceManager) {
+    if (BuildConfig.DEBUG) {
+      try {
+        /*
+         We use reflection here to pick up the class that initializes Flipper,
+        since Flipper library is not available in release mode
+        */
+        Class<?> aClass = Class.forName("com.bugsnagreactnativeclitest.ReactNativeFlipper");
+        aClass
+            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+            .invoke(null, context, reactInstanceManager);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      } catch (NoSuchMethodException e) {
+        e.printStackTrace();
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-before-2.java
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-before-2.java
@@ -1,0 +1,80 @@
+package com.bugsnagreactnativeclitest;
+
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override public void onCreate() {
+    // something between curly brace and super call
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+  private static void initializeFlipper(
+      Context context, ReactInstanceManager reactInstanceManager) {
+    if (BuildConfig.DEBUG) {
+      try {
+        /*
+         We use reflection here to pick up the class that initializes Flipper,
+        since Flipper library is not available in release mode
+        */
+        Class<?> aClass = Class.forName("com.bugsnagreactnativeclitest.ReactNativeFlipper");
+        aClass
+            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+            .invoke(null, context, reactInstanceManager);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      } catch (NoSuchMethodException e) {
+        e.printStackTrace();
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-before.java
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/MainApplication-before.java
@@ -1,0 +1,80 @@
+package com.bugsnagreactnativeclitest;
+
+import android.app.Application;
+import android.content.Context;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.soloader.SoLoader;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new ReactNativeHost(this) {
+        @Override
+        public boolean getUseDeveloperSupport() {
+          return BuildConfig.DEBUG;
+        }
+
+        @Override
+        protected List<ReactPackage> getPackages() {
+          @SuppressWarnings("UnnecessaryLocalVariable")
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return packages;
+        }
+
+        @Override
+        protected String getJSMainModuleName() {
+          return "index";
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    SoLoader.init(this, /* native exopackage */ false);
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+  private static void initializeFlipper(
+      Context context, ReactInstanceManager reactInstanceManager) {
+    if (BuildConfig.DEBUG) {
+      try {
+        /*
+         We use reflection here to pick up the class that initializes Flipper,
+        since Flipper library is not available in release mode
+        */
+        Class<?> aClass = Class.forName("com.bugsnagreactnativeclitest.ReactNativeFlipper");
+        aClass
+            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
+            .invoke(null, context, reactInstanceManager);
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      } catch (NoSuchMethodException e) {
+        e.printStackTrace();
+      } catch (IllegalAccessException e) {
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/packages/react-native-cli/src/lib/__test__/fixtures/index-after.js
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/index-after.js
@@ -1,0 +1,12 @@
+import Bugsnag from "@bugsnag/react-native";
+Bugsnag.start();
+
+/**
+ * @format
+ */
+
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/packages/react-native-cli/src/lib/__test__/fixtures/index-before.js
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/index-before.js
@@ -1,0 +1,9 @@
+/**
+ * @format
+ */
+
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
Adds `bugsnag-react-native-cli insert` command.

Unit tests included for relevant parts. Interactive CLI aspects will be test via maze runner at a later point.

To test this out, use the following steps:

- `git fetch && git checkout feature/rn-cli-insert-cmd`
- `npm i`
- `npm run bootstrap`
- `npm run build`
- `cd packages/react-native-cli`
- `npm link` (this symlinks the local cli package to your global npm modules)

On a React Native project:

- check that the command is linked up correctly `bugsnag-react-native-cli --help`
- run `bugsnag-react-native-cli insert`
- verify that the Bugsnag initialisation has been correctly inserted into `index.js`, `MainApplication.java` and `AppDelegate.m`