### PR TITLE
Ask for on-premise URLs up front, gated behind a confirmation prompt

### DIFF
--- a/packages/react-native-cli/src/commands/ConfigureCommand.ts
+++ b/packages/react-native-cli/src/commands/ConfigureCommand.ts
@@ -3,11 +3,9 @@ import logger from '../Logger'
 import onCancel from '../lib/OnCancel'
 import * as android from '../lib/AndroidManifest'
 import * as ios from '../lib/InfoPlist'
+import { UrlType, OnPremiseUrls } from '../lib/OnPremise'
 
-const DEFAULT_NOTIFY_ENDPOINT = 'https://notify.bugsnag.com'
-const DEFAULT_SESSIONS_ENDPOINT = 'https://sessions.bugsnag.com'
-
-export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
+export default async function run (projectRoot: string, urls: OnPremiseUrls): Promise<boolean> {
   try {
     const { apiKey } = await prompts({
       type: 'text',
@@ -20,28 +18,14 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
       }
     }, { onCancel })
 
-    const { notifyEndpoint } = await prompts({
-      type: 'text',
-      name: 'notifyEndpoint',
-      message: 'What is your Bugsnag notify endpoint?',
-      initial: DEFAULT_NOTIFY_ENDPOINT
-    }, { onCancel })
-
-    const { sessionsEndpoint } = await prompts({
-      type: 'text',
-      name: 'sessionsEndpoint',
-      message: 'What is your Bugsnag sessions endpoint?',
-      initial: DEFAULT_SESSIONS_ENDPOINT
-    }, { onCancel })
-
     const options: ios.Options & android.Options = { apiKey }
 
-    if (notifyEndpoint !== DEFAULT_NOTIFY_ENDPOINT) {
-      options.notifyEndpoint = notifyEndpoint
+    if (urls[UrlType.NOTIFY]) {
+      options.notifyEndpoint = urls[UrlType.NOTIFY]
     }
 
-    if (sessionsEndpoint !== DEFAULT_SESSIONS_ENDPOINT) {
-      options.sessionsEndpoint = sessionsEndpoint
+    if (urls[UrlType.SESSIONS]) {
+      options.sessionsEndpoint = urls[UrlType.SESSIONS]
     }
 
     logger.info('Updating AndroidManifest.xml')

--- a/packages/react-native-cli/src/commands/OnPremiseUrlsCommand.ts
+++ b/packages/react-native-cli/src/commands/OnPremiseUrlsCommand.ts
@@ -1,0 +1,48 @@
+import prompts, { PromptObject } from 'prompts'
+import { UrlType, OnPremiseUrls } from '../lib/OnPremise'
+import onCancel from '../lib/OnCancel'
+
+export default async function run (...requiredUrls: UrlType[]): Promise<OnPremiseUrls> {
+  const { isUsingOnPremise } = await prompts({
+    type: 'confirm',
+    name: 'isUsingOnPremise',
+    message: 'Are you using Bugsnag on-premise?',
+    initial: false
+  }, { onCancel })
+
+  if (!isUsingOnPremise) {
+    return {}
+  }
+
+  // Remove prompts that aren't relevant to the currently running command
+  const requiredPrompts = urlPrompts.filter(prompt => requiredUrls.includes(prompt.name as UrlType))
+
+  return prompts(requiredPrompts, { onCancel })
+}
+
+const urlPrompts: PromptObject[] = [
+  {
+    type: 'text',
+    name: UrlType.NOTIFY,
+    message: 'What is your Bugsnag notify endpoint?',
+    validate: value => value.length > 0
+  },
+  {
+    type: 'text',
+    name: UrlType.SESSIONS,
+    message: 'What is your Bugsnag sessions endpoint?',
+    validate: value => value.length > 0
+  },
+  {
+    type: 'text',
+    name: UrlType.UPLOAD,
+    message: 'What is your Bugsnag upload endpoint?',
+    validate: value => value.length > 0
+  },
+  {
+    type: 'text',
+    name: UrlType.BUILD,
+    message: 'What is your Bugsnag build endpoint?',
+    validate: value => value.length > 0
+  }
+]

--- a/packages/react-native-cli/src/lib/Gradle.ts
+++ b/packages/react-native-cli/src/lib/Gradle.ts
@@ -88,8 +88,8 @@ See ${DOCS_LINK} for more information`
 
 export async function enableReactNativeMappings (
   projectRoot: string,
-  uploadEndpoint: string|null,
-  buildEndpoint: string|null,
+  uploadEndpoint: string|undefined,
+  buildEndpoint: string|undefined,
   logger: Logger
 ): Promise<void> {
   logger.debug('Enabling Bugsnag Android Gradle plugin React Native mappings')

--- a/packages/react-native-cli/src/lib/OnPremise.ts
+++ b/packages/react-native-cli/src/lib/OnPremise.ts
@@ -1,0 +1,8 @@
+export enum UrlType {
+  NOTIFY = 'notify',
+  SESSIONS = 'sessions',
+  UPLOAD = 'upload',
+  BUILD = 'build',
+}
+
+export type OnPremiseUrls = Partial<Record<UrlType, string>>

--- a/packages/react-native-cli/src/lib/Xcode.ts
+++ b/packages/react-native-cli/src/lib/Xcode.ts
@@ -13,7 +13,7 @@ See ${DOCS_LINK} for more information`
 
 const EXTRA_PACKAGER_ARGS = 'export EXTRA_PACKAGER_ARGS="--sourcemap-output $CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle.map"'
 
-export async function updateXcodeProject (projectRoot: string, endpoint: string|null, logger: Logger) {
+export async function updateXcodeProject (projectRoot: string, endpoint: string|undefined, logger: Logger) {
   const iosDir = path.join(projectRoot, 'ios')
   const xcodeprojDir = (await fs.readdir(iosDir)).find(p => p.endsWith('.xcodeproj'))
 
@@ -65,7 +65,7 @@ async function updateBuildReactNativeTask (buildPhaseMap: Record<string, Record<
 async function addUploadSourceMapsTask (
   proj: Project,
   buildPhaseMap: Record<string, Record<string, unknown>>,
-  endpoint: string|null,
+  endpoint: string|undefined,
   logger: Logger
 ): Promise<boolean> {
   for (const shellBuildPhaseKey in buildPhaseMap) {

--- a/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
@@ -166,7 +166,7 @@ test('enableReactNativeMappings(): success without initial bugsnag config', asyn
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', null, null, logger)
+  await enableReactNativeMappings('/random/path', undefined, undefined, logger)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', expected, 'utf8')
@@ -186,7 +186,7 @@ test('enableReactNativeMappings(): success with initial bugsnag config', async (
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', null, null, logger)
+  await enableReactNativeMappings('/random/path', undefined, undefined, logger)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', expected, 'utf8')
@@ -206,7 +206,7 @@ test('enableReactNativeMappings(): success with empty initial bugsnag config', a
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', null, null, logger)
+  await enableReactNativeMappings('/random/path', undefined, undefined, logger)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', expected, 'utf8')
@@ -226,7 +226,7 @@ test('enableReactNativeMappings(): failure mappings already enabled', async () =
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', null, null, logger)
+  await enableReactNativeMappings('/random/path', undefined, undefined, logger)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
@@ -240,7 +240,7 @@ test('enableReactNativeMappings(): failure gradle file not found', async () => {
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
 
-  await enableReactNativeMappings('/random/path', null, null, logger)
+  await enableReactNativeMappings('/random/path', undefined, undefined, logger)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
@@ -256,7 +256,7 @@ test('enableReactNativeMappings(): failure pattern not found', async () => {
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
 
-  await enableReactNativeMappings('/random/path', null, null, logger)
+  await enableReactNativeMappings('/random/path', undefined, undefined, logger)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
@@ -274,7 +274,7 @@ test('enableReactNativeMappings(): failure unexpected error', async () => {
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
 
-  await expect(enableReactNativeMappings('/random/path', null, null, logger)).rejects.toThrow(error)
+  await expect(enableReactNativeMappings('/random/path', undefined, undefined, logger)).rejects.toThrow(error)
 
   expect(readFileMock).toHaveBeenCalledWith('/random/path/android/app/build.gradle', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
@@ -302,7 +302,7 @@ test('enableReactNativeMappings(): success without initial bugsnag config and cu
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', 'https://upload.example.com', null, logger)
+  await enableReactNativeMappings('/random/path', 'https://upload.example.com', undefined, logger)
 
   expect(readFileMock).toHaveBeenNthCalledWith(1, '/random/path/android/app/build.gradle', 'utf8')
   expect(readFileMock).toHaveBeenNthCalledWith(2, '/random/path/android/app/build.gradle', 'utf8')
@@ -333,7 +333,7 @@ test('enableReactNativeMappings(): success with initial bugsnag config and custo
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', 'https://upload.example.com', null, logger)
+  await enableReactNativeMappings('/random/path', 'https://upload.example.com', undefined, logger)
 
   expect(readFileMock).toHaveBeenNthCalledWith(1, '/random/path/android/app/build.gradle', 'utf8')
   expect(readFileMock).toHaveBeenNthCalledWith(2, '/random/path/android/app/build.gradle', 'utf8')
@@ -364,7 +364,7 @@ test('enableReactNativeMappings(): success with initial bugsnag config and custo
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', null, 'https://build.example.com', logger)
+  await enableReactNativeMappings('/random/path', undefined, 'https://build.example.com', logger)
 
   expect(readFileMock).toHaveBeenNthCalledWith(1, '/random/path/android/app/build.gradle', 'utf8')
   expect(readFileMock).toHaveBeenNthCalledWith(2, '/random/path/android/app/build.gradle', 'utf8')
@@ -395,7 +395,7 @@ test('enableReactNativeMappings(): success with empty initial bugsnag config and
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', 'https://upload.example.com', null, logger)
+  await enableReactNativeMappings('/random/path', 'https://upload.example.com', undefined, logger)
 
   expect(readFileMock).toHaveBeenNthCalledWith(1, '/random/path/android/app/build.gradle', 'utf8')
   expect(readFileMock).toHaveBeenNthCalledWith(2, '/random/path/android/app/build.gradle', 'utf8')
@@ -426,7 +426,7 @@ test('enableReactNativeMappings(): success with empty initial bugsnag config and
     expect(encoding).toBe('utf8')
   })
 
-  await enableReactNativeMappings('/random/path', null, 'https://build.example.com', logger)
+  await enableReactNativeMappings('/random/path', undefined, 'https://build.example.com', logger)
 
   expect(readFileMock).toHaveBeenNthCalledWith(1, '/random/path/android/app/build.gradle', 'utf8')
   expect(readFileMock).toHaveBeenNthCalledWith(2, '/random/path/android/app/build.gradle', 'utf8')

--- a/packages/react-native-cli/src/lib/__test__/Xcode.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Xcode.test.ts
@@ -49,7 +49,7 @@ test('updateXcodeProject(): success', async () => {
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
   writeFileMock.mockResolvedValue()
 
-  await updateXcodeProject('/random/path', null, logger)
+  await updateXcodeProject('/random/path', undefined, logger)
 
   expect(readFileSyncMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest.xcodeproj/project.pbxproj', 'utf8')
   expect(writeFileMock).toHaveBeenCalledTimes(1)
@@ -120,7 +120,7 @@ test('updateXcodeProject(): modifications already exist', async () => {
   readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
 
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
-  await updateXcodeProject('/random/path', null, logger)
+  await updateXcodeProject('/random/path', undefined, logger)
   expect(readFileSyncMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest.xcodeproj/project.pbxproj', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
   expect(logger.warn).toHaveBeenCalledWith('An "Upload source maps to Bugsnag" build phase already exists')
@@ -143,7 +143,7 @@ test('updateXcodeProject(): can\'t find project', async () => {
   readdirMock.mockResolvedValue(['sdflkj'])
 
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
-  await updateXcodeProject('/random/path', null, logger)
+  await updateXcodeProject('/random/path', undefined, logger)
   expect(readFileSyncMock).not.toHaveBeenCalled()
   expect(writeFileMock).not.toHaveBeenCalled()
 

--- a/test/react-native-cli/features/automate-symbolication.feature
+++ b/test/react-native-cli/features/automate-symbolication.feature
@@ -11,9 +11,9 @@ Scenario: successfully modify project
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag upload endpoint?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -26,8 +26,6 @@ Scenario: successfully modify project
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
-    When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag build endpoint?"
     When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
@@ -49,9 +47,9 @@ Scenario: successfully modify project, choosing source-maps version
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag upload endpoint?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -64,8 +62,6 @@ Scenario: successfully modify project, choosing source-maps version
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
-    When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag build endpoint?"
     When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I input "1.0.0-beta.1" interactively
@@ -87,10 +83,14 @@ Scenario: successfully modify project with custom endpoints
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
-    When I press enter
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I input "y" interactively
     And I wait for the current stdout line to contain "What is your Bugsnag upload endpoint?"
     When I input "https://upload.example.com" interactively
+    And I wait for the current stdout line to contain "What is your Bugsnag build endpoint?"
+    When I input "https://build.example.com" interactively
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    When I press enter
     And I wait for the shell to output the following to stdout
         """
         To configure your project to upload dSYMs, follow the iOS symbolication guide:
@@ -103,8 +103,6 @@ Scenario: successfully modify project with custom endpoints
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag build endpoint?"
-    When I input "https://build.example.com" interactively
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
     Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout
@@ -126,9 +124,9 @@ Scenario: opt not to modify the Android project
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag upload endpoint?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -162,6 +160,8 @@ Scenario: opt not to modify the iOS project
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I input "n" interactively
     And I wait for the shell to output the following to stdout
@@ -176,10 +176,6 @@ Scenario: opt not to modify the iOS project
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I input "y" interactively
-    And I wait for the current stdout line to contain "What is your Bugsnag upload endpoint?"
-    When I press enter
-    And I wait for the current stdout line to contain "What is your Bugsnag build endpoint?"
-    When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
     Then I wait for the shell to output a line containing "@bugsnag/source-maps dependency is installed" to stdout
@@ -200,6 +196,8 @@ Scenario: opt not to modify either project
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
     When I input "n" interactively
     And I wait for the shell to output the following to stdout

--- a/test/react-native-cli/features/configure.feature
+++ b/test/react-native-cli/features/configure.feature
@@ -30,12 +30,10 @@ Scenario: no git repo, run anyway
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I press enter
     Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
     When I input "abcdefabcdefabcdefabcdef12345678" interactively
-    Then I wait for the current stdout line to contain "What is your Bugsnag notify endpoint?"
-    When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag sessions endpoint?"
-    When I press enter
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout
     And the last interactive command exited successfully
@@ -57,6 +55,8 @@ Scenario: no git repo, run anyway, invalid API key
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "y" interactively
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I press enter
     Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
     When I press enter
     Then I wait for the current stdout line to contain "API key is required. You can find it by going to https://app.bugsnag.com/settings/ > Projects"
@@ -64,10 +64,6 @@ Scenario: no git repo, run anyway, invalid API key
     Then I wait for the current stdout line to contain "API key is required. You can find it by going to https://app.bugsnag.com/settings/ > Projects"
     # Enter the last 28 characters of the API key as the previous input ("abcd") is still present
     When I input "efabcdefabcdefabcdef12345678" interactively
-    Then I wait for the current stdout line to contain "What is your Bugsnag notify endpoint?"
-    When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag sessions endpoint?"
-    When I press enter
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout
     And the last interactive command exited successfully
@@ -86,12 +82,10 @@ Scenario: git repo, run
     And I wait for the shell to output "review the diff and commit them to your project." to stdout
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I press enter
     Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
     When I input "abcdefabcdefabcdefabcdef12345678" interactively
-    Then I wait for the current stdout line to contain "What is your Bugsnag notify endpoint?"
-    When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag sessions endpoint?"
-    When I press enter
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout
     And the last interactive command exited successfully
@@ -128,12 +122,14 @@ Scenario: custom endpoints
     And I wait for the shell to output "review the diff and commit them to your project." to stdout
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
-    When I input "abcdefabcdefabcdefabcdef12345678" interactively
+    And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
+    When I input "y" interactively
     Then I wait for the current stdout line to contain "What is your Bugsnag notify endpoint?"
     When I input "https://notify.example.com" interactively
     Then I wait for the current stdout line to contain "What is your Bugsnag sessions endpoint?"
     When I input "https://sessions.example.com" interactively
+    Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
+    When I input "abcdefabcdefabcdefabcdef12345678" interactively
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout
     And the last interactive command exited successfully

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -11,6 +11,21 @@ spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
 expect "Do you want to continue anyway?"
 send -- "Y\r"
 
+expect "Are you using Bugsnag on-premise?"
+send -- "Y\r"
+
+expect "What is your Bugsnag notify endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag sessions endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag upload endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag build endpoint?"
+send -- http://bs-local.com:9339\r
+
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- $notifierVersion\r
 
@@ -21,12 +36,6 @@ send -- 5.5.0-alpha01\r
 # TODO: Use the usual 123123... test API key
 expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
-
-expect "What is your Bugsnag notify endpoint?"
-send -- http://bs-local.com:9339\r
-
-expect "What is your Bugsnag sessions endpoint?"
-send -- http://bs-local.com:9339\r
 
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
 send -- n

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -11,6 +11,21 @@ spawn ./node_modules/bugsnag-react-native-cli/bin/cli init
 expect "Do you want to continue anyway?"
 send -- "Y\r"
 
+expect "Are you using Bugsnag on-premise?"
+send -- "Y\r"
+
+expect "What is your Bugsnag notify endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag sessions endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag upload endpoint?"
+send -- http://bs-local.com:9339\r
+
+expect "What is your Bugsnag build endpoint?"
+send -- http://bs-local.com:9339\r
+
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- $notifierVersion\r
 
@@ -21,12 +36,6 @@ send -- 5.5.0-alpha01\r
 # TODO: Use the usual 123123... test API key
 expect "What is your Bugsnag API key?"
 send -- b161f2dbabe3204527bbe5ed4b9334a4\r
-
-expect "What is your Bugsnag notify endpoint?"
-send -- http://bs-local.com:9339\r
-
-expect "What is your Bugsnag sessions endpoint?"
-send -- http://bs-local.com:9339\r
 
 expect "Do you want to automatically upload source maps as part of the Xcode build?"
 send -- n


### PR DESCRIPTION
## Goal

Changes the way we ask for on-premise URLs; there is now an initial "Are you using Bugsnag on-premise?" question and URLs are requested only if the user answers "yes"

We still only ask for the URLs that are required for the command that is running; `notify` & `session` for `configure`, `upload` & `build` for `automate-symbolication` and all four for `init`