### PR TITLE
refactor(react-native): Stop using BSGDictInsertIfNotNil

### DIFF
--- a/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagConfigSerializer.m
@@ -7,27 +7,24 @@
 //
 
 #import "BugsnagConfigSerializer.h"
-#import "BugsnagCollections.h"
 
 @implementation BugsnagConfigSerializer
 
 - (NSDictionary *)serialize:(BugsnagConfiguration *)config {
     NSMutableDictionary *dict = [NSMutableDictionary new];
-    BSGDictInsertIfNotNil(dict, config.apiKey, @"apiKey");
-    BSGDictInsertIfNotNil(dict, @(config.autoDetectErrors), @"autoDetectErrors");
-    BSGDictInsertIfNotNil(dict, @(config.autoTrackSessions), @"autoTrackSessions");
-    BSGDictInsertIfNotNil(dict, config.enabledReleaseStages.allObjects, @"enabledReleaseStages");
-    BSGDictInsertIfNotNil(dict, config.releaseStage, @"releaseStage");
-    BSGDictInsertIfNotNil(dict, config.appVersion, @"appVersion");
-    BSGDictInsertIfNotNil(dict, config.appType, @"appType");
-    BSGDictInsertIfNotNil(dict, @(config.persistUser), @"persistUser");
-    BSGDictInsertIfNotNil(dict, @(config.maxBreadcrumbs), @"maxBreadcrumbs");
-    
-    BSGDictInsertIfNotNil(dict, [self serializeThreadSendPolicy:config.sendThreads], @"sendThreads");
-    BSGDictInsertIfNotNil(dict, [self serializeBreadcrumbTypes:config], @"enabledBreadcrumbTypes");
-    BSGDictInsertIfNotNil(dict, [self serializeErrorTypes:config], @"enabledErrorTypes");
-    BSGDictInsertIfNotNil(dict, [self serializeEndpoints:config], @"endpoints");
-
+    dict[@"apiKey"] = config.apiKey;
+    dict[@"autoDetectErrors"] = @(config.autoDetectErrors);
+    dict[@"autoTrackSessions"] = @(config.autoTrackSessions);
+    dict[@"enabledReleaseStages"] = config.enabledReleaseStages.allObjects;
+    dict[@"releaseStage"] = config.releaseStage;
+    dict[@"appVersion"] = config.appVersion;
+    dict[@"appType"] = config.appType;
+    dict[@"persistUser"] = @(config.persistUser);
+    dict[@"maxBreadcrumbs"] = @(config.maxBreadcrumbs);
+    dict[@"sendThreads"] = [self serializeThreadSendPolicy:config.sendThreads];
+    dict[@"enabledBreadcrumbTypes"] = [self serializeBreadcrumbTypes:config];
+    dict[@"enabledErrorTypes"] = [self serializeErrorTypes:config];
+    dict[@"endpoints"] = [self serializeEndpoints:config];
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 


### PR DESCRIPTION
## Goal

The `BSGDictInsertIfNotNil` function has been [removed from the Cocoa notifier](https://github.com/bugsnag/bugsnag-cocoa/pull/926) so these changes are required before or when adopting the next Cocoa release.

## Testing

TBD