### PR TITLE
RN CLI: messaging improvements

### DIFF
--- a/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
+++ b/packages/react-native-cli/src/commands/AutomateSymbolicationCommand.ts
@@ -19,7 +19,7 @@ export default async function run (projectRoot: string, urls: OnPremiseUrls): Pr
     const { iosIntegration } = await prompts({
       type: 'confirm',
       name: 'iosIntegration',
-      message: 'Do you want to automatically upload source maps as part of the Xcode build?',
+      message: 'Do you want to automatically upload JavaScript source maps as part of the Xcode build?',
       initial: true
     }, { onCancel })
 
@@ -38,7 +38,7 @@ export default async function run (projectRoot: string, urls: OnPremiseUrls): Pr
     const { androidIntegration } = await prompts({
       type: 'confirm',
       name: 'androidIntegration',
-      message: 'Do you want to automatically upload source maps as part of the Gradle build?',
+      message: 'Do you want to automatically upload JavaScript source maps as part of the Gradle build?',
       initial: true
     }, { onCancel })
 

--- a/packages/react-native-cli/src/commands/ConfigureCommand.ts
+++ b/packages/react-native-cli/src/commands/ConfigureCommand.ts
@@ -10,7 +10,7 @@ export default async function run (projectRoot: string, urls: OnPremiseUrls): Pr
     const { apiKey } = await prompts({
       type: 'text',
       name: 'apiKey',
-      message: 'What is your Bugsnag API key?',
+      message: 'What is your Bugsnag project API key?',
       validate: value => {
         return /[A-Fa-f0-9]{32}/.test(value)
           ? true

--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -10,7 +10,7 @@ export default async function run (argv: string[], projectRoot: string, opts: Re
     await installJavaScriptPackage(projectRoot)
     await addGradlePluginDependency(projectRoot)
 
-    logger.info('Installing cocoapods')
+    logger.info('Installing CocoaPods')
     await podInstall(projectRoot, logger)
     return true
   } catch (e) {

--- a/packages/react-native-cli/src/lib/Pod.ts
+++ b/packages/react-native-cli/src/lib/Pod.ts
@@ -40,6 +40,6 @@ export async function install (projectRoot: string, logger: Logger): Promise<voi
   }
 }
 
-const COCOAPODS_NOT_FOUND = `Cocoapods does not appear to be installed.
+const COCOAPODS_NOT_FOUND = `CocoaPods does not appear to be installed.
 
 Install it and run "pod install" inside the "ios" directory manaully.`

--- a/packages/react-native-cli/src/lib/__test__/Pod.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Pod.test.ts
@@ -88,7 +88,7 @@ test('install(): ENOENT error from cocoapods', async () => {
   await install('/example/dir', logger)
 
   expect(spawnMock).toHaveBeenCalledWith('pod', ['install'], { cwd: '/example/dir/ios', stdio: 'inherit' })
-  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Cocoapods does not appear to be installed.'))
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('CocoaPods does not appear to be installed.'))
 })
 
 test('install(): unknown child process error', async () => {

--- a/test/react-native-cli/features/cli-tests/automate-symbolication.feature
+++ b/test/react-native-cli/features/cli-tests/automate-symbolication.feature
@@ -13,7 +13,7 @@ Scenario: successfully modify project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -25,7 +25,7 @@ Scenario: successfully modify project
         """
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
     When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
@@ -49,7 +49,7 @@ Scenario: successfully modify project, choosing source-maps version
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -61,7 +61,7 @@ Scenario: successfully modify project, choosing source-maps version
         """
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
     When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I input "1.0.0-beta.1" interactively
@@ -89,7 +89,7 @@ Scenario: successfully modify project with custom endpoints
     When I input "https://upload.example.com" interactively
     And I wait for the current stdout line to contain "What is your Bugsnag build endpoint?"
     When I input "https://build.example.com" interactively
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -101,7 +101,7 @@ Scenario: successfully modify project with custom endpoints
         """
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
     When I press enter
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
@@ -126,7 +126,7 @@ Scenario: opt not to modify the Android project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
     When I press enter
     And I wait for the shell to output the following to stdout
         """
@@ -138,7 +138,7 @@ Scenario: opt not to modify the Android project
         """
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
     When I input "n" interactively
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
@@ -162,7 +162,7 @@ Scenario: opt not to modify the iOS project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
     When I input "n" interactively
     And I wait for the shell to output the following to stdout
         """
@@ -174,7 +174,7 @@ Scenario: opt not to modify the iOS project
         """
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
     When I input "y" interactively
     And I wait for the current stdout line to contain "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"
     When I press enter
@@ -198,7 +198,7 @@ Scenario: opt not to modify either project
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Xcode build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
     When I input "n" interactively
     And I wait for the shell to output the following to stdout
         """
@@ -210,7 +210,7 @@ Scenario: opt not to modify either project
         """
     And I wait for the current stdout line to contain "Hit enter to continue"
     When I press enter
-    And I wait for the current stdout line to contain "Do you want to automatically upload source maps as part of the Gradle build?"
+    And I wait for the current stdout line to contain "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
     When I input "n" interactively
     Then the last interactive command exited successfully
     And bugsnag source maps library is not in the package.json file

--- a/test/react-native-cli/features/cli-tests/configure.feature
+++ b/test/react-native-cli/features/cli-tests/configure.feature
@@ -32,7 +32,7 @@ Scenario: no git repo, run anyway
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
+    Then I wait for the current stdout line to contain "What is your Bugsnag project API key?"
     When I input "abcdefabcdefabcdefabcdef12345678" interactively
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout
@@ -57,7 +57,7 @@ Scenario: no git repo, run anyway, invalid API key
     When I input "y" interactively
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
+    Then I wait for the current stdout line to contain "What is your Bugsnag project API key?"
     When I press enter
     Then I wait for the current stdout line to contain "API key is required. You can find it by going to https://app.bugsnag.com/settings/ > Projects"
     When I input "abcd" interactively
@@ -84,7 +84,7 @@ Scenario: git repo, run
     When I press enter
     And I wait for the current stdout line to contain "Are you using Bugsnag on-premise?"
     When I press enter
-    Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
+    Then I wait for the current stdout line to contain "What is your Bugsnag project API key?"
     When I input "abcdefabcdefabcdefabcdef12345678" interactively
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout
@@ -128,7 +128,7 @@ Scenario: custom endpoints
     When I input "https://notify.example.com" interactively
     Then I wait for the current stdout line to contain "What is your Bugsnag sessions endpoint?"
     When I input "https://sessions.example.com" interactively
-    Then I wait for the current stdout line to contain "What is your Bugsnag API key?"
+    Then I wait for the current stdout line to contain "What is your Bugsnag project API key?"
     When I input "abcdefabcdefabcdefabcdef12345678" interactively
     Then I wait for the shell to output a line containing "Updated AndroidManifest.xml" to stdout
     And I wait for the shell to output a line containing "Updated Info.plist" to stdout

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -38,13 +38,13 @@ send -- 5.5.0-alpha01\r
 expect "What is your Bugsnag API key?"
 send -- 1234567890ABCDEF1234567890ABCDEF\r
 
-expect "Do you want to automatically upload source maps as part of the Xcode build?"
+expect "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
 send -- n
 
 expect "This will enable you to see full native stacktraces. It can't be done automatically."
 send -- \r
 
-expect "Do you want to automatically upload source maps as part of the Gradle build?"
+expect "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
 send -- y
 
 expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -35,7 +35,7 @@ send -- $notifierVersion\r
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
 send -- 5.5.0-alpha01\r
 
-expect "What is your Bugsnag API key?"
+expect "What is your Bugsnag project API key?"
 send -- 1234567890ABCDEF1234567890ABCDEF\r
 
 expect "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -38,13 +38,13 @@ send -- "5.5.0-alpha01\r"
 expect "What is your Bugsnag API key?"
 send -- "1234567890ABCDEF1234567890ABCDEF\r"
 
-expect "Do you want to automatically upload source maps as part of the Xcode build?"
+expect "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
 send -- y
 
 expect "This will enable you to see full native stacktraces. It can't be done automatically."
 send -- \r
 
-expect "Do you want to automatically upload source maps as part of the Gradle build?"
+expect "Do you want to automatically upload JavaScript source maps as part of the Gradle build?"
 send -- n
 
 expect "If you want the latest version of @bugsnag/source-maps hit enter, otherwise type the version you want"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -35,7 +35,7 @@ send -- $notifierVersion\r
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
 send -- "5.5.0-alpha01\r"
 
-expect "What is your Bugsnag API key?"
+expect "What is your Bugsnag project API key?"
 send -- "1234567890ABCDEF1234567890ABCDEF\r"
 
 expect "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"


### PR DESCRIPTION
## Goal

Improve some messaging in the RN CLI:

- Clarify API key prompt
- Specify "JavaScript" source maps
- Correct capitalisation of 'CocoaPods'