### PR TITLE
Always use the resilient Appium driver

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -109,6 +109,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
+          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -133,6 +134,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
+          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -162,6 +164,7 @@ steps:
           - --retry=2
           - --appium-version=1.18.0
           - --capabilities={"appWaitForLaunch":"false"}
+          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -188,6 +191,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
+          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -212,6 +216,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
+          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -236,6 +241,7 @@ steps:
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
+          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -221,6 +221,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -244,6 +245,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -266,6 +268,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -289,6 +292,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -311,6 +315,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -335,6 +340,7 @@ steps:
           - --username=$BROWSER_STACK_USERNAME
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
+          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -356,6 +362,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -380,6 +387,7 @@ steps:
           - --username=$BROWSER_STACK_USERNAME
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
+          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -401,6 +409,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -425,6 +434,7 @@ steps:
           - --username=$BROWSER_STACK_USERNAME
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
+          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -446,6 +456,7 @@ steps:
         - --username=$BROWSER_STACK_USERNAME
         - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
+        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -470,6 +481,7 @@ steps:
           - --username=$BROWSER_STACK_USERNAME
           - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
+          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'


### PR DESCRIPTION
## Goal

Tell MazeRunner to use its "resilient" Appium driver.

## Design

The resilient driver added in MazeRunner is able to rescue most broken Appium sessions.  It's not perfect, but should save us from some flakes.  If the Appium session doesn't die then the driver behaves precisely like the standard driver.

## Testing

Covered by CI.