### PR TITLE
RN-CLI: Tests for automate-symbolication command

### DIFF
--- a/test/react-native-cli/features/automate-symbolication.feature
+++ b/test/react-native-cli/features/automate-symbolication.feature
@@ -1,0 +1,121 @@
+Feature: automate symbolication command
+
+Scenario: successfully modify project
+    When I run the React Native service interactively
+    And I input "bugsnag-react-native-cli automate-symbolication" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I press enter
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    When I press enter
+    And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+    When I press enter
+    And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+    When I press enter
+    Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout
+    Then the last interactive command exited successfully
+    And bugsnag source maps library is in the package.json file
+    And the iOS build has been modified to upload source maps
+    And the Android build has been modified to upload source maps
+
+Scenario: successfully modify project, choosing source-maps version
+    When I run the React Native service interactively
+    And I input "bugsnag-react-native-cli automate-symbolication" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I press enter
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    When I press enter
+    And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+    When I press enter
+    And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+    When I input "1.0.0-beta.1" interactively
+    Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout
+    Then the last interactive command exited successfully
+    And bugsnag source maps library version "^1.0.0-beta.1" is in the package.json file
+    And the iOS build has been modified to upload source maps
+    And the Android build has been modified to upload source maps
+
+Scenario: opt not to modify the Android project
+    When I run the React Native service interactively
+    And I input "bugsnag-react-native-cli automate-symbolication" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I press enter
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+    When I press enter
+    And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+    When I press enter
+    Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout
+    Then the last interactive command exited successfully
+    And bugsnag source maps library is in the package.json file
+    And the iOS build has been modified to upload source maps
+    And the Android build has not been modified to upload source maps
+
+Scenario: opt not to modify the iOS project
+    When I run the React Native service interactively
+    And I input "bugsnag-react-native-cli automate-symbolication" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I input "n" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+    When I press enter
+    And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+    When I press enter
+    Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout
+    Then the last interactive command exited successfully
+    And bugsnag source maps library is in the package.json file
+    And the iOS build has not been modified to upload source maps
+    And the Android build has been modified to upload source maps
+
+Scenario: opt not to modify either project
+    When I run the React Native service interactively
+    And I input "bugsnag-react-native-cli automate-symbolication" interactively
+    Then I wait for the shell to output a line containing "No repo detected." to stdout
+    And I wait for the shell to output the following to stdout
+        """
+        This command may make modifications to your project. It is recommended that you commit the
+        current status of your code to a git repo before continuing.
+        """
+    And I wait for the current stdout line to contain "Do you want to continue anyway?"
+    When I input "y" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I input "n" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    When I input "n" interactively
+    Then the last interactive command exited successfully
+    And bugsnag source maps library is not in the package.json file
+    And the iOS build has not been modified to upload source maps
+    And the Android build has not been modified to upload source maps

--- a/test/react-native-cli/features/automate-symbolication.feature
+++ b/test/react-native-cli/features/automate-symbolication.feature
@@ -64,9 +64,7 @@ Scenario: opt not to modify the Android project
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
-    When I input "y" interactively
-    And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-    When I press enter
+    When I input "n" interactively
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
     Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout

--- a/test/react-native-cli/features/fixtures/rn0_60/check-ios-build-script.sh
+++ b/test/react-native-cli/features/fixtures/rn0_60/check-ios-build-script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# This 'fgrep' command has major issues when running through MazeRunner because
+# of the escaped quotes. Cucumber rejects the input that would make a valid
+# fgrep command and adding or removing escaping makes the fgrep invalid
+
+set -ex
+
+fgrep 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"' ios/rn0_60.xcodeproj/project.pbxproj

--- a/test/react-native-cli/features/fixtures/rn0_61/check-ios-build-script.sh
+++ b/test/react-native-cli/features/fixtures/rn0_61/check-ios-build-script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# This 'fgrep' command has major issues when running through MazeRunner because
+# of the escaped quotes. Cucumber rejects the input that would make a valid
+# fgrep command and adding or removing escaping makes the fgrep invalid
+
+set -ex
+
+fgrep 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"' ios/rn0_61.xcodeproj/project.pbxproj

--- a/test/react-native-cli/features/fixtures/rn0_62/check-ios-build-script.sh
+++ b/test/react-native-cli/features/fixtures/rn0_62/check-ios-build-script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# This 'fgrep' command has major issues when running through MazeRunner because
+# of the escaped quotes. Cucumber rejects the input that would make a valid
+# fgrep command and adding or removing escaping makes the fgrep invalid
+
+set -ex
+
+fgrep 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"' ios/rn0_62.xcodeproj/project.pbxproj

--- a/test/react-native-cli/features/fixtures/rn0_63/check-ios-build-script.sh
+++ b/test/react-native-cli/features/fixtures/rn0_63/check-ios-build-script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# This 'fgrep' command has major issues when running through MazeRunner because
+# of the escaped quotes. Cucumber rejects the input that would make a valid
+# fgrep command and adding or removing escaping makes the fgrep invalid
+
+set -ex
+
+fgrep 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"' ios/rn0_63.xcodeproj/project.pbxproj

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -131,8 +131,11 @@ end
 Then("the iOS build has been modified to upload source maps") do
   filename = "ios/#{current_fixture}.xcodeproj/project.pbxproj"
 
-  step("the file '#{filename}' contains 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"'")
-  step("the file '#{filename}' contains 'Upload source maps to Bugsnag'")
+  steps %Q{
+    Then I input "./check-ios-build-script.sh" interactively
+    And the last interactive command exited successfully
+    And the file '#{filename}' contains 'Upload source maps to Bugsnag'
+  }
 end
 
 Then("the Android build has not been modified to upload source maps") do
@@ -174,9 +177,8 @@ Then("bugsnag react-native is not in the package.json file") do
 end
 
 Then("the file {string} contains {string}") do |filename, expected|
-  # grep's "-x" makes the pattern have to match an entire line
   steps %Q{
-    When I input "fgrep '#{expected.gsub(/"/, '\\"')}' #{filename}" interactively
+    When I input "fgrep '#{expected.gsub(/"/, '\"')}' #{filename}" interactively
     Then the last interactive command exited successfully
   }
 end
@@ -189,9 +191,8 @@ Then("the file {string} contains") do |filename, expected|
 end
 
 Then("the file {string} does not contain {string}") do |filename, expected|
-  # grep's "-x" makes the pattern have to match an entire line
   steps %Q{
-    When I input "fgrep '#{expected.gsub(/"/, '\\"')}' #{filename}" interactively
+    When I input "fgrep '#{expected.gsub(/"/, '\"')}' #{filename}" interactively
     Then the last interactive command exited with an error code
   }
 end

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -99,6 +99,58 @@ def parse_package_json
   JSON.parse(json.join("\n"))
 end
 
+Then("bugsnag source maps library is in the package.json file") do
+  json = parse_package_json
+
+  assert_includes(json, "devDependencies")
+  assert_includes(json["devDependencies"], "@bugsnag/source-maps")
+end
+
+Then("bugsnag source maps library version {string} is in the package.json file") do |expected|
+  json = parse_package_json
+
+  assert_includes(json, "devDependencies")
+  assert_includes(json["devDependencies"], "@bugsnag/source-maps")
+  assert_equal(json["devDependencies"]["@bugsnag/source-maps"], expected)
+end
+
+Then("bugsnag source maps library is not in the package.json file") do
+  json = parse_package_json
+
+  assert_includes(json, "devDependencies")
+  refute_includes(json["devDependencies"], "@bugsnag/source-maps")
+end
+
+Then("the iOS build has not been modified to upload source maps") do
+  filename = "ios/#{current_fixture}.xcodeproj/project.pbxproj"
+
+  step("the file '#{filename}' does not contain 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"'")
+  step("the file '#{filename}' does not contain 'Upload source maps to Bugsnag'")
+end
+
+Then("the iOS build has been modified to upload source maps") do
+  filename = "ios/#{current_fixture}.xcodeproj/project.pbxproj"
+
+  step("the file '#{filename}' contains 'EXTRA_PACKAGER_ARGS=\"--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map\"'")
+  step("the file '#{filename}' contains 'Upload source maps to Bugsnag'")
+end
+
+Then("the Android build has not been modified to upload source maps") do
+  rootGradle = "android/build.gradle"
+  appGradle = "android/app/build.gradle"
+
+  step("the file '#{rootGradle}' does not contain 'classpath(\"com.bugsnag:bugsnag-android-gradle-plugin:'")
+  step("the file '#{appGradle}' does not contain 'apply plugin: \"com.bugsnag.android.gradle\"'")
+end
+
+Then("the Android build has been modified to upload source maps") do
+  rootGradle = "android/build.gradle"
+  appGradle = "android/app/build.gradle"
+
+  step("the file '#{rootGradle}' contains 'classpath(\"com.bugsnag:bugsnag-android-gradle-plugin:'")
+  step("the file '#{appGradle}' contains 'apply plugin: \"com.bugsnag.android.gradle\"'")
+end
+
 Then("bugsnag react-native is in the package.json file") do
   json = parse_package_json
 


### PR DESCRIPTION
## Goal

Adds tests for the RN CLI 'automate-symbolication' command:

- successful modification
- successful modification, selecting desired `@bugsnag/source-maps` version
- opting out of iOS modification
- opting out of Android modification
- opting out of both

## Testing

Manually run against the four RN fixtures