### PR TITLE
Create @bugsnag/in-flight internal package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -78,6 +78,7 @@ module.exports = {
     ]),
     project('node plugins', [
       'delivery-node',
+      'in-flight',
       'plugin-express',
       'plugin-koa',
       'plugin-restify',

--- a/packages/core/client.d.ts
+++ b/packages/core/client.d.ts
@@ -41,6 +41,7 @@ interface Delivery {
 export default class ClientWithInternals<T extends Config = Config> extends Client {
   public constructor(opts: T, schema?: {[key: string]: any}, internalPlugins?: Plugin[], notifier?: Notifier)
   _config: T
+  _depth: number
   _logger: LoggerConfig
   _breadcrumbs: Breadcrumb[];
   _delivery: Delivery

--- a/packages/in-flight/LICENSE.txt
+++ b/packages/in-flight/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/in-flight/README.md
+++ b/packages/in-flight/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/in-flight
+
+Internal [@bugsnag/js](https://github.com/bugsnag/bugsnag-js) package to keep track of in-flight requests
+
+## License
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/in-flight/package-lock.json
+++ b/packages/in-flight/package-lock.json
@@ -1,0 +1,13 @@
+{
+	"name": "@bugsnag/in-flight",
+	"version": "7.7.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@bugsnag/cuid": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
+		}
+	}
+}

--- a/packages/in-flight/package.json
+++ b/packages/in-flight/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bugsnag/in-flight",
+  "version": "7.7.0",
+  "main": "src/in-flight.js",
+  "types": "types/bugsnag-in-flight.d.ts",
+  "description": "Internal package to keep track of in-flight requests to Bugsnag",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "src",
+    "types"
+  ],
+  "author": "Bugsnag",
+  "license": "MIT",
+  "dependencies": {
+    "@bugsnag/cuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "@bugsnag/core": "^7.7.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
+  }
+}

--- a/packages/in-flight/src/in-flight.js
+++ b/packages/in-flight/src/in-flight.js
@@ -1,0 +1,67 @@
+const cuid = require('@bugsnag/cuid')
+
+const FLUSH_POLL_INTERVAL_MS = 50
+const inFlightRequests = new Map()
+
+const noop = () => {}
+
+module.exports = {
+  trackInFlight (client) {
+    const originalNotify = client._notify
+
+    client._notify = function (event, onError, callback = noop) {
+      const id = cuid()
+      inFlightRequests.set(id, true)
+
+      const _callback = function () {
+        inFlightRequests.delete(id)
+        callback.apply(null, arguments)
+      }
+
+      client._depth += 1
+
+      try {
+        originalNotify.call(client, event, onError, _callback)
+      } finally {
+        client._depth -= 1
+      }
+    }
+
+    const delivery = client._delivery
+    const originalSendSession = delivery.sendSession
+
+    delivery.sendSession = function (session, callback = noop) {
+      const id = cuid()
+      inFlightRequests.set(id, true)
+
+      const _callback = function () {
+        inFlightRequests.delete(id)
+        callback.apply(null, arguments)
+      }
+
+      originalSendSession.call(delivery, session, _callback)
+    }
+  },
+
+  flush (timeoutMs) {
+    return new Promise(function (resolve, reject) {
+      const timeout = setTimeout(
+        () => { reject(new Error(`flush timed out after ${timeoutMs}ms`)) },
+        timeoutMs
+      )
+
+      const resolveIfNoRequests = function () {
+        if (inFlightRequests.size === 0) {
+          clearTimeout(timeout)
+          resolve()
+
+          return
+        }
+
+        setTimeout(resolveIfNoRequests, FLUSH_POLL_INTERVAL_MS)
+      }
+
+      resolveIfNoRequests()
+    })
+  }
+}

--- a/packages/in-flight/src/in-flight.js
+++ b/packages/in-flight/src/in-flight.js
@@ -45,20 +45,25 @@ module.exports = {
 
   flush (timeoutMs) {
     return new Promise(function (resolve, reject) {
-      const timeout = setTimeout(
-        () => { reject(new Error(`flush timed out after ${timeoutMs}ms`)) },
+      let resolveTimeout
+      const rejectTimeout = setTimeout(
+        () => {
+          if (resolveTimeout) clearTimeout(resolveTimeout)
+
+          reject(new Error(`flush timed out after ${timeoutMs}ms`))
+        },
         timeoutMs
       )
 
       const resolveIfNoRequests = function () {
         if (inFlightRequests.size === 0) {
-          clearTimeout(timeout)
+          clearTimeout(rejectTimeout)
           resolve()
 
           return
         }
 
-        setTimeout(resolveIfNoRequests, FLUSH_POLL_INTERVAL_MS)
+        resolveTimeout = setTimeout(resolveIfNoRequests, FLUSH_POLL_INTERVAL_MS)
       }
 
       resolveIfNoRequests()

--- a/packages/in-flight/test/in-flight.test.ts
+++ b/packages/in-flight/test/in-flight.test.ts
@@ -1,7 +1,219 @@
+import Client, { EventDeliveryPayload, SessionDeliveryPayload } from '@bugsnag/core/client'
+
+// The in-flight package has module level state which can leak between tests
+// We can avoid this using jest's 'isolateModules' but need to type the
+// 'bugsnagInFlight' variable for this test to compile
+import BugsnagInFlightJustForTypescript from '../types/bugsnag-in-flight'
+
+let bugsnagInFlight: BugsnagInFlightJustForTypescript
+jest.isolateModules(() => { bugsnagInFlight = require('../src/in-flight') })
+
 describe('@bugsnag/in-flight', () => {
-  it.todo('tracks in-flight events')
-  it.todo('tracks in-flight sessions')
-  it.todo('tracks all in-flight requests')
-  it.todo('can flush successfully')
-  it.todo('will timeout if flush takes too long')
+  it('tracks in-flight events', () => {
+    const client = new Client({ apiKey: 'AN_API_KEY' })
+    const payloads: EventDeliveryPayload[] = []
+    const sendSession = jest.fn()
+
+    client._setDelivery(() => ({
+      sendEvent: (payload, cb) => {
+        expect(client._depth).toBe(2)
+        payloads.push(payload)
+        cb()
+      },
+      sendSession
+    }))
+
+    bugsnagInFlight.trackInFlight(client)
+
+    expect(payloads.length).toBe(0)
+
+    const onError = jest.fn()
+    const callback = jest.fn()
+
+    expect(client._depth).toBe(1)
+
+    client.notify(new Error('xyz'), onError, callback)
+
+    expect(client._depth).toBe(1)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(payloads.length).toBe(1)
+    expect(sendSession).not.toHaveBeenCalled()
+  })
+
+  it('tracks in-flight sessions', () => {
+    const client = new Client({ apiKey: 'AN_API_KEY' })
+    const payloads: SessionDeliveryPayload[] = []
+    const sendEvent = jest.fn()
+    const callback = jest.fn()
+
+    client._sessionDelegate = {
+      startSession: jest.fn(function (client, session) {
+        client._delivery.sendSession(session, callback)
+      }),
+      pauseSession: jest.fn(),
+      resumeSession: jest.fn()
+    }
+
+    client._setDelivery(() => ({
+      sendEvent,
+      sendSession: (payload, cb) => {
+        payloads.push(payload)
+        cb()
+      }
+    }))
+
+    bugsnagInFlight.trackInFlight(client)
+
+    expect(payloads.length).toBe(0)
+    expect(callback).not.toHaveBeenCalled()
+    expect(client._sessionDelegate.startSession).not.toHaveBeenCalled()
+    expect(client._sessionDelegate.pauseSession).not.toHaveBeenCalled()
+    expect(client._sessionDelegate.resumeSession).not.toHaveBeenCalled()
+
+    client.startSession()
+
+    expect(payloads.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(client._sessionDelegate.startSession).toHaveBeenCalledTimes(1)
+    expect(client._sessionDelegate.pauseSession).not.toHaveBeenCalled()
+    expect(client._sessionDelegate.resumeSession).not.toHaveBeenCalled()
+  })
+
+  it('tracks all in-flight requests', () => {
+    const client = new Client({ apiKey: 'AN_API_KEY' })
+    const eventPayloads: EventDeliveryPayload[] = []
+    const sessionPayloads: SessionDeliveryPayload[] = []
+    const sessionCallback = jest.fn()
+
+    client._sessionDelegate = {
+      startSession: jest.fn(function (client, session) {
+        client._delivery.sendSession(session, sessionCallback)
+      }),
+      pauseSession: jest.fn(),
+      resumeSession: jest.fn()
+    }
+
+    client._setDelivery(() => ({
+      sendEvent: (payload, cb) => {
+        expect(client._depth).toBe(2)
+        eventPayloads.push(payload)
+        cb()
+      },
+      sendSession: (payload, cb) => {
+        sessionPayloads.push(payload)
+        cb()
+      }
+    }))
+
+    bugsnagInFlight.trackInFlight(client)
+
+    expect(eventPayloads.length).toBe(0)
+    expect(sessionPayloads.length).toBe(0)
+
+    const onError = jest.fn()
+    const notifyCallback = jest.fn()
+
+    expect(client._depth).toBe(1)
+
+    client.notify(new Error('xyz'), onError, notifyCallback)
+    client.startSession()
+
+    expect(client._depth).toBe(1)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(notifyCallback).toHaveBeenCalledTimes(1)
+    expect(sessionCallback).toHaveBeenCalledTimes(1)
+    expect(eventPayloads.length).toBe(1)
+    expect(sessionPayloads.length).toBe(1)
+  })
+
+  it('can flush successfully', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY' })
+    const eventPayloads: EventDeliveryPayload[] = []
+    const sessionPayloads: SessionDeliveryPayload[] = []
+
+    client._sessionDelegate = {
+      startSession (client, session) {
+        client._delivery.sendSession(session, () => {})
+      },
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        setTimeout(function () {
+          eventPayloads.push(payload)
+          cb()
+        }, 100)
+      },
+      sendSession (payload, cb) {
+        setTimeout(function () {
+          sessionPayloads.push(payload)
+          cb()
+        }, 100)
+      }
+    }))
+
+    bugsnagInFlight.trackInFlight(client)
+
+    client.notify(new Error('xyz'))
+    client.startSession()
+
+    expect(eventPayloads.length).toBe(0)
+    expect(sessionPayloads.length).toBe(0)
+
+    await bugsnagInFlight.flush(1000)
+
+    expect(eventPayloads.length).toBe(1)
+    expect(sessionPayloads.length).toBe(1)
+  })
+
+  it('will timeout if flush takes too long', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY' })
+    const eventPayloads: EventDeliveryPayload[] = []
+    const sessionPayloads: SessionDeliveryPayload[] = []
+
+    client._sessionDelegate = {
+      startSession: (client, session) => {
+        client._delivery.sendSession(session, () => {})
+      },
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        setTimeout(() => {
+          eventPayloads.push(payload)
+          cb()
+        }, 250)
+      },
+      sendSession (payload, cb) {
+        setTimeout(() => {
+          sessionPayloads.push(payload)
+          cb()
+        }, 250)
+      }
+    }))
+
+    bugsnagInFlight.trackInFlight(client)
+
+    client.notify(new Error('xyz'))
+    client.startSession()
+
+    expect(eventPayloads.length).toBe(0)
+    expect(sessionPayloads.length).toBe(0)
+
+    const expected = new Error('flush timed out after 10ms')
+    await expect(() => bugsnagInFlight.flush(10)).rejects.toThrow(expected)
+
+    expect(eventPayloads.length).toBe(0)
+    expect(sessionPayloads.length).toBe(0)
+
+    await bugsnagInFlight.flush(1000)
+
+    expect(eventPayloads.length).toBe(1)
+    expect(sessionPayloads.length).toBe(1)
+  })
 })

--- a/packages/in-flight/test/in-flight.test.ts
+++ b/packages/in-flight/test/in-flight.test.ts
@@ -1,0 +1,7 @@
+describe('@bugsnag/in-flight', () => {
+  it.todo('tracks in-flight events')
+  it.todo('tracks in-flight sessions')
+  it.todo('tracks all in-flight requests')
+  it.todo('can flush successfully')
+  it.todo('will timeout if flush takes too long')
+})

--- a/packages/in-flight/types/bugsnag-in-flight.d.ts
+++ b/packages/in-flight/types/bugsnag-in-flight.d.ts
@@ -1,0 +1,8 @@
+import { Client } from '@bugsnag/core'
+
+interface BugsnagInFlight {
+  trackInFlight (client: Client): void
+  flush (timeoutMs: number): Promise<void>
+}
+
+export default BugsnagInFlight

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,7 @@
     "packages/delivery-react-native",
     "packages/delivery-x-domain-request",
     "packages/delivery-xml-http-request",
+    "packages/in-flight",
     "packages/plugin-app-duration",
     "packages/plugin-browser-context",
     "packages/plugin-browser-device",


### PR DESCRIPTION
## Goal

This PR adds a new `@bugsnag/in-flight` package, to be used internally

This package exports two functions: `trackInFlight` and `flush`. `trackInFlight` will monkey-patch the Client passed to it in order to track all calls to `_notify` and it's Delivery's `sendSession`. `flush` uses this tracking to determine if there are any outstanding requests — it will resolve if there are no requests, retrying repeatedly until all requests settle or it times out