### PR TITLE
[PLAT-5094] Add manual instructions for dSYM uploads to RN CLI

### DIFF
--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -5,6 +5,14 @@ import { updateXcodeProject } from '../lib/Xcode'
 import { install, detectInstalled, guessPackageManager } from '../lib/Npm'
 import onCancel from '../lib/OnCancel'
 
+const DSYM_INSTRUCTIONS = `To configure your project to upload dSYMs, follow the iOS symbolication guide:
+
+    https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+
+  This will enable you to see full native stacktraces. It can't be done automatically.
+
+`
+
 export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
   try {
     const { iosIntegration } = await prompts({
@@ -18,6 +26,13 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
       logger.info('Modifying the Xcode project')
       await updateXcodeProject(projectRoot, logger)
     }
+
+    await prompts({
+      type: 'text',
+      name: 'dsymUploadInstructions',
+      message: DSYM_INSTRUCTIONS,
+      initial: 'Hit enter to continue …'
+    }, { onCancel })
 
     const { androidIntegration } = await prompts({
       type: 'confirm',

--- a/test/react-native-cli/features/automate-symbolication.feature
+++ b/test/react-native-cli/features/automate-symbolication.feature
@@ -17,7 +17,7 @@ Scenario: successfully modify project
         """
         To configure your project to upload dSYMs, follow the iOS symbolication guide:
 
-            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+        https://docs.bugsnag.com/platforms/ios/symbolication-guide/
 
         This will enable you to see full native stacktraces. It can't be done automatically.
         """
@@ -52,7 +52,7 @@ Scenario: successfully modify project, choosing source-maps version
         """
         To configure your project to upload dSYMs, follow the iOS symbolication guide:
 
-            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+        https://docs.bugsnag.com/platforms/ios/symbolication-guide/
 
         This will enable you to see full native stacktraces. It can't be done automatically.
         """
@@ -87,7 +87,7 @@ Scenario: opt not to modify the Android project
         """
         To configure your project to upload dSYMs, follow the iOS symbolication guide:
 
-            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+        https://docs.bugsnag.com/platforms/ios/symbolication-guide/
 
         This will enable you to see full native stacktraces. It can't be done automatically.
         """
@@ -120,7 +120,7 @@ Scenario: opt not to modify the iOS project
         """
         To configure your project to upload dSYMs, follow the iOS symbolication guide:
 
-            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+        https://docs.bugsnag.com/platforms/ios/symbolication-guide/
 
         This will enable you to see full native stacktraces. It can't be done automatically.
         """
@@ -155,7 +155,7 @@ Scenario: opt not to modify either project
         """
         To configure your project to upload dSYMs, follow the iOS symbolication guide:
 
-            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+        https://docs.bugsnag.com/platforms/ios/symbolication-guide/
 
         This will enable you to see full native stacktraces. It can't be done automatically.
         """

--- a/test/react-native-cli/features/automate-symbolication.feature
+++ b/test/react-native-cli/features/automate-symbolication.feature
@@ -13,6 +13,16 @@ Scenario: successfully modify project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I press enter
+    And I wait for the shell to output the following to stdout
+        """
+        To configure your project to upload dSYMs, follow the iOS symbolication guide:
+
+            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+
+        This will enable you to see full native stacktraces. It can't be done automatically.
+        """
+    And I wait for the current stdout line to contain "Hit enter to continue"
+    When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
@@ -37,6 +47,16 @@ Scenario: successfully modify project, choosing source-maps version
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I press enter
+    And I wait for the shell to output the following to stdout
+        """
+        To configure your project to upload dSYMs, follow the iOS symbolication guide:
+
+            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+
+        This will enable you to see full native stacktraces. It can't be done automatically.
+        """
+    And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I press enter
@@ -63,6 +83,16 @@ Scenario: opt not to modify the Android project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I press enter
+    And I wait for the shell to output the following to stdout
+        """
+        To configure your project to upload dSYMs, follow the iOS symbolication guide:
+
+            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+
+        This will enable you to see full native stacktraces. It can't be done automatically.
+        """
+    And I wait for the current stdout line to contain "Hit enter to continue"
+    When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I input "n" interactively
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
@@ -86,6 +116,16 @@ Scenario: opt not to modify the iOS project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I input "n" interactively
+    And I wait for the shell to output the following to stdout
+        """
+        To configure your project to upload dSYMs, follow the iOS symbolication guide:
+
+            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+
+        This will enable you to see full native stacktraces. It can't be done automatically.
+        """
+    And I wait for the current stdout line to contain "Hit enter to continue"
+    When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I input "y" interactively
     And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
@@ -111,6 +151,16 @@ Scenario: opt not to modify either project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I input "n" interactively
+    And I wait for the shell to output the following to stdout
+        """
+        To configure your project to upload dSYMs, follow the iOS symbolication guide:
+
+            https://docs.bugsnag.com/platforms/ios/symbolication-guide/
+
+        This will enable you to see full native stacktraces. It can't be done automatically.
+        """
+    And I wait for the current stdout line to contain "Hit enter to continue"
+    When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I input "n" interactively
     Then the last interactive command exited successfully


### PR DESCRIPTION
## Goal

In lieu of being able to automate the upload of dSYMs for iOS builds, output the link to the setup guide during the `automate-symbolication` step.

## Changeset

Adds a prompt to ensure the user has the opportunity to read the output.

## Testing

Tested manually and end to end tests updated.