### PR TITLE
e2e tests for running a CLI initialized RN app

### DIFF
--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -172,7 +172,7 @@ steps:
       - npm run test:build-react-native-cli-ios
 
   #
-  # Built app end-to-end tests
+  # Init, build and notify end-to-end tests
   #
   - label: ':runner: RN 0.60 Android end-to-end tests'
     depends_on: "rn-0-60-apk"

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -66,7 +66,6 @@ steps:
   #
   - label: ':docker: Build RN Android Builder image'
     key: 'android-builder-image'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v3.7.0:
@@ -78,7 +77,6 @@ steps:
 
   - label: ':android: Build RN 0.60 apk'
     key: 'rn-0-60-apk'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     depends_on:
       - 'android-builder-image'
     timeout_in_minutes: 15
@@ -92,7 +90,6 @@ steps:
 
   - label: ':android: Build RN 0.61 apk'
     key: 'rn-0-61-apk'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     depends_on:
       - 'android-builder-image'
     timeout_in_minutes: 15
@@ -106,7 +103,6 @@ steps:
 
   - label: ':android: Build RN 0.62 apk'
     key: 'rn-0-62-apk'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     depends_on:
       - 'android-builder-image'
     timeout_in_minutes: 15
@@ -120,7 +116,6 @@ steps:
 
   - label: ':android: Build RN 0.63 apk'
     key: 'rn-0-63-apk'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     depends_on:
       - 'android-builder-image'
     timeout_in_minutes: 15
@@ -134,7 +129,6 @@ steps:
 
   - label: ':ios: Build RN 0.60 ipa'
     key: 'rn-0-60-ipa'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     timeout_in_minutes: 60
     agents:
       queue: 'opensource-mac-rn'
@@ -146,7 +140,6 @@ steps:
 
   - label: ':ios: Build RN 0.61 ipa'
     key: 'rn-0-61-ipa'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     timeout_in_minutes: 60
     agents:
       queue: 'opensource-mac-rn'
@@ -158,7 +151,6 @@ steps:
 
   - label: ':ios: Build RN 0.62 ipa'
     key: 'rn-0-62-ipa'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     timeout_in_minutes: 60
     agents:
       queue: 'opensource-mac-rn'
@@ -170,7 +162,6 @@ steps:
 
   - label: ':ios: Build RN 0.63 ipa'
     key: 'rn-0-63-ipa'
-    skip: 'Builds successfully, but skipped until later steps are implemented.'
     timeout_in_minutes: 60
     agents:
       queue: 'opensource-mac-rn'

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -127,7 +127,7 @@ steps:
     artifact_paths:
       - build/rn0_63.apk
 
-  - label: ':ios: Build RN 0.60 ipa'
+  - label: ':ios: Init and build RN 0.60 ipa'
     key: 'rn-0-60-ipa'
     timeout_in_minutes: 30
     agents:
@@ -138,7 +138,7 @@ steps:
     commands:
       - npm run test:build-react-native-cli-ios
 
-  - label: ':ios: Build RN 0.61 ipa'
+  - label: ':ios: Init and build RN 0.61 ipa'
     key: 'rn-0-61-ipa'
     timeout_in_minutes: 30
     agents:
@@ -149,7 +149,7 @@ steps:
     commands:
       - npm run test:build-react-native-cli-ios
 
-  - label: ':ios: Build RN 0.62 ipa'
+  - label: ':ios: Init and build RN 0.62 ipa'
     key: 'rn-0-62-ipa'
     timeout_in_minutes: 30
     agents:
@@ -160,7 +160,7 @@ steps:
     commands:
       - npm run test:build-react-native-cli-ios
 
-  - label: ':ios: Build RN 0.63 ipa'
+  - label: ':ios: Init and build RN 0.63 ipa'
     key: 'rn-0-63-ipa'
     timeout_in_minutes: 30
     agents:

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -129,7 +129,7 @@ steps:
 
   - label: ':ios: Build RN 0.60 ipa'
     key: 'rn-0-60-ipa'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: 'opensource-mac-rn'
     env:
@@ -140,7 +140,7 @@ steps:
 
   - label: ':ios: Build RN 0.61 ipa'
     key: 'rn-0-61-ipa'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: 'opensource-mac-rn'
     env:
@@ -151,7 +151,7 @@ steps:
 
   - label: ':ios: Build RN 0.62 ipa'
     key: 'rn-0-62-ipa'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: 'opensource-mac-rn'
     env:
@@ -162,7 +162,7 @@ steps:
 
   - label: ':ios: Build RN 0.63 ipa'
     key: 'rn-0-63-ipa'
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: 'opensource-mac-rn'
     env:

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -24,7 +24,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["-e", "features/built_app.feature"]
+        command: ["-e", "features/built-app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_60"
 
@@ -35,7 +35,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["-e", "features/built_app.feature"]
+        command: ["-e", "features/built-app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_61"
 
@@ -46,7 +46,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["-e", "features/built_app.feature"]
+        command: ["-e", "features/built-app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_62"
 
@@ -57,7 +57,7 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["-e", "features/built_app.feature"]
+        command: ["-e", "features/built-app.feature"]
     env:
       REACT_NATIVE_VERSION: "rn0_63"
 
@@ -172,5 +172,148 @@ steps:
       - npm run test:build-react-native-cli-ios
 
   #
-  # TODO Built app end-to-end tests
+  # Built app end-to-end tests
   #
+  - label: ':android: React Native 0.60 end-to-end tests on Android 11'
+    depends_on: "rn-0-60-apk"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_60.apk"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_60.apk
+          - --farm=bs
+          - --device=ANDROID_11_0
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: React Native 0.61 end-to-end tests on Android 11'
+    depends_on: "rn-0-61-apk"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_61.apk"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_61.apk
+          - --farm=bs
+          - --device=ANDROID_11_0
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: React Native 0.62 end-to-end tests on Android 11'
+    depends_on: "rn-0-62-apk"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_62.apk"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_62.apk
+          - --farm=bs
+          - --device=ANDROID_11_0
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: React Native 0.63 end-to-end tests on Android 11'
+    depends_on: "rn-0-63-apk"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_63.apk"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_63.apk
+          - --farm=bs
+          - --device=ANDROID_11_0
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':ios: React Native 0.60 end-to-end tests on iOS 14'
+    depends_on: "rn-0-60-ipa"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_60.ipa"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_60.ipa
+          - --farm=bs
+          - --device=IOS_14
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':ios: React Native 0.61 end-to-end tests on iOS 14'
+    depends_on: "rn-0-61-ipa"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_61.ipa"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_61.ipa
+          - --farm=bs
+          - --device=IOS_14
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':ios: React Native 0.62 end-to-end tests on iOS 14'
+    depends_on: "rn-0-62-ipa"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_62.ipa"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_62.ipa
+          - --farm=bs
+          - --device=IOS_14
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':ios: React Native 0.63 end-to-end tests on iOS 14'
+    depends_on: "rn-0-63-ipa"
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/rn0_63.ipa"
+      docker-compose#v3.3.0:
+        run: react-native-cli-maze-runner
+        use-aliases: true
+        command:
+          - --app=build/rn0_63.ipa
+          - --farm=bs
+          - --device=IOS_14
+          - --a11y-locator
+          - features/built-app.feature
+    concurrency: 9
+    concurrency_group: 'browserstack-app'

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -75,7 +75,7 @@ steps:
       - docker-compose#v3.7.0:
           push: react-native-cli-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
-  - label: ':android: Build RN 0.60 apk'
+  - label: ':android: Init and build RN 0.60 apk'
     key: 'rn-0-60-apk'
     depends_on:
       - 'android-builder-image'
@@ -88,7 +88,7 @@ steps:
     artifact_paths:
       - build/rn0_60.apk
 
-  - label: ':android: Build RN 0.61 apk'
+  - label: ':android: Init and build RN 0.61 apk'
     key: 'rn-0-61-apk'
     depends_on:
       - 'android-builder-image'
@@ -101,7 +101,7 @@ steps:
     artifact_paths:
       - build/rn0_61.apk
 
-  - label: ':android: Build RN 0.62 apk'
+  - label: ':android: Init and build RN 0.62 apk'
     key: 'rn-0-62-apk'
     depends_on:
       - 'android-builder-image'
@@ -114,7 +114,7 @@ steps:
     artifact_paths:
       - build/rn0_62.apk
 
-  - label: ':android: Build RN 0.63 apk'
+  - label: ':android: Init and build RN 0.63 apk'
     key: 'rn-0-63-apk'
     depends_on:
       - 'android-builder-image'
@@ -174,13 +174,13 @@ steps:
   #
   # Built app end-to-end tests
   #
-  - label: ':android: React Native 0.60 end-to-end tests on Android 11'
+  - label: ':runner: RN 0.60 Android end-to-end tests'
     depends_on: "rn-0-60-apk"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_60.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -192,13 +192,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: React Native 0.61 end-to-end tests on Android 11'
+  - label: ':runner: RN 0.61 Android end-to-end tests'
     depends_on: "rn-0-61-apk"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_61.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -210,13 +210,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: React Native 0.62 end-to-end tests on Android 11'
+  - label: ':runner: RN 0.62 Android end-to-end tests'
     depends_on: "rn-0-62-apk"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_62.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -228,13 +228,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: React Native 0.63 end-to-end tests on Android 11'
+  - label: ':runner: RN 0.63 Android end-to-end tests'
     depends_on: "rn-0-63-apk"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_63.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -246,13 +246,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':ios: React Native 0.60 end-to-end tests on iOS 14'
+  - label: ':runner: RN 0.60 iOS end-to-end tests'
     depends_on: "rn-0-60-ipa"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_60.ipa"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -264,13 +264,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':ios: React Native 0.61 end-to-end tests on iOS 14'
+  - label: ':runner: RN 0.61 iOS end-to-end tests'
     depends_on: "rn-0-61-ipa"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_61.ipa"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -282,13 +282,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':ios: React Native 0.62 end-to-end tests on iOS 14'
+  - label: ':runner: RN 0.62 iOS end-to-end tests'
     depends_on: "rn-0-62-ipa"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_62.ipa"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:
@@ -300,13 +300,13 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':ios: React Native 0.63 end-to-end tests on iOS 14'
+  - label: ':runner: RN 0.63 iOS end-to-end tests'
     depends_on: "rn-0-63-ipa"
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_63.ipa"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
         run: react-native-cli-maze-runner
         use-aliases: true
         command:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.5.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.6.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 1f471086782f0bc5d306b1ca87d81965d54518b8
-  tag: v3.5.0
+  revision: b73093f128efdea444966969cd3526e26de8ed5b
+  tag: v3.6.0
   specs:
-    bugsnag-maze-runner (3.5.0)
+    bugsnag-maze-runner (3.6.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -23,7 +23,7 @@ GEM
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.11.0)
+    appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.18.2)
@@ -66,7 +66,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.6)
+    test-unit (3.3.7)
       power_assert
     tomlrb (1.3.0)
     websocket-driver (0.7.3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.react-native-android-builder
       args:
+        - REGISTRY_URL
         - REG_BASIC_CREDENTIAL
         - REG_NPM_EMAIL
     environment:
@@ -156,6 +157,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.react-native-cli-android-builder
       args:
+        - REGISTRY_URL
         - REG_BASIC_CREDENTIAL
         - REG_NPM_EMAIL
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,8 @@ services:
   react-native-cli-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
     environment:
+      BUILDKITE:
+      BUILDKITE_PIPELINE_NAME:
       DEBUG:
       MAZE_DEVICE_FARM_USERNAME:
       MAZE_DEVICE_FARM_ACCESS_KEY:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,16 @@ services:
     volumes:
       - ./build:/app/test/react-native/build
 
+  react-native-cli-maze-runner:
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
+    environment:
+      DEBUG:
+      MAZE_DEVICE_FARM_USERNAME:
+      MAZE_DEVICE_FARM_ACCESS_KEY:
+    volumes:
+      - ./build:/app/build
+      - ./test/react-native-cli/features/:/app/features/
+
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-js-maze-runner}

--- a/dockerfiles/Dockerfile.react-native-cli-android-builder
+++ b/dockerfiles/Dockerfile.react-native-cli-android-builder
@@ -8,8 +8,10 @@ WORKDIR /app
 
 # npm auth
 RUN rm -f ~/.npmrc
+ARG REGISTRY_URL
 ARG REG_BASIC_CREDENTIAL
 ARG REG_NPM_EMAIL
+RUN echo "registry=$REGISTRY_URL" >> ~/.npmrc
 RUN echo "_auth=$REG_BASIC_CREDENTIAL" >> ~/.npmrc
 RUN echo "email=$REG_NPM_EMAIL" >> ~/.npmrc
 RUN echo "always-auth=true" >> ~/.npmrc

--- a/dockerfiles/Dockerfile.react-native-cli-android-builder
+++ b/dockerfiles/Dockerfile.react-native-cli-android-builder
@@ -1,6 +1,6 @@
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/js:android-builder-base
 
-RUN apt-get install -y nodejs rsync
+RUN apt-get install -y nodejs rsync expect
 
 RUN npm i -g run-func
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,7 +38,8 @@
     "ios/vendor/bugsnag-cocoa/Bugsnag.podspec.json",
     "BugsnagReactNative.podspec",
     "react-native.config.js",
-    "bugsnag-react-native.gradle"
+    "bugsnag-react-native.gradle",
+    "bugsnag-react-native-xcode.sh"
   ],
   "author": "Bugsnag",
   "license": "MIT",

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -19,7 +19,7 @@ module.exports = {
 
     // JavaScript layer
     common.changeDir(`${destFixtures}/${rnVersion}`)
-    common.run(`npm install`, true)
+    common.run('npm install', true)
 
     // Install and run the CLI
     const installCommand = `npm install bugsnag-react-native-cli@${version}`
@@ -52,7 +52,7 @@ module.exports = {
 
     // JavaScript layer
     common.changeDir(`${targetDir}`)
-    common.run(`npm install`, true)
+    common.run('npm install', true)
 
     // Install and run the CLI
     const installCommand = `npm install bugsnag-react-native-cli@${version}`

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -8,7 +8,6 @@ module.exports = {
   buildAndroid: function buildAndroid (sourceFixtures, destFixtures) {
     const version = process.env.NOTIFIER_VERSION || common.determineVersion()
     const rnVersion = process.env.REACT_NATIVE_VERSION
-    const registryUrl = process.env.REGISTRY_URL
 
     console.log(`Installing CLI version: ${version}`)
 
@@ -20,10 +19,10 @@ module.exports = {
 
     // JavaScript layer
     common.changeDir(`${destFixtures}/${rnVersion}`)
-    common.run(`npm install --registry ${registryUrl}`, true)
+    common.run(`npm install`, true)
 
     // Install and run the CLI
-    const installCommand = `npm install bugsnag-react-native-cli@${version} --registry ${registryUrl}`
+    const installCommand = `npm install bugsnag-react-native-cli@${version}`
     common.run(installCommand, true)
 
     // Use Expect to run the init command interactively
@@ -42,22 +41,21 @@ module.exports = {
   buildIOS: function buildIOS () {
     const version = process.env.NOTIFIER_VERSION || common.determineVersion()
     const rnVersion = process.env.REACT_NATIVE_VERSION
-    const registryUrl = process.env.REGISTRY_URL
     const fixturesDir = 'test/react-native-cli/features/fixtures'
     const targetDir = `${fixturesDir}/${rnVersion}`
     const initialDir = process.cwd()
 
-    // We're not in docker so check the above are set
-    if (rnVersion === undefined || registryUrl === undefined) {
-      throw new Error('Both REACT_NATIVE_VERSION and REGISTRY_URL environment variables must be set')
+    // We're not in docker so check RN version is set
+    if (rnVersion === undefined) {
+      throw new Error('REACT_NATIVE_VERSION environment variable must be set')
     }
 
     // JavaScript layer
     common.changeDir(`${targetDir}`)
-    common.run(`npm install --registry ${registryUrl}`, true)
+    common.run(`npm install`, true)
 
     // Install and run the CLI
-    const installCommand = `npm install bugsnag-react-native-cli@${version} --registry ${registryUrl}`
+    const installCommand = `npm install bugsnag-react-native-cli@${version}`
     common.run(installCommand, true)
 
     // Use Expect to run the init command interactively

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -6,7 +6,7 @@ const fs = require('fs')
 
 module.exports = {
   buildAndroid: function buildAndroid (sourceFixtures, destFixtures) {
-    const version = common.determineVersion()
+    const version = process.env.NOTIFIER_VERSION || common.determineVersion()
     const rnVersion = process.env.REACT_NATIVE_VERSION
     const registryUrl = process.env.REGISTRY_URL
 
@@ -37,7 +37,7 @@ module.exports = {
                     `${process.env.PWD}/build/${rnVersion}.apk`)
   },
   buildIOS: function buildIOS () {
-    const version = common.determineVersion()
+    const version = process.env.NOTIFIER_VERSION || common.determineVersion()
     const rnVersion = process.env.REACT_NATIVE_VERSION
     const registryUrl = process.env.REGISTRY_URL
     const fixturesDir = 'test/react-native-cli/features/fixtures'
@@ -67,7 +67,7 @@ module.exports = {
     if (!fs.existsSync('./build-ios.sh')) {
       throw new Error('Local iOS build file at ./build-ios.sh not found')
     }
-    common.run(`./build-ios.sh ${rnVersion}`, true)
+    // common.run(`./build-ios.sh ${rnVersion}`, true)
 
     // Copy file to build directory
     common.changeDir(initialDir)

--- a/scripts/rn-cli-init-interactive.sh
+++ b/scripts/rn-cli-init-interactive.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+
+cd $env(REACT_NATIVE_VERSION)
+spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
+
+expect "Do you want to continue anyway?"
+send -- "Y\r"
+
+expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
+send -- latest\r
+
+expect "What is your Bugsnag API key?"
+send -- 12312312312312312312312312312312\r
+
+expect "Do you want to automatically upload source maps as part of the Xcode build?"
+send -- y
+
+expect "Do you want to automatically upload source maps as part of the Gradle build?"
+send -- y
+
+# TODO Remove once BAGP is released for real
+expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+send -- v5.5.0-alpha01\r
+
+expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+send -- latest\r
+
+expect eof

--- a/test/react-native-cli/features/built-app.feature
+++ b/test/react-native-cli/features/built-app.feature
@@ -13,4 +13,4 @@ Scenario: Build app sends JavaScript and Native handled errors
   And the event "unhandled" is false
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
     | android | java.lang.Exception |
-    | ios     | NSException         |
+    | ios     | NSError             |

--- a/test/react-native-cli/features/built-app.feature
+++ b/test/react-native-cli/features/built-app.feature
@@ -1,6 +1,16 @@
 Feature: Tests against a React Native app that was initialized using the Bugsnag React Native CLI
 
 Scenario: Build app sends JavaScript and Native handled errors
-  When I cause a handled JavaScript error
-  And I cause a handled native error
-  And I wait to receive 2 requests
+  When I notify a handled JavaScript error
+  And I wait to receive a request
+  Then the event "unhandled" is false
+  And the event "exceptions.0.errorClass" equals "ReferenceError"
+  And the exception "type" equals "reactnativejs"
+  And I discard the oldest request
+
+  And I notify a handled native error
+  And I wait to receive a request
+  And the event "unhandled" is false
+  And the event "exceptions.0.errorClass" equals the platform-dependent string:
+    | android | java.lang.Exception |
+    | ios     | NSException         |

--- a/test/react-native-cli/features/built-app.feature
+++ b/test/react-native-cli/features/built-app.feature
@@ -1,0 +1,5 @@
+Feature: Tests against a React Native app that was initialized using the Bugsnag React Native CLI
+
+Scenario: Build app sends JavaScript and Native handled errors
+  When I cause a handled JavaScript error
+  And I cause a handled native error

--- a/test/react-native-cli/features/built-app.feature
+++ b/test/react-native-cli/features/built-app.feature
@@ -1,7 +1,12 @@
 Feature: Tests against a React Native app that was initialized using the Bugsnag React Native CLI
 
 Scenario: Build app sends JavaScript and Native handled errors
-  When I notify a handled JavaScript error
+  When I wait to receive a request
+  And the request is valid for the session reporting API version "1.0" for the React Native notifier
+  And I discard the oldest request
+
+
+  And I notify a handled JavaScript error
   And I wait to receive a request
   Then the event "unhandled" is false
   And the event "exceptions.0.errorClass" equals "ReferenceError"

--- a/test/react-native-cli/features/built-app.feature
+++ b/test/react-native-cli/features/built-app.feature
@@ -3,3 +3,4 @@ Feature: Tests against a React Native app that was initialized using the Bugsnag
 Scenario: Build app sends JavaScript and Native handled errors
   When I cause a handled JavaScript error
   And I cause a handled native error
+  And I wait to receive 2 requests

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -21,12 +21,17 @@ send -- 5.5.0-alpha01\r
 expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 
+expect "What is your Bugsnag notify endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag sessions endpoint?"
+send -- http://bs-local.com:9339\r
+
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
 send -- n
 
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
 send -- n
-
 
 # TODO: Disable source map uploads for now
 #expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -19,7 +19,7 @@ expect "Do you want to automatically upload source maps as part of the Xcode bui
 send -- n
 
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
-send -- y
+send -- n
 
 # TODO Remove once BAGP is released for real
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -21,11 +21,12 @@ send -- n
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
 send -- n
 
-# TODO Remove once BAGP is released for real
-expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-send -- 5.5.0-alpha01\r
+# TODO: Use latest once BAGP is released for real
+#expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+#send -- 5.5.0-alpha01\r
 
-expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
-send -- latest\r
+# TODO: Disable source map uploads for now
+#expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+#send -- latest\r
 
 expect eof

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -12,8 +12,12 @@ send -- "Y\r"
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- "$notifierVersion\r"
 
+# TODO: Use latest once BAGP is released for real
+expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+send -- 5.5.0-alpha01\r
+
 expect "What is your Bugsnag API key?"
-send -- 12312312312312312312312312312312\r
+send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
 send -- n
@@ -21,9 +25,6 @@ send -- n
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
 send -- n
 
-# TODO: Use latest once BAGP is released for real
-#expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-#send -- 5.5.0-alpha01\r
 
 # TODO: Disable source map uploads for now
 #expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -3,6 +3,8 @@
 set timeout -1
 set notifierVersion [lindex $argv 0];
 
+puts "Using notifier version: $notifierVersion"
+
 cd $env(REACT_NATIVE_VERSION)
 spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
 
@@ -10,7 +12,7 @@ expect "Do you want to continue anyway?"
 send -- "Y\r"
 
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
-send -- "$notifierVersion\r"
+send -- $notifierVersion\r
 
 # TODO: Use latest once BAGP is released for real
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -18,6 +18,7 @@ send -- $notifierVersion\r
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
 send -- 5.5.0-alpha01\r
 
+# TODO: Use the usual 123123... test API key
 expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+set notifierVersion [lindex $argv 0];
+
+cd $env(REACT_NATIVE_VERSION)
+spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
+
+expect "Do you want to continue anyway?"
+send -- "Y\r"
+
+expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
+send -- "$notifierVersion\r"
+
+expect "What is your Bugsnag API key?"
+send -- 12312312312312312312312312312312\r
+
+expect "Do you want to automatically upload source maps as part of the Xcode build?"
+send -- n
+
+expect "Do you want to automatically upload source maps as part of the Gradle build?"
+send -- y
+
+# TODO Remove once BAGP is released for real
+expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+send -- 5.5.0-alpha01\r
+
+expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+send -- latest\r
+
+expect eof

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -3,6 +3,8 @@
 set timeout -1
 set notifierVersion [lindex $argv 0];
 
+puts "Using notifier version: $notifierVersion"
+
 cd $env(REACT_NATIVE_VERSION)
 spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
 
@@ -10,7 +12,7 @@ expect "Do you want to continue anyway?"
 send -- "Y\r"
 
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
-send -- "$notifierVersion\r"
+send -- $notifierVersion\r
 
 # TODO: Use latest once BAGP is released for real
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
@@ -19,10 +21,20 @@ send -- 5.5.0-alpha01\r
 expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 
+expect "What is your Bugsnag notify endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag sessions endpoint?"
+send -- http://bs-local.com:9339\r
+
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
 send -- n
 
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
 send -- n
+
+# TODO: Disable source map uploads for now
+#expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+#send -- latest\r
 
 expect eof

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -12,8 +12,12 @@ send -- "Y\r"
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- "$notifierVersion\r"
 
+# TODO: Use latest once BAGP is released for real
+expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+send -- 5.5.0-alpha01\r
+
 expect "What is your Bugsnag API key?"
-send -- 12312312312312312312312312312312\r
+send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
 send -- y

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -18,6 +18,7 @@ send -- $notifierVersion\r
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
 send -- 5.5.0-alpha01\r
 
+# TODO: Use the usual 123123... test API key
 expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/expect -f
 
 set timeout -1
+set notifierVersion [lindex $argv 0];
 
 cd $env(REACT_NATIVE_VERSION)
 spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
@@ -9,7 +10,7 @@ expect "Do you want to continue anyway?"
 send -- "Y\r"
 
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
-send -- latest\r
+send -- "$notifierVersion\r"
 
 expect "What is your Bugsnag API key?"
 send -- 12312312312312312312312312312312\r
@@ -18,11 +19,11 @@ expect "Do you want to automatically upload source maps as part of the Xcode bui
 send -- y
 
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
-send -- y
+send -- n
 
 # TODO Remove once BAGP is released for real
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-send -- v5.5.0-alpha01\r
+send -- 5.5.0-alpha01\r
 
 expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
 send -- latest\r

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -20,12 +20,9 @@ expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
 
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
-send -- y
+send -- n
 
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
 send -- n
-
-expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
-send -- latest\r
 
 expect eof

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -21,10 +21,6 @@ send -- y
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
 send -- n
 
-# TODO Remove once BAGP is released for real
-expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-send -- 5.5.0-alpha01\r
-
 expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
 send -- latest\r
 

--- a/test/react-native-cli/features/fixtures/rn0_60/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_60/App.js
@@ -14,15 +14,14 @@ import {
   View,
   Text,
   StatusBar,
+  Button
 } from 'react-native';
 
 import {
   Header,
-  LearnMoreLinks,
-  Colors,
-  DebugInstructions,
-  ReloadInstructions,
+  Colors
 } from 'react-native/Libraries/NewAppScreen';
+
 
 const App = () => {
   return (
@@ -39,32 +38,15 @@ const App = () => {
             </View>
           )}
           <View style={styles.body}>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Step One</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>App.js</Text> to change this
-                screen and then come back to see your edits.
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>See Your Changes</Text>
-              <Text style={styles.sectionDescription}>
-                <ReloadInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Debug</Text>
-              <Text style={styles.sectionDescription}>
-                <DebugInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Learn More</Text>
-              <Text style={styles.sectionDescription}>
-                Read the docs to discover what to do next:
-              </Text>
-            </View>
-            <LearnMoreLinks />
+            <Text>React Native CLI end-to-end test app</Text>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='js_notify'
+                    title='JS Notify'
+                    onPress={this.jsNotify}/>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='native_notify'
+                    title='Native Notify'
+                    onPress={this.nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>
@@ -109,6 +91,14 @@ const styles = StyleSheet.create({
     paddingRight: 12,
     textAlign: 'right',
   },
+  clickyButton: {
+    backgroundColor: '#acbcef',
+    borderWidth: 0.5,
+    borderColor: '#000',
+    borderRadius: 4,
+    margin: 5,
+    padding: 5
+  }
 });
 
 export default App;

--- a/test/react-native-cli/features/fixtures/rn0_60/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_60/App.js
@@ -1,12 +1,6 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- * @flowx
- */
-
 import React, {Fragment} from 'react';
+import Bugsnag from "@bugsnag/react-native";
+import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,
@@ -14,13 +8,26 @@ import {
   View,
   Text,
   StatusBar,
-  Button
-} from 'react-native';
+  Button, NativeModules
+} from 'react-native'
 
 import {
   Colors
 } from 'react-native/Libraries/NewAppScreen';
 
+function jsNotify() {
+  try { // execute crashy code
+    iMadeThisUp();
+  } catch (error) {
+    console.log('Bugsnag.notify JS error')
+    Bugsnag.notify(error);
+  }
+}
+
+function nativeNotify() {
+  console.log('Bugsnag.notify native error')
+  NativeModules.CrashyCrashy.handledError()
+}
 
 const App = () => {
   return (
@@ -40,11 +47,11 @@ const App = () => {
             <Button style={styles.clickyButton}
                     accessibilityLabel='js_notify'
                     title='JS Notify'
-                    onPress={this.jsNotify}/>
+                    onPress={jsNotify}/>
             <Button style={styles.clickyButton}
                     accessibilityLabel='native_notify'
                     title='Native Notify'
-                    onPress={this.nativeNotify}/>
+                    onPress={nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/test/react-native-cli/features/fixtures/rn0_60/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_60/App.js
@@ -1,6 +1,5 @@
 import React, {Fragment} from 'react';
 import Bugsnag from "@bugsnag/react-native";
-import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,

--- a/test/react-native-cli/features/fixtures/rn0_60/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_60/App.js
@@ -3,7 +3,7 @@
  * https://github.com/facebook/react-native
  *
  * @format
- * @flow
+ * @flowx
  */
 
 import React, {Fragment} from 'react';
@@ -18,7 +18,6 @@ import {
 } from 'react-native';
 
 import {
-  Header,
   Colors
 } from 'react-native/Libraries/NewAppScreen';
 
@@ -31,7 +30,6 @@ const App = () => {
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
-          <Header />
           {global.HermesInternal == null ? null : (
             <View style={styles.engine}>
               <Text style={styles.footer}>Engine: Hermes</Text>

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/CrashyModule.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/CrashyModule.java
@@ -1,0 +1,34 @@
+package com.rn0_60;
+
+import com.bugsnag.android.Bugsnag;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class CrashyModule extends ReactContextBaseJavaModule {
+    public CrashyModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "CrashyCrashy";
+    }
+
+    @ReactMethod
+    public void generateCrash() throws Exception {
+        throw new Exception("Ooopsy from Java!");
+    }
+
+    @ReactMethod
+    public void generatePromiseRejection(Promise promise) {
+        promise.reject(new Exception("Oops - rejected promise from Java!"));
+    }
+
+    @ReactMethod
+    public void handledError() throws Exception {
+        Bugsnag.notify(new Exception("Handled ooopsy from Java!"));
+    }
+}

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/CrashyPackage.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/CrashyPackage.java
@@ -1,0 +1,34 @@
+package com.rn0_60;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class CrashyPackage implements ReactPackage {
+
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new CrashyModule(reactContext));
+
+        return modules;
+    }
+}
+

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainApplication.java
@@ -25,8 +25,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       @SuppressWarnings("UnnecessaryLocalVariable")
       List<ReactPackage> packages = new PackageList(this).getPackages();
-      // Packages that cannot be autolinked yet can be added manually here, for example:
-      // packages.add(new MyReactNativePackage());
+      packages.add(new CrashyPackage());
       return packages;
     }
 

--- a/test/react-native-cli/features/fixtures/rn0_60/ios/rn0_60.xcodeproj/project.pbxproj
+++ b/test/react-native-cli/features/fixtures/rn0_60/ios/rn0_60.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* rn0_60Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* rn0_60Tests.m */; };
 		7E5C247C96A42393F79D4304 /* libPods-rn0_60.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BA553B9130651067A3DD8ED /* libPods-rn0_60.a */; };
+		AAEFE0292588C03C00EDF698 /* CrashyCrashy.m in Sources */ = {isa = PBXBuildFile; fileRef = AAEFE0272588C03B00EDF698 /* CrashyCrashy.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,8 @@
 		623872899F05334A39282274 /* libPods-rn0_60Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_60Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		746308286360F05E9B8F1230 /* Pods-rn0_60-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_60-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-rn0_60-tvOSTests/Pods-rn0_60-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		85F663D460F599CDF6B1D608 /* libPods-rn0_60-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_60-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAEFE0272588C03B00EDF698 /* CrashyCrashy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CrashyCrashy.m; path = rn0_60/CrashyCrashy.m; sourceTree = "<group>"; };
+		AAEFE0282588C03B00EDF698 /* CrashyCrashy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CrashyCrashy.h; path = rn0_60/CrashyCrashy.h; sourceTree = "<group>"; };
 		C7A8599D79E81E1A97FAA16F /* libPods-rn0_60-tvOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_60-tvOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D360BD17C7828EECA37277B9 /* Pods-rn0_60.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_60.release.xcconfig"; path = "Target Support Files/Pods-rn0_60/Pods-rn0_60.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -125,6 +128,8 @@
 		13B07FAE1A68108700A75B9A /* rn0_60 */ = {
 			isa = PBXGroup;
 			children = (
+				AAEFE0282588C03B00EDF698 /* CrashyCrashy.h */,
+				AAEFE0272588C03B00EDF698 /* CrashyCrashy.m */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -532,6 +537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				AAEFE0292588C03C00EDF698 /* CrashyCrashy.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/test/react-native-cli/features/fixtures/rn0_60/ios/rn0_60/CrashyCrashy.h
+++ b/test/react-native-cli/features/fixtures/rn0_60/ios/rn0_60/CrashyCrashy.h
@@ -1,0 +1,14 @@
+//
+//  CrashyCrashy.h
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface CrashyCrashy : NSObject <RCTBridgeModule>
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_60/ios/rn0_60/CrashyCrashy.m
+++ b/test/react-native-cli/features/fixtures/rn0_60/ios/rn0_60/CrashyCrashy.m
@@ -1,0 +1,32 @@
+//
+//  CrashyCrashy.m
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import "CrashyCrashy.h"
+#import <React/RCTBridgeModule.h>
+#import <Bugsnag/Bugsnag.h>
+
+@implementation CrashyCrashy
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(generateCrash)
+{
+  NSArray *items = [NSArray new];
+  NSLog(@"This item does not exist: %@", items[42]);
+}
+
+RCT_REMAP_METHOD(generatePromiseRejection, resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  reject(@"iOSReject", @"Oops - rejected promise from iOS!", [NSError errorWithDomain:@"com.example" code:562 userInfo:nil]);
+}
+
+RCT_EXPORT_METHOD(handledError)
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"com.example" code:408 userInfo:nil]];
+}
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_61/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_61/App.js
@@ -14,14 +14,12 @@ import {
   View,
   Text,
   StatusBar,
+  Button
 } from 'react-native';
 
 import {
   Header,
-  LearnMoreLinks,
-  Colors,
-  DebugInstructions,
-  ReloadInstructions,
+  Colors
 } from 'react-native/Libraries/NewAppScreen';
 
 const App: () => React$Node = () => {
@@ -39,32 +37,15 @@ const App: () => React$Node = () => {
             </View>
           )}
           <View style={styles.body}>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Step One</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>App.js</Text> to change this
-                screen and then come back to see your edits.
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>See Your Changes</Text>
-              <Text style={styles.sectionDescription}>
-                <ReloadInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Debug</Text>
-              <Text style={styles.sectionDescription}>
-                <DebugInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Learn More</Text>
-              <Text style={styles.sectionDescription}>
-                Read the docs to discover what to do next:
-              </Text>
-            </View>
-            <LearnMoreLinks />
+            <Text>React Native CLI end-to-end test app</Text>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='js_notify'
+                    title='JS Notify'
+                    onPress={this.jsNotify}/>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='native_notify'
+                    title='Native Notify'
+                    onPress={this.nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>
@@ -109,6 +90,14 @@ const styles = StyleSheet.create({
     paddingRight: 12,
     textAlign: 'right',
   },
+  clickyButton: {
+    backgroundColor: '#acbcef',
+    borderWidth: 0.5,
+    borderColor: '#000',
+    borderRadius: 4,
+    margin: 5,
+    padding: 5
+  }
 });
 
 export default App;

--- a/test/react-native-cli/features/fixtures/rn0_61/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_61/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Bugsnag from "@bugsnag/react-native";
-import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,
@@ -8,7 +7,7 @@ import {
   View,
   Text,
   StatusBar,
-  Button
+  Button, NativeModules
 } from 'react-native';
 
 import {

--- a/test/react-native-cli/features/fixtures/rn0_61/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_61/App.js
@@ -1,11 +1,3 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- * @flow
- */
-
 import React from 'react';
 import Bugsnag from "@bugsnag/react-native";
 import { NativeModules } from 'react-native'

--- a/test/react-native-cli/features/fixtures/rn0_61/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_61/App.js
@@ -7,6 +7,8 @@
  */
 
 import React from 'react';
+import Bugsnag from "@bugsnag/react-native";
+import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,
@@ -20,6 +22,20 @@ import {
 import {
   Colors
 } from 'react-native/Libraries/NewAppScreen';
+
+function jsNotify() {
+  try { // execute crashy code
+    iMadeThisUp();
+  } catch (error) {
+    console.log('Bugsnag.notify JS error')
+    Bugsnag.notify(error);
+  }
+}
+
+function nativeNotify() {
+  console.log('Bugsnag.notify native error')
+  NativeModules.CrashyCrashy.handledError()
+}
 
 const App: () => React$Node = () => {
   return (
@@ -39,11 +55,11 @@ const App: () => React$Node = () => {
             <Button style={styles.clickyButton}
                     accessibilityLabel='js_notify'
                     title='JS Notify'
-                    onPress={this.jsNotify}/>
+                    onPress={jsNotify}/>
             <Button style={styles.clickyButton}
                     accessibilityLabel='native_notify'
                     title='Native Notify'
-                    onPress={this.nativeNotify}/>
+                    onPress={nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/test/react-native-cli/features/fixtures/rn0_61/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_61/App.js
@@ -18,7 +18,6 @@ import {
 } from 'react-native';
 
 import {
-  Header,
   Colors
 } from 'react-native/Libraries/NewAppScreen';
 
@@ -30,7 +29,6 @@ const App: () => React$Node = () => {
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
-          <Header />
           {global.HermesInternal == null ? null : (
             <View style={styles.engine}>
               <Text style={styles.footer}>Engine: Hermes</Text>

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
+      android:usesCleartextTraffic="true"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
       <activity

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/CrashyModule.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/CrashyModule.java
@@ -1,0 +1,34 @@
+package com.rn0_61;
+
+import com.bugsnag.android.Bugsnag;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class CrashyModule extends ReactContextBaseJavaModule {
+    public CrashyModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "CrashyCrashy";
+    }
+
+    @ReactMethod
+    public void generateCrash() throws Exception {
+        throw new Exception("Ooopsy from Java!");
+    }
+
+    @ReactMethod
+    public void generatePromiseRejection(Promise promise) {
+        promise.reject(new Exception("Oops - rejected promise from Java!"));
+    }
+
+    @ReactMethod
+    public void handledError() throws Exception {
+        Bugsnag.notify(new Exception("Handled ooopsy from Java!"));
+    }
+}

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/CrashyPackage.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/CrashyPackage.java
@@ -1,0 +1,34 @@
+package com.rn0_61;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class CrashyPackage implements ReactPackage {
+
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new CrashyModule(reactContext));
+
+        return modules;
+    }
+}
+

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainApplication.java
@@ -23,8 +23,7 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
+          packages.add(new CrashyPackage());
           return packages;
         }
 

--- a/test/react-native-cli/features/fixtures/rn0_61/ios/rn0_61.xcodeproj/project.pbxproj
+++ b/test/react-native-cli/features/fixtures/rn0_61/ios/rn0_61.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* rn0_61Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* rn0_61Tests.m */; };
 		870295CBBC874434079B26FC /* libPods-rn0_61-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C35F7B653D61D364330C5BD /* libPods-rn0_61-tvOSTests.a */; };
+		AAC9B0E72588C87500CF0726 /* CrashyCrashy.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC9B0E52588C87500CF0726 /* CrashyCrashy.m */; };
 		CE0DE651FCFE16719966CFD3 /* libPods-rn0_61.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3529EFA3014553823D29CEE3 /* libPods-rn0_61.a */; };
 		F6CB8F6CC8447EA8E7509ABC /* libPods-rn0_61Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CC773FC25D2071AEA7414FF3 /* libPods-rn0_61Tests.a */; };
 /* End PBXBuildFile section */
@@ -60,6 +61,8 @@
 		5EB4DE0AF71D1D9DF7195A8A /* Pods-rn0_61-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_61-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-rn0_61-tvOS/Pods-rn0_61-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		8DC1C979BE014598DE52E035 /* Pods-rn0_61-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_61-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-rn0_61-tvOSTests/Pods-rn0_61-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		A2A6E803CBB80CD17E308B36 /* Pods-rn0_61Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_61Tests.debug.xcconfig"; path = "Target Support Files/Pods-rn0_61Tests/Pods-rn0_61Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		AAC9B0E52588C87500CF0726 /* CrashyCrashy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CrashyCrashy.m; path = rn0_61/CrashyCrashy.m; sourceTree = "<group>"; };
+		AAC9B0E62588C87500CF0726 /* CrashyCrashy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CrashyCrashy.h; path = rn0_61/CrashyCrashy.h; sourceTree = "<group>"; };
 		B00BD222ECCEB99442A9DDAB /* Pods-rn0_61Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_61Tests.release.xcconfig"; path = "Target Support Files/Pods-rn0_61Tests/Pods-rn0_61Tests.release.xcconfig"; sourceTree = "<group>"; };
 		BA344E5C215E4A63D911FE43 /* Pods-rn0_61.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_61.debug.xcconfig"; path = "Target Support Files/Pods-rn0_61/Pods-rn0_61.debug.xcconfig"; sourceTree = "<group>"; };
 		CC773FC25D2071AEA7414FF3 /* libPods-rn0_61Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_61Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +128,8 @@
 		13B07FAE1A68108700A75B9A /* rn0_61 */ = {
 			isa = PBXGroup;
 			children = (
+				AAC9B0E62588C87500CF0726 /* CrashyCrashy.h */,
+				AAC9B0E52588C87500CF0726 /* CrashyCrashy.m */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -532,6 +537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				AAC9B0E72588C87500CF0726 /* CrashyCrashy.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/test/react-native-cli/features/fixtures/rn0_61/ios/rn0_61/CrashyCrashy.h
+++ b/test/react-native-cli/features/fixtures/rn0_61/ios/rn0_61/CrashyCrashy.h
@@ -1,0 +1,14 @@
+//
+//  CrashyCrashy.h
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface CrashyCrashy : NSObject <RCTBridgeModule>
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_61/ios/rn0_61/CrashyCrashy.m
+++ b/test/react-native-cli/features/fixtures/rn0_61/ios/rn0_61/CrashyCrashy.m
@@ -1,0 +1,32 @@
+//
+//  CrashyCrashy.m
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import "CrashyCrashy.h"
+#import <React/RCTBridgeModule.h>
+#import <Bugsnag/Bugsnag.h>
+
+@implementation CrashyCrashy
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(generateCrash)
+{
+  NSArray *items = [NSArray new];
+  NSLog(@"This item does not exist: %@", items[42]);
+}
+
+RCT_REMAP_METHOD(generatePromiseRejection, resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  reject(@"iOSReject", @"Oops - rejected promise from iOS!", [NSError errorWithDomain:@"com.example" code:562 userInfo:nil]);
+}
+
+RCT_EXPORT_METHOD(handledError)
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"com.example" code:408 userInfo:nil]];
+}
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_62/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_62/App.js
@@ -17,7 +17,6 @@ import {
 } from 'react-native';
 
 import {
-  Header,
   LearnMoreLinks,
   Colors,
   DebugInstructions,
@@ -32,7 +31,6 @@ const App: () => React$Node = () => {
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
-          <Header />
           {global.HermesInternal == null ? null : (
             <View style={styles.engine}>
               <Text style={styles.footer}>Engine: Hermes</Text>

--- a/test/react-native-cli/features/fixtures/rn0_62/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_62/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Bugsnag from "@bugsnag/react-native";
-import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,

--- a/test/react-native-cli/features/fixtures/rn0_62/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_62/App.js
@@ -13,14 +13,11 @@ import {
   ScrollView,
   View,
   Text,
-  StatusBar,
-} from 'react-native';
+  StatusBar, Button
+} from 'react-native'
 
 import {
-  LearnMoreLinks,
-  Colors,
-  DebugInstructions,
-  ReloadInstructions,
+  Colors
 } from 'react-native/Libraries/NewAppScreen';
 
 const App: () => React$Node = () => {
@@ -37,32 +34,15 @@ const App: () => React$Node = () => {
             </View>
           )}
           <View style={styles.body}>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Step One</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>App.js</Text> to change this
-                screen and then come back to see your edits.
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>See Your Changes</Text>
-              <Text style={styles.sectionDescription}>
-                <ReloadInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Debug</Text>
-              <Text style={styles.sectionDescription}>
-                <DebugInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Learn More</Text>
-              <Text style={styles.sectionDescription}>
-                Read the docs to discover what to do next:
-              </Text>
-            </View>
-            <LearnMoreLinks />
+            <Text>React Native CLI end-to-end test app</Text>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='js_notify'
+                    title='JS Notify'
+                    onPress={this.jsNotify}/>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='native_notify'
+                    title='Native Notify'
+                    onPress={this.nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/test/react-native-cli/features/fixtures/rn0_62/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_62/App.js
@@ -1,24 +1,32 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- * @flow strict-local
- */
-
 import React from 'react';
+import Bugsnag from "@bugsnag/react-native";
+import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,
   ScrollView,
   View,
   Text,
-  StatusBar, Button
+  StatusBar, Button, NativeModules
 } from 'react-native'
 
 import {
   Colors
 } from 'react-native/Libraries/NewAppScreen';
+
+function jsNotify() {
+  try { // execute crashy code
+    iMadeThisUp();
+  } catch (error) {
+    console.log('Bugsnag.notify JS error')
+    Bugsnag.notify(error);
+  }
+}
+
+function nativeNotify() {
+  console.log('Bugsnag.notify native error')
+  NativeModules.CrashyCrashy.handledError()
+}
 
 const App: () => React$Node = () => {
   return (
@@ -38,11 +46,11 @@ const App: () => React$Node = () => {
             <Button style={styles.clickyButton}
                     accessibilityLabel='js_notify'
                     title='JS Notify'
-                    onPress={this.jsNotify}/>
+                    onPress={jsNotify}/>
             <Button style={styles.clickyButton}
                     accessibilityLabel='native_notify'
                     title='Native Notify'
-                    onPress={this.nativeNotify}/>
+                    onPress={nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/CrashyModule.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/CrashyModule.java
@@ -1,0 +1,34 @@
+package com.rn0_62;
+
+import com.bugsnag.android.Bugsnag;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class CrashyModule extends ReactContextBaseJavaModule {
+    public CrashyModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "CrashyCrashy";
+    }
+
+    @ReactMethod
+    public void generateCrash() throws Exception {
+        throw new Exception("Ooopsy from Java!");
+    }
+
+    @ReactMethod
+    public void generatePromiseRejection(Promise promise) {
+        promise.reject(new Exception("Oops - rejected promise from Java!"));
+    }
+
+    @ReactMethod
+    public void handledError() throws Exception {
+        Bugsnag.notify(new Exception("Handled ooopsy from Java!"));
+    }
+}

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/CrashyPackage.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/CrashyPackage.java
@@ -1,0 +1,34 @@
+package com.rn0_62;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class CrashyPackage implements ReactPackage {
+
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new CrashyModule(reactContext));
+
+        return modules;
+    }
+}
+

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainApplication.java
@@ -24,8 +24,7 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
+          packages.add(new CrashyPackage());
           return packages;
         }
 

--- a/test/react-native-cli/features/fixtures/rn0_62/ios/rn0_62.xcodeproj/project.pbxproj
+++ b/test/react-native-cli/features/fixtures/rn0_62/ios/rn0_62.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2DCD954D1E0B4F2C00145EB5 /* rn0_62Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* rn0_62Tests.m */; };
 		625895BDD39C4E5E5A5FAA25 /* libPods-rn0_62-rn0_62Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 67674E71DF31D3EF271624EC /* libPods-rn0_62-rn0_62Tests.a */; };
 		6A74BF44DB3AC9BB94A4BD67 /* libPods-rn0_62-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E76759CDD932E509D75DE20E /* libPods-rn0_62-tvOSTests.a */; };
+		AA578F1A2588C89B006B3C61 /* CrashyCrashy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA578F182588C89A006B3C61 /* CrashyCrashy.m */; };
 		BDC5C01FC178A99D8AEEED30 /* libPods-rn0_62-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53D01F24AC86DACC3674C402 /* libPods-rn0_62-tvOS.a */; };
 		C0E2676FB9F0A4F827DBAED4 /* libPods-rn0_62.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 577433FA6BF8F3E7E84E729D /* libPods-rn0_62.a */; };
 /* End PBXBuildFile section */
@@ -62,6 +63,8 @@
 		6273BDEACE700A5A3FFF0A30 /* Pods-rn0_62-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_62-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-rn0_62-tvOSTests/Pods-rn0_62-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		67674E71DF31D3EF271624EC /* libPods-rn0_62-rn0_62Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_62-rn0_62Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		88923560766DA954C0A09F6E /* Pods-rn0_62.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_62.debug.xcconfig"; path = "Target Support Files/Pods-rn0_62/Pods-rn0_62.debug.xcconfig"; sourceTree = "<group>"; };
+		AA578F182588C89A006B3C61 /* CrashyCrashy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CrashyCrashy.m; path = rn0_62/CrashyCrashy.m; sourceTree = "<group>"; };
+		AA578F192588C89B006B3C61 /* CrashyCrashy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CrashyCrashy.h; path = rn0_62/CrashyCrashy.h; sourceTree = "<group>"; };
 		BBA49835904E5F0732D5A518 /* Pods-rn0_62-rn0_62Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_62-rn0_62Tests.debug.xcconfig"; path = "Target Support Files/Pods-rn0_62-rn0_62Tests/Pods-rn0_62-rn0_62Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		E256BE5BE681B96D8524362B /* Pods-rn0_62-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_62-tvOS.release.xcconfig"; path = "Target Support Files/Pods-rn0_62-tvOS/Pods-rn0_62-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		E76759CDD932E509D75DE20E /* libPods-rn0_62-tvOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_62-tvOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +128,8 @@
 		13B07FAE1A68108700A75B9A /* rn0_62 */ = {
 			isa = PBXGroup;
 			children = (
+				AA578F192588C89B006B3C61 /* CrashyCrashy.h */,
+				AA578F182588C89A006B3C61 /* CrashyCrashy.m */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -531,6 +536,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				AA578F1A2588C89B006B3C61 /* CrashyCrashy.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/test/react-native-cli/features/fixtures/rn0_62/ios/rn0_62/CrashyCrashy.h
+++ b/test/react-native-cli/features/fixtures/rn0_62/ios/rn0_62/CrashyCrashy.h
@@ -1,0 +1,14 @@
+//
+//  CrashyCrashy.h
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface CrashyCrashy : NSObject <RCTBridgeModule>
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_62/ios/rn0_62/CrashyCrashy.m
+++ b/test/react-native-cli/features/fixtures/rn0_62/ios/rn0_62/CrashyCrashy.m
@@ -1,0 +1,32 @@
+//
+//  CrashyCrashy.m
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import "CrashyCrashy.h"
+#import <React/RCTBridgeModule.h>
+#import <Bugsnag/Bugsnag.h>
+
+@implementation CrashyCrashy
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(generateCrash)
+{
+  NSArray *items = [NSArray new];
+  NSLog(@"This item does not exist: %@", items[42]);
+}
+
+RCT_REMAP_METHOD(generatePromiseRejection, resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  reject(@"iOSReject", @"Oops - rejected promise from iOS!", [NSError errorWithDomain:@"com.example" code:562 userInfo:nil]);
+}
+
+RCT_EXPORT_METHOD(handledError)
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"com.example" code:408 userInfo:nil]];
+}
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_63/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_63/App.js
@@ -17,7 +17,6 @@ import {
 } from 'react-native';
 
 import {
-  Header,
   LearnMoreLinks,
   Colors,
   DebugInstructions,
@@ -32,7 +31,6 @@ const App: () => React$Node = () => {
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
-          <Header />
           {global.HermesInternal == null ? null : (
             <View style={styles.engine}>
               <Text style={styles.footer}>Engine: Hermes</Text>

--- a/test/react-native-cli/features/fixtures/rn0_63/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_63/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Bugsnag from "@bugsnag/react-native";
-import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,

--- a/test/react-native-cli/features/fixtures/rn0_63/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_63/App.js
@@ -13,14 +13,11 @@ import {
   ScrollView,
   View,
   Text,
-  StatusBar,
-} from 'react-native';
+  StatusBar, Button
+} from 'react-native'
 
 import {
-  LearnMoreLinks,
-  Colors,
-  DebugInstructions,
-  ReloadInstructions,
+  Colors
 } from 'react-native/Libraries/NewAppScreen';
 
 const App: () => React$Node = () => {
@@ -37,32 +34,15 @@ const App: () => React$Node = () => {
             </View>
           )}
           <View style={styles.body}>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Step One</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>App.js</Text> to change this
-                screen and then come back to see your edits.
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>See Your Changes</Text>
-              <Text style={styles.sectionDescription}>
-                <ReloadInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Debug</Text>
-              <Text style={styles.sectionDescription}>
-                <DebugInstructions />
-              </Text>
-            </View>
-            <View style={styles.sectionContainer}>
-              <Text style={styles.sectionTitle}>Learn More</Text>
-              <Text style={styles.sectionDescription}>
-                Read the docs to discover what to do next:
-              </Text>
-            </View>
-            <LearnMoreLinks />
+            <Text>React Native CLI end-to-end test app</Text>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='js_notify'
+                    title='JS Notify'
+                    onPress={this.jsNotify}/>
+            <Button style={styles.clickyButton}
+                    accessibilityLabel='native_notify'
+                    title='Native Notify'
+                    onPress={this.nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/test/react-native-cli/features/fixtures/rn0_63/App.js
+++ b/test/react-native-cli/features/fixtures/rn0_63/App.js
@@ -1,24 +1,32 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- * @flow strict-local
- */
-
 import React from 'react';
+import Bugsnag from "@bugsnag/react-native";
+import { NativeModules } from 'react-native'
 import {
   SafeAreaView,
   StyleSheet,
   ScrollView,
   View,
   Text,
-  StatusBar, Button
+  StatusBar, Button, NativeModules
 } from 'react-native'
 
 import {
   Colors
 } from 'react-native/Libraries/NewAppScreen';
+
+function jsNotify() {
+  try { // execute crashy code
+    iMadeThisUp();
+  } catch (error) {
+    console.log('Bugsnag.notify JS error')
+    Bugsnag.notify(error);
+  }
+}
+
+function nativeNotify() {
+  console.log('Bugsnag.notify native error')
+  NativeModules.CrashyCrashy.handledError()
+}
 
 const App: () => React$Node = () => {
   return (
@@ -38,11 +46,11 @@ const App: () => React$Node = () => {
             <Button style={styles.clickyButton}
                     accessibilityLabel='js_notify'
                     title='JS Notify'
-                    onPress={this.jsNotify}/>
+                    onPress={jsNotify}/>
             <Button style={styles.clickyButton}
                     accessibilityLabel='native_notify'
                     title='Native Notify'
-                    onPress={this.nativeNotify}/>
+                    onPress={nativeNotify}/>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/CrashyModule.java
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/CrashyModule.java
@@ -1,0 +1,34 @@
+package com.rn0_63;
+
+import com.bugsnag.android.Bugsnag;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class CrashyModule extends ReactContextBaseJavaModule {
+    public CrashyModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "CrashyCrashy";
+    }
+
+    @ReactMethod
+    public void generateCrash() throws Exception {
+        throw new Exception("Ooopsy from Java!");
+    }
+
+    @ReactMethod
+    public void generatePromiseRejection(Promise promise) {
+        promise.reject(new Exception("Oops - rejected promise from Java!"));
+    }
+
+    @ReactMethod
+    public void handledError() throws Exception {
+        Bugsnag.notify(new Exception("Handled ooopsy from Java!"));
+    }
+}

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/CrashyPackage.java
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/CrashyPackage.java
@@ -1,0 +1,34 @@
+package com.rn0_63;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class CrashyPackage implements ReactPackage {
+
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("rawtypes") // the ReactPackage interface uses a raw type, ignore it
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new CrashyModule(reactContext));
+
+        return modules;
+    }
+}
+

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/MainApplication.java
@@ -24,8 +24,7 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
+          packages.add(new CrashyPackage());
           return packages;
         }
 

--- a/test/react-native-cli/features/fixtures/rn0_63/ios/rn0_63.xcodeproj/project.pbxproj
+++ b/test/react-native-cli/features/fixtures/rn0_63/ios/rn0_63.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		970AD54C972C4737F6F8FFB7 /* libPods-rn0_63-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C4D03E2F3C04CDCFDC1D2AC8 /* libPods-rn0_63-tvOS.a */; };
 		A8803100BCC0F7B6EE79CBA4 /* libPods-rn0_63-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39F1958968D79114AC2C5ED2 /* libPods-rn0_63-tvOSTests.a */; };
+		AA578F1D2588C8CC006B3C61 /* CrashyCrashy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA578F1B2588C8CC006B3C61 /* CrashyCrashy.m */; };
 		E7643CED6E8189C59AF7A360 /* libPods-rn0_63-rn0_63Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED996B2B64B976EC89A53BC4 /* libPods-rn0_63-rn0_63Tests.a */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +60,8 @@
 		39F1958968D79114AC2C5ED2 /* libPods-rn0_63-tvOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_63-tvOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		76F8C8663ADAD62A49F15AC1 /* libPods-rn0_63.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_63.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = rn0_63/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		AA578F1B2588C8CC006B3C61 /* CrashyCrashy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CrashyCrashy.m; path = rn0_63/CrashyCrashy.m; sourceTree = "<group>"; };
+		AA578F1C2588C8CC006B3C61 /* CrashyCrashy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CrashyCrashy.h; path = rn0_63/CrashyCrashy.h; sourceTree = "<group>"; };
 		B4DDD653E237FD955A789C45 /* Pods-rn0_63-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_63-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-rn0_63-tvOSTests/Pods-rn0_63-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		BF054C5C0714A629C72AE373 /* Pods-rn0_63-rn0_63Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-rn0_63-rn0_63Tests.debug.xcconfig"; path = "Target Support Files/Pods-rn0_63-rn0_63Tests/Pods-rn0_63-rn0_63Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		C4D03E2F3C04CDCFDC1D2AC8 /* libPods-rn0_63-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-rn0_63-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +128,8 @@
 		13B07FAE1A68108700A75B9A /* rn0_63 */ = {
 			isa = PBXGroup;
 			children = (
+				AA578F1C2588C8CC006B3C61 /* CrashyCrashy.h */,
+				AA578F1B2588C8CC006B3C61 /* CrashyCrashy.m */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -569,6 +574,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				AA578F1D2588C8CC006B3C61 /* CrashyCrashy.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/test/react-native-cli/features/fixtures/rn0_63/ios/rn0_63/CrashyCrashy.h
+++ b/test/react-native-cli/features/fixtures/rn0_63/ios/rn0_63/CrashyCrashy.h
@@ -1,0 +1,14 @@
+//
+//  CrashyCrashy.h
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface CrashyCrashy : NSObject <RCTBridgeModule>
+
+@end

--- a/test/react-native-cli/features/fixtures/rn0_63/ios/rn0_63/CrashyCrashy.m
+++ b/test/react-native-cli/features/fixtures/rn0_63/ios/rn0_63/CrashyCrashy.m
@@ -1,0 +1,32 @@
+//
+//  CrashyCrashy.m
+//  BugsnagReactNativeExample
+//
+//  Created by Christian Schlensker on 1/3/17.
+//  Copyright © 2017 Bugsnag. All rights reserved.
+//
+
+#import "CrashyCrashy.h"
+#import <React/RCTBridgeModule.h>
+#import <Bugsnag/Bugsnag.h>
+
+@implementation CrashyCrashy
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(generateCrash)
+{
+  NSArray *items = [NSArray new];
+  NSLog(@"This item does not exist: %@", items[42]);
+}
+
+RCT_REMAP_METHOD(generatePromiseRejection, resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  reject(@"iOSReject", @"Oops - rejected promise from iOS!", [NSError errorWithDomain:@"com.example" code:562 userInfo:nil]);
+}
+
+RCT_EXPORT_METHOD(handledError)
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"com.example" code:408 userInfo:nil]];
+}
+
+@end

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -29,14 +29,14 @@ When('I run the React Native service interactively') do
   step("I run the service '#{current_fixture}' interactively")
 end
 
-When("I cause a handled JavaScript error") do
+When("I notify a handled JavaScript error") do
   steps %Q{
     Given the element "js_notify" is present within 60 seconds
     And I click the element "js_notify"
   }
 end
 
-When("I cause a handled native error") do
+When("I notify a handled native error") do
   steps %Q{
     Given the element "native_notify" is present within 60 seconds
     And I click the element "native_notify"

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -4,7 +4,8 @@ require 'securerandom'
 fixtures = Dir["#{__dir__}/../fixtures/rn0_*"].map { |dir| File.basename(dir) }.sort
 current_fixture = ENV['REACT_NATIVE_VERSION']
 
-unless fixtures.include?(current_fixture)
+# Ensure environment if set for the CLI tests (check not needed for device-based tests)
+if MazeRunner.config.farm == :none && !fixtures.include?(current_fixture)
   if current_fixture.nil?
     message = <<~ERROR.chomp
       \e[31;1mNo React Native fixture given!\e[0m
@@ -26,6 +27,20 @@ end
 
 When('I run the React Native service interactively') do
   step("I run the service '#{current_fixture}' interactively")
+end
+
+When("I cause a handled JavaScript error") do
+  steps %Q{
+    Given the element "js_notify" is present within 60 seconds
+    And I click the element "js_notify"
+  }
+end
+
+When("I cause a handled native error") do
+  steps %Q{
+    Given the element "native_notify" is present within 60 seconds
+    And I click the element "native_notify"
+  }
 end
 
 # TODO(PLAT-5566) migrate to Maze Runner (this step may need a bit more specific of a name)

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 fixtures = Dir["#{__dir__}/../fixtures/rn0_*"].map { |dir| File.basename(dir) }.sort
 current_fixture = ENV['REACT_NATIVE_VERSION']
 
-# Ensure environment if set for the CLI tests (check not needed for device-based tests)
+# Ensure environment is set for the CLI tests (check not needed for device-based tests)
 if MazeRunner.config.farm == :none && !fixtures.include?(current_fixture)
   if current_fixture.nil?
     message = <<~ERROR.chomp

--- a/test/react-native-cli/features/support/env.rb
+++ b/test/react-native-cli/features/support/env.rb
@@ -1,0 +1,3 @@
+# TODO: Change to 123123123... once the CLI supports all custom endpoints.
+#$api_key = '12312312312312312312312312312312'
+$api_key = 'b161f2dbabe3204527bbe5ed4b9334a4'


### PR DESCRIPTION
## Goal

Completes the end-to-end tests for dynamically initializing and building a React Native app, ensuring that JavaScript and Native errors are received when the app is run.

Also includes a small fix to the tool, ensuring that `bugsnag-react-native-xcode.sh` is included in the install.

## Design

There are a few TODOs that need to be revisited once other tools are released and the functionality of the tool is completed.

For now, source map uploads are disabled for both Android and iOS builds - checking of these will follow in a later PR.  Instructions for running locally will also be added later, as there is likely to be too much change to make it worthwhile doing now.

## Changeset

- New plumbing for dynamically initializing RN projects using the RN CLI.  Uses Expect to interact with the shell.
- New steps to run the e2e tests for each supported version of React Native, on the latest available iOS and Android versions.
- Test scenario that invokes the reporting of handled JS and Native errors.
- RN CLI test fixtures updated to support JS/Native handled errors off of button presses.
- New Cucumber steps to support button presses

## Testing

Covered by CI and run locally successfully prior to review.