### PR TITLE
test(react-native-cli): Source map upload for RN now defaults to overwrite=true

### DIFF
--- a/test/react-native-cli/features/build-app-tests/build-android-app.feature
+++ b/test/react-native-cli/features/build-app-tests/build-android-app.feature
@@ -10,4 +10,4 @@ Feature: Tests for building a React Native app (for Android only) that was initi
     Then the Content-Type header is valid multipart form-data
     And the payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the payload field "platform" equals "android"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"

--- a/test/react-native-cli/features/build-app-tests/build-ios-app.feature
+++ b/test/react-native-cli/features/build-app-tests/build-ios-app.feature
@@ -7,4 +7,4 @@ Feature: Tests for building a React Native app (for iOS only) that was initializ
     Then the Content-Type header is valid multipart form-data
     And the payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the payload field "platform" equals "ios"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"


### PR DESCRIPTION
`@bugsnag/source-maps` v2 now defaults to `overwrite=true` for RN uploads.

The RN CLI tests in this repo grab the latest source maps CLI and have an assertion against the overwrite value in the upload, so tests are incorrect and failing from this point on.

This updates the assertion in the tests and gets CI passing again.