### PR TITLE
Allow regex to match pre-release version numbers

### DIFF
--- a/test/aws-lambda/features/scripts/build-fixtures
+++ b/test/aws-lambda/features/scripts/build-fixtures
@@ -66,7 +66,7 @@ def pack
 
   # Strip the version suffix from the packages
   Dir["#{FileUtils.pwd}/bugsnag-*.tgz"].each do |package|
-    package_with_no_version = package.gsub(/-\d+\.\d+\.\d+/, '')
+    package_with_no_version = package.gsub(/-\d+\.\d+\.\d+.*(?=\.tgz)/, '')
     File.rename(package, package_with_no_version)
   end
 end


### PR DESCRIPTION
## Goal

The AWS Lambda `build-fixtures` script doesn't work with pre-release versions — it tries to strip the version number from the tarball but this didn't account for `-alpha.0` at the end

It will now strip the version from pre-releases, e.g. 'bugsnag-core-7.9.0-alpha.0.tgz'