### PR TITLE
(test): RN CLI - use the latest version of BAGP

### DIFF
--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -31,9 +31,8 @@ send -- http://localhost:9339\r
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- $notifierVersion\r
 
-# TODO: Use latest once BAGP is released for real
 expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-send -- 5.5.0-alpha01\r
+send -- \r
 
 expect "What is your Bugsnag project API key?"
 send -- 1234567890ABCDEF1234567890ABCDEF\r


### PR DESCRIPTION
## Goal

Use the latest version of the Bugsnag Android Gradle Plugin, now that 5.7.0 has been released.

## Testing

Covered by CI.