### PR TITLE
[PLAT-4790] Tests: Remove concurrency limits from lerna

### DIFF
--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -11,7 +11,7 @@ RUN npm install
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json packages/expo/unimodules-core.d.ts ./
 ADD min_packages.tar .
 COPY bin ./bin
-RUN npx lerna bootstrap --concurrency 1
+RUN npx lerna bootstrap
 COPY packages ./packages
 RUN npm run build
 

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -11,7 +11,7 @@ RUN npm install
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json packages/expo/unimodules-core.d.ts ./
 ADD min_packages.tar .
 COPY bin ./bin
-RUN npx lerna bootstrap --concurrency 1
+RUN npx lerna bootstrap
 COPY scripts ./scripts
 COPY test ./test
 COPY packages ./packages

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -10,7 +10,7 @@ RUN npm install
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json packages/expo/unimodules-core.d.ts ./
 COPY packages ./packages
 COPY bin ./bin
-RUN npx lerna bootstrap --concurrency 1
+RUN npx lerna bootstrap
 RUN npx lerna run build --scope "@bugsnag/expo" --scope "@bugsnag/plugin-react"
 
 RUN npx lerna exec --scope "@bugsnag/plugin-react-native-unhandled-rejection" -- npm prune --production

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -11,7 +11,7 @@ RUN npm install
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json packages/expo/unimodules-core.d.ts ./
 ADD min_packages.tar .
 COPY bin ./bin
-RUN npx lerna bootstrap --concurrency 1
+RUN npx lerna bootstrap
 COPY packages ./packages
 RUN npm run build
 

--- a/dockerfiles/Dockerfile.react-native-cli-tool
+++ b/dockerfiles/Dockerfile.react-native-cli-tool
@@ -10,7 +10,7 @@ COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconf
 COPY bin ./bin
 COPY packages ./packages
 
-RUN npm run bootstrap -- --concurrency 1
+RUN npm run bootstrap
 
 RUN npx lerna run build --scope @bugsnag/react-native-cli
 RUN npm pack --verbose packages/react-native-cli/


### PR DESCRIPTION
## Goal
This limit was previously added due to potential flakes due to concurrency issues with npm and lerna.

Since [this PR](https://github.com/isaacs/chownr/pull/22) was merged this issue should have been resolved.

## Tests

A branch was set up which ran the build process with concurrency limits removed several times [here](https://buildkite.com/bugsnag/bugsnag-js/builds?branch=tests%2Fsoak-lerna-tests).  The previously seen error did not occur in any of these test builds.