### PR TITLE
fix(react-native): Append correct source map endpoint path

### DIFF
--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -49,7 +49,7 @@ if [ ! -z "$ENDPOINT" ]; then
   # Remove any trailing trailing '/'
   ENDPOINT=$(echo $ENDPOINT | sed 's/\/$//')
   ARGS+=("--endpoint")
-  ARGS+=("$ENDPOINT/sourcemap")
+  ARGS+=("$ENDPOINT/react-native-source-map")
 fi
 
 ../node_modules/.bin/bugsnag-source-maps upload-react-native "${ARGS[@]}"


### PR DESCRIPTION
RN source maps go to `/react-native-source-map` not `/source(-)map`.