### PR TITLE
Fix app duration test flakes

### DIFF
--- a/packages/plugin-app-duration/test/app.test.ts
+++ b/packages/plugin-app-duration/test/app.test.ts
@@ -46,19 +46,19 @@ describe('plugin-app-duration', () => {
     await sleep(50)
 
     appDurationCallback(event)
-    expect(event.app.duration).toBeGreaterThanOrEqual(50)
+    expect(event.app.duration).toBeGreaterThanOrEqual(45)
 
     await sleep(50)
 
     appDurationCallback(event)
-    expect(event.app.duration).toBeGreaterThanOrEqual(100)
+    expect(event.app.duration).toBeGreaterThanOrEqual(90)
 
     result.reset()
 
     await sleep(25)
 
     appDurationCallback(event)
-    expect(event.app.duration).toBeGreaterThanOrEqual(25)
-    expect(event.app.duration).toBeLessThanOrEqual(100)
+    expect(event.app.duration).toBeGreaterThanOrEqual(20)
+    expect(event.app.duration).toBeLessThanOrEqual(90)
   })
 })


### PR DESCRIPTION
## Goal

On GH actions sometimes the timeout can be invoked slightly too soon in the new `reset` test, e.g. after 24ms instead of 25

This PR builds in 5ms of leeway to each assertion, which should hopefully be enough to ensure it doesn't flake