### PR TITLE
Add new AWS Lambda plugin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -79,6 +79,7 @@ module.exports = {
     project('node plugins', [
       'delivery-node',
       'in-flight',
+      'plugin-aws-lambda',
       'plugin-express',
       'plugin-koa',
       'plugin-restify',

--- a/packages/plugin-aws-lambda/LICENSE.txt
+++ b/packages/plugin-aws-lambda/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/plugin-aws-lambda/README.md
+++ b/packages/plugin-aws-lambda/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/plugin-aws-lambda
+
+A [@bugsnag/js](https://github.com/bugsnag/bugsnag-js) plugin for capturing errors in AWS Lambda functions.
+
+## License
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@bugsnag/plugin-aws-lambda",
+  "version": "7.7.0",
+  "main": "dist/bugsnag-aws-lambda.js",
+  "types": "types/bugsnag-plugin-aws-lambda.d.ts",
+  "description": "AWS Lambda support for @bugsnag/node",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "types"
+  ],
+  "scripts": {
+    "clean": "rm -fr dist && mkdir dist",
+    "build": "npm run clean && ../../bin/bundle src/index.js --node --standalone=BugsnagPluginAwsLambda | ../../bin/extract-source-map dist/bugsnag-aws-lambda.js",
+    "postversion": "npm run build"
+  },
+  "author": "Bugsnag",
+  "license": "MIT",
+  "dependencies": {
+    "@bugsnag/in-flight": "^7.7.0"
+  },
+  "devDependencies": {
+    "@bugsnag/core": "^7.7.0"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
+  }
+}

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -36,7 +36,7 @@ function wrapHandler (client, flushTimeoutMs, handler) {
           severityReason: { type: 'unhandledException' }
         }
 
-        const event = client.Event.create(err, true, handledState, 1)
+        const event = client.Event.create(err, true, handledState, 'aws lambda plugin', 1)
 
         client._notify(event)
       }

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -1,0 +1,82 @@
+const bugsnagInFlight = require('@bugsnag/in-flight')
+
+const BugsnagPluginAwsLambda = {
+  name: 'awsLambda',
+
+  load (client) {
+    bugsnagInFlight.trackInFlight(client)
+
+    return {
+      createHandler ({ flushTimeoutMs = 2000 } = {}) {
+        return wrapHandler.bind(null, client, flushTimeoutMs)
+      }
+    }
+  }
+}
+
+function wrapHandler (client, flushTimeoutMs, handler) {
+  let _handler = handler
+
+  if (handler.length > 2) {
+    // This is a handler expecting a 'callback' argument, so we convert
+    // it to return a Promise so '_handler' always has the same API
+    _handler = promisifyHandler(handler)
+  }
+
+  return async function (event, context) {
+    client.addMetadata('AWS Lambda context', context)
+
+    try {
+      return await _handler(event, context)
+    } catch (err) {
+      const handledState = {
+        severity: 'error',
+        unhandled: true,
+        severityReason: { type: 'unhandledException' }
+      }
+
+      const event = client.Event.create(err, true, handledState, 1)
+
+      client._notify(event)
+
+      throw err
+    } finally {
+      try {
+        await bugsnagInFlight.flush(flushTimeoutMs)
+      } catch (err) {
+        client._logger.error(`Delivery may be unsuccessful: ${err.message}`)
+      }
+    }
+  }
+}
+
+// Convert a handler that uses callbacks to an async handler
+function promisifyHandler (handler) {
+  return function (event, context) {
+    return new Promise(function (resolve, reject) {
+      const result = handler(event, context, function (err, response) {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        resolve(response)
+      })
+
+      // Handle an edge case where the passed handler has the callback parameter
+      // but actually returns a promise. In this case we need to resolve/reject
+      // based on the returned promise instead of in the callback
+      if (isPromise(result)) {
+        result.then(resolve).catch(reject)
+      }
+    })
+  }
+}
+
+function isPromise (value) {
+  return (typeof value === 'object' || typeof value === 'function') &&
+    typeof value.then === 'function' &&
+    typeof value.catch === 'function'
+}
+
+module.exports = BugsnagPluginAwsLambda

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -29,15 +29,17 @@ function wrapHandler (client, flushTimeoutMs, handler) {
     try {
       return await _handler(event, context)
     } catch (err) {
-      const handledState = {
-        severity: 'error',
-        unhandled: true,
-        severityReason: { type: 'unhandledException' }
+      if (client._config.autoDetectErrors && client._config.enabledErrorTypes.unhandledExceptions) {
+        const handledState = {
+          severity: 'error',
+          unhandled: true,
+          severityReason: { type: 'unhandledException' }
+        }
+
+        const event = client.Event.create(err, true, handledState, 1)
+
+        client._notify(event)
       }
-
-      const event = client.Event.create(err, true, handledState, 1)
-
-      client._notify(event)
 
       throw err
     } finally {

--- a/packages/plugin-aws-lambda/test/index.test.ts
+++ b/packages/plugin-aws-lambda/test/index.test.ts
@@ -1,0 +1,298 @@
+import BugsnagPluginAwsLambda from '../src/'
+import Client, { EventDeliveryPayload } from '@bugsnag/core/client'
+
+describe('plugin: aws lambda', () => {
+  it('has a name', () => {
+    expect(BugsnagPluginAwsLambda.name).toBe('awsLambda')
+
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const plugin = client.getPlugin('awsLambda')
+
+    expect(plugin).toBeTruthy()
+  })
+
+  it('exports a "createHandler" function', () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const plugin = client.getPlugin('awsLambda')
+
+    expect(plugin).toMatchObject({ createHandler: expect.any(Function) })
+  })
+
+  it('adds the context as metadata', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+
+    const handler = (event: any, context: any) => 'abc'
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('abc')
+
+    expect(client.getMetadata('AWS Lambda context')).toEqual(context)
+  })
+
+  it('logs an error if flush times out', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    client._logger.error = jest.fn()
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        setTimeout(cb, 250)
+      },
+      sendSession: () => {}
+    }))
+
+    const handler = () => {
+      client.notify('hello')
+
+      return 'abc'
+    }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const timeoutError = new Error('flush timed out after 20ms')
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler({ flushTimeoutMs: 20 })
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('abc')
+    expect(client._logger.error).toHaveBeenCalledWith(`Delivery may be unsuccessful: ${timeoutError.message}`)
+  })
+
+  it('returns a wrapped handler that resolves to the original return value (async)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+
+    const handler = () => 'abc'
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await handler()).toBe('abc')
+    expect(await wrappedHandler(event, context)).toBe('abc')
+  })
+
+  it('notifies when an error is thrown (async)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('oh no')
+    const handler = (event: any, context: any) => { throw error }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+  })
+
+  it('returns a wrapped handler that resolves to the value passed to the callback (callback)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+
+    const handler = (event: any, context: any, callback: any) => { callback(null, 'xyz') }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('xyz')
+  })
+
+  it('notifies when an error is passed (callback)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('uh oh')
+    const handler = (event: any, context: any, callback: any) => { callback(error, 'xyz') }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+  })
+
+  it('works when an async handler has the callback parameter', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+
+    const handler = async (event: any, context: any, callback: any) => 'abcxyz'
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('abcxyz')
+  })
+
+  it('works when an async handler has the callback parameter and calls it', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+
+    const handler = async (event: any, context: any, callback: any) => { callback(null, 'abcxyz') }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('abcxyz')
+  })
+
+  it('works when an async handler has the callback parameter and throws', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('abcxyz')
+    const handler = async (event: any, context: any, callback: any) => { throw error }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+  })
+
+  it('works when an async handler has the callback parameter and calls it with an error', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('abcxyz')
+    const handler = async (event: any, context: any, callback: any) => { callback(error) }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(1)
+    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+  })
+})

--- a/packages/plugin-aws-lambda/test/index.test.ts
+++ b/packages/plugin-aws-lambda/test/index.test.ts
@@ -131,6 +131,74 @@ describe('plugin: aws lambda', () => {
     expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
   })
 
+  it('does not notify when "autoDetectErrors" is false (async)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], autoDetectErrors: false })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('oh no')
+    const handler = (event: any, context: any) => { throw error }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(0)
+  })
+
+  it('does not notify when "unhandledExceptions" are disabled (async)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], enabledErrorTypes: { unhandledExceptions: false } })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('oh no')
+    const handler = (event: any, context: any) => { throw error }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(0)
+  })
+
   it('returns a wrapped handler that resolves to the value passed to the callback (callback)', async () => {
     const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
 
@@ -184,6 +252,74 @@ describe('plugin: aws lambda', () => {
 
     expect(payloads).toHaveLength(1)
     expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+  })
+
+  it('does not notify when "autoDetectErrors" is false (callback)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], autoDetectErrors: false })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('uh oh')
+    const handler = (event: any, context: any, callback: any) => { callback(error, 'xyz') }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(0)
+  })
+
+  it('does not notify when "unhandledExceptions" are disabled (callback)', async () => {
+    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], enabledErrorTypes: { unhandledExceptions: false } })
+    const payloads: EventDeliveryPayload[] = []
+
+    client._setDelivery(() => ({
+      sendEvent (payload, cb) {
+        payloads.push(payload)
+        cb()
+      },
+      sendSession: () => {}
+    }))
+
+    const error = new Error('uh oh')
+    const handler = (event: any, context: any, callback: any) => { callback(error, 'xyz') }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(payloads).toHaveLength(0)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
+
+    expect(payloads).toHaveLength(0)
   })
 
   it('works when an async handler has the callback parameter', async () => {

--- a/packages/plugin-aws-lambda/types/bugsnag-plugin-aws-lambda.d.ts
+++ b/packages/plugin-aws-lambda/types/bugsnag-plugin-aws-lambda.d.ts
@@ -1,0 +1,24 @@
+import { Plugin, Client } from '@bugsnag/core'
+
+declare const BugsnagPluginAwsLambda: Plugin
+export default BugsnagPluginAwsLambda
+
+type AsyncHandler = (event: any, context: any) => Promise<any>
+type CallbackHandler = (event: any, context: any, callback: (err: Error|null, response: any) => void) => void
+
+export type BugsnagPluginAwsLambdaHandler = (handler: AsyncHandler|CallbackHandler) => AsyncHandler
+
+export interface BugsnagPluginAwsLambdaConfiguration {
+  flushTimeoutMs?: number
+}
+
+export interface BugsnagPluginAwsLambdaResult {
+  createHandler(configuration?: BugsnagPluginAwsLambdaConfiguration): BugsnagPluginAwsLambdaHandler
+}
+
+// add a new call signature for the getPlugin() method that types the plugin result
+declare module '@bugsnag/core' {
+  interface Client {
+    getPlugin(id: 'awsLambda'): BugsnagPluginAwsLambdaResult | undefined
+  }
+}

--- a/test/aws-lambda/features/fixtures/simple-app/async/handled-exception.js
+++ b/test/aws-lambda/features/fixtures/simple-app/async/handled-exception.js
@@ -1,9 +1,16 @@
 const Bugsnag = require('@bugsnag/js')
+const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
 
 Bugsnag.start({
   apiKey: process.env.BUGSNAG_API_KEY,
-  plugins: []
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  plugins: [BugsnagPluginAwsLambda]
 })
+
+const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler()
 
 const handler = async (event, context) => {
   Bugsnag.notify(new Error('Hello!'))
@@ -14,4 +21,4 @@ const handler = async (event, context) => {
   }
 }
 
-module.exports.lambdaHandler = handler
+module.exports.lambdaHandler = bugsnagHandler(handler)

--- a/test/aws-lambda/features/fixtures/simple-app/async/package.json
+++ b/test/aws-lambda/features/fixtures/simple-app/async/package.json
@@ -5,9 +5,11 @@
   "dependencies": {
     "@bugsnag/core": "bugsnag-core.tgz",
     "@bugsnag/delivery-node": "bugsnag-delivery-node.tgz",
+    "@bugsnag/in-flight": "bugsnag-in-flight.tgz",
     "@bugsnag/js": "bugsnag-js.tgz",
     "@bugsnag/node": "bugsnag-node.tgz",
     "@bugsnag/plugin-app-duration": "bugsnag-plugin-app-duration.tgz",
+    "@bugsnag/plugin-aws-lambda": "bugsnag-plugin-aws-lambda.tgz",
     "@bugsnag/plugin-contextualize": "bugsnag-plugin-contextualize.tgz",
     "@bugsnag/plugin-intercept": "bugsnag-plugin-intercept.tgz",
     "@bugsnag/plugin-node-device": "bugsnag-plugin-node-device.tgz",

--- a/test/aws-lambda/features/fixtures/simple-app/async/unhandled-exception.js
+++ b/test/aws-lambda/features/fixtures/simple-app/async/unhandled-exception.js
@@ -1,12 +1,19 @@
 const Bugsnag = require('@bugsnag/js')
+const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
 
 Bugsnag.start({
   apiKey: process.env.BUGSNAG_API_KEY,
-  plugins: []
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  plugins: [BugsnagPluginAwsLambda]
 })
+
+const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler()
 
 const handler = async (event, context) => {
   throw new Error('Oh no!')
 }
 
-module.exports.lambdaHandler = handler
+module.exports.lambdaHandler = bugsnagHandler(handler)

--- a/test/aws-lambda/features/fixtures/simple-app/template.yaml
+++ b/test/aws-lambda/features/fixtures/simple-app/template.yaml
@@ -8,6 +8,8 @@ Globals:
     Environment:
       Variables:
         BUGSNAG_API_KEY:
+        BUGSNAG_NOTIFY_ENDPOINT:
+        BUGSNAG_SESSIONS_ENDPOINT:
 
 Resources:
   AsyncUnhandledExceptionFunction:

--- a/test/aws-lambda/features/handled.feature
+++ b/test/aws-lambda/features/handled.feature
@@ -2,7 +2,20 @@ Feature: Handled exceptions are reported correctly in lambda functions
 
 Scenario: handled exception in an async lambda
     Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+    And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
+    And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
     When I invoke the "AsyncHandledExceptionFunction" lambda in "features/fixtures/simple-app" with the "events/async/handled-exception.json" event
     Then the lambda response "body.message" equals "Did not crash!"
     And the lambda response "statusCode" equals 200
     And the SAM exit code equals 0
+    When I wait to receive an error
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is false
+    And the event "severity" equals "warning"
+    And the event "severityReason.type" equals "handledException"
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "Hello!"
+    And the exception "type" equals "nodejs"
+    And the "file" of stack frame 0 equals "handled-exception.js"
+    And the event "metaData.AWS Lambda context.functionName" equals "AsyncHandledExceptionFunction"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null

--- a/test/aws-lambda/features/scripts/build-fixtures
+++ b/test/aws-lambda/features/scripts/build-fixtures
@@ -17,9 +17,11 @@ ROOT = File.realpath("#{__dir__}/../../../../")
 BUGSNAG_PACKAGES = [
   "core",
   "delivery-node",
+  "in-flight",
   "js",
   "node",
   "plugin-app-duration",
+  "plugin-aws-lambda",
   "plugin-contextualize",
   "plugin-intercept",
   "plugin-node-device",
@@ -37,6 +39,14 @@ def heading(message)
   =   #{message}   =
   ====#{"=" * message.length}====
   HEADING
+end
+
+# Bootstrap and build Bugsnag packages so they're ready to install
+def bootstrap
+  Dir.chdir(ROOT) do
+    system("npm run bootstrap")
+    system("npm run build")
+  end
 end
 
 # Run "npm pack" on the required packages and strip the version suffix so they
@@ -126,6 +136,7 @@ def tidy_up
 end
 
 begin
+  bootstrap
   pack
   install_and_build
 ensure

--- a/test/aws-lambda/features/steps/aws-lambda-steps.rb
+++ b/test/aws-lambda/features/steps/aws-lambda-steps.rb
@@ -1,0 +1,7 @@
+Given('I store the notify endpoint in the environment variable {string}') do |name|
+  step("I set environment variable '#{name}' to 'http://host.docker.internal:9339/notify'")
+end
+
+Given('I store the sessions endpoint in the environment variable {string}') do |name|
+  step("I set environment variable '#{name}' to 'http://host.docker.internal:9339/sessions'")
+end

--- a/test/aws-lambda/features/support/env.rb
+++ b/test/aws-lambda/features/support/env.rb
@@ -1,3 +1,61 @@
+require 'maze/server'
+
+# FIXME: this is a temporary workaround that binds the Maze::Server to 0.0.0.0
+#        so that it is reachable from the docker containers started by AWS SAM
+#        This can be removed when PLAT-6116 is done
+module Maze
+  class Server
+    class << self
+      def start
+        attempts = 0
+        $logger.info "Maze Runner v#{Maze::VERSION}"
+        $logger.info 'Starting mock server'
+        loop do
+          @thread = Thread.new do
+            server = WEBrick::HTTPServer.new(
+              BindAddress: '0.0.0.0',
+              Port: PORT,
+              Logger: $logger,
+              AccessLog: []
+            )
+
+            # Mount a block to respond to all requests with status:200
+            server.mount_proc '/' do |_request, response|
+              $logger.info 'Received request on server root, responding with 200'
+              response.header['Access-Control-Allow-Origin'] = '*'
+              response.body = 'Maze runner received request'
+              response.status = 200
+            end
+
+            # When adding more endpoints, be sure to update the 'I should receive no requests' step
+            server.mount '/notify', Servlet, errors
+            server.mount '/sessions', Servlet, sessions
+            server.mount '/builds', Servlet, builds
+            # server.mount '/logs', LogServlet
+            server.start
+          rescue StandardError => e
+            $logger.warn "Failed to start mock server: #{e.message}"
+          ensure
+            server&.shutdown
+          end
+
+          # Need a short sleep here as a dying thread is still alive momentarily
+          sleep 1
+          break if running?
+
+          # Bail out after 3 attempts
+          attempts += 1
+          raise 'Too many failed attempts to start mock server' if attempts == 3
+
+          # Failed to start - sleep before retrying
+          $logger.info 'Retrying in 5 seconds'
+          sleep 5
+        end
+      end
+    end
+  end
+end
+
 `command -v sam`
 
 if $? != 0
@@ -20,3 +78,5 @@ unless success
   puts "Unable to build fixtures!"
   exit 1
 end
+
+Maze.config.enforce_bugsnag_integrity = false

--- a/test/aws-lambda/features/unhandled.feature
+++ b/test/aws-lambda/features/unhandled.feature
@@ -2,11 +2,24 @@ Feature: Unhandled exceptions are reported correctly in lambda functions
 
 Scenario: unhandled exception in an async lambda
     Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+    And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
+    And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
     When I invoke the "AsyncUnhandledExceptionFunction" lambda in "features/fixtures/simple-app" with the "events/async/unhandled-exception.json" event
     Then the lambda response "errorMessage" equals "Oh no!"
     And the lambda response "errorType" equals "Error"
-    And the lambda response "trace" is an array with 3 elements
+    And the lambda response "trace" is an array with 4 elements
     And the lambda response "trace.0" equals "Error: Oh no!"
     And the lambda response "body" is null
     And the lambda response "statusCode" is null
     And the SAM exit code equals 0
+    When I wait to receive an error
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "unhandledException"
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "Oh no!"
+    And the exception "type" equals "nodejs"
+    And the "file" of stack frame 0 equals "unhandled-exception.js"
+    And the event "metaData.AWS Lambda context.functionName" equals "AsyncUnhandledExceptionFunction"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,7 @@
     "packages/delivery-xml-http-request",
     "packages/in-flight",
     "packages/plugin-app-duration",
+    "packages/plugin-aws-lambda",
     "packages/plugin-browser-context",
     "packages/plugin-browser-device",
     "packages/plugin-contextualize",


### PR DESCRIPTION
## Goal

This PR adds a plugin to allow Bugsnag to work in an AWS Lambda function. There is more work to do before release, such as session support, but the plugin is functional in this state

This plugin works by using the new `@bugsnag/in-flight` package so that it can wait for all requests to finish before allowing the Lambda to terminate. There is a default 2 second timeout, but this can be configured by the user to whatever makes sense for their app

## Basic usage

```js
const Bugsnag = require('@bugsnag/js')
const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')

Bugsnag.start({
  apiKey: 'api key here',
  plugins: [BugsnagPluginAwsLambda]
})

const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler()

const handler = async (event, context) => // code goes here

module.exports.lambdaHandler = bugsnagHandler(handler)
```

`createHandler` takes an options object, with the only current option being `flushTimeoutMs`. This is the length of time (in milliseconds) that we will wait for requests to finish. For example:

```js
createHandler({ flushTimeoutMs: 5000 }) // 5 seconds
```

## Testing

Tested with unit tests and the MR tests have been updated to assert events are reported when using the new plugin