### PR TITLE
Fix project root normalisation

### DIFF
--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -24,6 +24,13 @@ module.exports = (opts) => {
     electron.app.getPath('crashDumps')
   )
 
+  // Normalise the project root upfront so renderers have a fully resolved path
+  // The renderers can't do this themselves as they cannot access the 'path' module
+  if (opts.projectRoot) {
+    const normalizePath = require('@bugsnag/core/lib/path-normalizer')
+    opts.projectRoot = normalizePath(opts.projectRoot)
+  }
+
   // main internal plugins go here
   const internalPlugins = [
     // THIS PLUGIN MUST BE FIRST!
@@ -50,13 +57,6 @@ module.exports = (opts) => {
   bugsnag._setDelivery(makeDelivery(filestore, electron.net, electron.app))
 
   bugsnag._logger.debug('Loaded! In main process.')
-
-  // Normalise the project root upfront so renderers have a fully resolved path
-  // The renderers can't do this themselves as they cannot access the 'path' module
-  if (bugsnag._config.projectRoot) {
-    const normalizePath = require('@bugsnag/core/lib/path-normalizer')
-    bugsnag._config.projectRoot = normalizePath(bugsnag._config.projectRoot)
-  }
 
   return bugsnag
 }

--- a/packages/electron/src/config/main.js
+++ b/packages/electron/src/config/main.js
@@ -3,6 +3,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 const listOfFunctions = require('@bugsnag/core/lib/validators/list-of-functions')
 const { inspect } = require('util')
 const { app } = require('electron')
+const normalizePath = require('@bugsnag/core/lib/path-normalizer')
 
 module.exports.schema = {
   ...schema,
@@ -30,7 +31,7 @@ module.exports.schema = {
     validate: value => typeof value === 'function'
   },
   projectRoot: {
-    defaultValue: () => app.getAppPath(),
+    defaultValue: () => normalizePath(app.getAppPath()),
     validate: value => value === null || stringWithLength(value),
     message: 'should be string'
   },


### PR DESCRIPTION
## Goal

The renderer config is cached when the plugin is loaded, so the path needs to be normalised before then to take effect