### PR TITLE
Allow notifier time to synch state with native layer

### DIFF
--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -223,7 +223,6 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-      DEBUG: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -247,7 +246,6 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-      DEBUG: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -270,7 +268,6 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-      DEBUG: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -294,7 +291,6 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
-      DEBUG: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -223,6 +223,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
+      DEBUG: "true"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -246,6 +247,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
+      DEBUG: "true"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -268,6 +270,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
+      DEBUG: "true"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -291,6 +294,7 @@ steps:
         - --fail-fast
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
+      DEBUG: "true"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -197,7 +197,7 @@ npm run test:build-react-native-ios
 
 Fnd Android:
 ```shell script
-npm run test:build-react-native-ios
+npm run test:build-react-native-android
 ```
 These will build a `.ipa` or `.apk` file respectively and copy into `./build`.
 

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -58,6 +58,10 @@ export default class App extends Component {
     this.setState({ sessionsEndpoint: 'https://sessions.bugsnag.com' })
   }
 
+  timeout (ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+
   startScenario = async () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
@@ -69,6 +73,8 @@ export default class App extends Component {
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     await NativeModules.BugsnagTestInterface.startBugsnag(configuration)
     Bugsnag.start(jsConfig)
+    // TODO Comment this if it actually helps
+    await this.timeout(2000)
     scenario.run()
   }
 

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -73,8 +73,10 @@ export default class App extends Component {
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     await NativeModules.BugsnagTestInterface.startBugsnag(configuration)
     Bugsnag.start(jsConfig)
-    // The notifier needs a little time to synch to the native layer, otherwise flakes occur
-    await this.timeout(5000)
+    // The notifier needs a little time to synch to the native layer, otherwise flakes occur - however it's also
+    // important that the scenario waits longer than this period before relaunching the app (see the Cucumber step
+    // 'I relaunch the app').
+    await this.timeout(2000)
     scenario.run()
   }
 

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -73,8 +73,8 @@ export default class App extends Component {
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     await NativeModules.BugsnagTestInterface.startBugsnag(configuration)
     Bugsnag.start(jsConfig)
-    // TODO Comment this if it actually helps
-    await this.timeout(2000)
+    // The notifier needs a little time to synch to the native layer, otherwise flakes occur
+    await this.timeout(5000)
     scenario.run()
   }
 

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -16,8 +16,8 @@ end
 
 When("I relaunch the app") do
   # This step should only be used when the app has crashed, but the notifier needs a little
-  # time to write the crash report before being forced to reopen.  From trials, 1s was not enough.
-  sleep(2)
+  # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
+  sleep(5)
   MazeRunner.driver.launch_app
 end
 


### PR DESCRIPTION
## Goal

Attempts to resolve a persistent flaking test that requires JS layer state to be synched with the native layer.

## Testing

The scenario in question was flaking for me 3/5 before the change.  With it in it has passed 10/10 times.