### PR TITLE
feat(electron): Default user.id to device.id

### DIFF
--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -35,7 +35,7 @@ module.exports = (opts) => {
     require('@bugsnag/plugin-electron-app')(NativeClient, process, electron.app, electron.BrowserWindow),
     require('@bugsnag/plugin-electron-app-breadcrumbs')(electron.app, electron.BrowserWindow),
     require('@bugsnag/plugin-electron-device')(electron.app, electron.screen, process, filestore, NativeClient, electron.powerMonitor),
-    require('@bugsnag/plugin-electron-session')(electron.app, electron.BrowserWindow),
+    require('@bugsnag/plugin-electron-session')(electron.app, electron.BrowserWindow, filestore),
     require('@bugsnag/plugin-console-breadcrumbs'),
     require('@bugsnag/plugin-strip-project-root'),
     require('@bugsnag/plugin-electron-preload-error')(electron.app),

--- a/packages/plugin-electron-device/test/device.test.ts
+++ b/packages/plugin-electron-device/test/device.test.ts
@@ -397,6 +397,26 @@ describe('plugin: electron device info', () => {
     const event3 = await sendEvent()
     expect(event3.getMetadata('device')).toEqual(makeExpectedMetadataDevice({ isLocked: false }))
   })
+
+  it('sets user id to device id if no user id is set', async () => {
+    const { sendEvent, sendSession } = makeClient()
+    await nextTick()
+    const event = await sendEvent()
+    expect(event.getUser().id).toBe(DEFAULTS.id)
+    const session = await sendSession()
+    expect(session.getUser().id).toBe(DEFAULTS.id)
+  })
+
+  it('doesn’t override user id if user id is already set', async () => {
+    const expectedId = '912837'
+    const { client, sendEvent, sendSession } = makeClient()
+    client.setUser(expectedId, 'tommy@testun.it', 'Tommy T. Unit')
+    await nextTick()
+    const event = await sendEvent()
+    expect(event.getUser().id).toBe(expectedId)
+    const session = await sendSession()
+    expect(session.getUser().id).toBe(expectedId)
+  })
 })
 
 // create a stub of '@bugsnag/electron-filestore'

--- a/packages/plugin-electron-session/session.js
+++ b/packages/plugin-electron-session/session.js
@@ -12,9 +12,9 @@ module.exports = (app, BrowserWindow, filestore) => ({
     }
 
     // jump through hoops to ensure the session gets started _after_ we have a device id
-    filestore.getDeviceInfo().then(() => {
-      app.whenReady().then(() => { setTimeout(() => client.startSession(), 10) })
-    }).catch(() => {})
+    Promise.all([filestore.getDeviceInfo(), app.whenReady()])
+      .then(() => { setTimeout(() => client.startSession(), 10) })
+      .catch(() => {})
 
     let lastInBackground = null
 

--- a/packages/plugin-electron-session/session.js
+++ b/packages/plugin-electron-session/session.js
@@ -2,7 +2,7 @@ const sessionDelegate = require('@bugsnag/plugin-browser-session')
 
 const SESSION_TIMEOUT_MS = 60 * 1000
 
-module.exports = (app, BrowserWindow) => ({
+module.exports = (app, BrowserWindow, filestore) => ({
   load (client) {
     // load the actual session delegate from plugin-browser-session
     sessionDelegate.load(client)
@@ -11,7 +11,10 @@ module.exports = (app, BrowserWindow) => ({
       return
     }
 
-    app.whenReady().then(() => { client.startSession() })
+    // jump through hoops to ensure the session gets started _after_ we have a device id
+    filestore.getDeviceInfo().then(() => {
+      app.whenReady().then(() => { setTimeout(() => client.startSession(), 10) })
+    }).catch(() => {})
 
     let lastInBackground = null
 

--- a/packages/plugin-electron-session/test/session.test.ts
+++ b/packages/plugin-electron-session/test/session.test.ts
@@ -4,6 +4,9 @@ import { makeApp, makeBrowserWindow } from '@bugsnag/electron-test-helpers'
 import plugin from '../'
 
 const expectCuid = expect.stringMatching(/^c[a-z0-9]{20,30}$/)
+const mockFileStore = {
+  getDeviceInfo: () => Promise.resolve()
+}
 
 describe('plugin: electron sessions', () => {
   beforeEach(() => { jest.useRealTimers() })
@@ -15,7 +18,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f' },
       undefined,
-      [plugin(app, BrowserWindow)]
+      [plugin(app, BrowserWindow, mockFileStore)]
     )
 
     const payload = await createSession(client)
@@ -60,7 +63,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f' },
       undefined,
-      [plugin(app, BrowserWindow)]
+      [plugin(app, BrowserWindow, mockFileStore)]
     )
 
     const window = new BrowserWindow(123, 'hello world')
@@ -110,7 +113,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f' },
       undefined,
-      [plugin(app, BrowserWindow)]
+      [plugin(app, BrowserWindow, mockFileStore)]
     )
 
     const window = new BrowserWindow(123, 'hello world')
@@ -166,7 +169,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f', autoTrackSessions: false },
       undefined,
-      [plugin(app, BrowserWindow)]
+      [plugin(app, BrowserWindow, mockFileStore)]
     )
 
     const window = new BrowserWindow(123, 'hello world')

--- a/test/electron/fixtures/events/main/handled-error/default.json
+++ b/test/electron/fixtures/events/main/handled-error/default.json
@@ -27,6 +27,9 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
       "metaData": {
         "app": {
           "name": "Runner"

--- a/test/electron/fixtures/events/main/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/default.json
@@ -28,6 +28,9 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
       "metaData": {
         "app": {
           "name": "Runner"

--- a/test/electron/fixtures/events/main/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/default.json
@@ -28,6 +28,9 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
       "metaData": {
         "app": {
           "name": "Runner"

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -27,6 +27,9 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
       "metaData": {
         "app": {
           "name": "Runner"

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -28,6 +28,9 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
       "metaData": {
         "app": {
           "name": "Runner"

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -28,6 +28,9 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
       "metaData": {
         "app": {
           "name": "Runner"

--- a/test/electron/fixtures/events/sessions/complex-config.json
+++ b/test/electron/fixtures/events/sessions/complex-config.json
@@ -5,6 +5,7 @@
     "url": "https://github.com/bugsnag/bugsnag-electron"
   },
   "device": {
+    "id": "{REGEX:[0-9a-f]{64}}",
     "totalMemory": "{TYPE:number}",
     "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
     "osName": "{REGEX:^Linux|macOS|Windows$}",

--- a/test/electron/fixtures/events/sessions/default.json
+++ b/test/electron/fixtures/events/sessions/default.json
@@ -5,6 +5,7 @@
     "url": "https://github.com/bugsnag/bugsnag-electron"
   },
   "device": {
+    "id": "{REGEX:[0-9a-f]{64}}",
     "totalMemory": "{TYPE:number}",
     "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
     "osName": "{REGEX:^Linux|macOS|Windows$}",
@@ -25,7 +26,9 @@
     {
       "id": "{TYPE:string}",
       "startedAt": "{REGEX:^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$}",
-      "user": {}
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Goal

When `user.id` is not set it should default to `device.id`.

## Design

It required more complexity than seems desirable to ensure the `device.id` was populated before sending a session. Any other ideas for workable solutions welcome!

## Changeset

- Updated `electron-session` to receive the filestore param so it can wait for the id to be loaded
- Added `setDefaultUserId()` function in Electron's device plugin which runs during onError and onSession to set `user.id` if it's not already set.

## Testing

Tested manually, with unit tests and end to end tests.