### PR TITLE
[PLAT-5850] Add end-to-end tests for Vue+TypeScript

### DIFF
--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <pre id="bugsnag-test-should-run">PENDING</pre>
+    <div id="app">
+      <div id="app">
+        <p>{{ message }}</p>
+        <span>{{ errr() }}</p>
+      </div>
+    </div>
+    <script>
+      var el = document.getElementById('bugsnag-test-should-run')
+      el.textContent = el.innerText = typeof Set !== 'undefined'
+        ? 'YES'
+        : 'NO'
+    </script>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/index.html
@@ -13,7 +13,7 @@
     </div>
     <script>
       var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Set !== 'undefined'
+      el.textContent = el.innerText = typeof Proxy !== 'undefined'
         ? 'YES'
         : 'NO'
     </script>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/package.json
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bugsnag-js-fixtures-vue3-typescript",
+  "private": true,
+  "scripts": {
+    "build": "NODE_ENV=production browserify src/index.ts -p [ tsify ] -g envify -o dist/bundle.js"
+  },
+  "dependencies": {
+    "browserify": "^17.0.0",
+    "envify": "^4.1.0",
+    "tsify": "^5.0.2",
+    "typescript": "^4.1.3",
+    "vue": "^2.0.0"
+  },
+  "browser": {
+    "vue": "vue/dist/vue.common.js"
+  }
+}

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/src/index.ts
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/src/index.ts
@@ -1,0 +1,20 @@
+import Bugsnag from '@bugsnag/browser'
+import BugsnagPluginVue from '@bugsnag/plugin-vue'
+import config from './lib/config'
+
+import Vue from 'vue'
+
+Bugsnag.start({ ...config, plugins: [new BugsnagPluginVue] })
+Bugsnag.getPlugin('vue')!.installVueErrorHandler(Vue)
+
+const app = new Vue({
+  el: '#app',
+  data: {
+    message: 'Hello Vue!'
+  },
+  methods: {
+    errr: function () {
+      throw new Error('borked')
+    }
+  }
+})

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/src/lib/config.ts
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/src/lib/config.ts
@@ -1,0 +1,5 @@
+var NOTIFY = decodeURIComponent((<Array<string>>window.location.search.match(/NOTIFY=([^&]+)/))[1])
+var SESSIONS = decodeURIComponent((<Array<string>>window.location.search.match(/SESSIONS=([^&]+)/))[1])
+var API_KEY = decodeURIComponent((<Array<string>>window.location.search.match(/API_KEY=([^&]+)/))[1])
+const config = { endpoints: { notify: NOTIFY, sessions: SESSIONS }, apiKey: API_KEY }
+export default config

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/tsconfig.json
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/tsconfig.json
@@ -1,0 +1,70 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./dist/bundle.js",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
@@ -13,7 +13,12 @@
     </div>
     <script>
       var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Proxy !== 'undefined'
+      var isClassSupported = false
+      try {
+        eval('class Foo extends Object {}')
+        isClassSupported = true
+      } catch (e) {}
+      el.textContent = el.innerText = isClassSupported && typeof Proxy !== 'undefined'
         ? 'YES'
         : 'NO'
     </script>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <pre id="bugsnag-test-should-run">PENDING</pre>
+    <div id="app">
+      <div id="app">
+        <p>{{ message }}</p>
+        <span>{{ errr() }}</p>
+      </div>
+    </div>
+    <script>
+      var el = document.getElementById('bugsnag-test-should-run')
+      el.textContent = el.innerText = typeof Set !== 'undefined'
+        ? 'YES'
+        : 'NO'
+    </script>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
@@ -13,7 +13,7 @@
     </div>
     <script>
       var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Set !== 'undefined'
+      el.textContent = el.innerText = typeof Proxy !== 'undefined'
         ? 'YES'
         : 'NO'
     </script>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/package.json
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bugsnag-js-fixtures-vue3-typescript",
+  "private": true,
+  "scripts": {
+    "build": "NODE_ENV=production browserify src/index.ts -p [ tsify ] -g envify -o dist/bundle.js"
+  },
+  "dependencies": {
+    "browserify": "^17.0.0",
+    "envify": "^4.1.0",
+    "tsify": "^5.0.2",
+    "typescript": "^4.1.3",
+    "vue": "^3.0.5"
+  }
+}

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/src/index.ts
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/src/index.ts
@@ -1,0 +1,22 @@
+import Bugsnag from '@bugsnag/browser'
+import BugsnagPluginVue from '@bugsnag/plugin-vue'
+import config from './lib/config'
+
+import { createApp, defineComponent } from 'vue'
+
+const App = defineComponent({
+  el: '#app',
+  data: () => {
+    return {
+      message: 'Hello Vue!'
+    }
+  },
+  methods: {
+    errr: function () {
+      throw new Error('borked')
+    }
+  }
+})
+
+Bugsnag.start({ ...config, plugins: [new BugsnagPluginVue] })
+createApp(App).use(Bugsnag.getPlugin('vue')!).mount('#app')

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/src/lib/config.ts
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/src/lib/config.ts
@@ -1,0 +1,5 @@
+var NOTIFY = decodeURIComponent((<Array<string>>window.location.search.match(/NOTIFY=([^&]+)/))[1])
+var SESSIONS = decodeURIComponent((<Array<string>>window.location.search.match(/SESSIONS=([^&]+)/))[1])
+var API_KEY = decodeURIComponent((<Array<string>>window.location.search.match(/API_KEY=([^&]+)/))[1])
+const config = { endpoints: { notify: NOTIFY, sessions: SESSIONS }, apiKey: API_KEY }
+export default config

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/tsconfig.json
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/tsconfig.json
@@ -1,0 +1,70 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./dist/bundle.js",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/test/browser/features/plugin_vue.feature
+++ b/test/browser/features/plugin_vue.feature
@@ -9,3 +9,13 @@ Scenario: basic error handler usage
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "borked"
   And the event "metaData.vue.errorInfo" is not null
+
+Scenario: vue3 + typescript usage
+  When I navigate to the test URL "/plugin_vue/typescript_vue3/index.html"
+  And the test should run in this browser
+  Then I wait to receive an error
+  And the error is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "borked"
+  And the event "metaData.vue.errorInfo" equals "render function"
+  And the event "metaData.vue.component" equals "App"

--- a/test/browser/features/plugin_vue.feature
+++ b/test/browser/features/plugin_vue.feature
@@ -19,3 +19,13 @@ Scenario: vue3 + typescript usage
   And the exception "message" equals "borked"
   And the event "metaData.vue.errorInfo" equals "render function"
   And the event "metaData.vue.component" equals "App"
+
+Scenario: vue2 + typescript usage
+  When I navigate to the test URL "/plugin_vue/typescript_vue2/index.html"
+  And the test should run in this browser
+  Then I wait to receive an error
+  And the error is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "borked"
+  And the event "metaData.vue.errorInfo" equals "render"
+  And the event "metaData.vue.component" equals "<Root>"


### PR DESCRIPTION
Add end to end test coverage for TypeScript + Vue 2-3. The types are written to support both versions so it's important we test against both.