### PR TITLE
[PLAT-5515] RN-CLI: Don't attempt to run pod install on non-darwin platforms

### DIFF
--- a/packages/react-native-cli/src/lib/Pod.ts
+++ b/packages/react-native-cli/src/lib/Pod.ts
@@ -2,9 +2,10 @@ import { spawn } from 'child_process'
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import { Logger } from '../Logger'
+import { platform } from 'os'
 
 export async function install (projectRoot: string, logger: Logger): Promise<void> {
-  if (process.platform !== 'darwin') {
+  if (platform() !== 'darwin') {
     logger.warn('Detected platform is not macOS, skipping')
     return
   }

--- a/packages/react-native-cli/src/lib/Pod.ts
+++ b/packages/react-native-cli/src/lib/Pod.ts
@@ -4,6 +4,11 @@ import { join } from 'path'
 import { Logger } from '../Logger'
 
 export async function install (projectRoot: string, logger: Logger): Promise<void> {
+  if (process.platform !== 'darwin') {
+    logger.warn('Detected platform is not macOS, skipping')
+    return
+  }
+
   try {
     const iosDirList = await fs.readdir(join(projectRoot, 'ios'))
     if (!iosDirList.includes('Podfile')) {

--- a/packages/react-native-cli/src/lib/__test__/Pod.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Pod.test.ts
@@ -5,6 +5,10 @@ import { spawn, ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
 import logger from '../../Logger'
 
+jest.mock('os', () => ({
+  platform: () => 'darwin'
+}))
+
 async function generateNotFoundError () {
   try {
     await jest.requireActual('fs').promises.readdir(path.join(__dirname, 'does-not-exist'))

--- a/test/react-native-cli/features/fixtures/Dockerfile
+++ b/test/react-native-cli/features/fixtures/Dockerfile
@@ -11,8 +11,4 @@ WORKDIR /app
 
 RUN npm i -g bugsnag-react-native-cli-*.tgz
 
-# TODO(PLAT-5515) 'pod install' is currently always run but will only work on
-# macOS, so we stub it out with a script that does nothing
-RUN printf '#!/usr/bin/env sh\nprintf "this is a stub of $0\n"' > /usr/bin/pod && chmod +x /usr/bin/pod
-
 ENTRYPOINT ["/bin/sh"]

--- a/test/react-native-cli/features/install.feature
+++ b/test/react-native-cli/features/install.feature
@@ -64,6 +64,7 @@ Scenario: no git repo, run anyway, default version
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
     When I press enter
+    And I wait for the shell to output a line containing "Detected platform is not macOS, skipping" to stdout
     Then the last interactive command exited successfully
     And bugsnag react-native is in the package.json file
     And the Bugsnag Android Gradle plugin is installed
@@ -83,6 +84,7 @@ Scenario: clean git repo, run, version 7.5.0
     Then I wait for the shell to output a line containing "+ @bugsnag/react-native" to stdout
     And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
     When I press enter
+    And I wait for the shell to output a line containing "Detected platform is not macOS, skipping" to stdout
     And the last interactive command exited successfully
     And bugsnag react-native version "^7.5.0" is in the package.json file
     And the Bugsnag Android Gradle plugin is installed


### PR DESCRIPTION
## Goal

The RN CLI might be run on non-macOS platforms, but cocoapods will only ever be available on macOS.

## Design

Skip the `pod install` command when the platform is not macOS, and output a warning.

## Testing

Manually tested + e2e tests updated.