### PR TITLE
MazeRunner tests for serverless-express

### DIFF
--- a/test/aws-lambda/Gemfile
+++ b/test/aws-lambda/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.11.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.12.1'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../../../maze-runner'

--- a/test/aws-lambda/Gemfile.lock
+++ b/test/aws-lambda/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b5925737b0c3db49ac38a5a68e6bfe38026ef508
-  tag: v4.11.1
+  revision: b9397574529d141ba07a8050cf7deb2213fda3b8
+  tag: v4.12.1
   specs:
-    bugsnag-maze-runner (4.11.1)
+    bugsnag-maze-runner (4.12.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/test/aws-lambda/README.md
+++ b/test/aws-lambda/README.md
@@ -17,3 +17,11 @@ $ bundle exec maze-runner --bind-address=0.0.0.0
 ```
 
 This will build all of the fixtures before running the tests
+
+### Running tests for a specific fixture
+
+All tests are tagged with the name of the fixture they run against. For example, to run only the tests that use the "[serverless-express-app](./features/fixtures/serverless-express-app)" fixture:
+
+```sh
+$ bundle exec maze-runner --bind-address=0.0.0.0 --tags @serverless-express-app
+```

--- a/test/aws-lambda/features/fixtures/serverless-express-app/app/app.js
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/app/app.js
@@ -1,0 +1,52 @@
+const Bugsnag = require('@bugsnag/js')
+const express = require('express')
+
+const app = express()
+
+const middleware = Bugsnag.getPlugin('express')
+app.use(middleware.requestHandler)
+
+app.get('/', (request, response) => {
+  response.json({ message: 'hello world!' })
+})
+
+app.get('/handled', (request, response) => {
+  Bugsnag.notify('no crashing here')
+
+  response.json({ message: 'did not crash :)' })
+})
+
+app.get('/unhandled', (request, response) => {
+  throw new Error('broken :(')
+})
+
+app.get('/unhandled-async', (request, response) => {
+  setTimeout(function () {
+    throw new Error('busted')
+  }, 100)
+})
+
+app.get('/unhandled-next', (request, response, next) => {
+  next(new Error('borked'))
+})
+
+app.get('/promise-rejection', (request, response) => {
+  Promise.reject(new Error('abc'))
+
+  response.json({ message: 'xyz' })
+})
+
+app.use(middleware.errorHandler)
+
+// Replace the built-in error handler with one that returns JSON. This allows us
+// to assert against it much more easily than the default HTML response
+app.use((error, request, response, next) => {
+  response.status(500)
+  response.json({
+    message: error.message,
+    type: error.constructor.name,
+    stacktrace: error.stack.split('\n')
+  })
+})
+
+module.exports = app

--- a/test/aws-lambda/features/fixtures/serverless-express-app/app/index.js
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/app/index.js
@@ -1,0 +1,22 @@
+const Bugsnag = require('@bugsnag/js')
+const BugsnagPluginAwsLambda = require('@bugsnag/plugin-aws-lambda')
+const BugsnagPluginExpress = require('@bugsnag/plugin-express')
+const serverlessExpress = require('@vendia/serverless-express')
+
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  plugins: [BugsnagPluginAwsLambda, BugsnagPluginExpress],
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  autoDetectErrors: process.env.BUGSNAG_AUTO_DETECT_ERRORS !== 'false',
+  autoTrackSessions: process.env.BUGSNAG_AUTO_TRACK_SESSIONS !== 'false'
+})
+
+const app = require('./app')
+
+const bugsnagHandler = Bugsnag.getPlugin('awsLambda').createHandler()
+const serverlessExpressHandler = serverlessExpress({ app })
+
+exports.lambdaHandler = bugsnagHandler(serverlessExpressHandler)

--- a/test/aws-lambda/features/fixtures/serverless-express-app/app/package.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/app/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "serverless-express-app",
+    "version": "1.2.3",
+    "dependencies": {
+        "@vendia/serverless-express": "^4.3.3",
+        "express": "^4.17.1",
+
+        "@bugsnag/core": "bugsnag-core.tgz",
+        "@bugsnag/delivery-node": "bugsnag-delivery-node.tgz",
+        "@bugsnag/in-flight": "bugsnag-in-flight.tgz",
+        "@bugsnag/js": "bugsnag-js.tgz",
+        "@bugsnag/node": "bugsnag-node.tgz",
+        "@bugsnag/plugin-app-duration": "bugsnag-plugin-app-duration.tgz",
+        "@bugsnag/plugin-aws-lambda": "bugsnag-plugin-aws-lambda.tgz",
+        "@bugsnag/plugin-contextualize": "bugsnag-plugin-contextualize.tgz",
+        "@bugsnag/plugin-express": "bugsnag-plugin-express.tgz",
+        "@bugsnag/plugin-intercept": "bugsnag-plugin-intercept.tgz",
+        "@bugsnag/plugin-node-device": "bugsnag-plugin-node-device.tgz",
+        "@bugsnag/plugin-node-in-project": "bugsnag-plugin-node-in-project.tgz",
+        "@bugsnag/plugin-node-surrounding-code": "bugsnag-plugin-node-surrounding-code.tgz",
+        "@bugsnag/plugin-node-uncaught-exception": "bugsnag-plugin-node-uncaught-exception.tgz",
+        "@bugsnag/plugin-node-unhandled-rejection": "bugsnag-plugin-node-unhandled-rejection.tgz",
+        "@bugsnag/plugin-server-session": "bugsnag-plugin-server-session.tgz",
+        "@bugsnag/plugin-strip-project-root": "bugsnag-plugin-strip-project-root.tgz"
+    }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/events/handled.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/events/handled.json
@@ -1,0 +1,51 @@
+{
+  "resource": "/handled",
+  "path": "/handled",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/handled",
+    "resourcePath": "/handled",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/events/index.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/events/index.json
@@ -1,0 +1,51 @@
+{
+  "resource": "/",
+  "path": "/",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/",
+    "resourcePath": "/",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/events/promise-rejection.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/events/promise-rejection.json
@@ -1,0 +1,51 @@
+{
+  "resource": "/promise-rejection",
+  "path": "/promise-rejection",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/promise-rejection",
+    "resourcePath": "/promise-rejection",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/events/unhandled-async.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/events/unhandled-async.json
@@ -1,0 +1,51 @@
+{
+  "resource": "/unhandled-async",
+  "path": "/unhandled-async",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/unhandled-async",
+    "resourcePath": "/unhandled-async",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/events/unhandled-next.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/events/unhandled-next.json
@@ -1,0 +1,51 @@
+{
+  "resource": "/unhandled-next",
+  "path": "/unhandled-next",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/unhandled-next",
+    "resourcePath": "/unhandled-next",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/events/unhandled.json
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/events/unhandled.json
@@ -1,0 +1,51 @@
+{
+  "resource": "/unhandled",
+  "path": "/unhandled",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/unhandled",
+    "resourcePath": "/unhandled",
+    "httpMethod": "GET",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/test/aws-lambda/features/fixtures/serverless-express-app/template.yaml
+++ b/test/aws-lambda/features/fixtures/serverless-express-app/template.yaml
@@ -1,0 +1,41 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: serverless-express-app
+
+Globals:
+  Function:
+    Timeout: 30
+    Environment:
+      Variables:
+        BUGSNAG_API_KEY:
+        BUGSNAG_NOTIFY_ENDPOINT:
+        BUGSNAG_SESSIONS_ENDPOINT:
+        BUGSNAG_AUTO_TRACK_SESSIONS: true
+        BUGSNAG_AUTO_DETECT_ERRORS: true
+
+Resources:
+  ExpressApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      BinaryMediaTypes: ['*/*']
+
+  ExpressFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: app/
+      Handler: index.lambdaHandler
+      Runtime: nodejs14.x
+      Events:
+        ProxyApiRoot:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ExpressApi
+            Path: /
+            Method: ANY
+        ProxyApiGreedy:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ExpressApi
+            Path: /{proxy+}
+            Method: ANY

--- a/test/aws-lambda/features/handled.feature
+++ b/test/aws-lambda/features/handled.feature
@@ -1,5 +1,6 @@
 Feature: Handled exceptions are reported correctly in lambda functions
 
+@simple-app
 Scenario Outline: handled exceptions are reported
     Given I setup the environment
     When I invoke the "<lambda>" lambda in "features/fixtures/simple-app" with the "events/<type>/handled-exception.json" event
@@ -30,6 +31,7 @@ Scenario Outline: handled exceptions are reported
         | CallbackHandledExceptionFunctionNode14 | callback | 14           |
         | CallbackHandledExceptionFunctionNode12 | callback | 12           |
 
+@simple-app
 Scenario Outline: handled exceptions are still reported when autoDetectErrors is false
     Given I setup the environment
     And I set environment variable "BUGSNAG_AUTO_DETECT_ERRORS" to "false"
@@ -60,3 +62,29 @@ Scenario Outline: handled exceptions are still reported when autoDetectErrors is
         | AsyncHandledExceptionFunctionNode12    | async    | 12           |
         | CallbackHandledExceptionFunctionNode14 | callback | 14           |
         | CallbackHandledExceptionFunctionNode12 | callback | 12           |
+
+@serverless-express-app
+Scenario: handled exceptions are reported when using serverless-express
+    Given I setup the environment
+    When I invoke the "ExpressFunction" lambda in "features/fixtures/serverless-express-app" with the "events/handled.json" event
+    Then the lambda response "body.message" equals "did not crash :)"
+    And the lambda response "statusCode" equals 200
+    And the SAM exit code equals 0
+    When I wait to receive an error
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is false
+    And the event "severity" equals "warning"
+    And the event "severityReason.type" equals "handledException"
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "no crashing here"
+    And the exception "type" equals "nodejs"
+    And the "file" of stack frame 0 equals "app.js"
+    And the event "metaData.AWS Lambda context.functionName" equals "ExpressFunction"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    And the event "device.runtimeVersions.node" matches "^14\.\d+\.\d+$"
+    When I wait to receive a session
+    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+    And the session "id" is not null
+    And the session "startedAt" is a timestamp
+    And the event "session.events.handled" equals 1
+    And the event "session.events.unhandled" equals 0

--- a/test/aws-lambda/features/promise-rejection.feature
+++ b/test/aws-lambda/features/promise-rejection.feature
@@ -1,5 +1,6 @@
 Feature: Unhandled promise rejections are reported correctly in lambda functions
 
+@simple-app
 Scenario Outline: unhandled promise rejections are reported
     Given I setup the environment
     When I invoke the "<lambda>" lambda in "features/fixtures/simple-app" with the "events/<type>/promise-rejection.json" event
@@ -34,6 +35,7 @@ Scenario Outline: unhandled promise rejections are reported
         | CallbackPromiseRejectionFunctionNode14 | callback | 14           |
         | CallbackPromiseRejectionFunctionNode12 | callback | 12           |
 
+@simple-app
 Scenario Outline: unhandled promise rejections are not reported when autoDetectErrors is false
     Given I setup the environment
     And I set environment variable "BUGSNAG_AUTO_DETECT_ERRORS" to "false"
@@ -53,3 +55,33 @@ Scenario Outline: unhandled promise rejections are not reported when autoDetectE
         | AsyncPromiseRejectionFunctionNode12    | async    |
         | CallbackPromiseRejectionFunctionNode14 | callback |
         | CallbackPromiseRejectionFunctionNode12 | callback |
+
+@serverless-express-app
+Scenario: promise rejections are reported when using serverless-express
+    Given I setup the environment
+    When I invoke the "ExpressFunction" lambda in "features/fixtures/serverless-express-app" with the "events/promise-rejection.json" event
+    Then the lambda response "errorMessage" equals "Error: abc"
+    And the lambda response "errorType" equals "Runtime.UnhandledPromiseRejection"
+    And the lambda response "trace" is an array with 4 elements
+    And the lambda response "trace.0" equals "Runtime.UnhandledPromiseRejection: Error: abc"
+    And the lambda response "body" is null
+    And the lambda response "statusCode" is null
+    And the SAM exit code equals 0
+    When I wait to receive an error
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "unhandledPromiseRejection"
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "abc"
+    And the exception "type" equals "nodejs"
+    And the "file" of stack frame 0 equals "app.js"
+    And the event "metaData.AWS Lambda context.functionName" equals "ExpressFunction"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    And the event "device.runtimeVersions.node" matches "^14\.\d+\.\d+$"
+    When I wait to receive a session
+    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+    And the session "id" is not null
+    And the session "startedAt" is a timestamp
+    And the event "session.events.handled" equals 0
+    And the event "session.events.unhandled" equals 1

--- a/test/aws-lambda/features/scripts/build-fixtures
+++ b/test/aws-lambda/features/scripts/build-fixtures
@@ -23,6 +23,7 @@ BUGSNAG_PACKAGES = [
   "plugin-app-duration",
   "plugin-aws-lambda",
   "plugin-contextualize",
+  "plugin-express",
   "plugin-intercept",
   "plugin-node-device",
   "plugin-node-in-project",
@@ -91,10 +92,12 @@ def install_and_build
 
     parsed_template = YAML.safe_load(File.read(template))
 
-    # Find all of the directories we need to install the packages in
-    destinations = parsed_template.fetch("Resources").values.map do |resource|
-      "#{fixture}/#{resource.fetch("Properties").fetch("CodeUri")}"
-    end.uniq
+    # Find all of the directories we need to install the packages in using the
+    # CodeUri of the "AWS::Serverless::Function" resources
+    destinations = parsed_template.fetch("Resources").values
+      .filter { |resource| resource["Type"] == "AWS::Serverless::Function" }
+      .map { |resource| "#{fixture}/#{resource.fetch("Properties").fetch("CodeUri")}" }
+      .uniq
 
     begin
       # Install the packages into each of the destination directories
@@ -115,7 +118,7 @@ def install_and_build
         raise "Failed to build #{fixture_name}" unless success
       end
     ensure
-      return if DEBUG
+      next if DEBUG
 
       # Remove the packages from the destination directories as they aren't
       # needed anymore. A built lambda has them in its node_modules directory

--- a/test/aws-lambda/features/sessions.feature
+++ b/test/aws-lambda/features/sessions.feature
@@ -1,5 +1,6 @@
 Feature: Sessions are reported correctly in lambda functions
 
+@simple-app
 Scenario Outline: sessions are reported
     Given I setup the environment
     When I invoke the "<lambda>" lambda in "features/fixtures/simple-app"
@@ -25,6 +26,7 @@ Scenario Outline: sessions are reported
         | CallbackHandledExceptionFunctionNode14         | 1             | 0               |
         | CallbackHandledExceptionFunctionNode12         | 1             | 0               |
 
+@simple-app
 Scenario Outline: no session is sent when autoTrackSessions is false
     Given I setup the environment
     And I set environment variable "BUGSNAG_AUTO_TRACK_SESSIONS" to "false"

--- a/test/aws-lambda/features/steps/aws-lambda-steps.rb
+++ b/test/aws-lambda/features/steps/aws-lambda-steps.rb
@@ -1,15 +1,7 @@
 Given('I setup the environment') do
   steps %Q{
     Given I store the api key in the environment variable "BUGSNAG_API_KEY"
-    And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
-    And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+    And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://host.docker.internal:9339/notify"
+    And I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to "http://host.docker.internal:9339/sessions"
   }
-end
-
-Given('I store the notify endpoint in the environment variable {string}') do |name|
-  step("I set environment variable '#{name}' to 'http://host.docker.internal:9339/notify'")
-end
-
-Given('I store the sessions endpoint in the environment variable {string}') do |name|
-  step("I set environment variable '#{name}' to 'http://host.docker.internal:9339/sessions'")
 end


### PR DESCRIPTION
## Goal

This PR adds MazeRunner tests for `serverless-express`, proving that the AWS Lambda plugin works with `@bugsnag/plugin-express` and that it works when wrapping other Lambda wrapeprs