### PR TITLE
[PLAT-4931] Add init command and repo state detection to RN CLI

### DIFF
--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -6,6 +6,7 @@ import automateSymbolication from '../commands/AutomateSymbolicationCommand'
 import install from '../commands/InstallCommand'
 import configure from '../commands/ConfigureCommand'
 import insert from '../commands/InsertCommand'
+import repoStatePreCommand from '../commands/RepoStatePreCommand'
 
 const topLevelDefs = [
   {
@@ -47,21 +48,26 @@ export default async function run (argv: string[]): Promise<void> {
     const remainingOpts = opts._unknown || []
     switch (opts.command) {
       case 'init':
+        await repoStatePreCommand(remainingOpts, projectRoot, opts)
         await install(remainingOpts, projectRoot, opts)
         await insert(remainingOpts, projectRoot, opts)
         await configure(remainingOpts, projectRoot, opts)
         await automateSymbolication(remainingOpts, projectRoot, opts)
         break
       case 'insert':
+        await repoStatePreCommand(remainingOpts, projectRoot, opts)
         await insert(remainingOpts, projectRoot, opts)
         break
       case 'configure':
+        await repoStatePreCommand(remainingOpts, projectRoot, opts)
         await configure(remainingOpts, projectRoot, opts)
         break
       case 'install':
+        await repoStatePreCommand(remainingOpts, projectRoot, opts)
         await install(remainingOpts, projectRoot, opts)
         break
       case 'automate-symbolication':
+        await repoStatePreCommand(remainingOpts, projectRoot, opts)
         await automateSymbolication(remainingOpts, projectRoot, opts)
         break
       default:

--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -22,6 +22,11 @@ const topLevelDefs = [
     name: 'version',
     type: Boolean,
     description: 'output the version of the CLI module'
+  },
+  {
+    name: 'project-root',
+    type: String,
+    description: 'the top level directory of the React Native project. Defaults to the current directory.'
   }
 ]
 
@@ -35,25 +40,31 @@ export default async function run (argv: string[]): Promise<void> {
       )
     }
 
+    if (opts.help) return usage()
+
+    const projectRoot = opts.projectRoot || process.cwd()
+
     const remainingOpts = opts._unknown || []
     switch (opts.command) {
       case 'init':
-        logger.info(`TODO ${opts.command}`)
+        await install(remainingOpts, projectRoot, opts)
+        await insert(remainingOpts, projectRoot, opts)
+        await configure(remainingOpts, projectRoot, opts)
+        await automateSymbolication(remainingOpts, projectRoot, opts)
         break
       case 'insert':
-        await insert(remainingOpts, opts)
+        await insert(remainingOpts, projectRoot, opts)
         break
       case 'configure':
-        await configure(remainingOpts, opts)
+        await configure(remainingOpts, projectRoot, opts)
         break
       case 'install':
-        await install(remainingOpts, opts)
+        await install(remainingOpts, projectRoot, opts)
         break
       case 'automate-symbolication':
-        await automateSymbolication(remainingOpts, opts)
+        await automateSymbolication(remainingOpts, projectRoot, opts)
         break
       default:
-        if (opts.help) return usage()
         if (opts.command) {
           logger.error(`Unrecognized command "${opts.command}".`)
         } else {

--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -5,9 +5,7 @@ import { updateXcodeProject } from '../lib/Xcode'
 import { install, detectInstalled, guessPackageManager } from '../lib/Npm'
 import onCancel from '../lib/OnCancel'
 
-export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
-  const projectRoot = process.cwd()
-
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
   try {
     const { iosIntegration } = await prompts({
       type: 'confirm',

--- a/packages/react-native-cli/src/commands/ConfigureCommand.ts
+++ b/packages/react-native-cli/src/commands/ConfigureCommand.ts
@@ -4,9 +4,7 @@ import onCancel from '../lib/OnCancel'
 import { addApiKey as addApiKeyAndroid } from '../lib/AndroidManifest'
 import { addApiKey as addApiKeyIos } from '../lib/InfoPlist'
 
-export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
-  const projectRoot = process.cwd()
-
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
   try {
     const { apiKey } = await prompts({
       type: 'text',

--- a/packages/react-native-cli/src/commands/InsertCommand.ts
+++ b/packages/react-native-cli/src/commands/InsertCommand.ts
@@ -1,9 +1,7 @@
 import logger from '../Logger'
 import { insertJs, insertAndroid, insertIos } from '../lib/Insert'
 
-export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
-  const projectRoot = process.cwd()
-
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
   try {
     await insertJs(projectRoot, logger)
     await insertIos(projectRoot, logger)

--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -4,9 +4,7 @@ import { install as npmInstall, detectInstalled, guessPackageManager } from '../
 import { install as podInstall } from '../lib/Pod'
 import onCancel from '../lib/OnCancel'
 
-export default async function run (argv: string[], opts: Record<string, unknown>): Promise<void> {
-  const projectRoot = process.cwd()
-
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
   try {
     const alreadyInstalled = await detectInstalled('@bugsnag/react-native', projectRoot)
     if (alreadyInstalled) {

--- a/packages/react-native-cli/src/commands/RepoStatePreCommand.ts
+++ b/packages/react-native-cli/src/commands/RepoStatePreCommand.ts
@@ -5,53 +5,20 @@ import onCancel from '../lib/OnCancel'
 
 export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
   logger.info('Detecting repo state')
+
   const state = detectState(projectRoot, logger)
-  switch (state) {
-    case RepoState.NONE: {
-      logger.warn(NONE_MSG)
-      const { confirm } = await prompts({
-        type: 'confirm',
-        name: 'confirm',
-        message: 'Do you want to continue anyway?',
-        initial: false
-      }, { onCancel })
-      if (!confirm) process.exit(0)
-      break
-    }
-    case RepoState.GIT_DIRTY: {
-      logger.warn(DIRTY_MSG)
-      const { confirm } = await prompts({
-        type: 'confirm',
-        name: 'confirm',
-        message: 'Do you want to continue anyway?',
-        initial: false
-      }, { onCancel })
-      if (!confirm) process.exit(0)
-      break
-    }
-    case RepoState.GIT_CLEAN: {
-      logger.warn(CLEAN_MSG)
-      const { confirm } = await prompts({
-        type: 'confirm',
-        name: 'confirm',
-        message: 'Do you want to continue?',
-        initial: true
-      }, { onCancel })
-      if (!confirm) process.exit(0)
-      break
-    }
-    default: {
-      logger.warn(UNKNOWN_MSG)
-      const { confirm } = await prompts({
-        type: 'confirm',
-        name: 'confirm',
-        message: 'Do you want to continue?',
-        initial: false
-      }, { onCancel })
-      if (!confirm) process.exit(0)
-      break
-    }
-  }
+  const continueByDefault = state === RepoState.GIT_CLEAN
+
+  logger.warn(messages[state])
+
+  const { confirm } = await prompts({
+    type: 'confirm',
+    name: 'confirm',
+    message: 'Do you want to continue anyway?',
+    initial: continueByDefault
+  }, { onCancel })
+
+  if (!confirm) process.exit(0)
 }
 
 const NONE_MSG = `No repo detected.
@@ -74,3 +41,10 @@ const UNKNOWN_MSG = `Unable to detect repo state.
 
 This command may make modifications to your project. It is recommended that you commit the
 current status of your code to a git repo before continuing.`
+
+const messages = {
+  [RepoState.NONE]: NONE_MSG,
+  [RepoState.GIT_DIRTY]: DIRTY_MSG,
+  [RepoState.GIT_CLEAN]: CLEAN_MSG,
+  [RepoState.UNKNOWN]: UNKNOWN_MSG
+}

--- a/packages/react-native-cli/src/commands/RepoStatePreCommand.ts
+++ b/packages/react-native-cli/src/commands/RepoStatePreCommand.ts
@@ -1,0 +1,76 @@
+import prompts from 'prompts'
+import logger from '../Logger'
+import { detectState, RepoState } from '../lib/Repo'
+import onCancel from '../lib/OnCancel'
+
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
+  logger.info('Detecting repo state')
+  const state = detectState(projectRoot, logger)
+  switch (state) {
+    case RepoState.NONE: {
+      logger.warn(NONE_MSG)
+      const { confirm } = await prompts({
+        type: 'confirm',
+        name: 'confirm',
+        message: 'Do you want to continue anyway?',
+        initial: false
+      }, { onCancel })
+      if (!confirm) process.exit(0)
+      break
+    }
+    case RepoState.GIT_DIRTY: {
+      logger.warn(DIRTY_MSG)
+      const { confirm } = await prompts({
+        type: 'confirm',
+        name: 'confirm',
+        message: 'Do you want to continue anyway?',
+        initial: false
+      }, { onCancel })
+      if (!confirm) process.exit(0)
+      break
+    }
+    case RepoState.GIT_CLEAN: {
+      logger.warn(CLEAN_MSG)
+      const { confirm } = await prompts({
+        type: 'confirm',
+        name: 'confirm',
+        message: 'Do you want to continue?',
+        initial: true
+      }, { onCancel })
+      if (!confirm) process.exit(0)
+      break
+    }
+    default: {
+      logger.warn(UNKNOWN_MSG)
+      const { confirm } = await prompts({
+        type: 'confirm',
+        name: 'confirm',
+        message: 'Do you want to continue?',
+        initial: false
+      }, { onCancel })
+      if (!confirm) process.exit(0)
+      break
+    }
+  }
+}
+
+const NONE_MSG = `No repo detected.
+
+This command may make modifications to your project. It is recommended that you commit the
+current status of your code to a git repo before continuing.`
+
+const DIRTY_MSG = `Uncommited changes detected.
+
+This command may make modifications to your project. It is recommended that you commit or
+stash your current changes before continuing.
+
+Afterwards you can review the diff of the changes made by this command and commit
+them to your project.`
+
+const CLEAN_MSG = `This command may make modifications to your project. Afterwards you can
+review the diff and commit them to your project.`
+
+const UNKNOWN_MSG = `Unable to detect repo state.
+
+This command may make modifications to your project. It is recommended that you commit the
+current status of your code to a git repo before continuing.`

--- a/packages/react-native-cli/src/lib/Repo.ts
+++ b/packages/react-native-cli/src/lib/Repo.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from 'child_process'
+import { Logger } from '../Logger'
+
+export enum RepoState { UNKNOWN, GIT_CLEAN, GIT_DIRTY, NONE }
+
+export function detectState (projectRoot: string, logger: Logger) {
+  const res = gitStatus(projectRoot)
+  if (res.error) {
+    logger.warn(res.error)
+    return RepoState.UNKNOWN
+  }
+  if (res.stderr.match(/not a git repository/)) return RepoState.NONE
+  if (res.stdout.length > 0) return RepoState.GIT_DIRTY
+  return RepoState.GIT_CLEAN
+}
+
+function gitStatus (cwd: string) {
+  return spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8' })
+}

--- a/packages/react-native-cli/src/lib/__test__/Repo.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Repo.test.ts
@@ -1,0 +1,89 @@
+import { detectState, RepoState } from '../Repo'
+import logger from '../../Logger'
+
+import { spawnSync, SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from 'child_process'
+
+jest.mock('child_process')
+jest.mock('../../Logger')
+
+afterEach(() => jest.resetAllMocks())
+type spawnSyncFn = (command: string, args?: readonly string[], options?: SpawnSyncOptionsWithStringEncoding) => SpawnSyncReturns<string>
+
+test('detectState(): no repo', async () => {
+  const spawnSyncMock = (spawnSync as unknown as jest.MockedFunction<spawnSyncFn>)
+  spawnSyncMock.mockReturnValue({
+    status: 128,
+    signal: null,
+    output: [
+      '',
+      '',
+      'fatal: not a git repository (or any of the parent directories): .git\n'
+    ],
+    pid: 185,
+    stdout: '',
+    stderr: 'fatal: not a git repository (or any of the parent directories): .git\n'
+  })
+
+  expect(detectState('/example/dir', logger)).toBe(RepoState.NONE)
+  expect(spawnSyncMock).toHaveBeenCalledWith('git', ['status', '--porcelain'], { cwd: '/example/dir', encoding: 'utf8' })
+})
+
+test('detectState(): dirty repo', async () => {
+  const spawnSyncMock = (spawnSync as unknown as jest.MockedFunction<spawnSyncFn>)
+  spawnSyncMock.mockReturnValue({
+    status: 0,
+    signal: null,
+    output: [
+      '',
+      '?? index.js\n?? package.json\n',
+      ''
+    ],
+    pid: 304,
+    stdout: '?? index.js\n?? package.json\n',
+    stderr: ''
+  })
+
+  expect(detectState('/example/dir', logger)).toBe(RepoState.GIT_DIRTY)
+  expect(spawnSyncMock).toHaveBeenCalledWith('git', ['status', '--porcelain'], { cwd: '/example/dir', encoding: 'utf8' })
+})
+
+test('detectState(): clean repo', async () => {
+  const spawnSyncMock = (spawnSync as unknown as jest.MockedFunction<spawnSyncFn>)
+  spawnSyncMock.mockReturnValue({
+    status: 0,
+    signal: null,
+    output: [
+      '',
+      '',
+      ''
+    ],
+    pid: 198,
+    stdout: '',
+    stderr: ''
+  })
+
+  expect(detectState('/example/dir', logger)).toBe(RepoState.GIT_CLEAN)
+  expect(spawnSyncMock).toHaveBeenCalledWith('git', ['status', '--porcelain'], { cwd: '/example/dir', encoding: 'utf8' })
+})
+
+test('detectState(): unknown error', async () => {
+  const spawnSyncMock = (spawnSync as unknown as jest.MockedFunction<spawnSyncFn>)
+  const error = new Error('fail')
+  spawnSyncMock.mockReturnValue({
+    status: 0,
+    signal: null,
+    output: [
+      '',
+      '',
+      ''
+    ],
+    pid: 198,
+    stdout: '',
+    stderr: '',
+    error
+  })
+
+  expect(detectState('/example/dir', logger)).toBe(RepoState.UNKNOWN)
+  expect(spawnSyncMock).toHaveBeenCalledWith('git', ['status', '--porcelain'], { cwd: '/example/dir', encoding: 'utf8' })
+  expect(logger.warn).toHaveBeenCalledWith(error)
+})


### PR DESCRIPTION
- Adds `bugsnag-react-native-cli init` command.
- Adds repo state detection, outputting a different message and prompt based on whether the git repo is clean/dirty/undectable before running any command that makes modifications.

Unit tests included for relevant parts. Interactive CLI aspects will be test via maze runner at a later point.

To test this out, use the following steps:

- `git fetch && git checkout feature/rn-cli-init-cmd-repo-state`
- `npm i`
- `npm run bootstrap`
- `npm run build`
- `cd packages/react-native-cli`
- `npm link` (this symlinks the local cli package to your global npm modules)

On a React Native project:

- check that the command is linked up correctly `bugsnag-react-native-cli --help`
- run `bugsnag-react-native-cli init`
- verify that it behaves differently based on the state of the local git repo, and that it runs through all of the other subcommands