### PR TITLE
Expo SDK 40 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (expo): Add support for Expo SDK v40 [#1219](https://github.com/bugsnag/bugsnag-js/pull/1219)
+
 ## v7.5.5 (2020-12-14)
 
 ### Changed

--- a/packages/delivery-expo/package-lock.json
+++ b/packages/delivery-expo/package-lock.json
@@ -5,19 +5,19 @@
 	"requires": true,
 	"dependencies": {
 		"@react-native-community/netinfo": {
-			"version": "5.9.6",
-			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.6.tgz",
-			"integrity": "sha512-cEkA1Apg8+VjnDdeDZRHI+2RqouiPKgYnewouRkvF4ettH9ZS4Cmi/nANQKIpIu2L+czboxM3fCZ44nc7IM9VQ=="
+			"version": "5.9.7",
+			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.7.tgz",
+			"integrity": "sha512-NAkkT68oF+M9o6El2xeUqZK7magPjG/tAcEbvCbqyhlh3yElKWnI1e1vpbVvFXzTefy67FwYFWOJqBN6U7Mnkg=="
 		},
 		"expo-crypto": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-8.3.0.tgz",
-			"integrity": "sha512-PbfxihKJsAkAy5M6jfv5Eiv9pRHU1BjBa7jLcwKDH6aUiWiJNjUvfdwku/Odt/lpXDuNcyDASy4WrD/PZDHtLA=="
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-8.4.0.tgz",
+			"integrity": "sha512-EHEFx5sHTDVIuQH8/juuecQWj1uQ7ClM98fKXPFcNYcBlYSCQvkik37hwfJC5WLcVnelFDpvZJmHxiTfB5GKCg=="
 		},
 		"expo-file-system": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-9.2.0.tgz",
-			"integrity": "sha512-GsDf+E6e1WyYqyUiXbcWthLk7oVO+WDticnHUGAzb17hVCgxJhlUbRriwY3kBkQAX1mr+Hq9lkgJPIRbV197Fw==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-9.3.0.tgz",
+			"integrity": "sha512-x83IVep6PVfzGLpzR5fhWgKGlDaF95vfRzvmLyOMnbSuM8gY9a8C92taxZxfitryy9+D46lbRcnxPvBqFkXMNg==",
 			"requires": {
 				"uuid": "^3.4.0"
 			}

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -17,9 +17,9 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@react-native-community/netinfo": "5.9.6",
-    "expo-crypto": "~8.3.0",
-    "expo-file-system": "~9.2"
+    "@react-native-community/netinfo": "5.9.7",
+    "expo-crypto": "~8.4.0",
+    "expo-file-system": "~9.3.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.5.4"

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -59,6 +59,7 @@ const selectVersion = async (dir) => {
     const isPre37 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '37.0.0'))
     const isPre38 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '38.0.0'))
     const isPre39 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '39.0.0'))
+    const isPre40 = (expoVersion && !semver.gte(semver.minVersion(expoVersion), '40.0.0'))
 
     if (isPre33) {
       throw new Error('Expo SDK <33 is no longer supported')
@@ -74,6 +75,9 @@ const selectVersion = async (dir) => {
     } else if (isPre39) {
       message = 'It looks like you’re using a version of Expo SDK <39. The last version of Bugsnag that supported your version of Expo is v7.3.5'
       defaultVersion = '7.3.5'
+    } else if (isPre40) {
+      message = 'It looks like you’re using a version of Expo SDK <40. The last version of Bugsnag that supported your version of Expo is v7.6.0'
+      defaultVersion = '7.6.0'
     }
 
     const { version } = await prompts({

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -76,8 +76,8 @@ const selectVersion = async (dir) => {
       message = 'It looks like you’re using a version of Expo SDK <39. The last version of Bugsnag that supported your version of Expo is v7.3.5'
       defaultVersion = '7.3.5'
     } else if (isPre40) {
-      message = 'It looks like you’re using a version of Expo SDK <40. The last version of Bugsnag that supported your version of Expo is v7.6.0'
-      defaultVersion = '7.6.0'
+      message = 'It looks like you’re using a version of Expo SDK <40. The last version of Bugsnag that supported your version of Expo is v7.5.5'
+      defaultVersion = '7.5.5'
     }
 
     const { version } = await prompts({

--- a/packages/expo/CONTRIBUTING.md
+++ b/packages/expo/CONTRIBUTING.md
@@ -8,11 +8,11 @@ When a new version of the Expo SDK is released, the dependencies we use must be 
 
 The following modules are currently used:
 
+- `@react-native-community/netinfo` (`@bugsnag/delivery-expo`)
 - `expo-constants` (`@bugsnag/expo`, `@bugsnag/plugin-expo-app`, `@bugsnag/plugin-expo-device`)
-- `expo-file-system`, `@react-native-community/netinfo` (`@bugsnag/delivery-expo`)
-- `expo-constants` (`@bugsnag/plugin-expo-app`)
-- `expo-device` (`@bugsnag/plugin-expo-device`)
 - `expo-crypto` (`@bugsnag/expo`, `@bugsnag/delivery-expo`)
+- `expo-device` (`@bugsnag/plugin-expo-device`)
+- `expo-file-system` (`@bugsnag/delivery-expo`)
 
 If you add a new dependency please add it to this list.
 
@@ -20,10 +20,8 @@ To check what native module versions are bundled with Expo, check this file:
 
 https://github.com/expo/expo/blob/master/packages/expo/bundledNativeModules.json
 
-To check what JS-only module versions are depended on by Expo, check this file:
-
-https://github.com/expo/expo/blob/master/changelogVersions.json
-
 ## Updating the CLI to install a compatible notifier version
 
 When the version of the bundled native modules changes the notifier will be incompatible with previous Expo SDKs. To prevent installing the conflicting versions, we need to update the CLI using the established pattern in [`packages/expo-cli/commands/install.js`](../expo-cli/commands/install.js).
+
+This should also be added to [the manual setup docs](https://docs.bugsnag.com/platforms/react-native/expo/manual-setup/#installation).

--- a/packages/expo/package-lock.json
+++ b/packages/expo/package-lock.json
@@ -12,10 +12,257 @@
 				"@babel/highlight": "^7.10.4"
 			}
 		},
+		"@babel/compat-data": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
+		},
+		"@babel/core": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+			"requires": {
+				"@babel/types": "^7.12.11",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
+			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+			"requires": {
+				"@babel/compat-data": "^7.12.5",
+				"@babel/helper-validator-option": "^7.12.1",
+				"browserslist": "^4.14.5",
+				"semver": "^5.5.0"
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+			"integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"regexpu-core": "^4.7.1"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+			"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+			"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+			"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.12.10",
+				"@babel/template": "^7.12.7",
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+			"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+			"requires": {
+				"@babel/types": "^7.12.7"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"requires": {
+				"@babel/types": "^7.12.5"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+			"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-wrap-function": "^7.10.4",
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.12.7",
+				"@babel/helper-optimise-call-expression": "^7.12.10",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+			"requires": {
+				"@babel/types": "^7.12.11"
+			}
+		},
 		"@babel/helper-validator-identifier": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
 			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+			"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
+			}
 		},
 		"@babel/highlight": {
 			"version": "7.10.4",
@@ -31,6 +278,672 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1",
+				"@babel/plugin-syntax-async-generators": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-export-namespace-from": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+			"integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-logical-assignment-operators": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+			"integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+			"integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+			"integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-transform-parameters": "^7.12.1"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+			"integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+			"integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-private-methods": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+			"integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+			"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-export-namespace-from": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
+			"integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+			"integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+			"integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
+			"integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+			"integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-define-map": "^7.10.4",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+			"integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+			"integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+			"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+			"integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+			"integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+			"integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+			"integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+			"integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+			"integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-simple-access": "^7.12.1",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+			"integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+			"integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+			"integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+			"integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
+			"requires": {
+				"regenerator-transform": "^0.14.2"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+			"integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+			"integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+			"integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+			"integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+			"integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz",
+			"integrity": "sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-typescript": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+			"integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+			"integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
+			"requires": {
+				"@babel/compat-data": "^7.12.7",
+				"@babel/helper-compilation-targets": "^7.12.5",
+				"@babel/helper-module-imports": "^7.12.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.11",
+				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+				"@babel/plugin-proposal-class-properties": "^7.12.1",
+				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+				"@babel/plugin-proposal-json-strings": "^7.12.1",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.7",
+				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.7",
+				"@babel/plugin-proposal-private-methods": "^7.12.1",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-class-properties": "^7.12.1",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.12.1",
+				"@babel/plugin-transform-arrow-functions": "^7.12.1",
+				"@babel/plugin-transform-async-to-generator": "^7.12.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.11",
+				"@babel/plugin-transform-classes": "^7.12.1",
+				"@babel/plugin-transform-computed-properties": "^7.12.1",
+				"@babel/plugin-transform-destructuring": "^7.12.1",
+				"@babel/plugin-transform-dotall-regex": "^7.12.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.12.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+				"@babel/plugin-transform-for-of": "^7.12.1",
+				"@babel/plugin-transform-function-name": "^7.12.1",
+				"@babel/plugin-transform-literals": "^7.12.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.12.1",
+				"@babel/plugin-transform-modules-amd": "^7.12.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.12.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.12.1",
+				"@babel/plugin-transform-modules-umd": "^7.12.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+				"@babel/plugin-transform-new-target": "^7.12.1",
+				"@babel/plugin-transform-object-super": "^7.12.1",
+				"@babel/plugin-transform-parameters": "^7.12.1",
+				"@babel/plugin-transform-property-literals": "^7.12.1",
+				"@babel/plugin-transform-regenerator": "^7.12.1",
+				"@babel/plugin-transform-reserved-words": "^7.12.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.12.1",
+				"@babel/plugin-transform-spread": "^7.12.1",
+				"@babel/plugin-transform-sticky-regex": "^7.12.7",
+				"@babel/plugin-transform-template-literals": "^7.12.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.10",
+				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
+				"@babel/plugin-transform-unicode-regex": "^7.12.1",
+				"@babel/preset-modules": "^0.1.3",
+				"@babel/types": "^7.12.11",
+				"core-js-compat": "^3.8.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"@babel/preset-modules": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"esutils": "^2.0.2"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz",
+			"integrity": "sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.1",
+				"@babel/plugin-transform-typescript": "^7.12.1"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/template": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
+			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.12.10",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.12.10",
+				"@babel/types": "^7.12.10",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/types": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 				}
 			}
 		},
@@ -67,6 +980,109 @@
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
 						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"@expo/babel-preset-cli": {
+			"version": "0.2.18",
+			"resolved": "https://registry.npmjs.org/@expo/babel-preset-cli/-/babel-preset-cli-0.2.18.tgz",
+			"integrity": "sha512-y2IZFynVtRxMQ4uxXYUnrnXZa+pvSH1R1aSUAfC6RsUb2UNOxC6zRehdLGSOyF4s9Wy+j3/CPm6fC0T5UJYoQg==",
+			"requires": {
+				"@babel/core": "^7.4.5",
+				"@babel/plugin-proposal-class-properties": "^7.4.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.7.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/preset-typescript": "^7.3.3"
+			}
+		},
+		"@expo/config": {
+			"version": "3.3.22",
+			"resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.22.tgz",
+			"integrity": "sha512-BzahndK+Uxsvzui1+9QiJXptjVPgbSCQ3saNVF4N3Wrxjyr0WXHNp3Gz3VAGkoHhoBlxZheslmiNoMwjG25xjw==",
+			"requires": {
+				"@babel/core": "7.9.0",
+				"@expo/babel-preset-cli": "0.2.18",
+				"@expo/config-types": "^40.0.0-beta.2",
+				"@expo/json-file": "8.2.25",
+				"find-up": "^5.0.0",
+				"fs-extra": "9.0.0",
+				"getenv": "0.7.0",
+				"glob": "7.1.6",
+				"require-from-string": "^2.0.2",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.1.3",
+				"slugify": "^1.3.4"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"semver": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"@expo/config-types": {
+			"version": "40.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-40.0.0-beta.2.tgz",
+			"integrity": "sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg=="
+		},
+		"@expo/json-file": {
+			"version": "8.2.25",
+			"resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.25.tgz",
+			"integrity": "sha512-KFX6grWVzttaDskq/NK8ByqFPgpDZGFnyeZVeecGoKx5kU61zuR7/xQM04OvN6BNXq3jTUst1TyS8fXEfJuscA==",
+			"requires": {
+				"@babel/code-frame": "~7.10.4",
+				"fs-extra": "9.0.0",
+				"json5": "^1.0.1",
+				"lodash": "^4.17.15",
+				"write-file-atomic": "^2.3.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
 					}
 				}
 			}
@@ -109,6 +1125,19 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -121,6 +1150,18 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"browserslist": {
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+			"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+			"requires": {
+				"caniuse-lite": "^1.0.30001165",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.621",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.67"
 			}
 		},
 		"buffer-from": {
@@ -274,6 +1315,20 @@
 				}
 			}
 		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
+			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001170",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
+			"integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA=="
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -296,6 +1351,11 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"colorette": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -360,10 +1420,34 @@
 			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
 			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
 		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
 		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+		},
+		"core-js-compat": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
+			"integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
+			"requires": {
+				"browserslist": "^4.15.0",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+				}
+			}
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -376,6 +1460,14 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"requires": {
 				"array-find-index": "^1.0.1"
+			}
+		},
+		"debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"requires": {
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -397,10 +1489,23 @@
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"electron-to-chromium": {
+			"version": "1.3.631",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.631.tgz",
+			"integrity": "sha512-mPEG/52142po0XK1jQkZtbMmp38MZtQ3JDFItYxV65WXyhxDYEQ54tP4rb93m0RbMlZqQ+4zBw2N7UumSgGfbA=="
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -426,16 +1531,27 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+		},
 		"expo-constants": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.2.0.tgz",
-			"integrity": "sha512-WKwiEMvBgPrEPEyZKm21UUB2KWQux9OCWf6ZDORLTln7kO3rsbaJEprfWUWTP7AxyaLMYfN+/0WFHjZc25SZWQ==",
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",
+			"integrity": "sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==",
 			"requires": {
+				"@expo/config": "^3.3.18",
 				"fbjs": "1.0.0",
 				"uuid": "^3.3.2"
 			}
@@ -538,10 +1654,53 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"fs-extra": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+			"integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+			"requires": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+				}
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+		},
+		"get-intrinsic": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"getenv": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/getenv/-/getenv-0.7.0.tgz",
+			"integrity": "sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4="
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -556,15 +1715,33 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-symbols": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -578,6 +1755,11 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -623,9 +1805,14 @@
 			}
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -636,6 +1823,30 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+				}
+			}
 		},
 		"lines-and-columns": {
 			"version": "1.1.6",
@@ -658,6 +1869,11 @@
 				}
 			}
 		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -678,6 +1894,14 @@
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
+			}
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
 			}
 		},
 		"map-obj": {
@@ -706,6 +1930,11 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
 		"minimist-options": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
@@ -715,6 +1944,11 @@
 				"is-plain-obj": "^1.1.0"
 			}
 		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -723,6 +1957,11 @@
 				"encoding": "^0.1.11",
 				"is-stream": "^1.0.1"
 			}
+		},
+		"node-releases": {
+			"version": "1.1.67",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -739,6 +1978,22 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+		},
+		"object.assign": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			}
 		},
 		"once": {
 			"version": "1.4.0",
@@ -897,6 +2152,70 @@
 			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
 			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
 		},
+		"regenerate": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+		},
+		"regenerate-unicode-properties": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+			"integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+		},
+		"regenerator-transform": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+			"requires": {
+				"@babel/runtime": "^7.8.4"
+			}
+		},
+		"regexpu-core": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.2.0",
+				"regjsgen": "^0.5.1",
+				"regjsparser": "^0.6.4",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.2.0"
+			}
+		},
+		"regjsgen": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+		},
+		"regjsparser": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+		},
 		"resolve": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -904,6 +2223,11 @@
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
+		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 		},
 		"run-parallel": {
 			"version": "1.1.9",
@@ -934,6 +2258,16 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slugify": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
+			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -1019,6 +2353,11 @@
 				"xtend": "~4.0.1"
 			}
 		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
 		"type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -1035,9 +2374,38 @@
 			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
 		},
 		"ua-parser-js": {
-			"version": "0.7.22",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+			"version": "0.7.23",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+			"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+		},
+		"universalify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -1045,9 +2413,9 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -1059,9 +2427,9 @@
 			}
 		},
 		"whatwg-fetch": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-			"integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+			"integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
 		},
 		"wordwrapjs": {
 			"version": "4.0.0",
@@ -1084,10 +2452,30 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
+		"write-file-atomic": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+			"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
 		}
 	}
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -47,7 +47,7 @@
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.5.4",
     "@bugsnag/source-maps": "^1.0.1",
     "bugsnag-build-reporter": "^1.0.1",
-    "expo-constants": "~9.2"
+    "expo-constants": "~9.3.3"
   },
   "peerDependencies": {
     "expo": ">=33.0.0",

--- a/packages/plugin-expo-app/package-lock.json
+++ b/packages/plugin-expo-app/package-lock.json
@@ -4,15 +4,1172 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+			"requires": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
+		},
+		"@babel/core": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+			"requires": {
+				"@babel/types": "^7.12.11",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
+			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+			"requires": {
+				"@babel/compat-data": "^7.12.5",
+				"@babel/helper-validator-option": "^7.12.1",
+				"browserslist": "^4.14.5",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+			"integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"regexpu-core": "^4.7.1"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+			"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+			"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+			"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.12.10",
+				"@babel/template": "^7.12.7",
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+			"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+			"requires": {
+				"@babel/types": "^7.12.7"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"requires": {
+				"@babel/types": "^7.12.5"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+			"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-wrap-function": "^7.10.4",
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.12.7",
+				"@babel/helper-optimise-call-expression": "^7.12.10",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+			"requires": {
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+			"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1",
+				"@babel/plugin-syntax-async-generators": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-export-namespace-from": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+			"integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-logical-assignment-operators": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+			"integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+			"integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+			"integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-transform-parameters": "^7.12.1"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+			"integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+			"integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-private-methods": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+			"integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+			"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-export-namespace-from": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
+			"integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+			"integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+			"integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
+			"integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+			"integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-define-map": "^7.10.4",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+			"integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+			"integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+			"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+			"integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+			"integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+			"integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+			"integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+			"integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+			"integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-simple-access": "^7.12.1",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+			"integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+			"integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+			"integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+			"integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
+			"requires": {
+				"regenerator-transform": "^0.14.2"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+			"integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+			"integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+			"integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+			"integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+			"integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz",
+			"integrity": "sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-typescript": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+			"integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+			"integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
+			"requires": {
+				"@babel/compat-data": "^7.12.7",
+				"@babel/helper-compilation-targets": "^7.12.5",
+				"@babel/helper-module-imports": "^7.12.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.11",
+				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+				"@babel/plugin-proposal-class-properties": "^7.12.1",
+				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+				"@babel/plugin-proposal-json-strings": "^7.12.1",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.7",
+				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.7",
+				"@babel/plugin-proposal-private-methods": "^7.12.1",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-class-properties": "^7.12.1",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.12.1",
+				"@babel/plugin-transform-arrow-functions": "^7.12.1",
+				"@babel/plugin-transform-async-to-generator": "^7.12.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.11",
+				"@babel/plugin-transform-classes": "^7.12.1",
+				"@babel/plugin-transform-computed-properties": "^7.12.1",
+				"@babel/plugin-transform-destructuring": "^7.12.1",
+				"@babel/plugin-transform-dotall-regex": "^7.12.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.12.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+				"@babel/plugin-transform-for-of": "^7.12.1",
+				"@babel/plugin-transform-function-name": "^7.12.1",
+				"@babel/plugin-transform-literals": "^7.12.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.12.1",
+				"@babel/plugin-transform-modules-amd": "^7.12.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.12.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.12.1",
+				"@babel/plugin-transform-modules-umd": "^7.12.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+				"@babel/plugin-transform-new-target": "^7.12.1",
+				"@babel/plugin-transform-object-super": "^7.12.1",
+				"@babel/plugin-transform-parameters": "^7.12.1",
+				"@babel/plugin-transform-property-literals": "^7.12.1",
+				"@babel/plugin-transform-regenerator": "^7.12.1",
+				"@babel/plugin-transform-reserved-words": "^7.12.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.12.1",
+				"@babel/plugin-transform-spread": "^7.12.1",
+				"@babel/plugin-transform-sticky-regex": "^7.12.7",
+				"@babel/plugin-transform-template-literals": "^7.12.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.10",
+				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
+				"@babel/plugin-transform-unicode-regex": "^7.12.1",
+				"@babel/preset-modules": "^0.1.3",
+				"@babel/types": "^7.12.11",
+				"core-js-compat": "^3.8.0",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/preset-modules": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"esutils": "^2.0.2"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz",
+			"integrity": "sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.1",
+				"@babel/plugin-transform-typescript": "^7.12.1"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/template": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
+			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.12.10",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.12.10",
+				"@babel/types": "^7.12.10",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/types": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@expo/babel-preset-cli": {
+			"version": "0.2.18",
+			"resolved": "https://registry.npmjs.org/@expo/babel-preset-cli/-/babel-preset-cli-0.2.18.tgz",
+			"integrity": "sha512-y2IZFynVtRxMQ4uxXYUnrnXZa+pvSH1R1aSUAfC6RsUb2UNOxC6zRehdLGSOyF4s9Wy+j3/CPm6fC0T5UJYoQg==",
+			"requires": {
+				"@babel/core": "^7.4.5",
+				"@babel/plugin-proposal-class-properties": "^7.4.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.7.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/preset-typescript": "^7.3.3"
+			}
+		},
+		"@expo/config": {
+			"version": "3.3.22",
+			"resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.22.tgz",
+			"integrity": "sha512-BzahndK+Uxsvzui1+9QiJXptjVPgbSCQ3saNVF4N3Wrxjyr0WXHNp3Gz3VAGkoHhoBlxZheslmiNoMwjG25xjw==",
+			"requires": {
+				"@babel/core": "7.9.0",
+				"@expo/babel-preset-cli": "0.2.18",
+				"@expo/config-types": "^40.0.0-beta.2",
+				"@expo/json-file": "8.2.25",
+				"find-up": "^5.0.0",
+				"fs-extra": "9.0.0",
+				"getenv": "0.7.0",
+				"glob": "7.1.6",
+				"require-from-string": "^2.0.2",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.1.3",
+				"slugify": "^1.3.4"
+			}
+		},
+		"@expo/config-types": {
+			"version": "40.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-40.0.0-beta.2.tgz",
+			"integrity": "sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg=="
+		},
+		"@expo/json-file": {
+			"version": "8.2.25",
+			"resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.25.tgz",
+			"integrity": "sha512-KFX6grWVzttaDskq/NK8ByqFPgpDZGFnyeZVeecGoKx5kU61zuR7/xQM04OvN6BNXq3jTUst1TyS8fXEfJuscA==",
+			"requires": {
+				"@babel/code-frame": "~7.10.4",
+				"fs-extra": "9.0.0",
+				"json5": "^1.0.1",
+				"lodash": "^4.17.15",
+				"write-file-atomic": "^2.3.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browserslist": {
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+			"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+			"requires": {
+				"caniuse-lite": "^1.0.30001165",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.621",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.67"
+			}
+		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
+			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001170",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
+			"integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA=="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"colorette": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
 		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+		},
+		"core-js-compat": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
+			"integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
+			"requires": {
+				"browserslist": "^4.15.0",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+				}
+			}
+		},
+		"debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"electron-to-chromium": {
+			"version": "1.3.631",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.631.tgz",
+			"integrity": "sha512-mPEG/52142po0XK1jQkZtbMmp38MZtQ3JDFItYxV65WXyhxDYEQ54tP4rb93m0RbMlZqQ+4zBw2N7UumSgGfbA=="
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -22,11 +1179,27 @@
 				"iconv-lite": "^0.6.2"
 			}
 		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+		},
 		"expo-constants": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.2.0.tgz",
-			"integrity": "sha512-WKwiEMvBgPrEPEyZKm21UUB2KWQux9OCWf6ZDORLTln7kO3rsbaJEprfWUWTP7AxyaLMYfN+/0WFHjZc25SZWQ==",
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",
+			"integrity": "sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==",
 			"requires": {
+				"@expo/config": "^3.3.18",
 				"fbjs": "1.0.0",
 				"uuid": "^3.3.2"
 			}
@@ -51,12 +1224,130 @@
 			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
 			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"fs-extra": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+			"integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+			"requires": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+		},
+		"get-intrinsic": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"getenv": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/getenv/-/getenv-0.7.0.tgz",
+			"integrity": "sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4="
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"graceful-fs": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-symbols": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+		},
 		"iconv-lite": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
 			"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-core-module": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"requires": {
+				"has": "^1.0.3"
 			}
 		},
 		"is-stream": {
@@ -74,9 +1365,51 @@
 			}
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+				}
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"requires": {
+				"p-locate": "^5.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -85,6 +1418,32 @@
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -95,10 +1454,70 @@
 				"is-stream": "^1.0.1"
 			}
 		},
+		"node-releases": {
+			"version": "1.1.67",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+		},
+		"object.assign": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"requires": {
+				"yocto-queue": "^0.1.0"
+			}
+		},
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -108,20 +1527,168 @@
 				"asap": "~2.0.3"
 			}
 		},
+		"regenerate": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+		},
+		"regenerate-unicode-properties": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+			"integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+		},
+		"regenerator-transform": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+			"requires": {
+				"@babel/runtime": "^7.8.4"
+			}
+		},
+		"regexpu-core": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.2.0",
+				"regjsgen": "^0.5.1",
+				"regjsparser": "^0.6.4",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.2.0"
+			}
+		},
+		"regjsgen": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+		},
+		"regjsparser": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+		},
+		"resolve": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+			"requires": {
+				"is-core-module": "^2.1.0",
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"semver": {
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+		},
+		"slugify": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
+			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
 		"ua-parser-js": {
-			"version": "0.7.22",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+			"version": "0.7.23",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+			"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+		},
+		"universalify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
 		},
 		"uuid": {
 			"version": "3.4.0",
@@ -129,9 +1696,34 @@
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"whatwg-fetch": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-			"integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+			"integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+			"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
 		}
 	}
 }

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -20,7 +20,7 @@
     "@bugsnag/core": "^7.5.4"
   },
   "dependencies": {
-    "expo-constants": "~9.2"
+    "expo-constants": "~9.3.3"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/packages/plugin-expo-device/package-lock.json
+++ b/packages/plugin-expo-device/package-lock.json
@@ -4,15 +4,1172 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+			"requires": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
+		},
+		"@babel/core": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+			"requires": {
+				"@babel/types": "^7.12.11",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
+			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+			"requires": {
+				"@babel/compat-data": "^7.12.5",
+				"@babel/helper-validator-option": "^7.12.1",
+				"browserslist": "^4.14.5",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+			"integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+			"integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"regexpu-core": "^4.7.1"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+			"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+			"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+			"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.12.10",
+				"@babel/template": "^7.12.7",
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+			"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+			"requires": {
+				"@babel/types": "^7.12.7"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"requires": {
+				"@babel/types": "^7.12.5"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+			"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+			"requires": {
+				"@babel/types": "^7.12.10"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-wrap-function": "^7.10.4",
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.12.7",
+				"@babel/helper-optimise-call-expression": "^7.12.10",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
+			"requires": {
+				"@babel/types": "^7.12.1"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+			"requires": {
+				"@babel/types": "^7.12.11"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+			"integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1",
+				"@babel/plugin-syntax-async-generators": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+			"integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+			"integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-export-namespace-from": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+			"integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+			"integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-logical-assignment-operators": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+			"integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+			"integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+			"integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-transform-parameters": "^7.12.1"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+			"integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+			"integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-private-methods": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+			"integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+			"integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-export-namespace-from": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+			"integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
+			"integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+			"integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+			"integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+			"integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
+			"integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+			"integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-define-map": "^7.10.4",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+			"integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+			"integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+			"integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+			"integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+			"integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+			"integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+			"integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
+			"requires": {
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+			"integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+			"integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+			"integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+			"integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-simple-access": "^7.12.1",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+			"integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"babel-plugin-dynamic-import-node": "^2.3.3"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+			"integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+			"integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+			"integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+			"integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+			"integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+			"integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+			"integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
+			"requires": {
+				"regenerator-transform": "^0.14.2"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+			"integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+			"integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+			"integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+			"integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+			"integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+			"integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz",
+			"integrity": "sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-typescript": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+			"integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+			"integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.1",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
+			"requires": {
+				"@babel/compat-data": "^7.12.7",
+				"@babel/helper-compilation-targets": "^7.12.5",
+				"@babel/helper-module-imports": "^7.12.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.11",
+				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+				"@babel/plugin-proposal-class-properties": "^7.12.1",
+				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+				"@babel/plugin-proposal-json-strings": "^7.12.1",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.7",
+				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.7",
+				"@babel/plugin-proposal-private-methods": "^7.12.1",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-class-properties": "^7.12.1",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.12.1",
+				"@babel/plugin-transform-arrow-functions": "^7.12.1",
+				"@babel/plugin-transform-async-to-generator": "^7.12.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.11",
+				"@babel/plugin-transform-classes": "^7.12.1",
+				"@babel/plugin-transform-computed-properties": "^7.12.1",
+				"@babel/plugin-transform-destructuring": "^7.12.1",
+				"@babel/plugin-transform-dotall-regex": "^7.12.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.12.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+				"@babel/plugin-transform-for-of": "^7.12.1",
+				"@babel/plugin-transform-function-name": "^7.12.1",
+				"@babel/plugin-transform-literals": "^7.12.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.12.1",
+				"@babel/plugin-transform-modules-amd": "^7.12.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.12.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.12.1",
+				"@babel/plugin-transform-modules-umd": "^7.12.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+				"@babel/plugin-transform-new-target": "^7.12.1",
+				"@babel/plugin-transform-object-super": "^7.12.1",
+				"@babel/plugin-transform-parameters": "^7.12.1",
+				"@babel/plugin-transform-property-literals": "^7.12.1",
+				"@babel/plugin-transform-regenerator": "^7.12.1",
+				"@babel/plugin-transform-reserved-words": "^7.12.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.12.1",
+				"@babel/plugin-transform-spread": "^7.12.1",
+				"@babel/plugin-transform-sticky-regex": "^7.12.7",
+				"@babel/plugin-transform-template-literals": "^7.12.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.10",
+				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
+				"@babel/plugin-transform-unicode-regex": "^7.12.1",
+				"@babel/preset-modules": "^0.1.3",
+				"@babel/types": "^7.12.11",
+				"core-js-compat": "^3.8.0",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/preset-modules": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"esutils": "^2.0.2"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz",
+			"integrity": "sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-validator-option": "^7.12.1",
+				"@babel/plugin-transform-typescript": "^7.12.1"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/template": {
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.12.7",
+				"@babel/types": "^7.12.7"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
+			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.12.10",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.12.10",
+				"@babel/types": "^7.12.10",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/types": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@expo/babel-preset-cli": {
+			"version": "0.2.18",
+			"resolved": "https://registry.npmjs.org/@expo/babel-preset-cli/-/babel-preset-cli-0.2.18.tgz",
+			"integrity": "sha512-y2IZFynVtRxMQ4uxXYUnrnXZa+pvSH1R1aSUAfC6RsUb2UNOxC6zRehdLGSOyF4s9Wy+j3/CPm6fC0T5UJYoQg==",
+			"requires": {
+				"@babel/core": "^7.4.5",
+				"@babel/plugin-proposal-class-properties": "^7.4.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.7.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/preset-typescript": "^7.3.3"
+			}
+		},
+		"@expo/config": {
+			"version": "3.3.22",
+			"resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.22.tgz",
+			"integrity": "sha512-BzahndK+Uxsvzui1+9QiJXptjVPgbSCQ3saNVF4N3Wrxjyr0WXHNp3Gz3VAGkoHhoBlxZheslmiNoMwjG25xjw==",
+			"requires": {
+				"@babel/core": "7.9.0",
+				"@expo/babel-preset-cli": "0.2.18",
+				"@expo/config-types": "^40.0.0-beta.2",
+				"@expo/json-file": "8.2.25",
+				"find-up": "^5.0.0",
+				"fs-extra": "9.0.0",
+				"getenv": "0.7.0",
+				"glob": "7.1.6",
+				"require-from-string": "^2.0.2",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.1.3",
+				"slugify": "^1.3.4"
+			}
+		},
+		"@expo/config-types": {
+			"version": "40.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-40.0.0-beta.2.tgz",
+			"integrity": "sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg=="
+		},
+		"@expo/json-file": {
+			"version": "8.2.25",
+			"resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.25.tgz",
+			"integrity": "sha512-KFX6grWVzttaDskq/NK8ByqFPgpDZGFnyeZVeecGoKx5kU61zuR7/xQM04OvN6BNXq3jTUst1TyS8fXEfJuscA==",
+			"requires": {
+				"@babel/code-frame": "~7.10.4",
+				"fs-extra": "9.0.0",
+				"json5": "^1.0.1",
+				"lodash": "^4.17.15",
+				"write-file-atomic": "^2.3.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+			"integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browserslist": {
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+			"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+			"requires": {
+				"caniuse-lite": "^1.0.30001165",
+				"colorette": "^1.2.1",
+				"electron-to-chromium": "^1.3.621",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.67"
+			}
+		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
+			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001170",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
+			"integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA=="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"colorette": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
 		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+		},
+		"core-js-compat": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
+			"integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
+			"requires": {
+				"browserslist": "^4.15.0",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+				}
+			}
+		},
+		"debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"electron-to-chromium": {
+			"version": "1.3.631",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.631.tgz",
+			"integrity": "sha512-mPEG/52142po0XK1jQkZtbMmp38MZtQ3JDFItYxV65WXyhxDYEQ54tP4rb93m0RbMlZqQ+4zBw2N7UumSgGfbA=="
 		},
 		"encoding": {
 			"version": "0.1.13",
@@ -22,19 +1179,35 @@
 				"iconv-lite": "^0.6.2"
 			}
 		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+		},
 		"expo-constants": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.2.0.tgz",
-			"integrity": "sha512-WKwiEMvBgPrEPEyZKm21UUB2KWQux9OCWf6ZDORLTln7kO3rsbaJEprfWUWTP7AxyaLMYfN+/0WFHjZc25SZWQ==",
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",
+			"integrity": "sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==",
 			"requires": {
+				"@expo/config": "^3.3.18",
 				"fbjs": "1.0.0",
 				"uuid": "^3.3.2"
 			}
 		},
 		"expo-device": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/expo-device/-/expo-device-2.3.0.tgz",
-			"integrity": "sha512-nClXT+YocEaUGImiOGfdAkDP6T/3U8zeKsu3ZfQ0HzToTHjpv8ri+J6NzHkkoGCTXTjejU55IqZPyeSPrihLFg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/expo-device/-/expo-device-2.4.0.tgz",
+			"integrity": "sha512-mxBiX6nvvtbKot3Kmmb2y8lo4Ki8jWGdUnpC2OX70Yiy75c8mOVbHUe2VMEnx3SysXycwvC5KzJSDy+PuDqovg==",
 			"requires": {
 				"fbjs": "1.0.0",
 				"ua-parser-js": "^0.7.19"
@@ -60,12 +1233,130 @@
 			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
 			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"fs-extra": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+			"integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+			"requires": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+		},
+		"get-intrinsic": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"getenv": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/getenv/-/getenv-0.7.0.tgz",
+			"integrity": "sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4="
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"graceful-fs": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-symbols": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+		},
 		"iconv-lite": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
 			"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-core-module": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"requires": {
+				"has": "^1.0.3"
 			}
 		},
 		"is-stream": {
@@ -87,6 +1378,48 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+				}
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"requires": {
+				"p-locate": "^5.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -94,6 +1427,32 @@
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -104,10 +1463,70 @@
 				"is-stream": "^1.0.1"
 			}
 		},
+		"node-releases": {
+			"version": "1.1.67",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+		},
+		"object.assign": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"requires": {
+				"yocto-queue": "^0.1.0"
+			}
+		},
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -117,20 +1536,168 @@
 				"asap": "~2.0.3"
 			}
 		},
+		"regenerate": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+		},
+		"regenerate-unicode-properties": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+			"integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+		},
+		"regenerator-transform": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+			"requires": {
+				"@babel/runtime": "^7.8.4"
+			}
+		},
+		"regexpu-core": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.2.0",
+				"regjsgen": "^0.5.1",
+				"regjsparser": "^0.6.4",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.2.0"
+			}
+		},
+		"regjsgen": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+		},
+		"regjsparser": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+		},
+		"resolve": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+			"requires": {
+				"is-core-module": "^2.1.0",
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"semver": {
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+		},
+		"slugify": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.6.tgz",
+			"integrity": "sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
 		"ua-parser-js": {
-			"version": "0.7.22",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+			"version": "0.7.23",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+			"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+		},
+		"universalify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
 		},
 		"uuid": {
 			"version": "3.4.0",
@@ -138,9 +1705,34 @@
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"whatwg-fetch": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-			"integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+			"integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+			"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
 		}
 	}
 }

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -20,8 +20,8 @@
     "@bugsnag/core": "^7.5.4"
   },
   "dependencies": {
-    "expo-constants": "~9.2",
-    "expo-device": "~2.3"
+    "expo-constants": "~9.3.3",
+    "expo-device": "~2.4.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"


### PR DESCRIPTION
- Bump versions of Expo packages we rely on to match the ones required by Expo 40
- Add another version check to expo-cli — assuming we'll release the RN CLI first, otherwise this will need to change slightly