### PR TITLE
RN CLI: Improve errors when required tools aren't installed

### DIFF
--- a/packages/react-native-cli/src/lib/Pod.ts
+++ b/packages/react-native-cli/src/lib/Pod.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawnSync } from 'child_process'
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import { Logger } from '../Logger'
@@ -17,18 +17,23 @@ export async function install (projectRoot: string, logger: Logger): Promise<voi
     }
     throw e
   }
-  return new Promise((resolve, reject) => {
-    const proc = spawn('pod', ['install'], { cwd: join(projectRoot, 'ios'), stdio: 'inherit' })
 
-    proc.on('error', err => reject(err))
+  const res = spawnSync('pod', ['install'], { cwd: join(projectRoot, 'ios'), stdio: 'inherit' })
 
-    proc.on('close', code => {
-      if (code === 0) return resolve()
-      reject(
-        new Error(
-          `Command exited with non-zero exit code (${code}) "pod install"`
-        )
-      )
-    })
-  })
+  if (res.error) {
+    if ((res.error as NodeJS.ErrnoException).code === 'ENOENT') {
+      logger.warn(COCOAPODS_NOT_FOUND)
+      return
+    }
+
+    throw res.error
+  }
+
+  if (res.status !== 0) {
+    throw new Error(`Command "pod install" exited with non-zero exit code (${res.status})`)
+  }
 }
+
+const COCOAPODS_NOT_FOUND = `Cocoapods does not appear to be installed.
+
+Install it and run "pod install" inside the "ios" directory manaully.`

--- a/packages/react-native-cli/src/lib/Repo.ts
+++ b/packages/react-native-cli/src/lib/Repo.ts
@@ -5,10 +5,15 @@ export enum RepoState { UNKNOWN, GIT_CLEAN, GIT_DIRTY, NONE }
 
 export function detectState (projectRoot: string, logger: Logger) {
   const res = gitStatus(projectRoot)
+
   if (res.error) {
-    logger.warn(res.error)
+    if ((res.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.warn(res.error)
+    }
+
     return RepoState.UNKNOWN
   }
+
   if (res.stderr.match(/not a git repository/)) return RepoState.NONE
   if (res.stdout.length > 0) return RepoState.GIT_DIRTY
   return RepoState.GIT_CLEAN

--- a/packages/react-native-cli/src/lib/__test__/Pod.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Pod.test.ts
@@ -1,8 +1,7 @@
 import { install } from '../Pod'
 import path from 'path'
 import { promises as fs } from 'fs'
-import { spawn, ChildProcess } from 'child_process'
-import { EventEmitter } from 'events'
+import { spawnSync } from 'child_process'
 import logger from '../../Logger'
 
 async function generateNotFoundError () {
@@ -13,9 +12,9 @@ async function generateNotFoundError () {
   }
 }
 
-jest.mock('fs', () => {
-  return { promises: { readFile: jest.fn(), writeFile: jest.fn(), readdir: jest.fn() } }
-})
+jest.mock('fs', () => ({
+  promises: { readFile: jest.fn(), writeFile: jest.fn(), readdir: jest.fn() }
+}))
 jest.mock('child_process')
 jest.mock('../../Logger')
 
@@ -26,12 +25,8 @@ test('install(): success', async () => {
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
   readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj', 'Podfile'])
 
-  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
-  spawnMock.mockImplementation(() => {
-    const ee = new EventEmitter() as ChildProcess
-    process.nextTick(() => ee.emit('close', 0))
-    return ee
-  })
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
+  spawnMock.mockReturnValue({ status: 0 })
 
   await install('/example/dir', logger)
   expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
@@ -42,12 +37,8 @@ test('install(): no podfile', async () => {
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
   readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj'])
 
-  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
-  spawnMock.mockImplementation(() => {
-    const ee = new EventEmitter() as ChildProcess
-    process.nextTick(() => ee.emit('close', 0))
-    return ee
-  })
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
+  spawnMock.mockReturnValue({ status: 0 })
 
   await install('/example/dir', logger)
   expect(spawnMock).not.toHaveBeenCalled()
@@ -59,12 +50,8 @@ test('install(): no ios dir', async () => {
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
   readdirMock.mockRejectedValue(await generateNotFoundError())
 
-  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
-  spawnMock.mockImplementation(() => {
-    const ee = new EventEmitter() as ChildProcess
-    process.nextTick(() => ee.emit('close', 0))
-    return ee
-  })
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
+  spawnMock.mockReturnValue({ status: 0 })
 
   await install('/example/dir', logger)
   expect(spawnMock).not.toHaveBeenCalled()
@@ -76,15 +63,28 @@ test('install(): bad exit code', async () => {
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
   readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj', 'Podfile'])
 
-  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
-  spawnMock.mockImplementation(() => {
-    const ee = new EventEmitter() as ChildProcess
-    process.nextTick(() => ee.emit('close', 1))
-    return ee
-  })
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
+  spawnMock.mockReturnValue({ status: 1 })
 
-  await expect(install('/example/dir', logger)).rejects.toThrow('Command exited with non-zero exit code (1) "pod install"')
+  await expect(install('/example/dir', logger)).rejects.toThrow('Command "pod install" exited with non-zero exit code (1)')
   expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
+})
+
+test('install(): ENOENT error from cocoapods', async () => {
+  type readdir = (path: string) => Promise<string[]>
+  const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
+  readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj', 'Podfile'])
+
+  const error = new Error('oh dear')
+  error.code = 'ENOENT'
+
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
+  spawnMock.mockImplementation(() => ({ error, status: 255 }))
+
+  await install('/example/dir', logger)
+
+  expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Cocoapods does not appear to be installed.'))
 })
 
 test('install(): unknown child process error', async () => {
@@ -92,12 +92,8 @@ test('install(): unknown child process error', async () => {
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
   readdirMock.mockResolvedValue(['Pods', 'MyProject', 'MyProject.xcodeproj', 'Podfile'])
 
-  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
-  spawnMock.mockImplementation(() => {
-    const ee = new EventEmitter() as ChildProcess
-    process.nextTick(() => ee.emit('error', new Error('uh oh')))
-    return ee
-  })
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
+  spawnMock.mockImplementation(() => { throw new Error('uh oh') })
 
   await expect(install('/example/dir', logger)).rejects.toThrow('uh oh')
   expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
@@ -108,7 +104,7 @@ test('install(): unknown error', async () => {
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
   readdirMock.mockRejectedValue(new Error('uh oh'))
 
-  const spawnMock = spawn as jest.MockedFunction<typeof spawn>
+  const spawnMock = spawnSync as jest.MockedFunction<typeof spawnSync>
 
   await expect(install('/example/dir', logger)).rejects.toThrow('uh oh')
   expect(spawnMock).not.toHaveBeenCalled()

--- a/packages/react-native-cli/src/lib/__test__/Repo.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Repo.test.ts
@@ -87,3 +87,27 @@ test('detectState(): unknown error', async () => {
   expect(spawnSyncMock).toHaveBeenCalledWith('git', ['status', '--porcelain'], { cwd: '/example/dir', encoding: 'utf8' })
   expect(logger.warn).toHaveBeenCalledWith(error)
 })
+
+test('detectState(): ENOENT error should not log a warning', async () => {
+  const spawnSyncMock = (spawnSync as unknown as jest.MockedFunction<spawnSyncFn>)
+  const error = new Error('fail')
+  error.code = 'ENOENT'
+
+  spawnSyncMock.mockReturnValue({
+    status: 0,
+    signal: null,
+    output: [
+      '',
+      '',
+      ''
+    ],
+    pid: 198,
+    stdout: '',
+    stderr: '',
+    error
+  })
+
+  expect(detectState('/example/dir', logger)).toBe(RepoState.UNKNOWN)
+  expect(spawnSyncMock).toHaveBeenCalledWith('git', ['status', '--porcelain'], { cwd: '/example/dir', encoding: 'utf8' })
+  expect(logger.warn).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Goal

Improves the error messages that were logged when required tools aren't installed. For Git we don't log a special message as the default seemed clear enough:

> Unable to detect repo state.
>
> This command may make modifications to your project. It is recommended that you commit the current status of your code to a git repo before continuing.

For Cocoapods we now log a special error and fail gracefully rather than crashing with the `spawn` error directly

NPM commands will still crash as it seems incredibly unlikely that the CLI will be run without NPM being available