### PR TITLE
docs: fix objc diff in upgrade guide

### DIFF
--- a/packages/react-native/UPGRADING.md
+++ b/packages/react-native/UPGRADING.md
@@ -89,7 +89,7 @@ Update any of the following imports in. These will likely be in `AppDelegate.m` 
 ```diff
 - #import <BugsnagReactNative/BugsnagReactNative.h>
 - #import "BugsnagConfiguration.h"
-+ import <Bugsnag/Bugsnag.h>
++ #import <Bugsnag/Bugsnag.h>
 ```
 
 Inside your `application:didFinishLaunchingWithOptions` method, replace any Bugsnag initialization code with the updated version:


### PR DESCRIPTION
add missing "#" for `#import`

## Goal

fix code in documentation with correct objective-c syntax

## Design

N/A

## Changeset

upgrade guide for react-native

## Testing

N/A