### PR TITLE
feat(core): Support Electron renderer process in js-runtime detector

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -23,8 +23,8 @@
     "size": "./bin/size",
     "clean": "rm -fr dist && mkdir dist",
     "build": "npm run clean && npm run build:dist && npm run build:dist:min",
-    "build:dist": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
-    "build:dist:min": "NODE_ENV=production IS_BROWSER=yes ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/minify dist/bugsnag.min.js",
+    "build:dist": "NODE_ENV=production ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
+    "build:dist:min": "NODE_ENV=production ../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/minify dist/bugsnag.min.js",
     "cdn-upload": "./bin/cdn-upload",
     "postversion": "npm run build"
   },

--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -5,7 +5,6 @@ const map = require('./lib/es-utils/map')
 const reduce = require('./lib/es-utils/reduce')
 const filter = require('./lib/es-utils/filter')
 const assign = require('./lib/es-utils/assign')
-const jsRuntime = require('./lib/js-runtime')
 const metadataDelegate = require('./lib/metadata-delegate')
 const isError = require('./lib/iserror')
 
@@ -35,7 +34,7 @@ class Event {
       {
         errorClass: ensureString(errorClass),
         errorMessage: ensureString(errorMessage),
-        type: jsRuntime,
+        type: Event.__type,
         stacktrace: reduce(stacktrace, (accum, frame) => {
           const f = formatStackframe(frame)
           // don't include a stackframe if none of its properties are defined
@@ -245,6 +244,9 @@ const normaliseError = (maybeError, tolerateNonErrors, component, logger) => {
 
   return [error, internalFrames]
 }
+
+// default value for stacktrace.type
+Event.__type = 'browserjs'
 
 const hasNecessaryFields = error =>
   (typeof error.name === 'string' || typeof error.errorClass === 'string') &&

--- a/packages/core/lib/js-runtime.js
+++ b/packages/core/lib/js-runtime.js
@@ -1,5 +1,0 @@
-module.exports = process.env.IS_BROWSER
-  ? 'browserjs'
-  : ((typeof navigator !== 'undefined' && navigator.product === 'ReactNative')
-    ? (typeof Expo !== 'undefined' ? 'expojs' : 'reactnativejs')
-    : 'nodejs')

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -10,6 +10,8 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
+Event.__type = 'expojs'
+
 const delivery = require('@bugsnag/delivery-expo')
 
 const schema = { ...require('@bugsnag/core/config').schema, ...require('./config') }

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -7,6 +7,8 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
+Event.__type = 'nodejs'
+
 const delivery = require('@bugsnag/delivery-node')
 
 // extend the base config schema with some node-specific options

--- a/packages/plugin-aws-lambda/test/index.test.ts
+++ b/packages/plugin-aws-lambda/test/index.test.ts
@@ -5,6 +5,9 @@ import Client, { EventDeliveryPayload, SessionDeliveryPayload } from '@bugsnag/c
 const createClient = (events: EventDeliveryPayload[], sessions: SessionDeliveryPayload[], config = {}) => {
   const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginAwsLambda], ...config })
 
+  // @ts-ignore the following property is not defined on the public Event interface
+  client.Event.__type = 'nodejs'
+
   // a flush failure won't throw as we don't want to crash apps if delivery takes
   // too long. To avoid the unit tests passing when this happens, we make the logger
   // throw on any 'error' log call

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -25,6 +25,8 @@ const Event = require('@bugsnag/core/event')
 const Session = require('@bugsnag/core/session')
 const Breadcrumb = require('@bugsnag/core/breadcrumb')
 
+Event.__type = 'reactnativejs'
+
 const delivery = require('@bugsnag/delivery-react-native')
 
 const BugsnagPluginReact = require('@bugsnag/plugin-react')

--- a/test/expo/features/handled.feature
+++ b/test/expo/features/handled.feature
@@ -10,6 +10,7 @@ Scenario: Calling notify() with an Error
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledError"
+  And the exception "type" equals "expojs"
   And the error Bugsnag-Integrity header is valid
 
 Scenario: Calling notify() with a caught Error
@@ -18,4 +19,5 @@ Scenario: Calling notify() with a caught Error
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "HandledCaughtError"
+  And the exception "type" equals "expojs"
   And the error Bugsnag-Integrity header is valid

--- a/test/expo/features/unhandled.feature
+++ b/test/expo/features/unhandled.feature
@@ -10,6 +10,7 @@ Scenario: Catching an Unhandled error
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UnhandledError"
+  And the exception "type" equals "expojs"
   And the error Bugsnag-Integrity header is valid
 
 Scenario: Catching an Unhandled promise rejection
@@ -18,4 +19,5 @@ Scenario: Catching an Unhandled promise rejection
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "UnhandledPromiseRejection"
+  And the exception "type" equals "expojs"
   And the error Bugsnag-Integrity header is valid


### PR DESCRIPTION
The existing setup used a mostly-dynamic approach to detect what stacktrace type value to use at runtime.

Electron processes with nodeIntegration=false have no process global variable so the existing logic in js-runtime.js was not compatible.

The existing logic has been reworked so that each notifier.js for each different notifier sets `Event.__type` during the setup phase. Because the notifier platform is known, there is no longer any logic required at runtime.