### PR TITLE
Fix Node Maze Runner tests on Maze Runner v3.6.0

### DIFF
--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v3.5.1-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node test/node

--- a/test/node/features/koa-1x.feature
+++ b/test/node/features/koa-1x.feature
@@ -58,9 +58,11 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
 
 Scenario: A non-5XX error created with ctx.throw()
-  Then I open the URL "http://koa-1x/ctx-throw-400"
-  And I wait for 1 second
-  Then I should receive no requests
+  When I open the URL "http://koa-1x/ctx-throw-400"
+  And I wait to receive a request
+  Then the request is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
 
 Scenario: A handled error with ctx.bugsnag.notify()
   Then I open the URL "http://koa-1x/handled"

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -71,9 +71,11 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
 
 Scenario: A non-5XX error created with ctx.throw()
-  Then I open the URL "http://koa/ctx-throw-400"
-  And I wait for 1 second
-  Then I should receive no requests
+  When I open the URL "http://koa/ctx-throw-400"
+  And I wait to receive a request
+  Then the request is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
 
 Scenario: A handled error with ctx.bugsnag.notify()
   Then I open the URL "http://koa/handled"

--- a/test/node/features/restify.feature
+++ b/test/node/features/restify.feature
@@ -58,9 +58,11 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
 
 Scenario: an explicit 404
-  Then I open the URL "http://restify/not-found"
-  And I wait for 1 second
-  Then I should receive no requests
+  When I open the URL "http://restify/not-found"
+  And I wait to receive a request
+  Then the request is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+  And the payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
 
 Scenario: an explicit internal server error
   Then I open the URL "http://restify/internal"


### PR DESCRIPTION
## Goal

The Node Maze Runner tests were failing due to the "I should receive no requests" step receiving a session payload. These tests now expect the session payload and are now passing on the latest v3 MR release