### PR TITLE
fix(expo): Ensure Expo plugins depend on same version of NetInfo package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+## Fixed
+
+- (expo): Ensure Expo plugins depend on same version of NetInfo package [#1319](https://github.com/bugsnag/bugsnag-js/pull/1319)
+
 ## v7.8.1 (2021-02-25)
 
 ## Changed

--- a/packages/expo/CONTRIBUTING.md
+++ b/packages/expo/CONTRIBUTING.md
@@ -8,7 +8,7 @@ When a new version of the Expo SDK is released, the dependencies we use must be 
 
 The following modules are currently used:
 
-- `@react-native-community/netinfo` (`@bugsnag/delivery-expo`)
+- `@react-native-community/netinfo` (`@bugsnag/delivery-expo`, `@bugsnsag/plugin-react-native-connectivity-breadcrumbs`)
 - `expo-constants` (`@bugsnag/expo`, `@bugsnag/plugin-expo-app`, `@bugsnag/plugin-expo-device`)
 - `expo-crypto` (`@bugsnag/expo`, `@bugsnag/delivery-expo`)
 - `expo-device` (`@bugsnag/plugin-expo-device`)

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package-lock.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@react-native-community/netinfo": {
-			"version": "5.9.6",
-			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.6.tgz",
-			"integrity": "sha512-cEkA1Apg8+VjnDdeDZRHI+2RqouiPKgYnewouRkvF4ettH9ZS4Cmi/nANQKIpIu2L+czboxM3fCZ44nc7IM9VQ=="
+			"version": "5.9.7",
+			"resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.7.tgz",
+			"integrity": "sha512-NAkkT68oF+M9o6El2xeUqZK7magPjG/tAcEbvCbqyhlh3yElKWnI1e1vpbVvFXzTefy67FwYFWOJqBN6U7Mnkg=="
 		}
 	}
 }

--- a/packages/plugin-react-native-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/package.json
@@ -17,7 +17,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@react-native-community/netinfo": "5.9.6"
+    "@react-native-community/netinfo": "5.9.7"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.7.0"


### PR DESCRIPTION
Ensures the plugins used by `@bugsnag/expo` all depend on the same version of NetInfo. [Expo 40 depends on v5.9.7](https://github.com/expo/expo/blob/45dd06df4c3d844e8adf774207d64015e76ec902/packages/expo/bundledNativeModules.json#L3).

I also updated the CONTRIBUTING.md guide because it was missing the connectivity breadcrumbs package.