### PR TITLE
Make Plist update log consistent with Android

### DIFF
--- a/packages/react-native-cli/src/lib/InfoPlist.ts
+++ b/packages/react-native-cli/src/lib/InfoPlist.ts
@@ -34,7 +34,7 @@ export async function addApiKey (projectRoot: string, apiKey: string, logger: Lo
     const infoPlist = plist.parse(await fs.readFile(plistPath, 'utf8'))
     infoPlist.bugsnag = { apiKey }
     await fs.writeFile(plistPath, `${plist.build(infoPlist, { indent: '\t', indentSize: 1, offset: -1 })}\n`, 'utf8')
-    logger.success('Updating Info.plist')
+    logger.success('Updated Info.plist')
   } catch (e) {
     logger.warn(PLIST_FAIL_MSG)
   }


### PR DESCRIPTION
## Goal

The 'configure' command currently outputs the following:

> ```
> ℹ Adding API key to AndroidManifest.xml
> ✔ Updated AndroidManifest.xml
> ℹ Adding API key to Info.plist
> ✔ Updating Info.plist
> ```

"Updating Info.plist" should be "Updat**ed** Info.plist" to match Android and because it's done the update at the point it's logged