### PR TITLE
Add `idleTime` to device metadata

### DIFF
--- a/packages/electron-test-helpers/src/PowerMonitor.ts
+++ b/packages/electron-test-helpers/src/PowerMonitor.ts
@@ -26,13 +26,16 @@ class PowerMonitor {
 
   private usingBattery: boolean
   private isLocked: boolean
+  private idleTime: number
 
   constructor ({
     usingBattery = false,
-    isLocked = false
+    isLocked = false,
+    idleTime = 0
   } = {}) {
     this.usingBattery = usingBattery
     this.isLocked = isLocked
+    this.idleTime = idleTime
   }
 
   on (event: PowerMonitorEvent, callback: Function): void {
@@ -46,6 +49,10 @@ class PowerMonitor {
 
     // https://github.com/electron/electron/blob/a9924e1c32e8445887e3a6b5cdff445d93c2b18f/shell/browser/api/electron_api_power_monitor.cc#L129-L130
     throw new TypeError('Invalid idle threshold, must be greater than 0')
+  }
+
+  getSystemIdleTime () {
+    return this.idleTime
   }
 
   get onBatteryPower () {

--- a/packages/plugin-electron-device/device.js
+++ b/packages/plugin-electron-device/device.js
@@ -115,6 +115,8 @@ module.exports = (app, screen, process, filestore, NativeClient, powerMonitor) =
         }
       )
 
+      event.addMetadata('device', { idleTime: powerMonitor.getSystemIdleTime() })
+
       setDefaultUserId(event)
     }, true)
 

--- a/packages/plugin-electron-device/test/device.test.ts
+++ b/packages/plugin-electron-device/test/device.test.ts
@@ -33,7 +33,8 @@ const DEFAULTS = {
   time: expect.any(Date),
   totalMemory: 100, // this is in KiB to match Electron's API
   usingBattery: false,
-  isLocked: false
+  isLocked: false,
+  idleTime: 0
 }
 
 // expected data for 'session.device'
@@ -61,6 +62,7 @@ const makeExpectedMetadataDevice = (customisations = {}) => ({
   screenDensity: DEFAULTS.screenDensity,
   screenResolution: DEFAULTS.screenResolution,
   usingBattery: DEFAULTS.usingBattery,
+  idleTime: DEFAULTS.idleTime,
   ...customisations
 })
 
@@ -396,6 +398,17 @@ describe('plugin: electron device info', () => {
 
     const event3 = await sendEvent()
     expect(event3.getMetadata('device')).toEqual(makeExpectedMetadataDevice({ isLocked: false }))
+  })
+
+  it('records the system idle time', async () => {
+    const powerMonitor = makePowerMonitor({ idleTime: 1234 })
+
+    const { sendEvent } = makeClient({ powerMonitor })
+
+    await nextTick()
+
+    const event = await sendEvent()
+    expect(event.getMetadata('device')).toEqual(makeExpectedMetadataDevice({ idleTime: 1234 }))
   })
 
   it('sets user id to device id if no user id is set', async () => {

--- a/test/electron/fixtures/events/main/breadcrumbs/cancelled.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/cancelled.json
@@ -34,6 +34,8 @@
           "name": "Runner"
         },
         "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/breadcrumbs/complex-config.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/complex-config.json
@@ -39,6 +39,8 @@
           "part": 3
         },
         "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/breadcrumbs/default.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/default.json
@@ -34,6 +34,8 @@
           "name": "Runner"
         },
         "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/main/handled-error/complex-config.json
@@ -39,6 +39,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/handled-error/default.json
+++ b/test/electron/fixtures/events/main/handled-error/default.json
@@ -37,6 +37,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
@@ -40,6 +40,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/default.json
@@ -38,6 +38,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
@@ -40,6 +40,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/main/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/default.json
@@ -38,6 +38,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/on-error/complex-config.json
+++ b/test/electron/fixtures/events/on-error/complex-config.json
@@ -39,6 +39,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/on-error/default.json
+++ b/test/electron/fixtures/events/on-error/default.json
@@ -33,6 +33,8 @@
           "name": "Runner"
         },
         "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/config/appType.json
+++ b/test/electron/fixtures/events/renderer/config/appType.json
@@ -36,6 +36,8 @@
           "name": "Runner"
         },
         "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/renderer/handled-error/complex-config.json
@@ -39,6 +39,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -36,6 +36,8 @@
           "name": "Runner"
         },
         "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
@@ -40,6 +40,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -38,6 +38,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
@@ -40,6 +40,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -38,6 +38,7 @@
         },
         "device": {
           "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
           "screenResolution": {
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"


### PR DESCRIPTION
## Goal

Adds a new `idleTime` field to device metadata using [`powerMonitor#getSystemIdleTime`](https://www.electronjs.org/docs/api/power-monitor#powermonitorgetsystemidletime)

This shows the number of seconds since the last mouse/keyboard activity, e.g. for macOS it's implemented using [`CGEventSourceSecondsSinceLastEventType`](https://developer.apple.com/documentation/coregraphics/1408790-cgeventsourcesecondssincelasteve) with an `eventType` of `kCGAnyInputEventType`

## Testing

Can be manually tested by triggering an event in a `setTimeout` call and not interacting with the system until after it fires