### PR TITLE
[PLAT-5575]: Ensure init exits after any subcommand fails

### DIFF
--- a/packages/react-native-cli/src/bin/cli.ts
+++ b/packages/react-native-cli/src/bin/cli.ts
@@ -49,10 +49,11 @@ export default async function run (argv: string[]): Promise<void> {
     switch (opts.command) {
       case 'init':
         await repoStatePreCommand(remainingOpts, projectRoot, opts)
-        await install(remainingOpts, projectRoot, opts)
-        await insert(remainingOpts, projectRoot, opts)
-        await configure(remainingOpts, projectRoot, opts)
-        await automateSymbolication(remainingOpts, projectRoot, opts)
+        if (!await install(remainingOpts, projectRoot, opts)) return
+        if (!await insert(remainingOpts, projectRoot, opts)) return
+        if (!await configure(remainingOpts, projectRoot, opts)) return
+        if (!await automateSymbolication(remainingOpts, projectRoot, opts)) return
+        logger.success('Finished')
         break
       case 'insert':
         await repoStatePreCommand(remainingOpts, projectRoot, opts)

--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -7,7 +7,7 @@ import { enableReactNativeMappings } from '../lib/Gradle'
 
 const DEFAULT_UPLOAD_ENDPOINT = 'https://upload.bugsnag.com'
 
-export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
   try {
     let uploadEndpoint: string|null = null
 
@@ -41,8 +41,10 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
     if (androidIntegration || iosIntegration) {
       await installJavaScriptPackage(projectRoot)
     }
+    return true
   } catch (e) {
     logger.error(e)
+    return false
   }
 }
 

--- a/packages/react-native-cli/src/commands/ConfigureCommand.ts
+++ b/packages/react-native-cli/src/commands/ConfigureCommand.ts
@@ -7,7 +7,7 @@ import * as ios from '../lib/InfoPlist'
 const DEFAULT_NOTIFY_ENDPOINT = 'https://notify.bugsnag.com'
 const DEFAULT_SESSIONS_ENDPOINT = 'https://sessions.bugsnag.com'
 
-export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
   try {
     const { apiKey } = await prompts({
       type: 'text',
@@ -49,7 +49,9 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
 
     logger.info('Updating Info.plist')
     await ios.configure(projectRoot, options, logger)
+    return true
   } catch (e) {
     logger.error(e)
+    return false
   }
 }

--- a/packages/react-native-cli/src/commands/InsertCommand.ts
+++ b/packages/react-native-cli/src/commands/InsertCommand.ts
@@ -1,12 +1,14 @@
 import logger from '../Logger'
 import { insertJs, insertAndroid, insertIos } from '../lib/Insert'
 
-export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
   try {
     await insertJs(projectRoot, logger)
     await insertIos(projectRoot, logger)
     await insertAndroid(projectRoot, logger)
+    return true
   } catch (e) {
     logger.error(e)
+    return false
   }
 }

--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -5,15 +5,17 @@ import { install as podInstall } from '../lib/Pod'
 import onCancel from '../lib/OnCancel'
 import { modifyRootBuildGradle, modifyAppBuildGradle } from '../lib/Gradle'
 
-export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<void> {
+export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
   try {
     await installJavaScriptPackage(projectRoot)
     await addGradlePluginDependency(projectRoot)
 
     logger.info('Installing cocoapods')
     await podInstall(projectRoot, logger)
+    return true
   } catch (e) {
     logger.error(e)
+    return false
   }
 }
 


### PR DESCRIPTION
## Goal

If any of the subcommands fails in a fatal way, it shouldn't carry on. e.g. when an npm install fails due to a non-existant version.

## Design

Despite detecting and logging the failure, the subcommand did not pass the information back up to the `init` command, so it carried on executing tasks.
I updated the return type of each of the commands to `Promise<boolean>` to signify sucess (`true`) or failure (`false`) so that `init` could know whether to continue or not.

Perhaps I could have used an enum to make it more clear what the boolean means?

## Changeset

- Updated the commands with the new return type
- Updated `init` to check the return value before running the next command

## Testing

Tested manually. An end to end test should be added when the tests for `init` land.