### PR TITLE
Automatically notify when a lambda may timeout

### DIFF
--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -60,16 +60,10 @@ function wrapHandler (client, flushTimeoutMs, lambdaTimeoutNotifyMs, handler) {
     // Guard against the "getRemainingTimeInMillis" being missing. This should
     // never happen but could when unit testing
     if (typeof context.getRemainingTimeInMillis === 'function' &&
-      lambdaTimeoutNotifyMs > 0
+      lambdaTimeoutNotifyMs > 0 &&
+      lambdaTimeoutNotifyMs <= MAX_TIMER_VALUE
     ) {
-      // Clamp the timeout value between 0 and MAX_TIMER_VALUE
-      const timeoutMs = Math.min(
-        Math.max(
-          context.getRemainingTimeInMillis() - lambdaTimeoutNotifyMs,
-          0
-        ),
-        MAX_TIMER_VALUE
-      )
+      const timeoutMs = context.getRemainingTimeInMillis() - lambdaTimeoutNotifyMs
 
       lambdaTimeout = setTimeout(function () {
         const handledState = {

--- a/packages/plugin-aws-lambda/src/lambda-timeout-approaching.js
+++ b/packages/plugin-aws-lambda/src/lambda-timeout-approaching.js
@@ -1,0 +1,11 @@
+module.exports = class LambdaTimeoutApproaching extends Error {
+  constructor (remainingMs) {
+    const message = `Lambda will timeout in ${remainingMs}ms`
+
+    super(message)
+
+    this.name = 'LambdaTimeoutApproaching'
+    this.message = message
+    this.stack = []
+  }
+}

--- a/packages/plugin-aws-lambda/src/lambda-timeout-approaching.js
+++ b/packages/plugin-aws-lambda/src/lambda-timeout-approaching.js
@@ -5,7 +5,6 @@ module.exports = class LambdaTimeoutApproaching extends Error {
     super(message)
 
     this.name = 'LambdaTimeoutApproaching'
-    this.message = message
     this.stack = []
   }
 }

--- a/packages/plugin-aws-lambda/types/bugsnag-plugin-aws-lambda.d.ts
+++ b/packages/plugin-aws-lambda/types/bugsnag-plugin-aws-lambda.d.ts
@@ -10,6 +10,7 @@ export type BugsnagPluginAwsLambdaHandler = (handler: AsyncHandler|CallbackHandl
 
 export interface BugsnagPluginAwsLambdaConfiguration {
   flushTimeoutMs?: number
+  lambdaTimeoutNotifyMs?: number
 }
 
 export interface BugsnagPluginAwsLambdaResult {


### PR DESCRIPTION
## Goal

We can never be 100% sure that a timeout will happen because we need to notify with enough time for the event to be delivered. Therefore this is a best effort with a generous default value (1000ms) that errs on the side of delivering the warning at the cost of possible false positives. The default value can be changed by providing the new `lambdaTimeoutNotifyMs` parameter to `createHandler`, e.g.:

```js
const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler({
  lambdaTimeoutNotifyMs: 500
})
```

If set to "0" we don't bother adding the warning at all. This is largely arbitrary as a value of 0 would never be triggered (because the lambda would timeout at the same time so we would never be able to deliver the event) but it allows users to turn this feature off if they don't want it

## Testing

This can only be covered by unit tests because of a bug in AWS' SAM CLI: https://github.com/aws/aws-sam-cli/issues/2519

In short, SAM returns a Unix timestamp from `getRemainingTimeInMillis` so the timeout could never be triggered with `sam local invoke` (short of mocking the function, which isn't really better than a unit test)