### PR TITLE
[PLAT-5433] Fix Expo Android 8 failures

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -136,9 +136,14 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-#  - block: "Trigger full test suite"
+  - block: "Trigger full test suite"
+    key: "trigger-full-suite"
 
   - label: ':runner: expo Android 8'
+    depends_on:
+      - "trigger-full-suite"
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -163,6 +168,10 @@ steps:
       - exit_status: "*"
 
   - label: ':runner: expo Android 7'
+    depends_on:
+      - "trigger-full-suite"
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -183,6 +192,10 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo Android 6'
+    depends_on:
+      - "trigger-full-suite"
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -203,6 +216,10 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo Android 5'
+    depends_on:
+      - "trigger-full-suite"
+      - "build-expo-apk"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -223,6 +240,10 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 11'
+    depends_on:
+      - "trigger-full-suite"
+      - "build-expo-ipa"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:
@@ -245,6 +266,10 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: expo iOS 10'
+    depends_on:
+      - "trigger-full-suite"
+      - "build-expo-ipa"
+      - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
       artifacts#v1.2.0:

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -136,7 +136,7 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - block: "Trigger full test suite"
+#  - block: "Trigger full test suite"
 
   - label: ':runner: expo Android 8'
     timeout_in_minutes: 50
@@ -155,6 +155,8 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
+          - --appium-version=1.18.0
+          - --capabilities={"appWaitForLaunch":"false"}
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:

--- a/test/expo/features/fixtures/test-app/App.js
+++ b/test/expo/features/fixtures/test-app/App.js
@@ -13,6 +13,7 @@ import ManualBreadcrumbs from './app/manual_breadcrumbs'
 import DeviceFeature from './app/device'
 import Sessions from './app/sessions'
 import NetworkBreadcrumbs from './app/network_breadcrumbs'
+import * as ScreenOrientation from 'expo-screen-orientation';
 
 const SCENARIOS = [
   'handled',
@@ -36,6 +37,7 @@ export default class App extends React.Component {
     this.state = {
       scenario: null
     }
+    ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
   }
 
   renderScenario() {

--- a/test/expo/features/fixtures/test-app/package.json
+++ b/test/expo/features/fixtures/test-app/package.json
@@ -10,6 +10,7 @@
     "@babel/runtime": "7.4.2",
     "expo": "^37.0.0",
     "expo-cli": "^3.17.5",
+    "expo-screen-orientation": "2.1.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",


### PR DESCRIPTION
## Goal

Fixes the previously occurring test failures for the Expo e2e tests running against Android 8 by:
- Adding an additional required capability for the Android 8 test run
- Using the expo-screen-orientation package to lock the app screen in portrait mode, ensuring essential UI elements do not get cut off.