### PR TITLE
Avoid building unnecessary ABIs in test fixture

### DIFF
--- a/test/react-native/features/fixtures/rn0.60/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.60/android/app/build.gradle
@@ -135,6 +135,9 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        ndk {
+            abiFilters "arm64-v8a", "x86"
+        }
     }
     splits {
         abi {

--- a/test/react-native/features/fixtures/rn0.63/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.63/android/app/build.gradle
@@ -137,6 +137,9 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        ndk {
+            abiFilters "arm64-v8a", "x86"
+        }
     }
     splits {
         abi {


### PR DESCRIPTION
## Goal

Reduces the size of the mazerunner test fixture by excluding the `x86_64` and `armeabi_v7a` architectures. We don't actively test with these so excluding them makes sense to decrease the time spent waiting for APKs to upload.

This is based on the approach taken in the following Android PR: https://github.com/bugsnag/bugsnag-android/pull/1054