### PR TITLE
Link to the official docs rather than duplicating instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use the following plugins and guides to integrate Bugsnag with various framework
 
 * Check out the [FAQ](https://docs.bugsnag.com/platforms/javascript/faq) and [configuration options](https://docs.bugsnag.com/platforms/javascript/configuration-options)
 * [Search open and closed issues](https://github.com/bugsnag/bugsnag-js/issues?q=+) for similar problems
-* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-js/issues/new)
+* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-js/issues/new/choose)
 
 ## Contributing
 

--- a/packages/plugin-angular/README.md
+++ b/packages/plugin-angular/README.md
@@ -6,46 +6,20 @@ This package enables you to integrate Bugsnag's error reporting with an Angular 
 
 Reported errors will contain useful debugging info from Angular's internals, such as the component and context.
 
-## Installation
+## Getting started
 
-```sh
-npm i --save @bugsnag/js @bugsnag/plugin-angular
-# or
-yarn add @bugsnag/js @bugsnag/plugin-angular
-```
-
-## Usage
-
-In your the root of your angular app, typically `app.module.ts`:
-
-```typescript
-// Import bugsnag-js and @bugsnag/plugin-angular
-import { BugsnagErrorHandler } from '@bugsnag/plugin-angular'
-import Bugsnag from 'bugsnag-js'
-
-// configure Bugsnag ASAP, before any other imports
-Bugsnag.start('API_KEY')
-
-// create a factory which will return the Bugsnag error handler
-export function errorHandlerFactory() {
-  return new BugsnagErrorHandler()
-}
-
-import { ErrorHandler, NgModule } from '@angular/core'
-// ... other imports omitted for brevity
-
-@NgModule({
-  /* Pass the BugsnagErrorHandler class along to the providers for your module */
-  providers: [ { provide: ErrorHandler, useFactory: errorHandlerFactory } ]
-  /* other properties passed to the decorator omitted for brevity */
-})
-```
+1. [Create a Bugsnag account](https://www.bugsnag.com)
+2. Complete the instructions in the [integration guide](https://docs.bugsnag.com/platforms/javascript/angular/)
+3. Report handled exceptions using
+   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/angular/#reporting-handled-errors)
+4. Customize your integration using the
+   [configuration options](https://docs.bugsnag.com/platforms/javascript/angular/configuration-options/)
 
 ## Support
 
-* Check out the [documentation](https://docs.bugsnag.com/platforms/browsers/)
+* Check out the [documentation](https://docs.bugsnag.com/platforms/javascript/angular/)
 * [Search open and closed issues](https://github.com/bugsnag/bugsnag-js/issues?q=is%3Aissue) for similar problems
-* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-js/issues/new)
+* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-js/issues/new/choose)
 
 ## License
 

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -11,43 +11,20 @@ This package enables you to integrate Bugsnag's error reporting with React's [er
 
 Reported errors will contain useful debugging info from Reacts's internals such as the component name where the error originated, and the component stack.
 
-## Installation
+## Getting started
 
-```sh
-npm i --save @bugsnag/js @bugsnag/plugin-react
-# or
-yarn add @bugsnag/js @bugsnag/plugin-react
-```
-
-## Usage
-
-Depending on how your application is structured, usage differs slightly:
-
-```js
-// initialize bugsnag ASAP, before other imports
-import Bugsnag from '@bugsnag/js'
-Bugsnag.start('API_KEY')
-
-import ReactDOM from 'react-dom'
-import React from 'react'
-import bugsnagReact from '@bugsnag/plugin-react'
-Bugsnag.use(bugsnagReact, React)
-
-// wrap your entire app tree in the ErrorBoundary provided
-const ErrorBoundary = Bugsnag.getPlugin('react');
-ReactDOM.render(
-  <ErrorBoundary>
-    <YourApp />
-  </ErrorBoundary>,
-  document.getElementById('app')
-)
-```
+1. [Create a Bugsnag account](https://www.bugsnag.com)
+2. Complete the instructions in the [integration guide](https://docs.bugsnag.com/platforms/javascript/react/)
+3. Report handled exceptions using
+   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/react/#reporting-handled-errors)
+4. Customize your integration using the
+   [configuration options](https://docs.bugsnag.com/platforms/javascript/react/configuration-options/)
 
 ## Support
 
 * Check out the [documentation](https://docs.bugsnag.com/platforms/javascript/react)
 * [Search open and closed issues](https://github.com/bugsnag/bugsnag-js/issues?q=is%3Aissue) for similar problems
-* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-js/issues/new)
+* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-js/issues/new/choose)
 
 ## License
 

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -8,30 +8,20 @@ This package enables you to integrate Bugsnag's error reporting with a Vue.js ap
 
 Reported errors will contain useful debugging info from Vue's internals, such as the component name, props and any other context that Vue can provide.
 
-## Installation
+## Getting started
 
-```sh
-npm i --save @bugsnag/js @bugsnag/plugin-vue
-# or
-yarn add @bugsnag/js @bugsnag/plugin-vue
-```
-
-## Usage
-
-```js
-const Vue = require('vue')
-const Bugsnag = require('@bugsnag/js')
-const bugsnagVue = require('@bugsnag/plugin-vue')
-
-Bugsnag.start('API_KEY')
-Bugsnag.use(bugsnagVue, Vue)
-```
+1. [Create a Bugsnag account](https://www.bugsnag.com)
+2. Complete the instructions in the [integration guide](https://docs.bugsnag.com/platforms/javascript/vue/)
+3. Report handled exceptions using
+   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/vue/#reporting-handled-errors)
+4. Customize your integration using the
+   [configuration options](https://docs.bugsnag.com/platforms/javascript/vue/configuration-options/)
 
 ## Support
 
 * Check out the [documentation](https://docs.bugsnag.com/platforms/javascript/vue/)
 * [Search open and closed issues](https://github.com/bugsnag/bugsnag/js/issues?q=is%3Aissue) for similar problems
-* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag/js/issues/new)
+* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag/js/issues/new/choose)
 
 ## License
 


### PR DESCRIPTION
## Goal

Instructions on some of the plugins had drifted out of date with changes made to the official [docs](https://docs.bugsnag.com/platforms/javascript/).

## Design

Link to the relevant sections of the documentation.

## Changeset

The React, Vue and Angular plugins were the ones where we previously duplicated integration instructions.

## Testing

N/A