### PR TITLE
ci: lint native node extensions

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -49,6 +49,12 @@ jobs:
     - run: npx lerna bootstrap
     - run: npm run build:electron
       shell: bash
+    - run: sudo apt-get install cppcheck --assume-yes
+      name: Install cppcheck
+      if: contains(matrix.os, 'ubuntu')
+    - run: npm run test:lint-native
+      name: Lint C/C++ extensions
+      if: contains(matrix.os, 'ubuntu')
     - name: (macOS) disable crash dialog
       if: contains(matrix.os, 'macos')
       run: defaults write com.apple.CrashReporter DialogType none

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ min_packages.tar
 .cucumber-failures
 .webpack
 out
+compile_commands.json
+.cache
+.clangd

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "build": "lerna run build --scope '@bugsnag/node' --scope '@bugsnag/browser' --scope '@bugsnag/expo' && lerna run build --ignore '@bugsnag/node' --ignore '@bugsnag/browser' --ignore '@bugsnag/expo'",
     "build:electron": "lerna run build --scope '@bugsnag/plugin-electron-ipc' --scope '@bugsnag/plugin-electron-app' --scope '@bugsnag/plugin-electron-client-state-persistence'",
     "test:lint": "eslint --ext .ts,.js --report-unused-disable-directives --max-warnings=0 .",
+    "test:lint-native": "bash scripts/cppcheck.sh",
     "test:unit": "xvfb-maybe --auto-servernum -- jest",
     "test:types": "tsc -p tsconfig.json && lerna run test:types",
     "test:test-container-registry-login": "aws ecr get-login-password --profile=opensource | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com",

--- a/packages/plugin-electron-app/package.json
+++ b/packages/plugin-electron-app/package.json
@@ -21,7 +21,8 @@
     "app.js"
   ],
   "scripts": {
-    "build": "node-gyp configure build"
+    "build": "node-gyp configure build",
+    "generate-compile-commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py; mv Release/compile_commands.json .; rm -rf Debug Release"
   },
   "devDependencies": {
     "@bugsnag/core": "^7.10.0-alpha.0",

--- a/packages/plugin-electron-client-state-persistence/package.json
+++ b/packages/plugin-electron-client-state-persistence/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "node-gyp configure build",
-    "clangd-gen": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py; mv Release/compile_commands.json .; rm -rf Debug Release"
+    "generate-compile-commands": "node-gyp configure --release -- -f gyp.generator.compile_commands_json.py; mv Release/compile_commands.json .; rm -rf Debug Release"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+## fail on any error
+set -e
+
+# Generate compile_commands.json files
+npx lerna run generate-compile-commands
+
+# Hide flagged errors arising from style checks in dependencies or false positives
+# * The "memleak" is a known long-lived allocation
+# * Node API package declarations appear as unused functions
+SUPPRESSED_ERRORS=(\
+    --suppress='unmatchedSuppression' \
+    --suppress='unreadVariable:*/deps/*' \
+    --suppress='unusedFunction:*/deps/*' \
+    --suppress='unusedStructMember:*/deps/*' \
+    --suppress='unusedVariable:*/deps/*' \
+    --suppress='variableScope:*/deps/*' \
+    --suppress='ConfigurationNotChecked:*/deps/parson/parson.c:1425' \
+    --suppress='knownConditionTrueFalse:*/deps/parson/parson.c:692' \
+    --suppress='memleak:*/plugin-electron-client-state-persistence/src/deps/tinycthread/tinycthread.c:620' \
+    --suppress='unusedFunction:*/plugin-electron-client-state-persistence/src/api.c:429' \
+    --suppress='unusedFunction:*/plugin-electron-app/src/api.c:40')
+
+# Shared arguments:
+# --enable=all: Run all checks
+# -DCLOCK_REALTIME: define CLOCK_REALTIME to be 0 for the purposes of validating usage
+# --force: evaluate all combinations of preprocessor defines
+CHECK_CONFIGURATION=(${SUPPRESSED_ERRORS[@]} --error-exitcode=1 --quiet --enable=all -DCLOCK_REALTIME=0 --force)
+
+# Run for each package with C/C++ components
+for project in $(ls $(pwd)/packages/*/compile_commands.json); do
+  echo Checking $(dirname "$project")
+  cppcheck ${CHECK_CONFIGURATION[@]} --project="$project"
+done


### PR DESCRIPTION
Adds a new command `test:lint-native` which validates the C/C++ Node extensions using [cppcheck](http://cppcheck.sourceforge.net/)

## Changeset

* Adds a script for generating project files and running the checker
* Adds supressions for style nits in dependency files and known false positives

## Testing

* Added some temporary double frees and memory leaks to ensure the build failed