### PR TITLE
Pin RN Navigation dependency versions

### DIFF
--- a/test/react-native/features/fixtures/app/react_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_navigation_js/install.sh
@@ -1,9 +1,9 @@
 npm i @bugsnag/plugin-react-navigation@$BUGSNAG_VERSION --registry=$REGISTRY_URL
 
-npm i @react-native-community/masked-view --registry=$REGISTRY_URL
-npm i @react-navigation/native --registry=$REGISTRY_URL
-npm i @react-navigation/stack --registry=$REGISTRY_URL
-npm i react-native-gesture-handler --registry=$REGISTRY_URL
-npm i react-native-reanimated --registry=$REGISTRY_URL
-npm i react-native-safe-area-context --registry=$REGISTRY_URL
-npm i react-native-screens --registry=$REGISTRY_URL
+npm i @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
+npm i @react-navigation/native@^5.9 --registry=$REGISTRY_URL
+npm i @react-navigation/stack@^5.14 --registry=$REGISTRY_URL
+npm i react-native-gesture-handler@^1.10 --registry=$REGISTRY_URL
+npm i react-native-reanimated@^1.13 --registry=$REGISTRY_URL
+npm i react-native-safe-area-context@^3.1 --registry=$REGISTRY_URL
+npm i react-native-screens@^2.18 --registry=$REGISTRY_URL


### PR DESCRIPTION
## Goal

`react-native-reanimated` v2 breaks our RN Navigation fixture's Gradle build. This was pulled in automatically because the versions the fixture installs aren't pinned

This PR pins the fixture versions to a range that should always work so the build doesn't randomly break