### PR TITLE
Add tvOS to the @bugsnag/react-native podspec

### DIFF
--- a/packages/react-native/BugsnagReactNative.podspec
+++ b/packages/react-native/BugsnagReactNative.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/bugsnag/"
   s.license      = "MIT"
   s.author       = { "Bugsnag" => "platforms@bugsnag.com" }
-  s.platform     = :ios, "7.0"
+  s.platforms    = { :ios => "7.0", :tvos => "10.0" }
   s.source       = { :git => "https://github.com/bugsnag/bugsnag-js.git", :tag => "v#{s.version}" }
   s.source_files = "ios/BugsnagReactNative/**/*.{h,m}",
                    "ios/vendor/bugsnag-cocoa/**/*.{h,mm,m,cpp,c}",


### PR DESCRIPTION
## Goal

When building a React Native project for a tvOS target the error `Bugsnag/Bugsnag.h file not found` occurs.

## Design

The library seems to work fine with tvOS as it is, the podspec just needed to reflect this. It's possible version 9 can also be supported, but most React Native libraries seem to be targeting version 10.

## Changeset

Added the tvOS platform to the podspec.

## Testing

Successful build for a tvOS target and confirmed that handled and unhandled errors are submitted from JavaScript. I did not test native tvOS errors since I'm not a native developer.