### PR TITLE
RN CLI: install tests

### DIFF
--- a/test/react-native-cli/features/fixtures/Dockerfile
+++ b/test/react-native-cli/features/fixtures/Dockerfile
@@ -2,6 +2,9 @@ FROM node:lts-alpine
 
 RUN apk add git
 
+RUN git config --global user.email "noone@example.com"
+RUN git config --global user.name "No One"
+
 COPY . /app
 
 WORKDIR /app

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -12,7 +12,7 @@ Scenario: no git repo, do not run
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
     Then the last interactive command exited successfully
-    And bugsnag has not been added to the package.json file
+    And bugsnag react-native is not in the package.json file
 
 Scenario: dirty git repo, do not run
     When I run the React Native service interactively
@@ -30,7 +30,7 @@ Scenario: dirty git repo, do not run
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
     Then the last interactive command exited successfully
-    And bugsnag has not been added to the package.json file
+    And bugsnag react-native is not in the package.json file
 
 Scenario: clean git repo, do not run
     When I run the React Native service interactively
@@ -42,7 +42,7 @@ Scenario: clean git repo, do not run
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "n" interactively
     Then the last interactive command exited successfully
-    And bugsnag has not been added to the package.json file
+    And bugsnag react-native is not in the package.json file
 
 Scenario: no git repo, run anyway, default version
     When I run the React Native service interactively
@@ -62,7 +62,7 @@ Scenario: no git repo, run anyway, default version
     When I press enter
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And the last interactive command exited successfully
-    And bugsnag has been added to the package.json file
+    And bugsnag react-native is in the package.json file
 
 Scenario: clean git repo, run, version 7.5.0
     When I run the React Native service interactively
@@ -80,14 +80,14 @@ Scenario: clean git repo, run, version 7.5.0
     When I input "7.5.0" interactively
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And the last interactive command exited successfully
-    And bugsnag version "^7.5.0" has been added to the package.json file
+    And bugsnag react-native version "^7.5.0" is in the package.json file
 
 Scenario: no git repo, run anyway, already installed
     When I run the React Native service interactively
     And I input "npm install @bugsnag/react-native" interactively
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And the last interactive command exited successfully
-    And bugsnag has been added to the package.json file
+    And bugsnag react-native is in the package.json file
     When I input "bugsnag-react-native-cli install" interactively
     And I wait for the shell to output the following to stdout
         """

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -1,6 +1,35 @@
 Feature: install command
 
-Scenario: running 'install' on an empty fixture
+Scenario: no git repo, do not run
     When I run the React Native service interactively
-    And I input "bugsnag-react-native-cli" interactively
-    Then I wait for the shell to output "bugsnag-react-native-cli <command>" to stdout
+    And I input "bugsnag-react-native-cli install" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And the current stdout line contains "Do you want to continue anyway?"
+    When I press enter
+    Then the last interactive command exited successfully
+    And bugsnag has not been added to the package.json file
+
+Scenario: no git repo, run anyway, default version
+    When I run the React Native service interactively
+    And I input "bugsnag-react-native-cli install" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And the current stdout line contains "Do you want to continue anyway?"
+    When I input "y" interactively
+    Then I wait for the shell to output a line containing "Adding @bugsnag/react-native dependency" to stdout
+    And I wait for the shell to output a line containing "Using yarn or npm" to stdout
+    When I press enter
+    Then I wait for the current stdout line to contain "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
+    When I press enter
+    Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
+    And the last interactive command exited successfully
+    And bugsnag has been added to the package.json file

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -81,3 +81,20 @@ Scenario: clean git repo, run, version 7.5.0
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And the last interactive command exited successfully
     And bugsnag version "^7.5.0" has been added to the package.json file
+
+Scenario: no git repo, run anyway, already installed
+    When I run the React Native service interactively
+    And I input "npm install @bugsnag/react-native" interactively
+    Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
+    And the last interactive command exited successfully
+    And bugsnag has been added to the package.json file
+    When I input "bugsnag-react-native-cli install" interactively
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "y" interactively
+    Then I wait for the shell to output a line containing "@bugsnag/react-native is already installed, skipping" to stdout
+    And the last interactive command exited successfully

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -9,8 +9,38 @@ Scenario: no git repo, do not run
         This command may make modifications to your project. It is recommended that you commit the
         current status of your code to a git repo before continuing.
         """
-    And the current stdout line contains "Do you want to continue anyway?"
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
+    Then the last interactive command exited successfully
+    And bugsnag has not been added to the package.json file
+
+Scenario: dirty git repo, do not run
+    When I run the React Native service interactively
+    And I input "git init" interactively
+    And I input "bugsnag-react-native-cli install" interactively
+    Then I wait for the shell to output a line containing "Uncommited changes detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit or
+        stash your current changes before continuing.
+
+        Afterwards you can review the diff of the changes made by this command and commit
+        them to your project.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I press enter
+    Then the last interactive command exited successfully
+    And bugsnag has not been added to the package.json file
+
+Scenario: clean git repo, do not run
+    When I run the React Native service interactively
+    And I input "git init" interactively
+    And I input "git add -A && git commit -qm 'changes'" interactively
+    And I input "bugsnag-react-native-cli install" interactively
+    Then I wait for the shell to output a line containing "This command may make modifications to your project. Afterwards you can" to stdout
+    And I wait for the shell to output "review the diff and commit them to your project." to stdout
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "n" interactively
     Then the last interactive command exited successfully
     And bugsnag has not been added to the package.json file
 
@@ -23,7 +53,7 @@ Scenario: no git repo, run anyway, default version
         This command may make modifications to your project. It is recommended that you commit the
         current status of your code to a git repo before continuing.
         """
-    And the current stdout line contains "Do you want to continue anyway?"
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
     Then I wait for the shell to output a line containing "Adding @bugsnag/react-native dependency" to stdout
     And I wait for the shell to output a line containing "Using yarn or npm" to stdout

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -63,3 +63,21 @@ Scenario: no git repo, run anyway, default version
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And the last interactive command exited successfully
     And bugsnag has been added to the package.json file
+
+Scenario: clean git repo, run, version 7.5.0
+    When I run the React Native service interactively
+    And I input "git init" interactively
+    And I input "git add -A && git commit -qm 'changes'" interactively
+    And I input "bugsnag-react-native-cli install" interactively
+    Then I wait for the shell to output a line containing "This command may make modifications to your project. Afterwards you can" to stdout
+    And I wait for the shell to output "review the diff and commit them to your project." to stdout
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I press enter
+    Then I wait for the shell to output a line containing "Adding @bugsnag/react-native dependency" to stdout
+    And I wait for the shell to output a line containing "Using yarn or npm" to stdout
+    When I press enter
+    Then I wait for the current stdout line to contain "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
+    When I input "7.5.0" interactively
+    Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
+    And the last interactive command exited successfully
+    And bugsnag version "^7.5.0" has been added to the package.json file

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -89,8 +89,12 @@ def parse_package_json
 
   difference = after - before
 
-  # Drop one line as it's the "cat package.json" command
-  JSON.parse(difference.drop(1).join("\n"))
+  # Drop lines that include the cat command above. This will sometimes appear
+  # once and sometimes appear twice, depending on if another command is running
+  # when it's input
+  json = difference.drop_while { |line| line.include?('cat package.json') }
+
+  JSON.parse(json.join("\n"))
 end
 
 Then("bugsnag has been added to the package.json file") do
@@ -98,6 +102,14 @@ Then("bugsnag has been added to the package.json file") do
 
   assert_includes(json, "dependencies")
   assert_includes(json["dependencies"], "@bugsnag/react-native")
+end
+
+Then("bugsnag version {string} has been added to the package.json file") do |expected|
+  json = parse_package_json
+
+  assert_includes(json, "dependencies")
+  assert_includes(json["dependencies"], "@bugsnag/react-native")
+  assert_equal(json["dependencies"]["@bugsnag/react-native"], expected)
 end
 
 Then("bugsnag has not been added to the package.json file") do

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -97,14 +97,14 @@ def parse_package_json
   JSON.parse(json.join("\n"))
 end
 
-Then("bugsnag has been added to the package.json file") do
+Then("bugsnag react-native is in the package.json file") do
   json = parse_package_json
 
   assert_includes(json, "dependencies")
   assert_includes(json["dependencies"], "@bugsnag/react-native")
 end
 
-Then("bugsnag version {string} has been added to the package.json file") do |expected|
+Then("bugsnag react-native version {string} is in the package.json file") do |expected|
   json = parse_package_json
 
   assert_includes(json, "dependencies")
@@ -112,7 +112,7 @@ Then("bugsnag version {string} has been added to the package.json file") do |exp
   assert_equal(json["dependencies"]["@bugsnag/react-native"], expected)
 end
 
-Then("bugsnag has not been added to the package.json file") do
+Then("bugsnag react-native is not in the package.json file") do
   json = parse_package_json
 
   assert_includes(json, "dependencies")

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -24,3 +24,85 @@ end
 When('I run the React Native service interactively') do
   step("I run the service '#{current_fixture}' interactively")
 end
+
+When('I press enter') do
+  step('I input "" interactively')
+end
+
+When('I wait for the shell to output the following to stdout') do |expected|
+  wait = Maze::Wait.new(timeout: MazeRunner.config.receive_requests_wait)
+
+  success = wait.until do
+    stdout = Runner.interactive_session.stdout_lines.join("\n")
+
+    stdout.include?(expected)
+  end
+
+  assert(
+    success,
+    <<~ERROR
+      Did not find the expected message in stdout
+
+      stdout:
+      #{Runner.interactive_session.stdout_lines.inspect}
+    ERROR
+  )
+end
+
+Then("I wait for the shell to output a line containing {string} to stdout") do |expected|
+  wait = Maze::Wait.new(timeout: MazeRunner.config.receive_requests_wait)
+  success = wait.until do
+    Runner.interactive_session.stdout_lines.any? do |line|
+      line.include?(expected)
+    end
+  end
+
+  assert(
+    success,
+    <<~ERROR
+      No stdout lines contained '#{expected}'
+
+      stdout:
+      #{Runner.interactive_session.stdout_lines.inspect}
+    ERROR
+  )
+end
+
+Then("I wait for the current stdout line to contain {string}") do |expected|
+  wait = Maze::Wait.new(timeout: MazeRunner.config.receive_requests_wait)
+  wait.until do
+    Runner.interactive_session.current_buffer.include?(expected)
+  end
+
+  assert_includes(Runner.interactive_session.current_buffer, expected)
+end
+
+def parse_package_json
+  before = Runner.interactive_session.stdout_lines.dup
+
+  steps %Q{
+    When I input "cat package.json" interactively
+    Then I wait for the shell to output '"dependencies": \{' to stdout
+  }
+
+  after = Runner.interactive_session.stdout_lines
+
+  difference = after - before
+
+  # Drop one line as it's the "cat package.json" command
+  JSON.parse(difference.drop(1).join("\n"))
+end
+
+Then("bugsnag has been added to the package.json file") do
+  json = parse_package_json
+
+  assert_includes(json, "dependencies")
+  assert_includes(json["dependencies"], "@bugsnag/react-native")
+end
+
+Then("bugsnag has not been added to the package.json file") do
+  json = parse_package_json
+
+  assert_includes(json, "dependencies")
+  refute_includes(json["dependencies"], "@bugsnag/react-native")
+end


### PR DESCRIPTION
## Goal

Adds tests for the RN CLI 'install' command:

- no git repo, do not run
- dirty git repo, do not run
- clean git repo, do not run
- no git repo, run anyway, default version
- clean git repo, run, version 7.5.0
- no git repo, run anyway, already installed

## Testing

Manually run against the four RN fixtures