### PR TITLE
feat(react-native-cli): Allow user to select BAGP version

### DIFF
--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -22,13 +22,19 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
     const { androidIntegration } = await prompts({
       type: 'confirm',
       name: 'androidIntegration',
-      message: 'Do you want to automatically upload source maps as part of the gradle build?',
+      message: 'Do you want to automatically upload source maps as part of the Gradle build?',
       initial: true
     }, { onCancel })
 
     if (androidIntegration) {
       logger.info('Modifying the Gradle build')
-      await modifyRootBuildGradle(projectRoot, logger)
+      const { gradlePluginVersion } = await prompts({
+        type: 'text',
+        name: 'gradlePluginVersion',
+        message: 'If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want',
+        initial: '5.+'
+      }, { onCancel })
+      await modifyRootBuildGradle(projectRoot, gradlePluginVersion, logger)
       await modifyAppBuildGradle(projectRoot, logger)
     }
 

--- a/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
@@ -28,7 +28,7 @@ test('modifyRootBuildGradle(): success', async () => {
   readFileMock.mockResolvedValue(rootBuildGradle)
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
-  await modifyRootBuildGradle('/random/path', logger)
+  await modifyRootBuildGradle('/random/path', '5.+', logger)
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
   expect(writeFileMock).toHaveBeenCalledWith(
     '/random/path/android/build.gradle',
@@ -42,7 +42,7 @@ test('modifyRootBuildGradle(): tolerates errors', async () => {
   readFileMock.mockResolvedValue('not a gradle file')
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
-  await modifyRootBuildGradle('/random/path', logger)
+  await modifyRootBuildGradle('/random/path', '5.+', logger)
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
   expect(logger.warn).toHaveBeenCalledWith(
@@ -56,7 +56,7 @@ test('modifyRootBuildGradle(): skips when no changes are required', async () => 
   readFileMock.mockResolvedValue(rootBuildGradle)
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
-  await modifyRootBuildGradle('/random/path', logger)
+  await modifyRootBuildGradle('/random/path', '5.+', logger)
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
   expect(logger.warn).toHaveBeenCalledWith(
@@ -70,7 +70,7 @@ test('modifyRootBuildGradle(): tolerates missing gradle file', async () => {
   readFileMock.mockRejectedValue(notFoundErr)
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
-  await modifyRootBuildGradle('/random/path', logger)
+  await modifyRootBuildGradle('/random/path', '5.+', logger)
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
   expect(logger.warn).toHaveBeenCalledWith(
@@ -84,7 +84,7 @@ test('modifyRootBuildGradle(): passes on unknown errors', async () => {
   readFileMock.mockRejectedValue(unknownErr)
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
-  await expect(modifyRootBuildGradle('/random/path', logger)).rejects.toThrowError('Unknown error')
+  await expect(modifyRootBuildGradle('/random/path', '5.+', logger)).rejects.toThrowError('Unknown error')
 })
 
 test('modifyAppBuildGradle(): success', async () => {


### PR DESCRIPTION
To enable testing the RN CLI before an update to BAGP is released proper, it's useful to be able to specify the version desired. This PR adds a prompt for it, defaulting to the previously hardcoded value (`5.+`).