### PR TITLE
[PLAT-5726] fix(react-native): Ensure project root is set correctly in xcode build phase

### DIFF
--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -30,6 +30,9 @@ if [ ! -f "$MAP_FILE" ]; then
   exit 1
 fi
 
+# This script gets executed in the <project_root>/ios directory
+PROJECT_ROOT=$(echo $PWD | sed -e 's/\ios$//')
+
 ARGS=(
     "--api-key" "$API_KEY"
     "--app-bundle-version" "$BUNDLE_VERSION"
@@ -37,6 +40,7 @@ ARGS=(
     "--bundle" "$BUNDLE_FILE"
     "--platform" "ios"
     "--source-map" "$MAP_FILE"
+    "--project-root" "$PROJECT_ROOT"
     )
 
 case "$CONFIGURATION" in

--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -31,7 +31,7 @@ if [ ! -f "$MAP_FILE" ]; then
 fi
 
 # This script gets executed in the <project_root>/ios directory
-PROJECT_ROOT=$(echo $PWD | sed -e 's/\ios$//')
+PROJECT_ROOT=${PWD%\/ios}
 
 ARGS=(
     "--api-key" "$API_KEY"


### PR DESCRIPTION
## Goal

Ensure source map uploads that were automated via the RN CLI injecting the build phase have their project root stripped correctly.

## Design

The cwd of the script was `<project_root>/ios`. Since none of the JS on a project lives inside the `ios` directory, to correctly have the source map tool strip the project root it needs to be set to `<project_root>`.

## Changeset

Updated the bugsnag-react-native-xcode.sh to pass the desired `--project-root` option to @bugsnag/source-maps.

## Testing

Tested manually on RN 0.61, 0.62 and 0.63.