### PR TITLE
Electron: Ensure stripping project root works on paths with spaces

### DIFF
--- a/packages/plugin-electron-renderer-strip-project-root/strip-project-root.js
+++ b/packages/plugin-electron-renderer-strip-project-root/strip-project-root.js
@@ -7,7 +7,7 @@ module.exports = {
       const allFrames = event.errors.reduce((accum, er) => accum.concat(er.stacktrace), [])
       allFrames.forEach(stackframe => {
         if (typeof stackframe.file !== 'string') return
-        stackframe.file = stackframe.file.replace(/^file:\/\//, '')
+        stackframe.file = decodeURI(stackframe.file).replace(/^file:\/\//, '')
         if (stackframe.file.match('^/[A-Z]:/')) {
           stackframe.file = stackframe.file.slice(1) // strip extra leading slash on windows
         }

--- a/packages/plugin-electron-renderer-strip-project-root/test/strip-project-root.test.ts
+++ b/packages/plugin-electron-renderer-strip-project-root/test/strip-project-root.test.ts
@@ -25,7 +25,7 @@ describe('plugin: stack frame file trimmer', () => {
 
   it('strips projectRoot from file URLs', async () => {
     const file = isWindows ? 'file:///D:/path/to/index.js' : 'file:///path/to/index.js'
-    const expected = isWindows ? 'to/index.js' : 'to/index.js'
+    const expected = 'to/index.js'
     const projectRoot = isWindows ? 'D:\\path\\' : '/path/'
     const event = await sendEvent({ file }, projectRoot)
     expect(event.errors[0].stacktrace[0]).toEqual({ file: expected })
@@ -33,7 +33,7 @@ describe('plugin: stack frame file trimmer', () => {
 
   it('strips project root from file paths', async () => {
     const file = isWindows ? 'D:/path/to/index.js' : '/path/to/index.js'
-    const expected = isWindows ? 'to/index.js' : 'to/index.js'
+    const expected = 'to/index.js'
     const projectRoot = isWindows ? 'D:\\path\\' : '/path/'
     const event = await sendEvent({ file }, projectRoot)
     expect(event.errors[0].stacktrace[0]).toEqual({ file: expected })

--- a/packages/plugin-electron-renderer-strip-project-root/test/strip-project-root.test.ts
+++ b/packages/plugin-electron-renderer-strip-project-root/test/strip-project-root.test.ts
@@ -38,6 +38,18 @@ describe('plugin: stack frame file trimmer', () => {
     const event = await sendEvent({ file }, projectRoot)
     expect(event.errors[0].stacktrace[0]).toEqual({ file: expected })
   })
+
+  it('decodes escaped URI characters', async () => {
+    const file = isWindows
+      ? 'file:///D:/Program%20Files/electron%20app/electron-app-win-32/app.js'
+      : 'file:///Applications/electron%20app/electron-app-darwin-x64/app.js'
+    const expected = 'app.js'
+    const projectRoot = isWindows
+      ? 'D:\\Program Files\\electron app\\electron-app-win-32\\'
+      : '/Applications/electron app/electron-app-darwin-x64/'
+    const event = await sendEvent({ file }, projectRoot)
+    expect(event.errors[0].stacktrace[0]).toEqual({ file: expected })
+  })
 })
 
 async function sendEvent (initialStackframe: any, projectRoot: string|null = null) {


### PR DESCRIPTION
## Goal

In a renderer stacktrace, paths are URI encoded (so for example a space is the literal `%20`). The goal of this PR is to fix a bug where the stacktrace (and also the context) showed with a the full, absolute path, rather than the relative path from the project root.

## Design

- `decodeURI` fits this exact use case

## Changeset

Once `stackframe.file` is confirmed to be a string, pass it through `decodeURI` before any subsequent processing.

## Testing
Tested manually on my mac. Unit tests added.