### PR TITLE
[PLAT-5357] fix(react-native): Ensure plugin usage does not crash debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (react-native):  Ensure plugin usage is compatible with running an app in a remote debugger [#1250](https://github.com/bugsnag/bugsnag-js/pull/1250)
+
 ## v7.6.0 (2020-01-18)
 
 As of 7.6.0 the monorepo contains `@bugsnag/react-native-cli`, a new command line tool to help set up Bugsnag in React Native projects.

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -109,6 +109,8 @@ const Bugsnag = {
     let initialised = false
 
     const stubSchema = { ...schema }
+    // remove the api key from the schema so it doesn't get validated – we know we don't
+    // have one at this point, and the only other alternative is to use a fake (but valid) one
     delete stubSchema.apiKey
     const stubClient = new Client({
       ...opts,
@@ -117,7 +119,7 @@ const Bugsnag = {
       enabledBreadcrumbTypes: []
     }, stubSchema, internalPlugins, { name, version, url })
 
-    CLIENT_METHODS.map((m) => {
+    CLIENT_METHODS.forEach((m) => {
       if (/^_/.test(m)) return
       stubClient[m] = new Proxy(stubClient[m], {
         apply: (target, thisArg, args) => {
@@ -140,7 +142,7 @@ const Bugsnag = {
   }
 }
 
-CLIENT_METHODS.map((m) => {
+CLIENT_METHODS.forEach((m) => {
   if (/^_/.test(m)) return
   Bugsnag[m] = function () {
     if (!Bugsnag._client) return console.warn(`Bugsnag.${m}() was called before Bugsnag.start()`)


### PR DESCRIPTION
## Goal

When run in the debugger, the React Native notifier starts asynchronously due to synchronous calls to native not being available in the debugging environment.

The existing workaround involved creating a no-op stubbed client interface, which covered most use cases, but not plugins where the return value of `Bugsnag.getPlugin('<name>')` was required, resulting in the following bugs: #1143 #1112.

## Design

The new solution is to create an actual `Client` instance so that plugins can be used in the short delay before the notifier starts properly.

## Changeset

- Updated the debugging-env only stub client to use an actual client object
- Added messaging to the debugging console warning

## Testing

The changes were manually tested in the remote debugger on an app using React Navigation.