### PR TITLE
Enforce presence of Bugsnag-Integrity header for Expo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.5.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 1f471086782f0bc5d306b1ca87d81965d54518b8
-  tag: v3.5.0
+  revision: dfe41e657bbf40ad85661b193555bc59773302ba
+  tag: v3.7.0
   specs:
-    bugsnag-maze-runner (3.5.0)
+    bugsnag-maze-runner (3.7.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -23,10 +23,10 @@ GEM
       appium_lib_core (~> 3.3)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.11.0)
+    appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.18.2)
+    backports (3.20.1)
     builder (3.2.4)
     childprocess (3.0.0)
     cucumber (3.1.2)
@@ -52,21 +52,23 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (1.2.0)
+    racc (1.5.2)
     rake (12.3.3)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.6)
+    test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
     websocket-driver (0.7.3)

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -63,8 +63,8 @@ Before('@skip_if_local_storage_is_unavailable') do |scenario|
 end
 
 AfterConfiguration do
-  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
-  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
+  MazeRunner.config.receive_no_requests_wait = 15
+  MazeRunner.config.enforce_bugsnag_integrity = false
 
   # Necessary as Appium removes any existing $driver instance on load
   bs_local_start

--- a/test/expo/features/support/env.rb
+++ b/test/expo/features/support/env.rb
@@ -1,7 +1,5 @@
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
-  # TODO: Remove once the Bugsnag-Integrity header has been implemented
-  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
+  MazeRunner.config.receive_no_requests_wait = 15
 end
 
 Before('@skip_android_5') do |scenario|

--- a/test/node/features/support/env.rb
+++ b/test/node/features/support/env.rb
@@ -1,4 +1,4 @@
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 15 if MazeRunner.config.respond_to? :receive_no_requests_wait=
-  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
+  MazeRunner.config.receive_no_requests_wait = 15
+  MazeRunner.config.enforce_bugsnag_integrity = false
 end


### PR DESCRIPTION
## Goal

Enforce presence of the Bugsnag-Integrity header on all requests for Expo in end-to-end tests.

## Design

MazeRunner now enforces the presence of the header on all requests by default.  This change ensures that the check is not disabled inappropriately and also simplifies code put in place during the period of time that the enforced checks were added to Maze Runner.

## Changeset

MazeRunner config and version when running locally.

## Testing

Covered by CI.