### PR TITLE
Add Maze Runner scaffolding for Lambda tests

### DIFF
--- a/test/aws-lambda/.gitignore
+++ b/test/aws-lambda/.gitignore
@@ -1,0 +1,3 @@
+.aws-sam
+node_modules/
+.tgz

--- a/test/aws-lambda/Gemfile
+++ b/test/aws-lambda/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.9.1'
+
+# Locally, you can run against Maze Runner branches and uncommitted changes:
+#gem 'bugsnag-maze-runner', path: '../../../maze-runner'

--- a/test/aws-lambda/Gemfile.lock
+++ b/test/aws-lambda/Gemfile.lock
@@ -1,0 +1,85 @@
+GIT
+  remote: https://github.com/bugsnag/maze-runner
+  revision: 8677bcf4c1ab27422084b19e7da8149ede954ded
+  tag: v4.9.1
+  specs:
+    bugsnag-maze-runner (4.9.1)
+      appium_lib (~> 11.2.0)
+      boring (~> 0.1.0)
+      cucumber (~> 3.1.2)
+      cucumber-expressions (~> 6.0.0)
+      curb (~> 0.9.6)
+      gherkin (~> 5.1.0)
+      minitest (~> 5.0)
+      optimist (~> 3.0.1)
+      os (~> 1.0.0)
+      rake (~> 12.3.3)
+      selenium-webdriver (~> 3.11)
+      test-unit (~> 3.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    appium_lib (11.2.0)
+      appium_lib_core (~> 4.1)
+      nokogiri (~> 1.8, >= 1.8.1)
+      tomlrb (~> 1.1)
+    appium_lib_core (4.4.1)
+      faye-websocket (~> 0.11.0)
+      selenium-webdriver (~> 3.14, >= 3.14.1)
+    backports (3.20.2)
+    boring (0.1.0)
+    builder (3.2.4)
+    childprocess (3.0.0)
+    cucumber (3.1.2)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
+    curb (0.9.11)
+    diff-lcs (1.4.4)
+    eventmachine (1.2.7)
+    faye-websocket (0.11.0)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
+    gherkin (5.1.0)
+    minitest (5.14.3)
+    multi_json (1.15.0)
+    multi_test (0.1.2)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
+    optimist (3.0.1)
+    os (1.0.1)
+    power_assert (2.0.0)
+    racc (1.5.2)
+    rake (12.3.3)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    test-unit (3.3.9)
+      power_assert
+    tomlrb (1.3.0)
+    websocket-driver (0.7.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  bugsnag-maze-runner!
+
+BUNDLED WITH
+   2.2.10

--- a/test/aws-lambda/README.md
+++ b/test/aws-lambda/README.md
@@ -1,0 +1,17 @@
+## Setup
+
+Install Maze Runner:
+
+```sh
+$ bundle install
+```
+
+## Running the tests
+
+Run Maze Runner:
+
+```sh
+$ bundle exec maze-runner
+```
+
+This will build all of the fixtures before running the tests

--- a/test/aws-lambda/README.md
+++ b/test/aws-lambda/README.md
@@ -1,10 +1,12 @@
 ## Setup
 
-Install Maze Runner:
+1. [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 
-```sh
-$ bundle install
-```
+1. Install Maze Runner:
+
+    ```sh
+    $ bundle install
+    ```
 
 ## Running the tests
 

--- a/test/aws-lambda/features/fixtures/simple-app/README.md
+++ b/test/aws-lambda/features/fixtures/simple-app/README.md
@@ -1,0 +1,17 @@
+1. Run the build script (requires Ruby):
+    ```sh
+    $ ../../scripts/build-fixtures simple-app
+    ```
+
+    Or run the build script all fixtures:
+
+    ```sh
+    $ ../../scripts/build-fixtures
+    ```
+
+1. Run a function:
+    ```sh
+    $ BUGSNAG_API_KEY=123 sam local invoke AsyncUnhandledExceptionFunction --event events/async/unhandled-exception.json
+    ```
+
+    Check `template.yaml` for all available functions

--- a/test/aws-lambda/features/fixtures/simple-app/async/handled-exception.js
+++ b/test/aws-lambda/features/fixtures/simple-app/async/handled-exception.js
@@ -1,0 +1,17 @@
+const Bugsnag = require('@bugsnag/js')
+
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  plugins: []
+})
+
+const handler = async (event, context) => {
+  Bugsnag.notify(new Error('Hello!'))
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: 'Did not crash!' })
+  }
+}
+
+module.exports.lambdaHandler = handler

--- a/test/aws-lambda/features/fixtures/simple-app/async/package.json
+++ b/test/aws-lambda/features/fixtures/simple-app/async/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "simple-app",
+  "version": "1.0.0",
+  "description": "simple lambda app for testing",
+  "dependencies": {
+    "@bugsnag/core": "bugsnag-core.tgz",
+    "@bugsnag/delivery-node": "bugsnag-delivery-node.tgz",
+    "@bugsnag/js": "bugsnag-js.tgz",
+    "@bugsnag/node": "bugsnag-node.tgz",
+    "@bugsnag/plugin-app-duration": "bugsnag-plugin-app-duration.tgz",
+    "@bugsnag/plugin-contextualize": "bugsnag-plugin-contextualize.tgz",
+    "@bugsnag/plugin-intercept": "bugsnag-plugin-intercept.tgz",
+    "@bugsnag/plugin-node-device": "bugsnag-plugin-node-device.tgz",
+    "@bugsnag/plugin-node-in-project": "bugsnag-plugin-node-in-project.tgz",
+    "@bugsnag/plugin-node-surrounding-code": "bugsnag-plugin-node-surrounding-code.tgz",
+    "@bugsnag/plugin-node-uncaught-exception": "bugsnag-plugin-node-uncaught-exception.tgz",
+    "@bugsnag/plugin-node-unhandled-rejection": "bugsnag-plugin-node-unhandled-rejection.tgz",
+    "@bugsnag/plugin-server-session": "bugsnag-plugin-server-session.tgz",
+    "@bugsnag/plugin-strip-project-root": "bugsnag-plugin-strip-project-root.tgz"
+  }
+}

--- a/test/aws-lambda/features/fixtures/simple-app/async/unhandled-exception.js
+++ b/test/aws-lambda/features/fixtures/simple-app/async/unhandled-exception.js
@@ -1,0 +1,12 @@
+const Bugsnag = require('@bugsnag/js')
+
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  plugins: []
+})
+
+const handler = async (event, context) => {
+  throw new Error('Oh no!')
+}
+
+module.exports.lambdaHandler = handler

--- a/test/aws-lambda/features/fixtures/simple-app/events/async/handled-exception.json
+++ b/test/aws-lambda/features/fixtures/simple-app/events/async/handled-exception.json
@@ -1,0 +1,46 @@
+{
+  "body": "",
+  "resource": "/{proxy+}",
+  "path": "/async/handled/exception",
+  "httpMethod": "GET",
+  "isBase64Encoded": false,
+  "queryStringParameters": {},
+  "multiValueQueryStringParameters": {},
+  "pathParameters": {},
+  "stageVariables": {},
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/async/handled/exception",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/simple-app/events/async/unhandled-exception.json
+++ b/test/aws-lambda/features/fixtures/simple-app/events/async/unhandled-exception.json
@@ -1,0 +1,46 @@
+{
+  "body": "",
+  "resource": "/{proxy+}",
+  "path": "/async/unhandled/exception",
+  "httpMethod": "GET",
+  "isBase64Encoded": false,
+  "queryStringParameters": {},
+  "multiValueQueryStringParameters": {},
+  "pathParameters": {},
+  "stageVariables": {},
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/async/unhandled/exception",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/simple-app/template.yaml
+++ b/test/aws-lambda/features/fixtures/simple-app/template.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: simple-app
+
+Globals:
+  Function:
+    Timeout: 30
+    Environment:
+      Variables:
+        BUGSNAG_API_KEY:
+
+Resources:
+  AsyncUnhandledExceptionFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: async/
+      Handler: unhandled-exception.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        AsyncUnhandledException:
+          Type: Api
+          Properties:
+            Path: /async/unhandled/exception
+            Method: get
+
+  AsyncHandledExceptionFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: async/
+      Handler: handled-exception.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        AsyncHandledException:
+          Type: Api
+          Properties:
+            Path: /async/handled/exception
+            Method: get

--- a/test/aws-lambda/features/handled.feature
+++ b/test/aws-lambda/features/handled.feature
@@ -1,0 +1,8 @@
+Feature: Handled exceptions are reported correctly in lambda functions
+
+Scenario: handled exception in an async lambda
+    Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+    When I invoke the "AsyncHandledExceptionFunction" lambda in "features/fixtures/simple-app" with the "events/async/handled-exception.json" event
+    Then the lambda response "body.message" equals "Did not crash!"
+    And the lambda response "statusCode" equals 200
+    And the SAM exit code equals 0

--- a/test/aws-lambda/features/scripts/build-fixtures
+++ b/test/aws-lambda/features/scripts/build-fixtures
@@ -1,0 +1,135 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+require "fileutils"
+
+# Allow specifying a specic fixture to build by passing it's name as an argument
+# e.g. ./build-fixtures simple-app
+SPECIFIC_FIXTURE = ARGV.first
+
+# Allow debugging by logging more verbosely and not tidying up packed packages
+DEBUG = ["1", "true", true].include?(ENV.fetch("DEBUG", false))
+
+# The root of bugsnag-js
+ROOT = File.realpath("#{__dir__}/../../../../")
+
+# Bugsnag packages that we need to pack & install into the fixtures
+BUGSNAG_PACKAGES = [
+  "core",
+  "delivery-node",
+  "js",
+  "node",
+  "plugin-app-duration",
+  "plugin-contextualize",
+  "plugin-intercept",
+  "plugin-node-device",
+  "plugin-node-in-project",
+  "plugin-node-surrounding-code",
+  "plugin-node-uncaught-exception",
+  "plugin-node-unhandled-rejection",
+  "plugin-server-session",
+  "plugin-strip-project-root",
+]
+
+def heading(message)
+  <<~HEADING
+  ====#{"=" * message.length}====
+  =   #{message}   =
+  ====#{"=" * message.length}====
+  HEADING
+end
+
+# Run "npm pack" on the required packages and strip the version suffix so they
+# can be depended on in a package.json file
+def pack
+  puts heading("Packing Bugsnag packages")
+
+  BUGSNAG_PACKAGES.each do |package|
+    path = "#{ROOT}/packages/#{package}"
+    flags = DEBUG ? "--verbose" : "--quiet"
+
+    success = system("npm pack #{flags} #{path}/")
+
+    raise "Failed to pack #{package}" unless success
+  end
+
+  # Strip the version suffix from the packages
+  Dir["#{FileUtils.pwd}/bugsnag-*.tgz"].each do |package|
+    package_with_no_version = package.gsub(/-\d+\.\d+\.\d+/, '')
+    File.rename(package, package_with_no_version)
+  end
+end
+
+# Install the packed packages in each fixture and build the fixture
+def install_and_build
+  Dir["#{__dir__}/../fixtures/*"].each do |fixture|
+    fixture = File.realpath(fixture)
+    fixture_name = File.basename(fixture)
+
+    if SPECIFIC_FIXTURE && SPECIFIC_FIXTURE != fixture_name
+      puts heading("Not building #{fixture_name} because it's not '#{SPECIFIC_FIXTURE}'")
+      next
+    end
+
+    puts heading("Installing Bugsnag packages in #{fixture_name}")
+
+    # We have to parse the template file to find out where to put the packages as
+    # any file outside of the function's directory is unavailable when building
+    template = "#{fixture}/template.yaml"
+
+    raise "template.yaml does not exist!" unless File.exist?(template)
+
+    parsed_template = YAML.safe_load(File.read(template))
+
+    # Find all of the directories we need to install the packages in
+    destinations = parsed_template.fetch("Resources").values.map do |resource|
+      "#{fixture}/#{resource.fetch("Properties").fetch("CodeUri")}"
+    end.uniq
+
+    begin
+      # Install the packages into each of the destination directories
+      destinations.each do |destination|
+        puts "Installing packages to #{fixture_name}/#{File.basename(destination)}"
+
+        FileUtils.copy(Dir["#{FileUtils.pwd}/bugsnag-*.tgz"], destination)
+      end
+
+      puts heading("Building #{fixture_name}")
+
+      # SAM builds projects in the PWD by default. This would mean we build all
+      # of the fixtures into the same directory so we change directories to
+      # build in the right place
+      Dir.chdir(fixture) do
+        success = system("sam build")
+
+        raise "Failed to build #{fixture_name}" unless success
+      end
+    ensure
+      return if DEBUG
+
+      # Remove the packages from the destination directories as they aren't
+      # needed anymore. A built lambda has them in its node_modules directory
+      destinations.each do |destination|
+        FileUtils.remove(Dir["#{destination}/bugsnag-*.tgz"])
+      end
+    end
+  end
+end
+
+# Tidy up PWD by removing all the packed packages created by "pack"
+def tidy_up
+  return if DEBUG
+
+  puts heading("Tidying up PWD")
+
+  FileUtils.remove(Dir["#{FileUtils.pwd}/bugsnag-*.tgz"])
+end
+
+begin
+  pack
+  install_and_build
+ensure
+  tidy_up
+
+  puts "Done!"
+end

--- a/test/aws-lambda/features/support/env.rb
+++ b/test/aws-lambda/features/support/env.rb
@@ -16,4 +16,7 @@ end
 
 success = system(File.realpath("#{__dir__}/../scripts/build-fixtures"))
 
-raise "Unable to build fixtures!" unless success
+unless success
+  puts "Unable to build fixtures!"
+  exit 1
+end

--- a/test/aws-lambda/features/support/env.rb
+++ b/test/aws-lambda/features/support/env.rb
@@ -1,3 +1,19 @@
+`command -v sam`
+
+if $? != 0
+  puts <<~ERROR
+  The AWS SAM CLI must be installed before running these tests!
+
+  See the installation instructions:
+  https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html
+
+  If you have already installed the SAM CLI, check that it's in your PATH:
+  $ command -v sam
+  ERROR
+
+  exit 127
+end
+
 success = system(File.realpath("#{__dir__}/../scripts/build-fixtures"))
 
 raise "Unable to build fixtures!" unless success

--- a/test/aws-lambda/features/support/env.rb
+++ b/test/aws-lambda/features/support/env.rb
@@ -1,0 +1,3 @@
+success = system(File.realpath("#{__dir__}/../scripts/build-fixtures"))
+
+raise "Unable to build fixtures!" unless success

--- a/test/aws-lambda/features/unhandled.feature
+++ b/test/aws-lambda/features/unhandled.feature
@@ -1,0 +1,12 @@
+Feature: Unhandled exceptions are reported correctly in lambda functions
+
+Scenario: unhandled exception in an async lambda
+    Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+    When I invoke the "AsyncUnhandledExceptionFunction" lambda in "features/fixtures/simple-app" with the "events/async/unhandled-exception.json" event
+    Then the lambda response "errorMessage" equals "Oh no!"
+    And the lambda response "errorType" equals "Error"
+    And the lambda response "trace" is an array with 3 elements
+    And the lambda response "trace.0" equals "Error: Oh no!"
+    And the lambda response "body" is null
+    And the lambda response "statusCode" is null
+    And the SAM exit code equals 0


### PR DESCRIPTION
## Goal

This PR adds the scaffolding necessary to be able to run Maze Runner tests against Lambda functions. The fixture and tests are by no means complete, but will be expanded on as further work. This PR is purely to prove that we can build, and run tests against, a Lambda fixture

Each commit is standalone so can be reviewed separately if that's easier

## Testing

As we can't run tests using SAM on Buildkite yet, this has to be run locally for now:

1. Install Maze Runner

    ```sh
    $ bundle install
    ```

2. Run the tests

    ```sh
    $ bundle exec maze-runner
    ```

Note: the tests don't assert against Bugsnag payloads as we don't guarantee delivery in Lambda functions (yet!) so they assert against the Lambda responses instead