### PR TITLE
Prepare for MazeRunner 3.6.0

### DIFF
--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-release:v3.5.1-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v3.5.1-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node test/node

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-release:v3.5.1-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node test/node

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -63,8 +63,8 @@ Before('@skip_if_local_storage_is_unavailable') do |scenario|
 end
 
 AfterConfiguration do
-  MazeRunner.config.receive_no_requests_wait = 15
-  MazeRunner.config.enforce_bugsnag_integrity = false
+  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
+  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
 
   # Necessary as Appium removes any existing $driver instance on load
   bs_local_start

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -63,6 +63,9 @@ Before('@skip_if_local_storage_is_unavailable') do |scenario|
 end
 
 AfterConfiguration do
+  MazeRunner.config.receive_no_requests_wait = 15
+  MazeRunner.config.enforce_bugsnag_integrity = false
+
   # Necessary as Appium removes any existing $driver instance on load
   bs_local_start
   $driver = driver_start

--- a/test/expo/features/support/env.rb
+++ b/test/expo/features/support/env.rb
@@ -1,3 +1,9 @@
+AfterConfiguration do |_config|
+  MazeRunner.config.receive_no_requests_wait = 15
+  # TODO: Remove once the Bugsnag-Integrity header has been implemented
+  MazeRunner.config.enforce_bugsnag_integrity = false
+end
+
 Before('@skip_android_5') do |scenario|
   if MazeRunner.driver.capabilities['os'] == 'android' and MazeRunner.config.os_version.floor == 5
     skip_this_scenario("Skipping Android 5")

--- a/test/expo/features/support/env.rb
+++ b/test/expo/features/support/env.rb
@@ -1,7 +1,7 @@
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 15
+  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
   # TODO: Remove once the Bugsnag-Integrity header has been implemented
-  MazeRunner.config.enforce_bugsnag_integrity = false
+  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
 end
 
 Before('@skip_android_5') do |scenario|

--- a/test/node/features/support/env.rb
+++ b/test/node/features/support/env.rb
@@ -1,4 +1,4 @@
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 15
-  MazeRunner.config.enforce_bugsnag_integrity = false
+  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
+  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
 end

--- a/test/node/features/support/env.rb
+++ b/test/node/features/support/env.rb
@@ -1,0 +1,4 @@
+AfterConfiguration do |_config|
+  MazeRunner.config.receive_no_requests_wait = 15
+  MazeRunner.config.enforce_bugsnag_integrity = false
+end

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -1,5 +1,5 @@
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 15
+  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
 end
 
 Before('@android_only') do |scenario|

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -1,7 +1,5 @@
 AfterConfiguration do |_config|
   MazeRunner.config.receive_no_requests_wait = 15
-  # TODO: Remove once the Bugsnag-Integrity header has been implemented
-  MazeRunner.config.enforce_bugsnag_integrity = false
 end
 
 Before('@android_only') do |scenario|

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -1,3 +1,9 @@
+AfterConfiguration do |_config|
+  MazeRunner.config.receive_no_requests_wait = 15
+  # TODO: Remove once the Bugsnag-Integrity header has been implemented
+  MazeRunner.config.enforce_bugsnag_integrity = false
+end
+
 Before('@android_only') do |scenario|
   skip_this_scenario("Skipping scenario") if MazeRunner.driver.capabilities["os"] == 'ios'
 end


### PR DESCRIPTION
## Goal

Prepare for the release of MazeRunner v3.6.0.

## Design

MazeRunner v3.6.0 will enforce the presence of the Bugsnag-Integrity and fail tests, unless configured otherwise.  This PR relaxes the check for platforms that are not implementing the header.

MazeRunner v3.6.0 also fixes a long standing problem with the `I should receive no requests` step, meaning that the test harness will now wait for a default time of 30s each time it is used.  As this is longer that the time needed in the JavaScript tests, we can prepare for the release by setting the appropriate config value to 15s, if it is available.

The fix to the above step has highlighted issues in the Node tests, where the notifier is sending requests that we do not expect.  The Node tests are therefore pinned to v3.5.1 and an internal ticket, PLAT-5584, has been raised to fix the Node tests and bring them back to the latest version of MazeRunner.

## Changeset

MazeRunner Docker and support files.

## Testing

All changes for v3.6.0 are now on the MazeRunner master branch and before creating this PR I configured each platform to run against the master version in order to smoke out any issues. When v3.6.0 is released, this should mean that there are no adverse effects on the JavaScript tests.