### PR TITLE
Remove use of VERBOSE environment with MazeRunner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
         - BUILDKITE_BUILD_NUMBER
     command: --fail-fast --retry 2
     environment:
-      VERBOSE:
       DEBUG:
       BROWSER: "${BROWSER:-chrome_61}"
       BROWSER_STACK_USERNAME:
@@ -55,7 +54,6 @@ services:
       NODE_VERSION: "${NODE_VERSION:-10}"
       COMPOSE_PROJECT_NAME: "node${NODE_VERSION:-10}"
       NETWORK_NAME: "${BUILDKITE_JOB_ID:-js-maze-runner}"
-      VERBOSE:
       DEBUG:
     networks:
       default:
@@ -71,7 +69,6 @@ services:
       args:
         - BUILDKITE_BUILD_NUMBER
     environment:
-      VERBOSE:
       DEBUG:
     networks:
       default:
@@ -98,7 +95,6 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.expo-android-builder
     environment:
-      VERBOSE:
       DEBUG:
       EXPO_USERNAME:
       EXPO_PASSWORD:
@@ -123,7 +119,6 @@ services:
         - REG_BASIC_CREDENTIAL
         - REG_NPM_EMAIL
     environment:
-      - VERBOSE
       - DEBUG
       - BRANCH_NAME
       - BUILDKITE
@@ -148,7 +143,6 @@ services:
       args:
         - BUILDKITE_BUILD_NUMBER
     environment:
-      VERBOSE:
       DEBUG:
       SKIP_NAVIGATION_SCENARIOS:
     networks:

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -13,7 +13,7 @@ ERRORS = YAML::load open 'features/fixtures/browser_errors.yml'
 FIXTURES_SERVER_PORT = "9020"
 
 # start a web server to serve fixtures
-if ENV['VERBOSE']
+if ENV['DEBUG']
   pid = Process.spawn({"PORT"=>FIXTURES_SERVER_PORT}, 'ruby features/lib/server.rb')
 else
   DEV_NULL = Gem.win_platform? ? 'NUL' : '/dev/null'


### PR DESCRIPTION
Removes the use of the VERBOSE environment variable when using MazeRunner.

VERBOSE and DEBUG are synonymous in MazeRunner, so there is no need to list both.  Ultimately we should remove VERBOSE from MazeRunner at the next breaking changing.