### PR TITLE
Session support for AWS Lambda functions

### DIFF
--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -24,7 +24,8 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/in-flight": "^7.7.0"
+    "@bugsnag/in-flight": "^7.7.0",
+    "@bugsnag/plugin-browser-session": "^7.7.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.7.0"

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -1,10 +1,12 @@
 const bugsnagInFlight = require('@bugsnag/in-flight')
+const BugsnagPluginBrowserSession = require('@bugsnag/plugin-browser-session')
 
 const BugsnagPluginAwsLambda = {
   name: 'awsLambda',
 
   load (client) {
     bugsnagInFlight.trackInFlight(client)
+    client._loadPlugin(BugsnagPluginBrowserSession)
 
     return {
       createHandler ({ flushTimeoutMs = 2000 } = {}) {
@@ -25,6 +27,10 @@ function wrapHandler (client, flushTimeoutMs, handler) {
 
   return async function (event, context) {
     client.addMetadata('AWS Lambda context', context)
+
+    if (client._config.autoTrackSessions) {
+      client.startSession()
+    }
 
     try {
       return await _handler(event, context)

--- a/packages/plugin-aws-lambda/test/index.test.ts
+++ b/packages/plugin-aws-lambda/test/index.test.ts
@@ -1,5 +1,28 @@
+import util from 'util'
 import BugsnagPluginAwsLambda from '../src/'
-import Client, { EventDeliveryPayload } from '@bugsnag/core/client'
+import Client, { EventDeliveryPayload, SessionDeliveryPayload } from '@bugsnag/core/client'
+
+const createClient = (events: EventDeliveryPayload[], sessions: SessionDeliveryPayload[], config = {}) => {
+  const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], ...config })
+
+  // a flush failure won't throw as we don't want to crash apps if delivery takes
+  // too long. To avoid the unit tests passing when this happens, we make the logger
+  // throw on any 'error' log call
+  client._logger.error = (...args) => { throw new Error(util.format(args)) }
+
+  client._delivery = {
+    sendEvent (payload, cb = () => {}) {
+      events.push(payload)
+      cb()
+    },
+    sendSession (payload, cb = () => {}) {
+      sessions.push(payload)
+      cb()
+    }
+  }
+
+  return client
+}
 
 describe('plugin: aws lambda', () => {
   it('has a name', () => {
@@ -19,7 +42,10 @@ describe('plugin: aws lambda', () => {
   })
 
   it('adds the context as metadata', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
 
     const handler = (event: any, context: any) => 'abc'
 
@@ -44,12 +70,14 @@ describe('plugin: aws lambda', () => {
     const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
     client._logger.error = jest.fn()
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
+    client._delivery = {
+      sendEvent (payload, cb = () => {}) {
         setTimeout(cb, 250)
       },
-      sendSession: () => {}
-    }))
+      sendSession (payload, cb = () => {}) {
+        setTimeout(cb, 250)
+      }
+    }
 
     const handler = () => {
       client.notify('hello')
@@ -76,7 +104,10 @@ describe('plugin: aws lambda', () => {
   })
 
   it('returns a wrapped handler that resolves to the original return value (async)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
 
     const handler = () => 'abc'
 
@@ -94,19 +125,16 @@ describe('plugin: aws lambda', () => {
 
     expect(await handler()).toBe('abc')
     expect(await wrappedHandler(event, context)).toBe('abc')
+
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('notifies when an error is thrown (async)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions)
 
     const error = new Error('oh no')
     const handler = (event: any, context: any) => { throw error }
@@ -123,25 +151,22 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(1)
-    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+    expect(events).toHaveLength(1)
+    expect(events[0].events[0].errors[0].errorMessage).toBe(error.message)
+
+    expect(sessions).toHaveLength(1)
   })
 
   it('does not notify when "autoDetectErrors" is false (async)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], autoDetectErrors: false })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions, { autoDetectErrors: false })
 
     const error = new Error('oh no')
     const handler = (event: any, context: any) => { throw error }
@@ -158,24 +183,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('does not notify when "unhandledExceptions" are disabled (async)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], enabledErrorTypes: { unhandledExceptions: false } })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions, { enabledErrorTypes: { unhandledExceptions: false } })
 
     const error = new Error('oh no')
     const handler = (event: any, context: any) => { throw error }
@@ -192,15 +213,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('returns a wrapped handler that resolves to the value passed to the callback (callback)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
 
     const handler = (event: any, context: any, callback: any) => { callback(null, 'xyz') }
 
@@ -216,20 +242,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
+
     expect(await wrappedHandler(event, context)).toBe('xyz')
+
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('notifies when an error is passed (callback)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions)
 
     const error = new Error('uh oh')
     const handler = (event: any, context: any, callback: any) => { callback(error, 'xyz') }
@@ -246,25 +272,22 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(1)
-    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+    expect(events).toHaveLength(1)
+    expect(events[0].events[0].errors[0].errorMessage).toBe(error.message)
+
+    expect(sessions).toHaveLength(1)
   })
 
   it('does not notify when "autoDetectErrors" is false (callback)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], autoDetectErrors: false })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions, { autoDetectErrors: false })
 
     const error = new Error('uh oh')
     const handler = (event: any, context: any, callback: any) => { callback(error, 'xyz') }
@@ -281,24 +304,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('does not notify when "unhandledExceptions" are disabled (callback)', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], enabledErrorTypes: { unhandledExceptions: false } })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions, { enabledErrorTypes: { unhandledExceptions: false } })
 
     const error = new Error('uh oh')
     const handler = (event: any, context: any, callback: any) => { callback(error, 'xyz') }
@@ -315,15 +334,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('works when an async handler has the callback parameter', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
 
     const handler = async (event: any, context: any, callback: any) => 'abcxyz'
 
@@ -339,11 +363,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
+
     expect(await wrappedHandler(event, context)).toBe('abcxyz')
+
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('works when an async handler has the callback parameter and calls it', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
 
     const handler = async (event: any, context: any, callback: any) => { callback(null, 'abcxyz') }
 
@@ -359,20 +392,20 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
+
     expect(await wrappedHandler(event, context)).toBe('abcxyz')
+
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
   })
 
   it('works when an async handler has the callback parameter and throws', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions)
 
     const error = new Error('abcxyz')
     const handler = async (event: any, context: any, callback: any) => { throw error }
@@ -389,25 +422,22 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(1)
-    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+    expect(events).toHaveLength(1)
+    expect(events[0].events[0].errors[0].errorMessage).toBe(error.message)
+
+    expect(sessions).toHaveLength(1)
   })
 
   it('works when an async handler has the callback parameter and calls it with an error', async () => {
-    const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda] })
-    const payloads: EventDeliveryPayload[] = []
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
 
-    client._setDelivery(() => ({
-      sendEvent (payload, cb) {
-        payloads.push(payload)
-        cb()
-      },
-      sendSession: () => {}
-    }))
+    const client = createClient(events, sessions)
 
     const error = new Error('abcxyz')
     const handler = async (event: any, context: any, callback: any) => { callback(error) }
@@ -424,11 +454,64 @@ describe('plugin: aws lambda', () => {
     const bugsnagHandler = plugin.createHandler()
     const wrappedHandler = bugsnagHandler(handler)
 
-    expect(payloads).toHaveLength(0)
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
 
     await expect(() => wrappedHandler(event, context)).rejects.toThrow(error)
 
-    expect(payloads).toHaveLength(1)
-    expect(payloads[0].events[0].errors[0].errorMessage).toBe(error.message)
+    expect(events).toHaveLength(1)
+    expect(events[0].events[0].errors[0].errorMessage).toBe(error.message)
+
+    expect(sessions).toHaveLength(1)
+  })
+
+  it('will track sessions when "autoTrackSessions" is enabled', async () => {
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+    const client = createClient(events, sessions, { autoTrackSessions: true })
+
+    const handler = () => 'abc'
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('abc')
+
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(1)
+  })
+
+  it('will not track sessions when "autoTrackSessions" is disabled', async () => {
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+    const client = createClient(events, sessions, { autoTrackSessions: false })
+
+    const handler = () => 'abc'
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    expect(await wrappedHandler(event, context)).toBe('abc')
+
+    expect(events).toHaveLength(0)
+    expect(sessions).toHaveLength(0)
   })
 })

--- a/test/aws-lambda/features/handled.feature
+++ b/test/aws-lambda/features/handled.feature
@@ -19,3 +19,7 @@ Scenario: handled exception in an async lambda
     And the "file" of stack frame 0 equals "handled-exception.js"
     And the event "metaData.AWS Lambda context.functionName" equals "AsyncHandledExceptionFunction"
     And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    When I wait to receive a session
+    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+    And the session "id" is not null
+    And the session "startedAt" is a timestamp

--- a/test/aws-lambda/features/unhandled.feature
+++ b/test/aws-lambda/features/unhandled.feature
@@ -23,3 +23,7 @@ Scenario: unhandled exception in an async lambda
     And the "file" of stack frame 0 equals "unhandled-exception.js"
     And the event "metaData.AWS Lambda context.functionName" equals "AsyncUnhandledExceptionFunction"
     And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    When I wait to receive a session
+    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+    And the session "id" is not null
+    And the session "startedAt" is a timestamp


### PR DESCRIPTION
## Goal

The existing Node session plugin uses a model that works well for long running processes (like traditional webservers) but won't work for short lived Lambda executions. To fix this we can use the browser session plugin, which isn't actually browser specific. This sends a session every time `startSession` is called, which is exactly what we want in a Lambda function

As always, the `autoTrackSessions` option can be disabled to prevent the automatic `startSession` call

## Testing

Unit tests have been updated and the MazeRunner tests also check for sessions