### PR TITLE
test(node): increase integration test timeout

### DIFF
--- a/packages/node/test/integration/handled-unhandled.test.ts
+++ b/packages/node/test/integration/handled-unhandled.test.ts
@@ -69,7 +69,7 @@ describe('@bugsnag/node: handled and unhandled errors', () => {
       expect(https._requests[0].body.events[0].unhandled).toBe(true)
       expect(https._requests[0].body.events[0].severityReason).toEqual({ type: 'unhandledException' })
       done()
-    }, 100)
+    }, 200)
   })
 
   it('should send an unhandled rejection', (done) => {
@@ -84,6 +84,6 @@ describe('@bugsnag/node: handled and unhandled errors', () => {
       expect(https._requests[0].body.events[0].unhandled).toBe(true)
       expect(https._requests[0].body.events[0].severityReason).toEqual({ type: 'unhandledPromiseRejection' })
       done()
-    }, 100)
+    }, 200)
   })
 })


### PR DESCRIPTION
## Goal

Reduce the incidences of flakey tests. This test fails more often when run on GH actions as part of the PR diff bot.

## Design

I looked at using jest fake timers instead of an arbitrary wait but that gives an error "Ran 100000 timers, and there are still more!".

Given that, I think increasing the wait a little is an acceptable solution. It shouldn't impact the overall test time given that jest runs tests in parallel.

## Changeset

- Increased timeout before running test assertions

## Testing

- Automated tests passing