### PR TITLE
Fix node build

### DIFF
--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -1,7 +1,6 @@
 const { schema } = require('@bugsnag/core/config')
 const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 const os = require('os')
-const process = require('process')
 const { inspect } = require('util')
 
 module.exports = {


### PR DESCRIPTION
## Goal

The `process` require is breaking the node build script as browserify can't find this module

I'm still not sure why this started breaking, but the require should be unnecessary anyway as `process` is a global