### PR TITLE
[PLAT-5618] RN-CLI: Let source map lib add the path

### DIFF
--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -46,10 +46,8 @@ case "$CONFIGURATION" in
 esac
 
 if [ ! -z "$ENDPOINT" ]; then
-  # Remove any trailing trailing '/'
-  ENDPOINT=$(echo $ENDPOINT | sed 's/\/$//')
   ARGS+=("--endpoint")
-  ARGS+=("$ENDPOINT/react-native-source-map")
+  ARGS+=("$ENDPOINT")
 fi
 
 ../node_modules/.bin/bugsnag-source-maps upload-react-native "${ARGS[@]}"


### PR DESCRIPTION
## Goal

One last change to this shell script – the source map lib [now determines the correct path](https://github.com/bugsnag/bugsnag-source-maps/pull/48).

## Testing

Tested manually. Will also be tested via e2e RN CLI tests when they land.