### PR TITLE
Handle promise rejections in AWS Lambda functions

### DIFF
--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/in-flight": "^7.7.0",
-    "@bugsnag/plugin-browser-session": "^7.7.0"
+    "@bugsnag/plugin-browser-session": "^7.7.0",
+    "@bugsnag/plugin-node-unhandled-rejection": "^7.7.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.7.0"

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -25,8 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@bugsnag/in-flight": "^7.7.0",
-    "@bugsnag/plugin-browser-session": "^7.7.0",
-    "@bugsnag/plugin-node-unhandled-rejection": "^7.7.0"
+    "@bugsnag/plugin-browser-session": "^7.7.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.7.0"

--- a/packages/plugin-node-unhandled-rejection/test/unhandled-rejection.test.ts
+++ b/packages/plugin-node-unhandled-rejection/test/unhandled-rejection.test.ts
@@ -88,4 +88,89 @@ describe('plugin: node unhandled rejection handler', () => {
     }))
     process.listeners('unhandledRejection')[0](new Error('never gonna catch me'), Promise.resolve())
   })
+
+  it('should return a promise that resolves after the onUnhandledRejection callback is called', async () => {
+    try {
+      const options = {
+        apiKey: 'api_key',
+        onUnhandledRejection: jest.fn(),
+        plugins: [plugin]
+      }
+
+      const pluginSchema = {
+        ...schema,
+        onUnhandledRejection: {
+          validate: (val: unknown) => typeof val === 'function',
+          message: 'should be a function',
+          defaultValue: () => {}
+        }
+      }
+
+      const client = new Client(options, pluginSchema)
+
+      client._setDelivery(client => ({
+        sendEvent: (payload, cb) => cb(),
+        sendSession: (payload, cb) => cb()
+      }))
+
+      const listener = process.listeners('unhandledRejection')[0]
+
+      expect(options.onUnhandledRejection).not.toHaveBeenCalled()
+
+      await listener(new Error('never gonna catch me'), Promise.resolve())
+
+      expect(options.onUnhandledRejection).toHaveBeenCalledTimes(1)
+    } finally {
+      plugin.destroy()
+    }
+  })
+
+  it('should prepend its listener (Node 6+)', async () => {
+    // Skip this test on Node 4/5 as prependListener doesn't exist
+    if (process.version.startsWith('v4.') || process.version.startsWith('v5.')) {
+      return
+    }
+
+    const listener = () => {}
+
+    try {
+      process.on('unhandledRejection', listener)
+
+      const listenersBefore = process.listeners('unhandledRejection')
+
+      expect(listenersBefore).toHaveLength(1)
+      expect(listenersBefore[0]).toBe(listener)
+
+      const options = {
+        apiKey: 'api_key',
+        onUnhandledRejection: jest.fn(),
+        plugins: [plugin]
+      }
+
+      const pluginSchema = {
+        ...schema,
+        onUnhandledRejection: {
+          validate: (val: unknown) => typeof val === 'function',
+          message: 'should be a function',
+          defaultValue: () => {}
+        }
+      }
+
+      const client = new Client(options, pluginSchema)
+
+      client._setDelivery(client => ({
+        sendEvent: (payload, cb) => cb(),
+        sendSession: (payload, cb) => cb()
+      }))
+
+      const listenersAfter = process.listeners('unhandledRejection')
+
+      expect(listenersAfter).toHaveLength(2)
+      expect(listenersAfter[0]).not.toBe(listener)
+      expect(listenersAfter[1]).toBe(listener)
+    } finally {
+      process.removeListener('unhandledRejection', listener)
+      plugin.destroy()
+    }
+  })
 })

--- a/packages/plugin-node-unhandled-rejection/unhandled-rejection.js
+++ b/packages/plugin-node-unhandled-rejection/unhandled-rejection.js
@@ -8,12 +8,22 @@ module.exports = {
         unhandled: true,
         severityReason: { type: 'unhandledPromiseRejection' }
       }, 'unhandledRejection handler', 1)
-      client._notify(event, () => {}, (e, event) => {
-        if (e) client._logger.error('Failed to send event to Bugsnag')
-        client._config.onUnhandledRejection(err, event, client._logger)
+
+      return new Promise(resolve => {
+        client._notify(event, () => {}, (e, event) => {
+          if (e) client._logger.error('Failed to send event to Bugsnag')
+          client._config.onUnhandledRejection(err, event, client._logger)
+          resolve()
+        })
       })
     }
-    process.on('unhandledRejection', _handler)
+
+    // Prepend the listener if we can (Node 6+)
+    if (process.prependListener) {
+      process.prependListener('unhandledRejection', _handler)
+    } else {
+      process.on('unhandledRejection', _handler)
+    }
   },
   destroy: () => {
     process.removeListener('unhandledRejection', _handler)

--- a/test/aws-lambda/features/fixtures/simple-app/async/promise-rejection.js
+++ b/test/aws-lambda/features/fixtures/simple-app/async/promise-rejection.js
@@ -1,0 +1,26 @@
+const Bugsnag = require('@bugsnag/js')
+const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
+
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  plugins: [BugsnagPluginAwsLambda],
+  autoDetectErrors: process.env.BUGSNAG_AUTO_DETECT_ERRORS !== 'false',
+  autoTrackSessions: process.env.BUGSNAG_AUTO_TRACK_SESSIONS !== 'false'
+})
+
+const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler()
+
+const handler = async (event, context) => {
+  Promise.reject(new Error('yikes'))
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: 'Did not crash!' })
+  }
+}
+
+module.exports.lambdaHandler = bugsnagHandler(handler)

--- a/test/aws-lambda/features/fixtures/simple-app/callback/promise-rejection.js
+++ b/test/aws-lambda/features/fixtures/simple-app/callback/promise-rejection.js
@@ -1,0 +1,26 @@
+const Bugsnag = require('@bugsnag/js')
+const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
+
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  plugins: [BugsnagPluginAwsLambda],
+  autoDetectErrors: process.env.BUGSNAG_AUTO_DETECT_ERRORS !== 'false',
+  autoTrackSessions: process.env.BUGSNAG_AUTO_TRACK_SESSIONS !== 'false'
+})
+
+const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler()
+
+const handler = (event, context, callback) => {
+  Promise.reject(new Error('yikes'))
+
+  callback(null, {
+    statusCode: 200,
+    body: JSON.stringify({ message: 'Did not crash!' })
+  })
+}
+
+module.exports.lambdaHandler = bugsnagHandler(handler)

--- a/test/aws-lambda/features/fixtures/simple-app/events/async/promise-rejection.json
+++ b/test/aws-lambda/features/fixtures/simple-app/events/async/promise-rejection.json
@@ -1,0 +1,46 @@
+{
+  "body": "",
+  "resource": "/{proxy+}",
+  "path": "/async/promise/rejection",
+  "httpMethod": "GET",
+  "isBase64Encoded": false,
+  "queryStringParameters": {},
+  "multiValueQueryStringParameters": {},
+  "pathParameters": {},
+  "stageVariables": {},
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/async/promise/rejection",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/simple-app/events/callback/promise-rejection.json
+++ b/test/aws-lambda/features/fixtures/simple-app/events/callback/promise-rejection.json
@@ -1,0 +1,46 @@
+{
+  "body": "",
+  "resource": "/{proxy+}",
+  "path": "/callback/promise/rejection",
+  "httpMethod": "GET",
+  "isBase64Encoded": false,
+  "queryStringParameters": {},
+  "multiValueQueryStringParameters": {},
+  "pathParameters": {},
+  "stageVariables": {},
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/callback/promise/rejection",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/simple-app/template.yaml
+++ b/test/aws-lambda/features/fixtures/simple-app/template.yaml
@@ -40,6 +40,19 @@ Resources:
             Path: /async/handled/exception
             Method: get
 
+  AsyncPromiseRejectionFunctionNode14:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: async/
+      Handler: promise-rejection.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        AsyncPromiseRejection:
+          Type: Api
+          Properties:
+            Path: /async/promise/rejection
+            Method: get
+
   CallbackUnhandledExceptionFunctionNode14:
     Type: AWS::Serverless::Function
     Properties:
@@ -79,6 +92,19 @@ Resources:
             Path: /callback/handled/exception
             Method: get
 
+  CallbackPromiseRejectionFunctionNode14:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: callback/
+      Handler: promise-rejection.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        CallbackPromiseRejection:
+          Type: Api
+          Properties:
+            Path: /callback/promise/rejection
+            Method: get
+
   AsyncUnhandledExceptionFunctionNode12:
     Type: AWS::Serverless::Function
     Properties:
@@ -103,6 +129,19 @@ Resources:
           Type: Api
           Properties:
             Path: /async/handled/exception
+            Method: get
+
+  AsyncPromiseRejectionFunctionNode12:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: async/
+      Handler: promise-rejection.lambdaHandler
+      Runtime: nodejs12.x
+      Events:
+        AsyncPromiseRejection:
+          Type: Api
+          Properties:
+            Path: /async/promise/rejection
             Method: get
 
   CallbackUnhandledExceptionFunctionNode12:
@@ -142,4 +181,17 @@ Resources:
           Type: Api
           Properties:
             Path: /callback/handled/exception
+            Method: get
+
+  CallbackPromiseRejectionFunctionNode12:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: callback/
+      Handler: promise-rejection.lambdaHandler
+      Runtime: nodejs12.x
+      Events:
+        CallbackPromiseRejection:
+          Type: Api
+          Properties:
+            Path: /callback/promise/rejection
             Method: get

--- a/test/aws-lambda/features/promise-rejection.feature
+++ b/test/aws-lambda/features/promise-rejection.feature
@@ -1,0 +1,55 @@
+Feature: Unhandled promise rejections are reported correctly in lambda functions
+
+Scenario Outline: unhandled promise rejections are reported
+    Given I setup the environment
+    When I invoke the "<lambda>" lambda in "features/fixtures/simple-app" with the "events/<type>/promise-rejection.json" event
+    Then the lambda response "errorMessage" equals "Error: yikes"
+    And the lambda response "errorType" equals "Runtime.UnhandledPromiseRejection"
+    And the lambda response "trace" is an array with 11 elements
+    And the lambda response "trace.0" equals "Runtime.UnhandledPromiseRejection: Error: yikes"
+    And the lambda response "body" is null
+    And the lambda response "statusCode" is null
+    And the SAM exit code equals 0
+    When I wait to receive an error
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "unhandledPromiseRejection"
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "yikes"
+    And the exception "type" equals "nodejs"
+    And the "file" of stack frame 0 equals "promise-rejection.js"
+    And the event "metaData.AWS Lambda context.functionName" equals "<lambda>"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    And the event "device.runtimeVersions.node" matches "^<node-version>\.\d+\.\d+$"
+    When I wait to receive a session
+    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+    And the session "id" is not null
+    And the session "startedAt" is a timestamp
+
+    Examples:
+        | lambda                                 | type     | node-version |
+        | AsyncPromiseRejectionFunctionNode14    | async    | 14           |
+        | AsyncPromiseRejectionFunctionNode12    | async    | 12           |
+        | CallbackPromiseRejectionFunctionNode14 | callback | 14           |
+        | CallbackPromiseRejectionFunctionNode12 | callback | 12           |
+
+Scenario Outline: unhandled promise rejections are not reported when autoDetectErrors is false
+    Given I setup the environment
+    And I set environment variable "BUGSNAG_AUTO_DETECT_ERRORS" to "false"
+    When I invoke the "<lambda>" lambda in "features/fixtures/simple-app" with the "events/<type>/promise-rejection.json" event
+    Then the lambda response "errorMessage" equals "Error: yikes"
+    And the lambda response "errorType" equals "Runtime.UnhandledPromiseRejection"
+    And the lambda response "trace" is an array with 6 elements
+    And the lambda response "trace.0" equals "Runtime.UnhandledPromiseRejection: Error: yikes"
+    And the lambda response "body" is null
+    And the lambda response "statusCode" is null
+    And the SAM exit code equals 0
+    And I should receive no errors
+
+    Examples:
+        | lambda                                 | type     |
+        | AsyncPromiseRejectionFunctionNode14    | async    |
+        | AsyncPromiseRejectionFunctionNode12    | async    |
+        | CallbackPromiseRejectionFunctionNode14 | callback |
+        | CallbackPromiseRejectionFunctionNode12 | callback |

--- a/test/aws-lambda/features/promise-rejection.feature
+++ b/test/aws-lambda/features/promise-rejection.feature
@@ -5,7 +5,7 @@ Scenario Outline: unhandled promise rejections are reported
     When I invoke the "<lambda>" lambda in "features/fixtures/simple-app" with the "events/<type>/promise-rejection.json" event
     Then the lambda response "errorMessage" equals "Error: yikes"
     And the lambda response "errorType" equals "Runtime.UnhandledPromiseRejection"
-    And the lambda response "trace" is an array with 11 elements
+    And the lambda response "trace" is an array with 4 elements
     And the lambda response "trace.0" equals "Runtime.UnhandledPromiseRejection: Error: yikes"
     And the lambda response "body" is null
     And the lambda response "statusCode" is null


### PR DESCRIPTION
## Goal

AWS have a promise rejection handler that forcefully exits the process. This means we can't send reports for promise rejections because 1) our handler is never called as it is always added after AWS' and 2) there's no time to deliver the event anyway

We can work around this by removing AWS' handler and calling it after delivery of the promise rejection

## Testing

MazeRunner tests added to cover this — they pass with & without the new handler, the only difference being the stacktrace