### PR TITLE
Use MR v3 style environment variables

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -105,8 +105,6 @@ steps:
           - --farm=bs
           - --device=ANDROID_9_0
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient
@@ -130,8 +128,6 @@ steps:
           - --device=IOS_12
           - --a11y-locator
           - --appium-version=1.16.0
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient
@@ -158,8 +154,6 @@ steps:
           - --farm=bs
           - --device=ANDROID_8_1
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --appium-version=1.18.0
@@ -187,8 +181,6 @@ steps:
           - --farm=bs
           - --device=ANDROID_7_1
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient
@@ -212,8 +204,6 @@ steps:
           - --farm=bs
           - --device=ANDROID_6_0
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient
@@ -237,8 +227,6 @@ steps:
           - --farm=bs
           - --device=ANDROID_5_0
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient
@@ -263,8 +251,6 @@ steps:
           - --device=IOS_11
           - --a11y-locator
           - --appium-version=1.16.0
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient
@@ -288,8 +274,6 @@ steps:
           - --farm=bs
           - --device=IOS_10
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --retry=2
           - --resilient

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -202,8 +202,6 @@ steps:
         - --farm=bs
         - --device=ANDROID_9_0
         - --a11y-locator
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
     env:
@@ -226,8 +224,6 @@ steps:
         - --device=IOS_12
         - --a11y-locator
         - --appium-version=1.18.0
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
     env:
@@ -249,8 +245,6 @@ steps:
         - --farm=bs
         - --device=ANDROID_9_0
         - --a11y-locator
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
     env:
@@ -273,8 +267,6 @@ steps:
         - --device=IOS_12
         - --a11y-locator
         - --appium-version=1.18.0
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
     env:
@@ -296,8 +288,6 @@ steps:
         - --farm=bs
         - --device=ANDROID_9_0
         - --a11y-locator
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
         - features/navigation.feature
@@ -321,8 +311,6 @@ steps:
           - --device=IOS_12
           - --a11y-locator
           - --appium-version=1.18.0
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --resilient
           - features/navigation.feature
@@ -343,8 +331,6 @@ steps:
         - --farm=bs
         - --device=ANDROID_9_0
         - --a11y-locator
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
         - features/navigation.feature
@@ -368,8 +354,6 @@ steps:
           - --device=IOS_13
           - --a11y-locator
           - --appium-version=1.18.0
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --resilient
           - features/navigation.feature
@@ -390,8 +374,6 @@ steps:
         - --farm=bs
         - --device=ANDROID_9_0
         - --a11y-locator
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
         - features/navigation.feature
@@ -415,8 +397,6 @@ steps:
           - --device=IOS_13
           - --appium-version=1.18.0
           - --a11y-locator
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --resilient
           - features/navigation.feature
@@ -437,8 +417,6 @@ steps:
         - --farm=bs
         - --device=ANDROID_9_0
         - --a11y-locator
-        - --username=$BROWSER_STACK_USERNAME
-        - --access-key=$BROWSER_STACK_ACCESS_KEY
         - --fail-fast
         - --resilient
         - features/navigation.feature
@@ -462,8 +440,6 @@ steps:
           - --device=IOS_13
           - --a11y-locator
           - --appium-version=1.18.0
-          - --username=$BROWSER_STACK_USERNAME
-          - --access-key=$BROWSER_STACK_ACCESS_KEY
           - --fail-fast
           - --resilient
           - features/navigation.feature

--- a/TESTING.md
+++ b/TESTING.md
@@ -138,8 +138,8 @@ They also require access to the Expo ecosystem in order to publish, then build, 
 The following environment variables need to be set:
 
 - `DEVICE_TYPE`: the mobile operating system you want to test on – one of ANDROID_5_0, ANDROID_6_0, ANDROID_7_1, ANDROID_8_1, ANDROID_9_0, IOS_10, IOS_11, IOS_12
-- `BROWSER_STACK_USERNAME`
-- `BROWSER_STACK_ACCESS_KEY`
+- `MAZE_DEVICE_FARM_USERNAME`
+- `MAZE_DEVICE_FARM_ACCESS_KEY`
 - `EXPO_USERNAME`
 - `EXPO_PASSWORD`
 
@@ -147,8 +147,6 @@ To run against an android device:
 
 ```sh
 DEVICE_TYPE=ANDROID_9_0 \
-BROWSER_STACK_USERNAME=xxx \
-BROWSER_STACK_ACCESS_KEY=xxx \
 EXPO_USERNAME=xxx \
 EXPO_PASSWORD=xxx \
   npm run test:expo:android

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,9 @@ services:
       args:
         - BUILDKITE_BUILD_NUMBER
     environment:
-      DEBUG:
       BUILDKITE:
+      BUILDKITE_PIPELINE_NAME:
+      DEBUG:
       MAZE_DEVICE_FARM_USERNAME:
       MAZE_DEVICE_FARM_ACCESS_KEY:
       HOST: "${HOST:-maze-runner}"
@@ -67,7 +68,11 @@ services:
       args:
         - BUILDKITE_BUILD_NUMBER
     environment:
+      BUILDKITE:
+      BUILDKITE_PIPELINE_NAME:
       DEBUG:
+      MAZE_DEVICE_FARM_USERNAME:
+      MAZE_DEVICE_FARM_ACCESS_KEY:
     networks:
       default:
         aliases:
@@ -181,7 +186,11 @@ services:
       args:
         - BUILDKITE_BUILD_NUMBER
     environment:
+      BUILDKITE:
+      BUILDKITE_PIPELINE_NAME:
       DEBUG:
+      MAZE_DEVICE_FARM_USERNAME:
+      MAZE_DEVICE_FARM_ACCESS_KEY:
       SKIP_NAVIGATION_SCENARIOS:
     networks:
       default:


### PR DESCRIPTION
## Goal

Tidy up the use of environment variables for running end-to-end tests, now that they are supported directly by the MazeRunner tool (as to being a commonly held convention).

## Design

In addition to updating `docker-compose.yml` to ensure that the relevant environment variables make it through to the MazeRunner Docker containers, I have updated our secrets bucket to ensure that the credentials are set in the first place.

## Changeset

Docker Compose and Buildkite pipeline files updated and `TESTING.md` to demonstrate the neater form of use now available.

## Testing

Covered by CI.  Inspecting the logs for RN, RN CLI and Expo e2e tests, you can now see the prettified link to the BrowserStack session:

![image](https://user-images.githubusercontent.com/5239394/107223492-28b57880-6a0e-11eb-8476-e27e428556d2.png)

The same will follow for Browsers on the next release of MazeRunner.