### PR TITLE
[PLAT-5501] RN-CLI: Have confidence in the guessed npm client

### DIFF
--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -44,16 +44,7 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
         logger.warn('@bugsnag/source-maps is already installed, skipping')
       } else {
         logger.info('Adding @bugsnag/source-maps dependency')
-        const { packageManager } = await prompts({
-          type: 'select',
-          name: 'packageManager',
-          message: 'Using yarn or npm?',
-          choices: [
-            { title: 'npm', value: 'npm' },
-            { title: 'yarn', value: 'yarn' }
-          ],
-          initial: await guessPackageManager(projectRoot) === 'npm' ? 0 : 1
-        })
+        const packageManager = await guessPackageManager(projectRoot)
 
         const { version } = await prompts({
           type: 'text',

--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -11,16 +11,7 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
       logger.warn('@bugsnag/react-native is already installed, skipping')
     } else {
       logger.info('Adding @bugsnag/react-native dependency')
-      const { packageManager } = await prompts({
-        type: 'select',
-        name: 'packageManager',
-        message: 'Using yarn or npm?',
-        choices: [
-          { title: 'npm', value: 'npm' },
-          { title: 'yarn', value: 'yarn' }
-        ],
-        initial: await guessPackageManager(projectRoot) === 'npm' ? 0 : 1
-      })
+      const packageManager = await guessPackageManager(projectRoot)
 
       const { version } = await prompts({
         type: 'text',

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -56,8 +56,6 @@ Scenario: no git repo, run anyway, default version
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
     Then I wait for the shell to output a line containing "Adding @bugsnag/react-native dependency" to stdout
-    And I wait for the shell to output a line containing "Using yarn or npm" to stdout
-    When I press enter
     Then I wait for the current stdout line to contain "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
     When I press enter
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
@@ -74,8 +72,6 @@ Scenario: clean git repo, run, version 7.5.0
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
     Then I wait for the shell to output a line containing "Adding @bugsnag/react-native dependency" to stdout
-    And I wait for the shell to output a line containing "Using yarn or npm" to stdout
-    When I press enter
     Then I wait for the current stdout line to contain "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
     When I input "7.5.0" interactively
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout


### PR DESCRIPTION
Remove the confirmations as it's an unncessary blocking step.

Tests in #1166 and ~#1157~ will need to be updated when this lands on the integration branch.