### PR TITLE
RN CLI: Add a warning when the gradle file is applied

### DIFF
--- a/packages/react-native/bugsnag-react-native.gradle
+++ b/packages/react-native/bugsnag-react-native.gradle
@@ -5,3 +5,5 @@ allprojects {
         }
     }
 }
+
+logger.warn('[Bugsnag] "bugsnag-react-native.gradle" should not applied manually. Install the Bugsnag Android Gradle Plugin and remove this from your Gradle file.')


### PR DESCRIPTION
The BAGP automatically applies this repository, so this file is no longer necessary