### PR TITLE
Avoid starting a session if one already exists

### DIFF
--- a/packages/plugin-browser-session/session.js
+++ b/packages/plugin-browser-session/session.js
@@ -31,13 +31,21 @@ const sessionDelegate = {
     return sessionClient
   },
   resumeSession: (client) => {
+    // Do nothing if there's already an active session
+    if (client._session) {
+      return client
+    }
+
+    // If we have a paused session then make it the active session
     if (client._pausedSession) {
       client._session = client._pausedSession
       client._pausedSession = null
+
       return client
-    } else {
-      return client.startSession()
     }
+
+    // Otherwise start a new session
+    return client.startSession()
   },
   pauseSession: (client) => {
     client._pausedSession = client._session

--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -18,8 +18,8 @@ module.exports = {
       const dom = domain.create()
 
       // Get a client to be scoped to this request. If sessions are enabled, use the
-      // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
+      // resumeSession() call to get a session client, otherwise, clone the existing client.
+      const requestClient = client._config.autoTrackSessions ? client.resumeSession() : clone(client)
 
       // attach it to the request
       req.bugsnag = requestClient

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -15,8 +15,8 @@ module.exports = {
   load: client => {
     const requestHandler = async (ctx, next) => {
       // Get a client to be scoped to this request. If sessions are enabled, use the
-      // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
+      // resumeSession() call to get a session client, otherwise, clone the existing client.
+      const requestClient = client._config.autoTrackSessions ? client.resumeSession() : clone(client)
 
       ctx.bugsnag = requestClient
 
@@ -47,8 +47,8 @@ module.exports = {
 
     requestHandler.v1 = function * (next) {
       // Get a client to be scoped to this request. If sessions are enabled, use the
-      // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
+      // resumeSession() call to get a session client, otherwise, clone the existing client.
+      const requestClient = client._config.autoTrackSessions ? client.resumeSession() : clone(client)
 
       this.bugsnag = requestClient
 

--- a/packages/plugin-koa/test/koa.test.ts
+++ b/packages/plugin-koa/test/koa.test.ts
@@ -7,7 +7,7 @@ describe('plugin: koa', () => {
     c._sessionDelegate = {
       startSession: () => c,
       pauseSession: () => {},
-      resumeSession: () => {}
+      resumeSession: () => c
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const middleware = c.getPlugin('koa')!
@@ -23,7 +23,7 @@ describe('plugin: koa', () => {
       c._sessionDelegate = {
         startSession: () => c,
         pauseSession: () => {},
-        resumeSession: () => {}
+        resumeSession: () => c
       }
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -17,8 +17,8 @@ module.exports = {
       const dom = domain.create()
 
       // Get a client to be scoped to this request. If sessions are enabled, use the
-      // startSession() call to get a session client, otherwise, clone the existing client.
-      const requestClient = client._config.autoTrackSessions ? client.startSession() : clone(client)
+      // resumeSession() call to get a session client, otherwise, clone the existing client.
+      const requestClient = client._config.autoTrackSessions ? client.resumeSession() : clone(client)
 
       // attach it to the request
       req.bugsnag = requestClient

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -22,13 +22,21 @@ module.exports = {
         client._session = null
       },
       resumeSession: (client) => {
+        // Do nothing if there's already an active session
+        if (client._session) {
+          return client
+        }
+
+        // If we have a paused session then make it the active session
         if (client._pausedSession) {
           client._session = client._pausedSession
           client._pausedSession = null
+
           return client
-        } else {
-          return client.startSession()
         }
+
+        // Otherwise start a new session
+        return client.startSession()
       }
     }
   },


### PR DESCRIPTION
## Goal

This change prevents multiple sessions from being started if separate plugins both call 'startSession' by making 'resumeSession' do nothing if a session already exists

This is necessary in order to run serverless versions of Express/Koa/Restify with `autoTrackSessions` on because both the AWS Lambda plugin and the framework plugin will attempt to start a session (resulting in 2 sessions per request)