### PR TITLE
fix(react-native): Fix propagation of enabledReleaseStages from Cocoa notifier

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
@@ -16,7 +16,7 @@
     BSGDictInsertIfNotNil(dict, config.apiKey, @"apiKey");
     BSGDictInsertIfNotNil(dict, @(config.autoDetectErrors), @"autoDetectErrors");
     BSGDictInsertIfNotNil(dict, @(config.autoTrackSessions), @"autoTrackSessions");
-    BSGDictInsertIfNotNil(dict, config.enabledReleaseStages, @"enabledReleaseStages");
+    BSGDictInsertIfNotNil(dict, config.enabledReleaseStages.allObjects, @"enabledReleaseStages");
     BSGDictInsertIfNotNil(dict, config.releaseStage, @"releaseStage");
     BSGDictInsertIfNotNil(dict, config.appVersion, @"appVersion");
     BSGDictInsertIfNotNil(dict, config.appType, @"appType");


### PR DESCRIPTION
## Goal

Fixes the propagation of `enabledReleaseStages` from the Cocoa notifier.

`enabledReleaseStages` is an NSSet, which is not a JSON compatible type.

## Changeset

Converting `enabledReleaseStages` to an array fixes the issue.

## Testing

Manually verified using a JavaScript remote debugger to ensure `enabledReleaseStages` is correctly populated on the JS side.