### PR TITLE
feat(electron): Enable process metadata on main and renderers

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -28,6 +28,7 @@
     "@bugsnag/plugin-electron-net-breadcrumbs": "^7.10.0-alpha.0",
     "@bugsnag/plugin-electron-network-status": "^7.10.0-alpha.0",
     "@bugsnag/plugin-electron-preload-error": "^7.10.0-alpha.0",
+    "@bugsnag/plugin-electron-process-info": "^7.10.0-alpha.0",
     "@bugsnag/plugin-electron-renderer-client-state-updates": "^7.10.0-alpha.0",
     "@bugsnag/plugin-electron-renderer-event-data": "^7.10.0-alpha.0",
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^7.10.0-alpha.0",

--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -38,6 +38,7 @@ module.exports = (opts) => {
     require('@bugsnag/plugin-electron-session')(electron.app, electron.BrowserWindow, filestore),
     require('@bugsnag/plugin-console-breadcrumbs'),
     require('@bugsnag/plugin-strip-project-root'),
+    require('@bugsnag/plugin-electron-process-info')(),
     require('@bugsnag/plugin-electron-preload-error')(electron.app),
     require('@bugsnag/plugin-electron-net-breadcrumbs')(electron.net),
     // THIS PLUGIN MUST BE LAST!

--- a/packages/electron/src/client/renderer.js
+++ b/packages/electron/src/client/renderer.js
@@ -23,6 +23,7 @@ module.exports = (rendererOpts) => {
     require('@bugsnag/plugin-network-breadcrumbs')(),
     require('@bugsnag/plugin-interaction-breadcrumbs')(),
     require('@bugsnag/plugin-console-breadcrumbs'),
+    require('@bugsnag/plugin-electron-process-info')(window.__bugsnag_ipc__.process),
     require('@bugsnag/plugin-electron-renderer-strip-project-root'),
     require('@bugsnag/plugin-electron-renderer-event-data')(window.__bugsnag_ipc__)
   ]

--- a/packages/plugin-electron-ipc/bugsnag-ipc-renderer.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-renderer.js
@@ -9,6 +9,10 @@ const safeInvoke = (runSynchronous, method, ...args) => {
 }
 
 const BugsnagIpcRenderer = {
+  // these static values are populated by preload.js
+  config: null,
+  process: null,
+
   update ({ context, user, metadata }) {
     return safeInvoke(false, 'update', { context, user, metadata })
   },

--- a/packages/plugin-electron-ipc/package.json
+++ b/packages/plugin-electron-ipc/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
   "scripts": {
-    "build": "browserify preload.js --exclude electron -o dist/preload.bundle.js",
+    "build": "browserify preload.js --exclude electron --bare -o dist/preload.bundle.js",
     "postversion": "npm run build"
   },
   "publishConfig": {

--- a/packages/plugin-electron-ipc/preload.js
+++ b/packages/plugin-electron-ipc/preload.js
@@ -12,6 +12,10 @@ if (!config) throw new Error('Bugsnag was not started in the main process before
 // attach config to the exposed interface
 BugsnagIpcRenderer.config = JSON.parse(config)
 
+// attach process info to the exposed interface
+const { isMainFrame, sandboxed, type } = process
+BugsnagIpcRenderer.process = { isMainFrame, sandboxed, type }
+
 // expose Bugsnag as a global object for the browser
 try {
   // assume contextIsolation=true

--- a/packages/plugin-electron-process-info/procinfo.js
+++ b/packages/plugin-electron-process-info/procinfo.js
@@ -3,19 +3,24 @@ module.exports = (source = process) => ({
     client.addOnError(function (event) {
       const info = {}
       if (typeof source.getHeapStatistics === 'function') {
+        // heapStatistics is only available in main
         info.heapStatistics = source.getHeapStatistics()
       }
 
       if (typeof source.type === 'string') {
+        // type should always be available
         info.type = source.type
       }
 
-      // sandboxed can be undefined and is assumed false
-      info.sandboxed = source.sandboxed === true
+      if (typeof source.sandboxed === 'boolean') {
+        // sandboxed is only present in renderers
+        info.sandboxed = source.sandboxed === true
+      }
 
-      // when the current process is the main frame, isMainFrame is guaranteed
-      // to be true, no guarantees about the inverse case
-      info.isMainFrame = source.isMainFrame === true
+      if (typeof source.isMainFrame === 'boolean') {
+        // isMainFrame is only present in renderers
+        info.isMainFrame = source.isMainFrame === true
+      }
 
       event.addMetadata('process', info)
     }, true)

--- a/packages/plugin-electron-process-info/test/procinfo.test.ts
+++ b/packages/plugin-electron-process-info/test/procinfo.test.ts
@@ -36,11 +36,11 @@ describe('plugin: electron process info', () => {
     client._notify(new Event('Error', 'incorrect lambda type', []))
   })
 
-  it('attaches sandboxed status when unset', (done) => {
+  it('does not attach sandboxed status when unset', (done) => {
     const processInfo = {}
     const client = makeClient((payload: any) => {
       const metadata = payload.events[0]._metadata
-      expect(metadata.process.sandboxed).toBe(false)
+      expect(metadata.process.sandboxed).toBe(undefined)
       done()
     }, processInfo)
     client._notify(new Event('Error', 'incorrect lambda type', []))
@@ -56,11 +56,11 @@ describe('plugin: electron process info', () => {
     client._notify(new Event('Error', 'incorrect lambda type', []))
   })
 
-  it('attaches main frame status when unset', (done) => {
+  it('does not attach main frame status when unset', (done) => {
     const processInfo = {}
     const client = makeClient((payload: any) => {
       const metadata = payload.events[0]._metadata
-      expect(metadata.process.isMainFrame).toBe(false)
+      expect(metadata.process.isMainFrame).toBe(undefined)
       done()
     }, processInfo)
     client._notify(new Event('Error', 'incorrect lambda type', []))

--- a/test/electron/fixtures/events/main/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/main/handled-error/complex-config.json
@@ -45,6 +45,10 @@
         },
         "site": {
           "name": "shop co"
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
         }
       },
       "severity": "warning",

--- a/test/electron/fixtures/events/main/handled-error/default.json
+++ b/test/electron/fixtures/events/main/handled-error/default.json
@@ -40,6 +40,10 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
         }
       },
       "severity": "warning",

--- a/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
@@ -46,6 +46,10 @@
         },
         "site": {
           "name": "shop co"
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/main/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/default.json
@@ -41,6 +41,10 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
@@ -46,6 +46,10 @@
         },
         "site": {
           "name": "shop co"
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/main/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/default.json
@@ -41,6 +41,10 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/renderer/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/renderer/handled-error/complex-config.json
@@ -45,6 +45,12 @@
         },
         "site": {
           "name": "shop co"
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
         }
       },
       "severity": "warning",

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -39,6 +39,12 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
         }
       },
       "severity": "warning",

--- a/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
@@ -46,6 +46,12 @@
         },
         "site": {
           "name": "shop co"
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -41,6 +41,12 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
@@ -46,6 +46,12 @@
         },
         "site": {
           "name": "shop co"
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
         }
       },
       "severity": "error",

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -41,6 +41,12 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
         }
       },
       "severity": "error",


### PR DESCRIPTION
## Goal

Enable process metadata in main and renderer processes.

## Design

A plugin already existed, but it added process data from the main process for all events, regardless of where they initiated. I've updated the plugin to run in both processes.

## Changeset

- Enable process info plugin
- Update it to work with renderers
- Update the preload build to not shim the node `process` variable

## Testing

Updated unit tests, added process metadata to expected payloads and manually tested.