### PR TITLE
test: tidy test output and fix open handles

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,100 +1,86 @@
 const testsForPackage = (packageName) => `<rootDir>/packages/${packageName}/**/*.test.[jt]s?(x)`
 
-module.exports = {
+const package = (displayName, packageNames, config = {}) => ({
   roots: ['<rootDir>/packages'],
+  displayName,
+  testMatch: packageNames.map(testsForPackage),
+  ...config
+})
+
+module.exports = {
   projects: [
-    {
-      displayName: 'core',
-      testMatch: [
-        testsForPackage('core')
-      ]
-    },
-    {
-      displayName: 'shared plugins',
-      testMatch: [
-        testsForPackage('plugin-app-duration')
-      ]
-    },
-    {
-      displayName: 'browser',
-      testMatch: [
-        testsForPackage('browser'),
-        testsForPackage('delivery-x-domain-request'),
-        testsForPackage('delivery-xml-http-request'),
-        testsForPackage('plugin-react'),
-        testsForPackage('plugin-vue'),
-        testsForPackage('plugin-browser-context'),
-        testsForPackage('plugin-browser-device'),
-        testsForPackage('plugin-browser-request'),
-        testsForPackage('plugin-client-ip'),
-        testsForPackage('plugin-navigation-breadcrumbs'),
-        testsForPackage('plugin-network-breadcrumbs'),
-        testsForPackage('plugin-window-unhandled-rejection'),
-        testsForPackage('plugin-window-onerror'),
-        testsForPackage('plugin-strip-query-string'),
-        testsForPackage('plugin-interaction-breadcrumbs'),
-        testsForPackage('plugin-simple-throttle'),
-        testsForPackage('plugin-console-breadcrumbs'),
-        testsForPackage('plugin-browser-session')
-      ]
-    },
-    {
-      displayName: 'react native',
+    package('core', ['core']),
+    package('shared plugins', ['plugin-app-duration']),
+    package('browser', [
+      'browser',
+      'delivery-x-domain-request',
+      'delivery-xml-http-request',
+      'plugin-react',
+      'plugin-vue',
+      'plugin-browser-context',
+      'plugin-browser-device',
+      'plugin-browser-request',
+      'plugin-client-ip',
+      'plugin-navigation-breadcrumbs',
+      'plugin-network-breadcrumbs',
+      'plugin-window-unhandled-rejection',
+      'plugin-window-onerror',
+      'plugin-strip-query-string',
+      'plugin-interaction-breadcrumbs',
+      'plugin-simple-throttle',
+      'plugin-console-breadcrumbs',
+      'plugin-browser-session'
+    ]),
+    package('react native', [
+      'react-native',
+      'delivery-react-native',
+      'plugin-react-native-app-state-breadcrumbs',
+      'plugin-react-native-connectivity-breadcrumbs',
+      'plugin-react-native-orientation-breadcrumbs',
+      'plugin-react-native-unhandled-rejection',
+      'plugin-react-native-hermes',
+      'plugin-react-native-client-sync',
+      'plugin-react-native-event-sync',
+      'plugin-react-native-global-error-handler',
+      'plugin-react-native-session',
+      'plugin-react-navigation',
+      'plugin-react-native-navigation'
+    ], {
       preset: 'react-native',
-      testMatch: [
-        testsForPackage('react-native'),
-        testsForPackage('delivery-react-native'),
-        testsForPackage('plugin-react-native-app-state-breadcrumbs'),
-        testsForPackage('plugin-react-native-connectivity-breadcrumbs'),
-        testsForPackage('plugin-react-native-orientation-breadcrumbs'),
-        testsForPackage('plugin-react-native-unhandled-rejection'),
-        testsForPackage('plugin-react-native-hermes'),
-        testsForPackage('plugin-react-native-client-sync'),
-        testsForPackage('plugin-react-native-event-sync'),
-        testsForPackage('plugin-react-native-global-error-handler'),
-        testsForPackage('plugin-react-native-session'),
-        testsForPackage('plugin-react-navigation'),
-        testsForPackage('plugin-react-native-navigation')
-      ],
       setupFiles: [
         '<rootDir>/packages/react-native/src/test/setup.js'
       ]
-    },
-    {
-      displayName: 'expo',
-      testMatch: [
-        testsForPackage('delivery-expo'),
-        testsForPackage('expo'),
-        testsForPackage('expo-cli'),
-        testsForPackage('plugin-expo-app'),
-        testsForPackage('plugin-expo-device')
-      ]
-    },
-    {
-      displayName: 'node plugins',
-      testEnvironment: 'node',
-      testMatch: [
-        testsForPackage('delivery-node'),
-        testsForPackage('plugin-express'),
-        testsForPackage('plugin-koa'),
-        testsForPackage('plugin-restify'),
-        testsForPackage('plugin-contextualize'),
-        testsForPackage('plugin-server-*'),
-        testsForPackage('plugin-strip-project-root'),
-        testsForPackage('plugin-intercept'),
-        testsForPackage('plugin-node-unhandled-rejection'),
-        testsForPackage('plugin-node-in-project'),
-        testsForPackage('plugin-node-device'),
-        testsForPackage('plugin-node-surrounding-code'),
-        testsForPackage('plugin-node-uncaught-exception')
-      ]
-    },
-    {
-      displayName: 'node integration tests',
+    }),
+    package('expo', [
+      'delivery-expo',
+      'expo',
+      'expo-cli',
+      'plugin-expo-app',
+      'plugin-expo-device'
+    ]),
+    package('node plugins', [
+      'delivery-node',
+      'plugin-express',
+      'plugin-koa',
+      'plugin-restify',
+      'plugin-contextualize',
+      'plugin-server-*',
+      'plugin-strip-project-root',
+      'plugin-intercept',
+      'plugin-node-unhandled-rejection',
+      'plugin-node-in-project',
+      'plugin-node-device',
+      'plugin-node-surrounding-code',
+      'plugin-node-uncaught-exception'
+    ], {
+      testEnvironment: 'node'
+    }),
+    package('node integration tests', [
+    ], {
       testEnvironment: 'node',
       testMatch: [
         '<rootDir>/packages/node/test/integration/**/*.test.[jt]s'
       ]
-    }
+    })
   ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 const testsForPackage = (packageName) => `<rootDir>/packages/${packageName}/**/*.test.[jt]s?(x)`
 
 module.exports = {
+  roots: ['<rootDir>/packages'],
   projects: [
     {
       displayName: 'core',

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cdn-upload": "lerna run cdn-upload --stream",
     "build": "lerna run build --scope '@bugsnag/node' --scope '@bugsnag/browser' --scope '@bugsnag/expo' && lerna run build --ignore '@bugsnag/node' --ignore '@bugsnag/browser' --ignore '@bugsnag/expo'",
     "test:lint": "eslint --ext .ts,.js --report-unused-disable-directives --max-warnings=0 .",
-    "test:unit": "jest && lerna run test --ignore '@bugsnag/browser' --ignore '@bugsnag/node'",
+    "test:unit": "jest",
     "test:types": "tsc -p tsconfig.json && lerna run test:types",
     "test:test-container-registry-login": "aws ecr get-login-password --profile=opensource | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com",
     "test:build-browser-container": "docker-compose up --build minimal-packager && docker-compose build --pull browser-maze-runner",

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -29,6 +29,11 @@ function mockFetch () {
 }
 
 describe('browser notifier', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
   beforeEach(() => {
     jest.resetModules()
     mockFetch()

--- a/packages/delivery-expo/test/delivery.test.ts
+++ b/packages/delivery-expo/test/delivery.test.ts
@@ -241,6 +241,8 @@ describe('delivery: expo', () => {
         expect(err).toBeTruthy()
         expect((err as any).code).toBe('ECONNRESET')
         expect(enqueueSpy).toHaveBeenCalled()
+
+        server.close()
         done()
       })
     })
@@ -268,6 +270,8 @@ describe('delivery: expo', () => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
         expect(enqueueSpy).toHaveBeenCalled()
+
+        server.close()
         done()
       })
     })

--- a/packages/delivery-node/test/delivery.test.ts
+++ b/packages/delivery-node/test/delivery.test.ts
@@ -125,6 +125,8 @@ describe('delivery:node', () => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
         expect(err.code).toBe('ECONNRESET')
+
+        server.close()
         done()
       })
     })
@@ -149,6 +151,8 @@ describe('delivery:node', () => {
       delivery({ _config: config, _logger: { error: log } } as unknown as Client).sendEvent(payload, (err) => {
         expect(didLog).toBe(true)
         expect(err).toBeTruthy()
+
+        server.close()
         done()
       })
     })

--- a/packages/expo/test/index.test.ts
+++ b/packages/expo/test/index.test.ts
@@ -105,6 +105,10 @@ describe('expo notifier', () => {
   let Bugsnag: typeof BugsnagExpoStatic
   let _delivery
 
+  beforeAll(() => {
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
   beforeEach(() => {
     (delivery as jest.MockedFunction<typeof delivery>).mockImplementation(() => {
       _delivery = {

--- a/packages/node/test/integration/handled-unhandled.test.ts
+++ b/packages/node/test/integration/handled-unhandled.test.ts
@@ -34,6 +34,9 @@ jest.mock('https', () => {
 // we can only start bugsnag once per file, because it installs global handlers
 // and doesn't have a way to uninstall itself
 beforeAll(() => {
+  jest.spyOn(console, 'debug').mockImplementation(() => {})
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+
   Bugsnag.start({
     apiKey: 'aaaabbbbccccdddd0000111122223333',
     // ordinarily after catching an uncaught exception we shut down the process,

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -25,6 +25,7 @@
     "build": "npm run clean && npm run build:esm2015 && npm run build:esm5",
     "build:esm2015": "ngc -p tsconfig.json",
     "build:esm5": "ngc -p tsconfig.esm5.json",
+    "test:types": "npm run build",
     "postversion": "npm run build"
   },
   "author": "Bugsnag",

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -25,7 +25,6 @@
     "build": "npm run clean && npm run build:esm2015 && npm run build:esm5",
     "build:esm2015": "ngc -p tsconfig.json",
     "build:esm5": "ngc -p tsconfig.esm5.json",
-    "test": "npm run build",
     "postversion": "npm run build"
   },
   "author": "Bugsnag",

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.ts
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.ts
@@ -3,6 +3,10 @@ import plugin from '../'
 import Client from '@bugsnag/core/client'
 
 describe('plugin: console breadcrumbs', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
   it('should leave a breadcrumb when console.log() is called', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin] })
     console.log('check 1, 2')

--- a/packages/plugin-react/src/test/index.test.tsx
+++ b/packages/plugin-react/src/test/index.test.tsx
@@ -16,6 +16,10 @@ type FallbackComponentType = React.ComponentType<FallbackComponentProps>
 // eslint-disable-next-line
 const ErrorBoundary = client.getPlugin('react')!.createErrorBoundary()
 
+beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
 beforeEach(() => (client._notify as jest.Mock).mockClear())
 
 test('formatComponentStack(str)', () => {

--- a/packages/plugin-vue/test/index.test.ts
+++ b/packages/plugin-vue/test/index.test.ts
@@ -3,6 +3,10 @@ import Client from '@bugsnag/core/client'
 import Vue from 'vue'
 
 describe('bugsnag vue', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
   it('throws when missing Vue', () => {
     expect(() => {
       new BugsnagVuePlugin(undefined).load(new Client({ apiKey: 'API_KEYYY' }))

--- a/packages/react-native/src/test/integration/handled-unhandled.test.ts
+++ b/packages/react-native/src/test/integration/handled-unhandled.test.ts
@@ -54,6 +54,8 @@ declare global {
 // we can only start bugsnag once per file, because it installs global handlers
 // and doesn't have a way to uninstall itself
 beforeAll(() => {
+  jest.spyOn(console, 'debug').mockImplementation(() => {})
+
   // leaving the default handler intact causes simulated unhandled errors to fail tests
   global.ErrorUtils.setGlobalHandler(() => {})
   Bugsnag.start()
@@ -94,7 +96,6 @@ describe('@bugsnag/react-native: handled and unhandled errors', () => {
       // @ts-ignore
       'sdf'.sdflkj()
     } catch (e) {
-      console.log(e)
       rnPromise.reject(e)
     }
     setTimeout(() => {

--- a/packages/react-native/test/index.test.ts
+++ b/packages/react-native/test/index.test.ts
@@ -32,6 +32,10 @@ jest.mock('react-native', () => ({
 describe('react native notifier', () => {
   let Bugsnag: typeof BugsnagReactNativeStatic
 
+  beforeAll(() => {
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
   beforeEach(() => {
     jest.isolateModules(() => {
       Bugsnag = require('..')


### PR DESCRIPTION
- Set the `roots` property in the jest config as a potential performance improvement. I noticed some haste-map warnings coming from the test/ director. I'm not sure why jest is looking in there but this might prevent it.
- Mock console to clean up the test output. We might want to consider asserting on calls being made in some cases though I haven't done that currently.
- Ensures open handles are closed, which fixes the "A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --runInBand --detectOpenHandles to find leaks." warning
