### PR TITLE
Allow OnErrorCallbacks to return Promise<boolean>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (core): the `OnErrorCallback` type definition now allows `Promise<boolean>` as a return type. [#1224](https://github.com/bugsnag/bugsnag-js/pull/1224)
+
 ## v7.5.6 (2021-01-11)
 
 ### Changed
@@ -21,7 +27,6 @@
   - Add persistenceDirectory config option for controlling event/session storage [bugsnag-android#998](https://github.com/bugsnag/bugsnag-android/pull/998)
   - Add configuration option to control maximum number of persisted events/sessions [bugsnag-android#980](https://github.com/bugsnag/bugsnag-android/pull/980)
   - Increase kotlin dependency version to 1.3.72 [bugsnag-android#1050](https://github.com/bugsnag/bugsnag-android/pull/1050)
-
 
 ## v7.5.5 (2020-12-14)
 

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -214,6 +214,26 @@ describe('@bugsnag/core/client', () => {
     })
 
     // eslint-disable-next-line jest/expect-expect
+    it('supports preventing send by returning a Promise that resolves to false in onError callback', done => {
+      const client = new Client({
+        apiKey: 'API_KEY_YEAH',
+        onError: () => Promise.resolve(false)
+      })
+
+      client._setDelivery(client => ({
+        sendEvent: (payload) => {
+          done('sendEvent() should not be called')
+        },
+        sendSession: () => {}
+      }))
+
+      client.notify(new Error('oh em gee'), () => {}, () => {
+        // give the event loop a tick to see if the event gets sent
+        process.nextTick(() => done())
+      })
+    })
+
+    // eslint-disable-next-line jest/expect-expect
     it('supports preventing send by returning false in notify callback', done => {
       const client = new Client({ apiKey: 'API_KEY_YEAH' })
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -29,7 +29,7 @@ export interface Config {
   user?: User | null
 }
 
-export type OnErrorCallback = (event: Event, cb?: (err: null | Error, shouldSend?: boolean) => void) => void | boolean | Promise<void | boolean>
+export type OnErrorCallback = (event: Event, cb: (err: null | Error, shouldSend?: boolean) => void) => void | boolean | Promise<void | boolean>
 export type OnSessionCallback = (session: Session) => void | boolean;
 export type OnBreadcrumbCallback = (breadcrumb: Breadcrumb) => void | boolean;
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -29,7 +29,7 @@ export interface Config {
   user?: User | null
 }
 
-export type OnErrorCallback = (event: Event, cb?: (err: null | Error) => void) => void | Promise<void> | boolean;
+export type OnErrorCallback = (event: Event, cb?: (err: null | Error) => void) => void | boolean | Promise<void | boolean>;
 export type OnSessionCallback = (session: Session) => void | boolean;
 export type OnBreadcrumbCallback = (breadcrumb: Breadcrumb) => void | boolean;
 

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -29,7 +29,7 @@ export interface Config {
   user?: User | null
 }
 
-export type OnErrorCallback = (event: Event, cb?: (err: null | Error) => void) => void | boolean | Promise<void | boolean>;
+export type OnErrorCallback = (event: Event, cb?: (err: null | Error, shouldSend?: boolean) => void) => void | boolean | Promise<void | boolean>
 export type OnSessionCallback = (session: Session) => void | boolean;
 export type OnBreadcrumbCallback = (breadcrumb: Breadcrumb) => void | boolean;
 


### PR DESCRIPTION
## Goal

Currently an async `OnErrorCallback` can only return `Promise<void>` in the Typescript, which means they can't be used to prevent events from sending without causing a compile error. Returning/resolving a boolean value does work, so we can safely allow `Promise<boolean>` as a return type