### PR TITLE
Add stackframe path normaliser plugin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
   ],
   projects: [
     project('core', ['core']),
-    project('shared plugins', ['plugin-app-duration']),
+    project('shared plugins', ['plugin-app-duration', 'plugin-stackframe-path-normaliser']),
     project('browser', [
       'browser',
       'delivery-x-domain-request',

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -38,6 +38,7 @@
     "@bugsnag/plugin-network-breadcrumbs": "^7.10.0-alpha.0",
     "@bugsnag/plugin-node-uncaught-exception": "^7.10.0-alpha.0",
     "@bugsnag/plugin-node-unhandled-rejection": "^7.10.0-alpha.0",
+    "@bugsnag/plugin-stackframe-path-normaliser": "^7.10.0-alpha.1",
     "@bugsnag/plugin-strip-project-root": "^7.10.0-alpha.0",
     "@bugsnag/plugin-window-onerror": "^7.10.0-alpha.0",
     "@bugsnag/plugin-window-unhandled-rejection": "^7.10.0-alpha.0"

--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -41,6 +41,7 @@ module.exports = (opts) => {
     require('@bugsnag/plugin-electron-process-info')(),
     require('@bugsnag/plugin-electron-preload-error')(electron.app),
     require('@bugsnag/plugin-electron-net-breadcrumbs')(electron.net),
+    require('@bugsnag/plugin-stackframe-path-normaliser'),
     // THIS PLUGIN MUST BE LAST!
     require('@bugsnag/plugin-internal-callback-marker').LastPlugin
   ]

--- a/packages/electron/src/client/renderer.js
+++ b/packages/electron/src/client/renderer.js
@@ -25,6 +25,7 @@ module.exports = (rendererOpts) => {
     require('@bugsnag/plugin-console-breadcrumbs'),
     require('@bugsnag/plugin-electron-process-info')(window.__bugsnag_ipc__.process),
     require('@bugsnag/plugin-electron-renderer-strip-project-root'),
+    require('@bugsnag/plugin-stackframe-path-normaliser'),
     require('@bugsnag/plugin-electron-renderer-event-data')(window.__bugsnag_ipc__)
   ]
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,6 +35,7 @@
     "@bugsnag/plugin-node-uncaught-exception": "^7.10.0-alpha.0",
     "@bugsnag/plugin-node-unhandled-rejection": "^7.10.0-alpha.0",
     "@bugsnag/plugin-server-session": "^7.10.0-alpha.0",
+    "@bugsnag/plugin-stackframe-path-normaliser": "^7.10.0-alpha.1",
     "@bugsnag/plugin-strip-project-root": "^7.10.0-alpha.0"
   },
   "dependencies": {

--- a/packages/node/src/notifier.js
+++ b/packages/node/src/notifier.js
@@ -27,6 +27,7 @@ const pluginNodeUncaughtException = require('@bugsnag/plugin-node-uncaught-excep
 const pluginNodeUnhandledRejection = require('@bugsnag/plugin-node-unhandled-rejection')
 const pluginIntercept = require('@bugsnag/plugin-intercept')
 const pluginContextualize = require('@bugsnag/plugin-contextualize')
+const pluginStackframePathNormaliser = require('@bugsnag/plugin-stackframe-path-normaliser')
 
 const internalPlugins = [
   pluginApp,
@@ -38,7 +39,8 @@ const internalPlugins = [
   pluginNodeUncaughtException,
   pluginNodeUnhandledRejection,
   pluginIntercept,
-  pluginContextualize
+  pluginContextualize,
+  pluginStackframePathNormaliser
 ]
 
 const Bugsnag = {

--- a/packages/plugin-stackframe-path-normaliser/LICENSE.txt
+++ b/packages/plugin-stackframe-path-normaliser/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/plugin-stackframe-path-normaliser/README.md
+++ b/packages/plugin-stackframe-path-normaliser/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/plugin-stackframe-path-normaliser
+
+@bugsnag/js plugin to normalise file paths in stackframes
+
+## License
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-stackframe-path-normaliser/package.json
+++ b/packages/plugin-stackframe-path-normaliser/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@bugsnag/plugin-stackframe-path-normaliser",
+  "version": "7.10.0-alpha.1",
+  "main": "path-normaliser.js",
+  "description": "@bugsnag/js plugin to normalise file paths in stackframes",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Bugsnag",
+  "license": "MIT",
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
+  },
+  "devDependencies": {
+    "@bugsnag/core": "^7.10.0-alpha.0"
+  }
+}

--- a/packages/plugin-stackframe-path-normaliser/path-normaliser.js
+++ b/packages/plugin-stackframe-path-normaliser/path-normaliser.js
@@ -1,0 +1,15 @@
+module.exports = {
+  load (client) {
+    client.addOnError(event => {
+      const allFrames = event.errors.reduce((accum, er) => accum.concat(er.stacktrace), [])
+
+      allFrames.forEach(stackframe => {
+        if (typeof stackframe.file !== 'string') {
+          return
+        }
+
+        stackframe.file = stackframe.file.replace(/\\/g, '/')
+      })
+    })
+  }
+}

--- a/packages/plugin-stackframe-path-normaliser/test/path-normaliser.test.ts
+++ b/packages/plugin-stackframe-path-normaliser/test/path-normaliser.test.ts
@@ -1,0 +1,128 @@
+import plugin from '../'
+import Event from '@bugsnag/core/event'
+import Client from '@bugsnag/core/client'
+
+describe('plugin: stackframe path normaliser', () => {
+  it('does not change frames with no file path', done => {
+    const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+    client._setDelivery(client => ({
+      sendEvent: (payload) => {
+        const event = payload.events[0]
+
+        expect(event.errors[0].stacktrace).toHaveLength(3)
+
+        const [frame1, frame2, frame3] = event.errors[0].stacktrace
+
+        expect(frame1.file).toBe('global code')
+        expect(frame2.file).toBe('global code')
+        expect(frame3.file).toBe('global code')
+
+        done()
+      },
+      sendSession: () => {}
+    }))
+
+    client._notify(new Event('Error', 'path normaliser', [
+      {
+        lineNumber: 22,
+        columnNumber: 18,
+        fileName: undefined
+      },
+      {
+        lineNumber: 31,
+        columnNumber: 7,
+        fileName: undefined
+      },
+      {
+        lineNumber: 118,
+        columnNumber: 28,
+        fileName: undefined
+      }
+    ]))
+  })
+
+  it('does not change file paths that use "/"', done => {
+    const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+    client._setDelivery(client => ({
+      sendEvent: (payload) => {
+        const event = payload.events[0]
+
+        expect(event.errors[0].stacktrace).toHaveLength(3)
+
+        const [frame1, frame2, frame3] = event.errors[0].stacktrace
+
+        expect(frame1.file).toBe('/a/b/c.js')
+        expect(frame2.file).toBe('/abc/def.js')
+        expect(frame3.file).toBe('/abcdef/ghijkl.js')
+
+        done()
+      },
+      sendSession: () => {}
+    }))
+
+    client._notify(new Event('Error', 'path normaliser', [
+      {
+        lineNumber: 22,
+        columnNumber: 18,
+        fileName: '/a/b/c.js'
+      },
+      {
+        lineNumber: 31,
+        columnNumber: 7,
+        fileName: '/abc/def.js'
+      },
+      {
+        lineNumber: 118,
+        columnNumber: 28,
+        fileName: '/abcdef/ghijkl.js'
+      }
+    ]))
+  })
+
+  it('changes file paths that use "\\" into file paths that use "/"', done => {
+    const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+    client._setDelivery(client => ({
+      sendEvent: (payload) => {
+        const event = payload.events[0]
+
+        expect(event.errors[0].stacktrace).toHaveLength(4)
+
+        const [frame1, frame2, frame3, frame4] = event.errors[0].stacktrace
+
+        expect(frame1.file).toBe('/a/b/c.js')
+        expect(frame2.file).toBe('/abc/def.js')
+        expect(frame3.file).toBe('/abcdef/ghijkl.js')
+        expect(frame4.file).toBe('/abcdefghijkl/mnopqrstuvwx.yz')
+
+        done()
+      },
+      sendSession: () => {}
+    }))
+
+    client._notify(new Event('Error', 'path normaliser', [
+      {
+        lineNumber: 22,
+        columnNumber: 18,
+        fileName: '\\a\\b\\c.js'
+      },
+      {
+        lineNumber: 31,
+        columnNumber: 7,
+        fileName: '\\abc\\def.js'
+      },
+      {
+        lineNumber: 118,
+        columnNumber: 28,
+        fileName: '\\abcdef\\ghijkl.js'
+      },
+      {
+        lineNumber: 2387,
+        columnNumber: 192,
+        fileName: '\\abcdefghijkl/mnopqrstuvwx.yz'
+      }
+    ]))
+  })
+})

--- a/test/electron/features/support/utils/source-mapper.js
+++ b/test/electron/features/support/utils/source-mapper.js
@@ -1,11 +1,13 @@
 const { access, readFile } = require('fs').promises
 const { F_OK } = require('fs').constants
 const { SourceMapConsumer } = require('source-map')
-const { join, normalize } = require('path')
+const { join, normalize: pathNormalize } = require('path')
 const { promisify } = require('util')
 const glob = promisify(require('glob'))
 
 const cache = {} // source map consumers are expensive
+
+const normalize = path => pathNormalize(path).replace(/\\/g, '/')
 
 const sourceMapFor = async (file) => {
   try {


### PR DESCRIPTION
## Goal

Adds a new plugin that changes stackframe file paths so they always use `/` as a separator. This fixes several issues, but primarily:

- source maps now work without needing to upload separate maps for Windows
- `onError` callbacks no longer need to worry about platform specific file separators