### PR TITLE
Reduce browserstack concurrency to 9

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -109,7 +109,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 12'
@@ -133,7 +133,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - block: "Trigger full test suite"
@@ -155,7 +155,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
       - exit_status: "*"
@@ -177,7 +177,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo Android 6'
@@ -197,7 +197,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo Android 5'
@@ -217,7 +217,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 11'
@@ -239,7 +239,7 @@ steps:
           - --fail-fast
           - --retry=2
           - --resilient
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 10'
@@ -260,5 +260,5 @@ steps:
           - --fail-fast
           - --retry=2
           - --resilient
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -223,7 +223,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':ios: RN 0.60 iOS 12 end-to-end tests'
@@ -246,7 +246,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: RN 0.63 Android 9 end-to-end tests'
@@ -268,7 +268,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':ios: RN 0.63 iOS 12 end-to-end tests'
@@ -291,7 +291,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: react-navigation 0.60 Android 9 end-to-end tests'
@@ -312,7 +312,7 @@ steps:
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   # See: PLAT-5173
@@ -336,7 +336,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: react-navigation 0.63 Android 9 end-to-end tests'
@@ -357,7 +357,7 @@ steps:
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   # See: PLAT-5173
@@ -381,7 +381,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: react-native-navigation 0.60 Android 9 end-to-end tests'
@@ -402,7 +402,7 @@ steps:
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   # See: PLAT-5173
@@ -426,7 +426,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: react-native-navigation 0.63 Android 9 end-to-end tests'
@@ -447,7 +447,7 @@ steps:
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   # See: PLAT-5173
@@ -471,5 +471,5 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - features/navigation.feature
-    concurrency: 10
+    concurrency: 9
     concurrency_group: 'browserstack-app'


### PR DESCRIPTION
## Goal

Reduces the browserstack concurrency from 10 to 9. This makes one device slot will always be available for running local tests, which speeds up the feedback loop without dramatically slowing down CI times.