### PR TITLE
Remove testing on Opera 12

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -174,19 +174,6 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack'
 
-  - label: ':desktop_computer: Opera v12 Browser tests'
-    depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
-    plugins:
-      docker-compose#v3.7.0:
-        run: browser-maze-runner
-        use-aliases: true
-        verbose: true
-    env:
-      BROWSER: "opera_12"
-    concurrency: 5
-    concurrency_group: 'browserstack'
-
   - label: ':iphone: iOS 10.3 Browser tests'
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 20

--- a/test/browser/features/browsers.yml
+++ b/test/browser/features/browsers.yml
@@ -54,12 +54,6 @@ safari_13:
   os: "OS X"
   os_version: "Catalina"
 
-opera_12:
-  browser: "opera"
-  browser_version: "12.16"
-  os: "windows"
-  os_version: "8"
-
 iphone_7:
   browser: "iphone"
   device: "iPhone 7"

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -229,28 +229,6 @@ safari_13:
     lineNumber: 17
     columnNumber: 25
 
-opera_12:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'Undefined variable: foo'
-  unhandled_syntax:
-    errorClass: 'Error'
-    errorMessage: "Syntax error at line 17 while loading: expected ';', got '!'"
-    lineNumber: 17
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "Uncaught exception: Error: bad things"
-    lineNumber: 17
-  unhandled_undefined_function:
-    errorClass: 'Error'
-    errorMessage: "Uncaught exception: ReferenceError: Undefined variable: nevergoingtoexist_notinamillionyears"
-    lineNumber: 17
-  unhandled_malformed_uri:
-    errorClass: 'Error'
-    errorMessage: "Uncaught exception: URIError: Malformed URI"
-    lineNumber: 17
-
 iphone_7:
   handled:
     errorClass: 'ReferenceError'


### PR DESCRIPTION
## Goal

Opera 12 is currently broken due to certificate issues with a CDN that we use in tests. This is an extremely old browser and we don't technically guarantee support for it anyway — the only reason we test on it is because it's the only supported version that Browserstack/Selenium can test with