### PR TITLE
Remove unnecessary setting of bind-address when call Maze Runner

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -28,7 +28,6 @@ steps:
         command:
           - --farm=bs
           - --browser=chrome_43
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -43,7 +42,6 @@ steps:
         command:
           - --farm=bs
           - --browser=chrome_61
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -58,7 +56,6 @@ steps:
         command:
           - --farm=bs
           - --browser=chrome_latest
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -73,7 +70,6 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_8
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -88,7 +84,6 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_9
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -103,7 +98,6 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_10
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -118,7 +112,6 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_11
-          - --bind-address=0.0.0.0
     env:
       HOST: 'localhost' # IE11 needs the host set to localhost for some reason!ß
     concurrency: 5
@@ -135,7 +128,6 @@ steps:
         command:
           - --farm=bs
           - --browser=edge_14
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -150,7 +142,6 @@ steps:
         command:
           - --farm=bs
           - --browser=edge_15
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -165,7 +156,6 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_6
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -180,7 +170,6 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_10
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -195,7 +184,6 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_13
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -210,7 +198,6 @@ steps:
         command:
           - --farm=bs
           - --browser=iphone_7
-          - --bind-address=0.0.0.0
     env:
       HOST: "bs-local.com"
     concurrency: 5
@@ -227,7 +214,6 @@ steps:
         command:
           - --farm=bs
           - --browser=android_s8
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -242,7 +228,6 @@ steps:
         command:
           - --farm=bs
           - --browser=firefox_30
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -257,7 +242,6 @@ steps:
         command:
           - --farm=bs
           - --browser=firefox_56
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'
 
@@ -272,6 +256,5 @@ steps:
         command:
           - --farm=bs
           - --browser=firefox_latest
-          - --bind-address=0.0.0.0
     concurrency: 5
     concurrency_group: 'browserstack'

--- a/.buildkite/node-pipeline.yml
+++ b/.buildkite/node-pipeline.yml
@@ -25,7 +25,7 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["--bind-address=0.0.0.0", "-e", "koa.feature", "-e", "koa-1x.feature", "-e", "webpack.feature"]
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "webpack.feature"]
     env:
       NODE_VERSION: "4"
 
@@ -37,7 +37,7 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["--bind-address=0.0.0.0", "-e", "koa.feature", "-e", "koa-1x.feature"]
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature"]
     env:
       NODE_VERSION: "6"
 
@@ -49,7 +49,6 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["--bind-address=0.0.0.0"]
     env:
       NODE_VERSION: "8"
 
@@ -61,7 +60,6 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["--bind-address=0.0.0.0"]
     env:
       NODE_VERSION: "10"
 
@@ -73,7 +71,6 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["--bind-address=0.0.0.0"]
     env:
       NODE_VERSION: "12"
 
@@ -85,6 +82,5 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["--bind-address=0.0.0.0"]
     env:
       NODE_VERSION: "14"


### PR DESCRIPTION
## Goal

Removes setting of the `--bind-address` Maze Runner option, which is now unnecessary having reverted a change in Maze Runner's default behaviour.