### PR TITLE
Ensure we skip the correct number of frames in Vue error handlers

### DIFF
--- a/packages/plugin-vue/src/vue.js
+++ b/packages/plugin-vue/src/vue.js
@@ -3,7 +3,7 @@ module.exports = (app, client) => {
 
   const handler = (err, vm, info) => {
     const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
-    const event = client.Event.create(err, true, handledState, 1)
+    const event = client.Event.create(err, true, handledState, 'vue error handler', 1)
 
     event.addMetadata('vue', {
       errorInfo: ErrorTypeStrings[info] || info,

--- a/packages/plugin-vue/src/vue2.js
+++ b/packages/plugin-vue/src/vue2.js
@@ -3,7 +3,7 @@ module.exports = (Vue, client) => {
 
   const handler = (err, vm, info) => {
     const handledState = { severity: 'error', unhandled: true, severityReason: { type: 'unhandledException' } }
-    const event = client.Event.create(err, true, handledState, 1)
+    const event = client.Event.create(err, true, handledState, 'vue error handler', 1)
 
     event.addMetadata('vue', {
       errorInfo: info,


### PR DESCRIPTION
## Goal

For non-Error events we need to skip internal frames to avoid Bugsnag ending up in the stack trace. In the Vue plugin we were not skipping the error handler's frame, so the top-most stack frame would be our Vue error handler rather than the call to it

This has been fixed and unit tests updated to check the stacktrace for non-Error events