### PR TITLE
Remove Flipper from React Native 0.63 test fixture

### DIFF
--- a/test/react-native/features/fixtures/rn0.63/ios/Podfile
+++ b/test/react-native/features/fixtures/rn0.63/ios/Podfile
@@ -12,15 +12,6 @@ target 'reactnative' do
     inherit! :complete
     # Pods for testing
   end
-
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
-  use_flipper!
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
 end
 
 target 'reactnative-tvOS' do


### PR DESCRIPTION
## Goal

The RN 0.63 IPA build varies in time, but can take almost 30 minutes (unlike RN 0.60).  We think this may be down to the inclusion of Flipper by default from RN 0.62 onwards, which this PR removes.

## Design

We do not need Flipper for running the end-to-end tests.

## Changeset

`Podfile` for the RN 0.63 test fixture.

## Testing

Covered by CI.