### PR TITLE
test(expo): Don't match against harcoded version in tests

### DIFF
--- a/packages/expo/test/index.test.ts
+++ b/packages/expo/test/index.test.ts
@@ -186,7 +186,7 @@ describe('expo notifier', () => {
             ])
           })
         ]),
-        notifier: { name: 'Bugsnag Expo', url: 'https://github.com/bugsnag/bugsnag-js', version: '7.5.2' }
+        notifier: { name: 'Bugsnag Expo', url: 'https://github.com/bugsnag/bugsnag-js', version: expect.any(String) }
       }), expect.any(Function))
       done()
     })


### PR DESCRIPTION
Stop unit tests from breaking after a release (or prerelease, where it was noticed)