### PR TITLE
[PLAT-5980] Ensure inline <script> detection only includes script content when relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Fix a rare crash that could occur in the event of JSON parsing failures. [bugsnag-cocoa#987](https://github.com/bugsnag/bugsnag-cocoa/pull/987)
 - (plugin-vue): Add support for Vue 3 [#1280](https://github.com/bugsnag/bugsnag-js/pull/1280)
 
+### Fixed
+
+- (plugin-inline-script-content): Ensure inline script content isn't included when the DOM `onreadystatechange` `interactive` event is missed. [#1290](https://github.com/bugsnag/bugsnag-js/pull/1290)
+
 ## v7.6.1 (2021-01-26)
 
 ## Changed

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -11,7 +11,7 @@ module.exports = (doc = document, win = window) => ({
 
     const originalLocation = win.location.href
     let html = ''
-    let DOMContentLoaded = false
+    let DOMContentLoaded = doc.readyState !== 'loading'
     const getHtml = () => doc.documentElement.outerHTML
 
     // get whatever HTML exists at this point in time
@@ -66,7 +66,7 @@ module.exports = (doc = document, win = window) => ({
       if (!frame) return
 
       // if frame.file exists and is not the original location of the page, this can't be an inline script
-      if ((frame.file && frame.file.replace(/#.*$/, '')) !== originalLocation.replace(/#.*$/, '')) return
+      if (frame && (frame.file && frame.file.replace(/#.*$/, '')) !== originalLocation.replace(/#.*$/, '')) return
 
       // grab the last script known to have run
       const currentScript = getCurrentScript()

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -62,8 +62,11 @@ module.exports = (doc = document, win = window) => ({
 
       const frame = event.errors[0].stacktrace[0]
 
+      // if there are no frames, we can't tell whether this is an inline script
+      if (!frame) return
+
       // if frame.file exists and is not the original location of the page, this can't be an inline script
-      if (frame && frame.file && frame.file.replace(/#.*$/, '') !== originalLocation.replace(/#.*$/, '')) return
+      if ((frame.file && frame.file.replace(/#.*$/, '')) !== originalLocation.replace(/#.*$/, '')) return
 
       // grab the last script known to have run
       const currentScript = getCurrentScript()
@@ -77,7 +80,7 @@ module.exports = (doc = document, win = window) => ({
       }
 
       // only attempt to grab some surrounding code if we have a line number
-      if (!frame || !frame.lineNumber) return
+      if (!frame.lineNumber) return
       frame.code = addSurroundingCode(frame.lineNumber)
     }, true)
 

--- a/packages/plugin-inline-script-content/test/inline-script-content.test.ts
+++ b/packages/plugin-inline-script-content/test/inline-script-content.test.ts
@@ -242,11 +242,11 @@ Lorem ipsum dolor sit amet.
     expect(payloads[0].events[0]._metadata.script.content).toEqual(scriptContent)
   })
 
-  it('doesn’t add a "script" tab to errors with no stacktrace', () => {
+  it('doesn’t add a "script" tab to errors with no stacktrace when currentScript=null', () => {
     const scriptContent = 'throw new Error(\'oh\')\nconsole.log(\'next\')'
     const document = {
       scripts: [{ innerHTML: scriptContent }],
-      currentScript: { innerHTML: scriptContent },
+      currentScript: null,
       documentElement: {
         outerHTML: `<script>${scriptContent}</script>`
       }

--- a/packages/plugin-inline-script-content/test/inline-script-content.test.ts
+++ b/packages/plugin-inline-script-content/test/inline-script-content.test.ts
@@ -241,4 +241,25 @@ Lorem ipsum dolor sit amet.
     expect(payloads[0].events[0]._metadata.script).toBeDefined()
     expect(payloads[0].events[0]._metadata.script.content).toEqual(scriptContent)
   })
+
+  it('doesn’t add a "script" tab to errors with no stacktrace', () => {
+    const scriptContent = 'throw new Error(\'oh\')\nconsole.log(\'next\')'
+    const document = {
+      scripts: [{ innerHTML: scriptContent }],
+      currentScript: { innerHTML: scriptContent },
+      documentElement: {
+        outerHTML: `<script>${scriptContent}</script>`
+      }
+    } as unknown as Document
+    const window = { location: { href: 'https://app.bugsnag.com/errors' } } as unknown as Window &typeof globalThis
+
+    const client = new Client({ apiKey: 'API_KEY_YEAH' }, undefined, [plugin(document, window)])
+    const payloads = []
+
+    expect(client._cbs.e.length).toBe(1)
+    client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload), sendSession: () => {} }))
+    client._notify(new Event('Error', 'oh', []))
+    expect(payloads.length).toEqual(1)
+    expect(payloads[0].events[0]._metadata.script).not.toBeDefined()
+  })
 })

--- a/test/browser/features/fixtures/inline_script/script/a.html
+++ b/test/browser/features/fixtures/inline_script/script/a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
+    <script type="text/javascript">
+      var NOTIFY = decodeURIComponent(window.location.search.match(/NOTIFY=([^&]+)/)[1])
+      var SESSIONS = decodeURIComponent(window.location.search.match(/SESSIONS=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+      Bugsnag.start({
+        apiKey: API_KEY,
+        endpoints: { notify: NOTIFY, sessions: SESSIONS }
+      })
+    </script>
+  </head>
+  <body>
+    <script>
+      Bugsnag.notify(new Error('hi'))
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/inline_script/script/b.html
+++ b/test/browser/features/fixtures/inline_script/script/b.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script type="text/javascript">
+      var NOTIFY = decodeURIComponent(window.location.search.match(/NOTIFY=([^&]+)/)[1])
+      var SESSIONS = decodeURIComponent(window.location.search.match(/SESSIONS=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+    </script>
+  </head>
+  <body>
+    <script src="b.js"></script>
+    <script>/* nothing to see here */</script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/inline_script/script/b.js
+++ b/test/browser/features/fixtures/inline_script/script/b.js
@@ -1,0 +1,16 @@
+window.onload = function () {
+  var bugsnagScript = document.createElement('SCRIPT')
+  bugsnagScript.src = '/node_modules/@bugsnag/browser/dist/bugsnag.min.js'
+  document.body.appendChild(bugsnagScript)
+  bugsnagScript.onload = function () {
+    Bugsnag.start({
+      apiKey: API_KEY,
+      endpoints: { notify: NOTIFY, sessions: SESSIONS }
+    })
+    Bugsnag.addOnError(function (event) {
+      // simulate an error with no stackframes
+      event.errors[0].stacktrace = []
+    }, true) // <-- `true` means the callback will run before the inline-script-content plugin
+    Bugsnag.notify(new Error('async hi'))
+  }
+}

--- a/test/browser/features/fixtures/inline_script/script/b.js
+++ b/test/browser/features/fixtures/inline_script/script/b.js
@@ -1,8 +1,22 @@
 window.onload = function () {
   var bugsnagScript = document.createElement('SCRIPT')
   bugsnagScript.src = '/node_modules/@bugsnag/browser/dist/bugsnag.min.js'
-  document.body.appendChild(bugsnagScript)
-  bugsnagScript.onload = function () {
+  document.documentElement.appendChild(bugsnagScript)
+
+  if (!document.attachEvent) {
+    bugsnagScript.onload = onScriptLoad
+  } else {
+    // onload doesn't fire in old IE
+    if (/^loaded|complete$/.test(bugsnagScript.readyState)) {
+      onScriptLoad()
+    } else {
+      bugsnagScript.onreadystatechange = function () {
+        if (/^loaded|complete$/.test(bugsnagScript.readyState)) onScriptLoad()
+      }
+    }
+  }
+
+  function onScriptLoad () {
     Bugsnag.start({
       apiKey: API_KEY,
       endpoints: { notify: NOTIFY, sessions: SESSIONS }

--- a/test/browser/features/fixtures/inline_script/script/package.json
+++ b/test/browser/features/fixtures/inline_script/script/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bugsnag-js-fixtures-inline-script",
+  "private": true,
+  "scripts": {
+    "build": "echo 'Done'"
+  },
+  "dependencies": {}
+}

--- a/test/browser/features/inline_script.feature
+++ b/test/browser/features/inline_script.feature
@@ -1,0 +1,22 @@
+@handled
+Feature: Inline script detection
+
+Scenario: loading Bugsnag before scripts have run
+  When I navigate to the test URL "/inline_script/script/a.html"
+  Then I wait to receive an error
+  And the error is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "hi"
+  And the exception "type" equals "browserjs"
+  And event 0 is handled
+  And the event "metaData.script" is not null
+
+Scenario: loading Bugsnag after scripts have run
+  When I navigate to the test URL "/inline_script/script/b.html"
+  Then I wait to receive an error
+  And the error is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "async hi"
+  And the exception "type" equals "browserjs"
+  And event 0 is handled
+  And the event "metaData.script" is null


### PR DESCRIPTION
## Goal

In certain edge cases it is possible for the inline script detection plugin to add `metadata.script.content` when the source of the error is not an inline script.

## Design

~The first problem is that errors without stacktraces were able to get past this line which exits early if the topmost stackframe `file` does not match that of the current page:~

https://github.com/bugsnag/bugsnag-js/blob/a53eaccefe343548ecb925d1f3d8b3aac2a8f6c3/packages/plugin-inline-script-content/inline-script-content.js#L66

~It stands to reason that if we have no stacktrace, we don't know whether the error was from an inline script or not, so attaching the inline script content seems like a bad idea.~

The second problem is that when Bugsnag is loaded _after_ the document `readyState=interactive` event has fired – note this is **not** recommended – it remains in a constant state believing that the document is still loading, and therefore running synchronous inline scripts.

https://github.com/bugsnag/bugsnag-js/blob/a53eaccefe343548ecb925d1f3d8b3aac2a8f6c3/packages/plugin-inline-script-content/inline-script-content.js#L14

When an error happens in this instance (but only when there are no stackframes), it grabs the last `<script>` tag on the page, believing that that is was the cause of the error.

The solution is simply to check the `document.readyState` before deciding whether the DOM content has loaded or not.

---

📢 **Update**: in old IE (8, 9 and 10), sometimes errors that we can get the inline script for don't have a stacktrace. We do this by determining if the document is "ready" – if it's not, and we're handling an error, we can assume it came from inline in the page, in the last script that exists.

Fixing the readyState logic above works for the modern browsers, because `getCurrentScript()` will now alway be `null` when an inline script is not running. However, it broke the use case for old IEs where the page is still loading due to [a bug where "interactive" event fires too early](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState#browser_compatibility). A special case has been made for those browsers to wait for the "complete" state, which is a reasonable workaround.

---

## Changeset

- Updated the inline script plugin based on the reasoning above.
- Updated unit tests
- Added some end to end tests for inline script hand

## Testing

Tested manually as well as the aforementioned automated tests.