### PR TITLE
Allow setting appType in renderer config

### DIFF
--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -3,7 +3,8 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 
 const ALLOWED_IN_RENDERER = [
   // a list of config keys that are allowed to be supplied to the renderer client
-  'onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins'
+  // this must be kept in sync with the typescript "AllowedRendererConfig" type
+  'onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins', 'appType'
 ]
 
 module.exports.schema = {

--- a/packages/electron/test/type.test.ts
+++ b/packages/electron/test/type.test.ts
@@ -30,7 +30,9 @@ describe.skip('@bugsnag/electron types', () => {
         onError: (event: Event) => {},
         onBreadcrumb: (breadcrumb: Breadcrumb) => {},
         plugins: [],
-        user: { id: '1234-abcd' }
+        user: { id: '1234-abcd' },
+        appType: 'good',
+        codeBundleId: '1245'
       })
     })
   })

--- a/packages/electron/types/notifier.d.ts
+++ b/packages/electron/types/notifier.d.ts
@@ -26,7 +26,8 @@ interface MainConfig extends Config {
 }
 
 // a renderer is only allowed a subset of properties from Config
-type AllowedRendererConfig = Pick<Config, 'context'|'logger'|'metadata'|'onError'|'onBreadcrumb'|'plugins'|'user'>
+// this must match the "ALLOWED_IN_RENDERER" list in the renderer config
+type AllowedRendererConfig = Pick<Config, 'onError'|'onBreadcrumb'|'logger'|'metadata'|'user'|'context'|'codeBundleId'|'plugins'|'appType'>
 
 interface RendererConfig extends AllowedRendererConfig {
   codeBundleId?: string

--- a/packages/plugin-electron-app/app.js
+++ b/packages/plugin-electron-app/app.js
@@ -56,7 +56,7 @@ module.exports = (NativeClient, process, electronApp, BrowserWindow, NativeApp =
       inForeground: BrowserWindow.getFocusedWindow() !== null,
       isLaunching: true,
       releaseStage: client._config.releaseStage,
-      type: osToAppType.get(process.platform),
+      type: client._config.appType || osToAppType.get(process.platform),
       version: version,
       bundleVersion: NativeApp.getPackageVersion() || version
     })

--- a/packages/plugin-electron-renderer-event-data/renderer-event-data.js
+++ b/packages/plugin-electron-renderer-event-data/renderer-event-data.js
@@ -29,6 +29,10 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
           event._metadata[section] = metadata[section]
         }
       }
+
+      if (client._config.appType) {
+        event.app.type = client._config.appType
+      }
     }, true)
   }
 })

--- a/test/electron/features/renderer-config.feature
+++ b/test/electron/features/renderer-config.feature
@@ -1,0 +1,17 @@
+Feature: Setting config options in renderers
+
+    Scenario Outline: Setting config options in renderers
+        Given I launch an app with configuration:
+            | renderer_config | <config> |
+        And I click "renderer-notify"
+        Then the total requests received by the server matches:
+            | events  | 1        |
+        Then the headers of every event request contains:
+            | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+            | Content-Type      | application/json                 |
+            | Bugsnag-Integrity | {BODY_SHA1}                      |
+        Then the contents of an event request matches "renderer/config/<property>.json"
+
+        Examples:
+            | property | config                      |
+            | appType  | { "appType": "real great" } |

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -19,14 +19,16 @@ Given('I launch an app', launchConfig, async () => {
 })
 
 Given('I launch an app with configuration:', launchConfig, (data) => {
-  const setup = { bugsnag: 'default', preload: 'default.js' }
+  const setup = { bugsnag: 'default', preload: 'default.js', renderer_config: '{}' }
   data.raw().forEach(row => {
     const [key, config] = row
     setup[key] = config
   })
+
   return global.automator.start({
     BUGSNAG_CONFIG: setup.bugsnag,
-    BUGSNAG_PRELOAD: setup.preload
+    BUGSNAG_PRELOAD: setup.preload,
+    BUGSNAG_RENDERER_CONFIG: setup.renderer_config
   })
 })
 

--- a/test/electron/fixtures/app/configs/complex-config.js
+++ b/test/electron/fixtures/app/configs/complex-config.js
@@ -1,5 +1,6 @@
 module.exports = () => {
   return {
+    appType: 'complicated',
     appVersion: '2.0.83-beta3',
     context: 'shopping cart',
     user: {

--- a/test/electron/fixtures/app/preloads/default.js
+++ b/test/electron/fixtures/app/preloads/default.js
@@ -1,6 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('RunnerAPI', {
+  rendererConfig: JSON.parse(process.env.BUGSNAG_RENDERER_CONFIG || '{}'),
   mainProcessCrash: () => {
     ipcRenderer.send('main-process-crash')
   },

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -1,6 +1,6 @@
 const Bugsnag = require('@bugsnag/electron')
 
-Bugsnag.start()
+Bugsnag.start(window.RunnerAPI.rendererConfig)
 const startupTimestamp = Date.now()
 
 function emulateOnlineStatus (online) {

--- a/test/electron/fixtures/events/main/breadcrumbs/cancelled.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/cancelled.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": true,
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/main/breadcrumbs/complex-config.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": true,
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/main/breadcrumbs/default.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": true,
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/main/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/main/handled-error/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/main/handled-error/default.json
+++ b/test/electron/fixtures/events/main/handled-error/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/main/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/main/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/on-error/complex-config.json
+++ b/test/electron/fixtures/events/on-error/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/on-error/default.json
+++ b/test/electron/fixtures/events/on-error/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/renderer/config/appType.json
+++ b/test/electron/fixtures/events/renderer/config/appType.json
@@ -1,0 +1,89 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "real great"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner"
+        },
+        "device": {
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 20,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/renderer/handled-error/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
@@ -13,6 +13,7 @@
         "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
         "version": "2.0.83-beta3"
       },
       "context": "shopping cart",

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -13,6 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
+        "type": "{REGEX:^Linux|macOS|Windows$}",
         "version": "1.0.2"
       },
       "device": {

--- a/test/electron/fixtures/events/sessions/complex-config.json
+++ b/test/electron/fixtures/events/sessions/complex-config.json
@@ -19,7 +19,7 @@
   "app": {
     "releaseStage": "beta",
     "version": "2.0.83-beta3",
-    "type": "{REGEX:^Linux|macOS|Windows$}",
+    "type": "complicated",
     "bundleVersion": "{TYPE:string}"
   },
   "sessions": [


### PR DESCRIPTION
## Goal

Adds `appType` to the `ALLOWED_IN_RENDERER` list and the related Typescript definition