### PR TITLE
[PLAT-5467] fix(react-native): Ensure unhandled promise rejections are logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (react-native): Ensure unhandled promise warning is logged in development [#1235](https://github.com/bugsnag/bugsnag-js/pull/1235)
+
 ## v7.5.6 (2021-01-11)
 
 ### Changed

--- a/packages/plugin-react-native-unhandled-rejection/rejection-handler.js
+++ b/packages/plugin-react-native-unhandled-rejection/rejection-handler.js
@@ -2,6 +2,8 @@
 * Automatically notifies Bugsnag when an unhandled promise rejection happens in React Native
 */
 
+/* global __DEV__ */
+
 const rnPromise = require('promise/setimmediate/rejection-tracking')
 
 module.exports = {
@@ -16,8 +18,20 @@ module.exports = {
           severityReason: { type: 'unhandledPromiseRejection' }
         }, 'promise rejection tracking', 1)
         client._notify(event)
+        // adding our own onUnhandled callback means the default log message doesn't happen, so make it happen here
+        if (typeof __DEV__ !== 'undefined' && __DEV__) logError(id, error)
       }
     })
     return () => rnPromise.disable()
   }
+}
+
+// this function is copied in from the promise module, since it's not exported and we can't reference it:
+// https://github.com/then/promise/blob/91b7b4cb6ad0cacc1c70560677458fe0aac2fa67/src/rejection-tracking.js#L101-L107
+function logError (id, error) {
+  console.warn('Possible Unhandled Promise Rejection (id: ' + id + '):')
+  var errStr = (error && (error.stack || error)) + ''
+  errStr.split('\n').forEach(function (line) {
+    console.warn('  ' + line)
+  })
 }

--- a/packages/plugin-react-native-unhandled-rejection/test/rejection-handler.test.ts
+++ b/packages/plugin-react-native-unhandled-rejection/test/rejection-handler.test.ts
@@ -9,11 +9,13 @@ import RnPromise from 'promise/setimmediate'
 beforeEach(() => {
   // @ts-ignore
   global.__DEV__ = true
-  jest.spyOn(console, 'warn')
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
 })
 
 afterEach(() => {
   jest.restoreAllMocks()
+  // @ts-ignore
+  delete global.__DEV__
 })
 
 describe('plugin: react native rejection handler', () => {

--- a/packages/plugin-react-native-unhandled-rejection/test/rejection-handler.test.ts
+++ b/packages/plugin-react-native-unhandled-rejection/test/rejection-handler.test.ts
@@ -6,9 +6,19 @@ import Client from '@bugsnag/core/client'
 // @ts-ignore
 import RnPromise from 'promise/setimmediate'
 
+beforeEach(() => {
+  // @ts-ignore
+  global.__DEV__ = true
+  jest.spyOn(console, 'warn')
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
 describe('plugin: react native rejection handler', () => {
   it('should hook in to the promise rejection tracker', (done) => {
-    expect.assertions(4)
+    expect.assertions(5)
 
     const c = new Client({ apiKey: 'api_key' })
     c._setDelivery(client => ({
@@ -18,7 +28,10 @@ describe('plugin: react native rejection handler', () => {
         expect(r.events[0].severity).toBe('error')
         expect(r.events[0].severityReason).toEqual({ type: 'unhandledPromiseRejection' })
         expect(r.events[0].unhandled).toBe(true)
-        done()
+        setTimeout(() => {
+          expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Possible Unhandled Promise Rejection'))
+          done()
+        }, 0)
       },
       sendSession: () => {}
     }))

--- a/packages/react-native/src/test/integration/handled-unhandled.test.ts
+++ b/packages/react-native/src/test/integration/handled-unhandled.test.ts
@@ -55,6 +55,7 @@ declare global {
 // and doesn't have a way to uninstall itself
 beforeAll(() => {
   jest.spyOn(console, 'debug').mockImplementation(() => {})
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
 
   // leaving the default handler intact causes simulated unhandled errors to fail tests
   global.ErrorUtils.setGlobalHandler(() => {})


### PR DESCRIPTION
## Goal

When adding the `onUnhandled` event to the rejection tracker, it inadvertantly prevents the "possibly unhandled rejection" warning from displaying.

Fixes #1135.

## Design

Unfortunately there was no way to import or reference the original function, so it needed to be copied into this repo. The risk here is that it gets out of date with the original.

## Changeset

Added warning log that only gets printed in dev (as per the default).

## Testing

Unit tests were updated and manual tests were run.