### PR TITLE
RN CLI: Fix flakes in Maze Runner tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'cocoapods'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.4'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 7f5dca67f077020b67e92ea35c5ef0c9bd72b558
-  tag: v3.7.1
+  revision: 06d2a4d4e07fe78e67d94eb757ea85c2f8747533
+  tag: v3.7.4
   specs:
-    bugsnag-maze-runner (3.7.1)
+    bugsnag-maze-runner (3.7.4)
       appium_lib (~> 10.2)
+      boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -39,6 +40,7 @@ GEM
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
     backports (3.20.1)
+    boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     claide (1.0.3)

--- a/test/react-native-cli/features/cli-tests/automate-symbolication.feature
+++ b/test/react-native-cli/features/cli-tests/automate-symbolication.feature
@@ -212,6 +212,7 @@ Scenario: opt not to modify either project
     When I press enter
     And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
     When I input "n" interactively
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And bugsnag source maps library is not in the package.json file
     And the iOS build has not been modified to upload source maps

--- a/test/react-native-cli/features/cli-tests/configure.feature
+++ b/test/react-native-cli/features/cli-tests/configure.feature
@@ -11,6 +11,7 @@ Scenario: no git repo, do not run
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And the iOS app does not contain a bugsnag API key
     And the iOS app does not contain a bugsnag notify URL
@@ -105,6 +106,7 @@ Scenario: git repo, do not run
     And I wait for the shell to output "review the diff and commit them to your project." to stdout
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "n" interactively
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And the iOS app does not contain a bugsnag API key
     And the iOS app does not contain a bugsnag notify URL

--- a/test/react-native-cli/features/cli-tests/insert.feature
+++ b/test/react-native-cli/features/cli-tests/insert.feature
@@ -11,6 +11,7 @@ Scenario: no git repo, do not run
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And the iOS app does not contain the bugsnag initialisation code
     And the Android app does not contain the bugsnag initialisation code

--- a/test/react-native-cli/features/cli-tests/install.feature
+++ b/test/react-native-cli/features/cli-tests/install.feature
@@ -11,6 +11,7 @@ Scenario: no git repo, do not run
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And bugsnag react-native is not in the package.json file
     And the Bugsnag Android Gradle plugin is not installed
@@ -30,6 +31,7 @@ Scenario: dirty git repo, do not run
         """
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I press enter
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And bugsnag react-native is not in the package.json file
     And the Bugsnag Android Gradle plugin is not installed
@@ -43,6 +45,7 @@ Scenario: clean git repo, do not run
     And I wait for the shell to output "review the diff and commit them to your project." to stdout
     And I wait for the current stdout line to contain "Do you want to continue anyway?"
     When I input "n" interactively
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
     And bugsnag react-native is not in the package.json file
     And the Bugsnag Android Gradle plugin is not installed
@@ -106,5 +109,6 @@ Scenario: no git repo, run anyway, already installed
     Then I wait for the shell to output a line containing "@bugsnag/react-native is already installed, skipping" to stdout
     And I wait for the current stdout line to contain "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
     When I press enter
+    And I wait for the current stdout line to contain "/app #"
     And the last interactive command exited successfully
     And the Bugsnag Android Gradle plugin is installed

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -179,6 +179,7 @@ Then("the iOS build has been modified to upload source maps") do
 
   steps %Q{
     Then I input "./check-ios-build-script.sh" interactively
+    And I wait for the current stdout line to contain "/app #"
     And the last interactive command exited successfully
     And the file '#{filename}' contains 'Upload source maps to Bugsnag'
   }
@@ -189,6 +190,7 @@ Then("the iOS build has been modified to upload source maps to {string}") do |ex
 
   steps %Q{
     Then I input "./check-ios-build-script.sh #{expected_endpoint}" interactively
+    And I wait for the current stdout line to contain "/app #"
     And the last interactive command exited successfully
     And the file '#{filename}' contains 'Upload source maps to Bugsnag'
   }
@@ -261,6 +263,7 @@ end
 Then("the file {string} contains {string}") do |filename, expected|
   steps %Q{
     When I input "fgrep '#{expected.gsub(/"/, '\"')}' #{filename}" interactively
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited successfully
   }
 end
@@ -277,6 +280,7 @@ end
 Then("the file {string} does not contain {string}") do |filename, expected|
   steps %Q{
     When I input "fgrep '#{expected.gsub(/"/, '\"')}' #{filename}" interactively
+    And I wait for the current stdout line to contain "/app #"
     Then the last interactive command exited with an error code
   }
 end


### PR DESCRIPTION
## Goal

The RN CLI tests sometimes seem to get stuck while checking the last command exit code. It seems that it was trying to run the command to check the exit code while the previous command was running. Usually this works but sometimes it seems to never run the exit code command, so I've added waits to ensure the prompt is ready before trying to check the exit code

We also now strip ANSI escape codes from output which seems to help, though I'm not entirely sure why