### PR TITLE
Run React Native CLI tests in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
 
   - label: 'Trigger React Native CLI pipeline'
     depends_on:
-# TODO: Reinstate later
+# TODO: Reinstate once triggered pipeline has evolved to require the published artifact
 #      - 'publish-js'
       - 'android-builder-base'
     trigger: 'bugsnag-js-react-native-cli'

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -57,14 +57,6 @@ steps:
     env:
       REACT_NATIVE_VERSION: "rn0_63"
 
-  - label: ':runner: Broken tests'
-    depends_on: "cli-maze-image"
-    timeout_in_minutes: 20
-    plugins:
-      docker-compose#v3.7.0:
-        run: react-native-cli-tool-maze-runner
-        use-aliases: true
-
   #
   # Built app test fixtures
   #

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -24,6 +24,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
+        command: ["-e", "features/built_app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_60"
 
@@ -34,6 +35,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
+        command: ["-e", "features/built_app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_61"
 
@@ -44,6 +46,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
+        command: ["-e", "features/built_app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_62"
 
@@ -54,6 +57,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
+        command: ["-e", "features/built_app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_63"
 

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -1,23 +1,85 @@
 steps:
 
   #
-  # Android builder
+  # CLI tests Maze Runner image
+  #
+  - label: ':docker: Build CLI test image'
+    key: 'cli-maze-image'
+    timeout_in_minutes: 30
+    plugins:
+      - docker-compose#v3.7.0:
+          build: react-native-cli-tool-maze-runner
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+          cache-from:  react-native-cli-tool-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:cli-maze-${BRANCH_NAME}
+      - docker-compose#v3.7.0:
+          push: react-native-cli-tool-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:cli-maze-${BRANCH_NAME}
+
+  #
+  # CLI tests
+  #
+  - label: ':runner: RN 0.60 CLI tests'
+    depends_on: "cli-maze-image"
+    timeout_in_minutes: 20
+    plugins:
+      docker-compose#v3.7.0:
+        run: react-native-cli-tool-maze-runner
+        use-aliases: true
+    env:
+      REACT_NATIVE_VERSION: "rn0_60"
+
+  - label: ':runner: RN 0.61 CLI tests'
+    depends_on: "cli-maze-image"
+    timeout_in_minutes: 20
+    plugins:
+      docker-compose#v3.7.0:
+        run: react-native-cli-tool-maze-runner
+        use-aliases: true
+    env:
+      REACT_NATIVE_VERSION: "rn0_61"
+
+  - label: ':runner: RN 0.62 CLI tests'
+    depends_on: "cli-maze-image"
+    timeout_in_minutes: 20
+    plugins:
+      docker-compose#v3.7.0:
+        run: react-native-cli-tool-maze-runner
+        use-aliases: true
+    env:
+      REACT_NATIVE_VERSION: "rn0_62"
+
+  - label: ':runner: RN 0.63 CLI tests'
+    depends_on: "cli-maze-image"
+    timeout_in_minutes: 20
+    plugins:
+      docker-compose#v3.7.0:
+        run: react-native-cli-tool-maze-runner
+        use-aliases: true
+    env:
+      REACT_NATIVE_VERSION: "rn0_63"
+
+  - label: ':runner: Broken tests'
+    depends_on: "cli-maze-image"
+    timeout_in_minutes: 20
+    plugins:
+      docker-compose#v3.7.0:
+        run: react-native-cli-tool-maze-runner
+        use-aliases: true
+
+  #
+  # Built app test fixtures
   #
   - label: ':docker: Build RN Android Builder image'
     key: 'android-builder-image'
     skip: 'Builds successfully, but skipped until later steps are implemented.'
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           build: react-native-cli-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:  react-native-cli-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           push: react-native-cli-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
-  #
-  # Test fixtures
-  #
   - label: ':android: Build RN 0.60 apk'
     key: 'rn-0-60-apk'
     skip: 'Builds successfully, but skipped until later steps are implemented.'
@@ -27,7 +89,7 @@ steps:
     env:
       REACT_NATIVE_VERSION: rn0_60
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           run: react-native-cli-android-builder
     artifact_paths:
       - build/rn0_60.apk
@@ -41,7 +103,7 @@ steps:
     env:
       REACT_NATIVE_VERSION: rn0_61
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           run: react-native-cli-android-builder
     artifact_paths:
       - build/rn0_61.apk
@@ -55,7 +117,7 @@ steps:
     env:
       REACT_NATIVE_VERSION: rn0_62
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           run: react-native-cli-android-builder
     artifact_paths:
       - build/rn0_62.apk
@@ -69,7 +131,7 @@ steps:
     env:
       REACT_NATIVE_VERSION: rn0_63
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.7.0:
           run: react-native-cli-android-builder
     artifact_paths:
       - build/rn0_63.apk
@@ -121,3 +183,7 @@ steps:
     artifact_paths: build/rn0_63.ipa
     commands:
       - npm run test:build-react-native-cli-ios
+
+  #
+  # TODO Built app end-to-end tests
+  #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,10 +141,10 @@ services:
       - ./test:/app/test
       - ./features:/app/features
 
-  react-native-cli:
+  react-native-cli-tool-maze-runner:
     build:
       context: .
-      dockerfile: dockerfiles/Dockerfile.react-native-cli
+      dockerfile: dockerfiles/Dockerfile.react-native-cli-tool
     environment:
       DEBUG:
       REACT_NATIVE_VERSION:

--- a/dockerfiles/Dockerfile.react-native-cli-tool
+++ b/dockerfiles/Dockerfile.react-native-cli-tool
@@ -27,3 +27,5 @@ COPY --from=react-native-cli-feature-builder /app/bugsnag-react-native-cli-*.tgz
 RUN for d in test/react-native-cli/features/fixtures/*/; do cp /app/*.tgz "$d"; done
 
 WORKDIR /app/test/react-native-cli
+
+ENTRYPOINT ["bundle", "exec", "maze-runner"]


### PR DESCRIPTION
## Goal

Automates the running of the React Native CLI test in the pipeline.

## Design

This uses the `npm pack` approach for installing the notifier.  Switching to npm (Lerna) publish/install will follow in a later PR.

## Changeset

- New pipeline steps
- Docker Compose Buildkite plugin bumped
- Docker Compose/Dockerfile renamed to distinguish from the forthcoming "build and run" tests

## Testing

Now covered by passing CI.