### PR TITLE
feat(react-native-cli): Pass --endpoint from Xcode build phase

### DIFF
--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -41,8 +41,15 @@ ARGS=(
 
 case "$CONFIGURATION" in
   *Debug*)
-    ARGS+="--dev"
+    ARGS+=("--dev")
     ;;
 esac
+
+if [ ! -z "$ENDPOINT" ]; then
+  # Remove any trailing trailing '/'
+  ENDPOINT=$(echo $ENDPOINT | sed 's/\/$//')
+  ARGS+=("--endpoint")
+  ARGS+=("$ENDPOINT/sourcemap")
+fi
 
 ../node_modules/.bin/bugsnag-source-maps upload-react-native "${ARGS[@]}"


### PR DESCRIPTION
## Goal

Allow upload endpoint to be configurable and passed to the source-map-upload command

## Changeset

The script now checks for a `sourceMapUploadEndpoint` value in the `bugsnag` dictionary of the Info.plist, and passes this to `bugsnag-source-maps upload-react-native` via the `--endpoint` argument.

## Testing

Verified using rn0.63 example project, the build phase ran the following:

`../node_modules/.bin/bugsnag-source-maps upload-react-native --api-key 0abcdef000000abcdef000000abcdef0 --app-bundle-version 1 --app-version 1.0 --bundle /Users/nick/Library/Developer/Xcode/DerivedData/rn063example-edbieehjhphcfpedkdzhcqundjem/Build/Products/Release-iphoneos/rn063example.app/main.jsbundle --platform ios --source-map /Users/nick/Library/Developer/Xcode/DerivedData/rn063example-edbieehjhphcfpedkdzhcqundjem/Build/Products/Release-iphoneos/rn063example.app/main.jsbundle.map --endpoint https://example.com`