### PR TITLE
refactor(react-native-cli): Put package under @bugsnag npm org

### DIFF
--- a/dockerfiles/Dockerfile.react-native-cli-tool
+++ b/dockerfiles/Dockerfile.react-native-cli-tool
@@ -12,7 +12,7 @@ COPY packages ./packages
 
 RUN npm run bootstrap -- --concurrency 1
 
-RUN npx lerna run build --scope bugsnag-react-native-cli
+RUN npx lerna run build --scope @bugsnag/react-native-cli
 RUN npm pack --verbose packages/react-native-cli/
 
 # The maze-runner test image

--- a/packages/react-native-cli/README.md
+++ b/packages/react-native-cli/README.md
@@ -1,4 +1,4 @@
-# bugsnag-react-native-cli
+# @bugsnag/react-native-cli
 
 A tool to help integrate Bugsnag with a React Native app.
 

--- a/packages/react-native-cli/package-lock.json
+++ b/packages/react-native-cli/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "bugsnag-react-native-cli",
+	"name": "@bugsnag/react-native-cli",
 	"version": "7.6.0-rc.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/packages/react-native-cli/package.json
+++ b/packages/react-native-cli/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "bugsnag-react-native-cli",
+  "name": "@bugsnag/react-native-cli",
   "version": "7.6.0-rc.1",
   "description": "A tool to help integrate Bugsnag with a React Native app",
-  "bin": "bin/cli",
+  "bin": {
+    "bugsnag-react-native-cli": "bin/cli"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "clean": "rm -fr dist",
     "build": "npm run clean && tsc -p tsconfig.build.json",

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -25,7 +25,7 @@ module.exports = {
     common.run('npm install', true)
 
     // Install and run the CLI
-    const installCommand = `npm install bugsnag-react-native-cli@${version}`
+    const installCommand = `npm install @bugsnag/react-native-cli@${version}`
     common.run(installCommand, true)
 
     // Use Expect to run the init command interactively
@@ -58,7 +58,7 @@ module.exports = {
     common.run('npm install', true)
 
     // Install and run the CLI
-    const installCommand = `npm install bugsnag-react-native-cli@${version}`
+    const installCommand = `npm install @bugsnag/react-native-cli@${version}`
     common.run(installCommand, true)
 
     // Use Expect to run the init command interactively


### PR DESCRIPTION
Move package from top level `bugsnag-react-native-cli` to under the `@bugsnag` org as `@bugsnag/react-native-cli`. Keeps the same full executable name `bugsnag-react-native-cli`, in case it is installed rather than `npx`'d.