### PR TITLE
Calculate the duration for Lambda functions

### DIFF
--- a/packages/plugin-app-duration/app.js
+++ b/packages/plugin-app-duration/app.js
@@ -1,4 +1,5 @@
-const appStart = new Date()
+let appStart = new Date()
+const reset = () => { appStart = new Date() }
 
 module.exports = {
   load: client => {
@@ -7,5 +8,7 @@ module.exports = {
 
       event.app.duration = now - appStart
     }, true)
+
+    return { reset }
   }
 }

--- a/packages/plugin-app-duration/app.js
+++ b/packages/plugin-app-duration/app.js
@@ -2,6 +2,7 @@ let appStart = new Date()
 const reset = () => { appStart = new Date() }
 
 module.exports = {
+  name: 'appDuration',
   load: client => {
     client.addOnError(event => {
       const now = new Date()

--- a/packages/plugin-app-duration/test/app.test.ts
+++ b/packages/plugin-app-duration/test/app.test.ts
@@ -22,6 +22,13 @@ describe('plugin-app-duration', () => {
     client.notify(new Error('acbd'))
   })
 
+  it('has a name', () => {
+    expect(plugin.name).toBe('appDuration')
+
+    const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+    expect(client.getPlugin('appDuration')).toBeDefined()
+  })
+
   it('can be restarted', async () => {
     let appDurationCallback = (event: Event) => { throw new Error('Should never be called') }
 

--- a/packages/plugin-app-duration/test/app.test.ts
+++ b/packages/plugin-app-duration/test/app.test.ts
@@ -1,5 +1,6 @@
 import plugin from '../app'
 import Client from '@bugsnag/core/client'
+import Event from '@bugsnag/core/event'
 
 describe('plugin-app-duration', () => {
   it('includes duration in event.app', done => {
@@ -19,5 +20,38 @@ describe('plugin-app-duration', () => {
     }))
 
     client.notify(new Error('acbd'))
+  })
+
+  it('can be restarted', async () => {
+    let appDurationCallback = (event: Event) => { throw new Error('Should never be called') }
+
+    const event = { app: {} } as unknown as Event
+    const client = {
+      addOnError (callback: typeof appDurationCallback) {
+        appDurationCallback = callback
+      }
+    }
+
+    const result = plugin.load(client)
+
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+    await sleep(50)
+
+    appDurationCallback(event)
+    expect(event.app.duration).toBeGreaterThanOrEqual(50)
+
+    await sleep(50)
+
+    appDurationCallback(event)
+    expect(event.app.duration).toBeGreaterThanOrEqual(100)
+
+    result.reset()
+
+    await sleep(25)
+
+    appDurationCallback(event)
+    expect(event.app.duration).toBeGreaterThanOrEqual(25)
+    expect(event.app.duration).toBeLessThanOrEqual(100)
   })
 })

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -8,6 +8,13 @@ const BugsnagPluginAwsLambda = {
     bugsnagInFlight.trackInFlight(client)
     client._loadPlugin(BugsnagPluginBrowserSession)
 
+    // Reset the app duration between invocations, if the plugin is loaded
+    const appDurationPlugin = client.getPlugin('appDuration')
+
+    if (appDurationPlugin) {
+      appDurationPlugin.reset()
+    }
+
     return {
       createHandler ({ flushTimeoutMs = 2000 } = {}) {
         return wrapHandler.bind(null, client, flushTimeoutMs)
@@ -26,14 +33,6 @@ function wrapHandler (client, flushTimeoutMs, handler) {
   }
 
   return async function (event, context) {
-    const startTime = new Date()
-
-    client.addOnError(event => {
-      const endTime = new Date()
-
-      event.app.duration = endTime - startTime
-    })
-
     client.addMetadata('AWS Lambda context', context)
 
     if (client._config.autoTrackSessions) {

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -26,6 +26,14 @@ function wrapHandler (client, flushTimeoutMs, handler) {
   }
 
   return async function (event, context) {
+    const startTime = new Date()
+
+    client.addOnError(event => {
+      const endTime = new Date()
+
+      event.app.duration = endTime - startTime
+    })
+
     client.addMetadata('AWS Lambda context', context)
 
     if (client._config.autoTrackSessions) {

--- a/packages/plugin-aws-lambda/test/index.test.ts
+++ b/packages/plugin-aws-lambda/test/index.test.ts
@@ -514,35 +514,4 @@ describe('plugin: aws lambda', () => {
     expect(events).toHaveLength(0)
     expect(sessions).toHaveLength(0)
   })
-
-  it('sets the app.duration field on events', async () => {
-    const events: EventDeliveryPayload[] = []
-    const sessions: SessionDeliveryPayload[] = []
-
-    const client = createClient(events, sessions)
-
-    const handler = () => { throw new Error('oh no') }
-
-    const event = { very: 'eventy' }
-    const context = { extremely: 'contextual' }
-
-    const plugin = client.getPlugin('awsLambda')
-
-    if (!plugin) {
-      throw new Error('Plugin was not loaded!')
-    }
-
-    const bugsnagHandler = plugin.createHandler()
-    const wrappedHandler = bugsnagHandler(handler)
-
-    await expect(() => wrappedHandler(event, context)).rejects.toThrow('oh no')
-
-    expect(events).toHaveLength(1)
-    expect(sessions).toHaveLength(1)
-
-    const duration = events[0].events[0].app.duration
-
-    expect(duration).toBeGreaterThanOrEqual(0)
-    expect(duration).toBeLessThan(500)
-  })
 })

--- a/packages/plugin-aws-lambda/test/index.test.ts
+++ b/packages/plugin-aws-lambda/test/index.test.ts
@@ -514,4 +514,35 @@ describe('plugin: aws lambda', () => {
     expect(events).toHaveLength(0)
     expect(sessions).toHaveLength(0)
   })
+
+  it('sets the app.duration field on events', async () => {
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
+
+    const handler = () => { throw new Error('oh no') }
+
+    const event = { very: 'eventy' }
+    const context = { extremely: 'contextual' }
+
+    const plugin = client.getPlugin('awsLambda')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+    const wrappedHandler = bugsnagHandler(handler)
+
+    await expect(() => wrappedHandler(event, context)).rejects.toThrow('oh no')
+
+    expect(events).toHaveLength(1)
+    expect(sessions).toHaveLength(1)
+
+    const duration = events[0].events[0].app.duration
+
+    expect(duration).toBeGreaterThanOrEqual(0)
+    expect(duration).toBeLessThan(500)
+  })
 })


### PR DESCRIPTION
## Goal

Our existing plugin-app-duration doesn't report the correct duration for Lambda functions because its 'appStart' is cached between invocations. This means the duration would essentially be the Lambda uptime, rather than the invocation time

We now reset the duration in the AWS plugin's `load` method so it starts fresh for each invocation