### PR TITLE
RN CLI: Move BAGP apply below react.gradle apply

### DIFF
--- a/packages/react-native-cli/src/lib/Gradle.ts
+++ b/packages/react-native-cli/src/lib/Gradle.ts
@@ -56,7 +56,7 @@ export async function modifyAppBuildGradle (projectRoot: string, logger: Logger)
   try {
     await insertValueAfterPattern(
       appBuildGradlePath,
-      /apply plugin: ["']com\.android\.application["']/,
+      /^apply from: ["']\.\.\/\.\.\/node_modules\/react-native\/react\.gradle["']$/m,
       GRADLE_PLUGIN_APPLY,
       GRADLE_PLUGIN_APPLY_REGEX,
       logger

--- a/packages/react-native-cli/src/lib/__test__/fixtures/app-build-after.gradle
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/app-build-after.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "com.bugsnag.android.gradle"
 
 import com.android.build.OutputFile
 
@@ -83,6 +82,7 @@ project.ext.react = [
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
+apply plugin: "com.bugsnag.android.gradle"
 
 /**
  * Set this to true to create two separate APKs instead of one:

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -32,7 +32,7 @@ module.exports = {
 
     // Native layer
     common.changeDir(`${destFixtures}/${rnVersion}/android`)
-    common.run('./gradlew assembleRelease', true)
+    common.run('./gradlew assembleRelease --stacktrace --info', true)
 
     // Finally, copy the APK back to the host
     fs.copyFileSync(`${destFixtures}/${rnVersion}/android/app/build/outputs/apk/release/app-release.apk`,

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -44,10 +44,9 @@ expect "This will enable you to see full native stacktraces. It can't be done au
 send -- \r
 
 expect "Do you want to automatically upload source maps as part of the Gradle build?"
-send -- n
+send -- y
 
-# TODO: Disable source map uploads for now
-#expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
-#send -- latest\r
+expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
+send -- latest\r
 
 expect eof


### PR DESCRIPTION
## Goal

The previous order meant BAGP couldn't detect that it was running in a React Native project. It must be applied after react.gradle for this to work properly

This also allows us to enable source map uploads in the APK build on CI (which is part of this PR)