### PR TITLE
Fix project root stripping in renderers

### DIFF
--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -51,6 +51,13 @@ module.exports = (opts) => {
 
   bugsnag._logger.debug('Loaded! In main process.')
 
+  // Normalise the project root upfront so renderers have a fully resolved path
+  // The renderers can't do this themselves as they cannot access the 'path' module
+  if (bugsnag._config.projectRoot) {
+    const normalizePath = require('@bugsnag/core/lib/path-normalizer')
+    bugsnag._config.projectRoot = normalizePath(bugsnag._config.projectRoot)
+  }
+
   return bugsnag
 }
 


### PR DESCRIPTION
## Goal

The current project root stripping doesn't quite work in renderers because it leaves a leading path separator e.g. `/root/a/b/c` is stripped to `/a/b/c` when it should be `a/b/c`

I've made two changes in this PR:

1. pre-normalise the default project root path
    This fixes the issue as it allows the renderer to use the normalised path. Renderers wouldn't normally be able to do this as the normalisation requires the `path` module
1. add a path separator to the project root when stripping paths
    This fixes the issue if a non-default project root is used. I think this is always safe unless the project root is a filename, but that doesn't seem like a reasonable use case as it would only work for one path and would leave an empty filename in the stacktrace