### PR TITLE
Ensure step fails if IPA export does

### DIFF
--- a/test/react-native-cli/scripts/init-and-build-test.sh
+++ b/test/react-native-cli/scripts/init-and-build-test.sh
@@ -13,6 +13,8 @@ xcrun --log xcodebuild -exportArchive -archivePath "${VERSION}/${VERSION}.xcarch
 # Clear the archive away
 rm -rf ${VERSION}/${VERSION}.xcarchive
 
-# Copy file to build directory0
+# Copy file to build directory, ensuring the exit code bubbles up
 cp output/${VERSION}.ipa ../../../../build
+STATUS=$?
 popd
+exit $STATUS


### PR DESCRIPTION
## Goal

Ensure the Buildkite step fails if exporting the IPA does.

## Design

If the IPA is not created for any reason, `cp` will return a non-zero code.  With this passed back to the called (Buildkite agent), the step will fail and a human can examine the log further to understand why, before potentially hitting retry.

## Testing

I've performed an initial cut-down CI run using both good and known-broken build servers.  The steps passed and failed accordingly.