### PR TITLE
chore: add json-summary coverage reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,9 @@ module.exports = {
     '!<rootDir>/packages/react-native/src/test/setup.js',
     '!<rootDir>/packages/plugin-node-surrounding-code/test/fixtures/**/*'
   ],
+  coverageReporters: [
+    'json-summary', 'json', 'lcov', 'text', 'clover'
+  ],
   projects: [
     project('core', ['core']),
     project('shared plugins', ['plugin-app-duration']),


### PR DESCRIPTION
Adds "json-summary" reporter. Required for coverage diffing. See https://github.com/bugsnag/bugsnag-js/pull/1226

`'json', 'lcov', 'text', 'clover'` are the jest defaults. We can remove the ones we don't end up using, which can be done in https://github.com/bugsnag/bugsnag-js/pull/1226