### PR TITLE
refactor(electron): Shorten native bindings name

### DIFF
--- a/packages/plugin-electron-app/app.js
+++ b/packages/plugin-electron-app/app.js
@@ -1,4 +1,4 @@
-const native = require('bindings')('bugsnag_plugin_electron_app_bindings')
+const native = require('bindings')('bugsnag_pea_bindings')
 
 const osToAppType = new Map([
   ['darwin', 'macOS'],

--- a/packages/plugin-electron-app/binding.gyp
+++ b/packages/plugin-electron-app/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "bugsnag_plugin_electron_app_bindings",
+      "target_name": "bugsnag_pea_bindings",
       "sources": [
         "src/api.c",
         "src/get_version.h",


### PR DESCRIPTION
Prevent issues with long file names on windows.