### PR TITLE
Add CFBundleVersion to app metadata

### DIFF
--- a/packages/plugin-electron-app/app.js
+++ b/packages/plugin-electron-app/app.js
@@ -62,7 +62,8 @@ module.exports = (NativeClient, process, electronApp, BrowserWindow, NativeApp =
 
     client.addMetadata('app', {
       installedFromStore: getInstalledFromStore(process),
-      name: electronApp.getName()
+      name: electronApp.getName(),
+      CFBundleVersion: NativeApp.getBundleVersion() || undefined
     })
 
     electronApp.on('browser-window-focus', () => {

--- a/packages/plugin-electron-app/src/api.c
+++ b/packages/plugin-electron-app/src/api.c
@@ -25,6 +25,22 @@ static napi_value GetPackageVersion(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value GetBundleVersion(napi_env env, napi_callback_info info) {
+  const char *raw_version = bugsnag_plugin_app_get_bundle_version();
+  if (raw_version) {
+    size_t len = strnlen(raw_version, max_version_length);
+    napi_value version;
+    napi_status status =
+        napi_create_string_utf8(env, raw_version, len, &version);
+    assert(status == napi_ok);
+    free((void *)raw_version);
+
+    return version;
+  }
+
+  return NULL;
+}
+
 #define DECLARE_NAPI_METHOD(name, func)                                        \
   (napi_property_descriptor) { name, 0, func, 0, 0, 0, napi_default, 0 }
 
@@ -32,6 +48,10 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor desc =
       DECLARE_NAPI_METHOD("getPackageVersion", GetPackageVersion);
   napi_status status = napi_define_properties(env, exports, 1, &desc);
+  assert(status == napi_ok);
+
+  desc = DECLARE_NAPI_METHOD("getBundleVersion", GetBundleVersion);
+  status = napi_define_properties(env, exports, 1, &desc);
   assert(status == napi_ok);
 
   return exports;

--- a/packages/plugin-electron-app/src/get_version-linux.c
+++ b/packages/plugin-electron-app/src/get_version-linux.c
@@ -1,3 +1,4 @@
 #include <stdlib.h>
 
 const char *bugsnag_plugin_app_get_package_version() { return NULL; }
+const char *bugsnag_plugin_app_get_bundle_version() { return NULL; }

--- a/packages/plugin-electron-app/src/get_version-mac.m
+++ b/packages/plugin-electron-app/src/get_version-mac.m
@@ -26,3 +26,27 @@ const char *bugsnag_plugin_app_get_package_version() {
 
   return value;
 }
+
+const char *bugsnag_plugin_app_get_bundle_version() {
+  // if any of the intermediate values (mainBundle, infoDictionary, etc) are
+  // nil, the entire chain evaluates to nil
+  const char *value =
+      [[[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"] UTF8String];
+  if (value) {
+    // copy the value as the existing reference will likely be invalidated in
+    // the immediate future
+    //
+    // > Discussion:
+    // >   This C string is a pointer to a structure inside the string object,
+    // >   which may have a lifetime shorter than the string object and will
+    // >   certainly not have a longer lifetime. Therefore, you should copy the
+    // >   C string if it needs to be stored outside of the memory context in
+    // >   which you use this property.
+    //
+    // from
+    // https://developer.apple.com/documentation/foundation/nsstring/1411189-utf8string?language=objc
+    value = strdup(value);
+  }
+
+  return value;
+}

--- a/packages/plugin-electron-app/src/get_version-win.c
+++ b/packages/plugin-electron-app/src/get_version-win.c
@@ -79,3 +79,5 @@ const char *bugsnag_plugin_app_get_package_version() {
   free(buffer);
   return version;
 }
+
+const char *bugsnag_plugin_app_get_bundle_version() { return NULL; }

--- a/packages/plugin-electron-app/src/get_version.h
+++ b/packages/plugin-electron-app/src/get_version.h
@@ -1,1 +1,2 @@
 const char *bugsnag_plugin_app_get_package_version(void);
+const char *bugsnag_plugin_app_get_bundle_version(void);

--- a/packages/plugin-electron-app/test/app.test.ts
+++ b/packages/plugin-electron-app/test/app.test.ts
@@ -93,7 +93,7 @@ describe('plugin: electron app info', () => {
     expect(session.app).toEqual(makeExpectedSessionApp({ type: 'Linux' }))
   })
 
-  it('reports app.version and app.bundleVersion for macOS', async () => {
+  it('reports app.version and metadata.app.CFBundleVersion for macOS', async () => {
     const process = makeProcess({ platform: 'darwin' })
     const electronApp = makeElectronApp({ version: '5.4.6' })
 
@@ -101,7 +101,8 @@ describe('plugin: electron app info', () => {
       electronApp,
       process,
       NativeApp: {
-        getPackageVersion: () => '5.4.6'
+        getPackageVersion: () => '5.4.6',
+        getBundleVersion: () => '8.7.9'
       }
     })
 
@@ -109,13 +110,13 @@ describe('plugin: electron app info', () => {
 
     const event = await sendEvent()
     expect(event.app).toEqual(makeExpectedEventApp(expected))
-    expect(event.getMetadata('app')).toEqual(makeExpectedMetadataApp())
+    expect(event.getMetadata('app')).toEqual(makeExpectedMetadataApp({ CFBundleVersion: '8.7.9' }))
 
     const session = await sendSession()
     expect(session.app).toEqual(makeExpectedSessionApp(expected))
   })
 
-  it('reports app.version and app.bundleVersion for Windows', async () => {
+  it('reports app.version for Windows', async () => {
     const process = makeProcess({ platform: 'win32' })
     const electronApp = makeElectronApp({ version: '1.0.0' })
 
@@ -123,7 +124,8 @@ describe('plugin: electron app info', () => {
       electronApp,
       process,
       NativeApp: {
-        getPackageVersion: () => '1.3.4'
+        getPackageVersion: () => '1.3.4',
+        getBundleVersion: () => null
       }
     })
 
@@ -778,5 +780,5 @@ function makeNativeClient () {
 }
 
 function makeNativeApp () {
-  return { getPackageVersion: () => null }
+  return { getPackageVersion: () => null, getBundleVersion: () => null }
 }

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -20,7 +20,7 @@ SUPPRESSED_ERRORS=(\
     --suppress='knownConditionTrueFalse:*/deps/parson/parson.c:692' \
     --suppress='memleak:*/plugin-electron-client-state-persistence/src/deps/tinycthread/tinycthread.c:620' \
     --suppress='unusedFunction:*/plugin-electron-client-state-persistence/src/api.c:429' \
-    --suppress='unusedFunction:*/plugin-electron-app/src/api.c:40')
+    --suppress='unusedFunction:*/plugin-electron-app/src/api.c:60')
 
 # Shared arguments:
 # --enable=all: Run all checks

--- a/test/electron/fixtures/events/main/breadcrumbs/cancelled.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/cancelled.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": true,
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -31,7 +31,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/breadcrumbs/complex-config.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/complex-config.json
@@ -36,7 +36,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/breadcrumbs/default.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": true,
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -31,7 +31,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/main/handled-error/complex-config.json
@@ -35,7 +35,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/handled-error/default.json
+++ b/test/electron/fixtures/events/main/handled-error/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -33,7 +33,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
@@ -36,7 +36,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -34,7 +34,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
@@ -36,7 +36,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/main/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -34,7 +34,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/on-error/complex-config.json
+++ b/test/electron/fixtures/events/on-error/complex-config.json
@@ -35,7 +35,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/on-error/default.json
+++ b/test/electron/fixtures/events/on-error/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -30,7 +30,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/config/appType.json
+++ b/test/electron/fixtures/events/renderer/config/appType.json
@@ -33,7 +33,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/config/codeBundleId.json
+++ b/test/electron/fixtures/events/renderer/config/codeBundleId.json
@@ -14,7 +14,7 @@
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
         "version": "1.0.2",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "codeBundleId": "1.0.0-r0123"
       },
       "device": {
@@ -34,7 +34,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/renderer/handled-error/complex-config.json
@@ -35,7 +35,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -33,7 +33,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
@@ -36,7 +36,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -34,7 +34,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
@@ -36,7 +36,8 @@
         },
         "app": {
           "name": "Runner",
-          "part": 3
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -13,7 +13,7 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{REGEX:^Linux|macOS|Windows$}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
         "version": "1.0.2"
       },
       "device": {
@@ -34,7 +34,8 @@
       },
       "metaData": {
         "app": {
-          "name": "Runner"
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
           "online": "{TYPE:boolean}",

--- a/test/electron/fixtures/events/sessions/default.json
+++ b/test/electron/fixtures/events/sessions/default.json
@@ -19,7 +19,7 @@
   "app": {
     "releaseStage": "production",
     "version": "1.0.2",
-    "type": "{REGEX:^Linux|macOS|Windows$}"
+    "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
   },
   "sessions": [
     {


### PR DESCRIPTION
## Goal

This PR adds `CFBundleVersion` to app metadata on macOS. The implementation exists for other platforms in case we want to add similar fields in the future, but they will currently always return `null`

## Testing

I've added support for platform specific matchers so this field can be checked on macOS and should be missing on Windows/Linux

e.g. `{PLATFORM_MACOS:123|PLATFORM_WINDOWS:456|PLATFORM_LINUX:789}` would expect '123' on macOS, '456' on Windows and '789' on Linux

A missing platform indicates that the field should not be present for that platform, e.g. `{PLATFORM_MACOS:123}` would expect '123' on macOS and no value on Windows/Linux

I also used this for `app.type` instead of the existing regex check as it's a bit stricter (previously macOS could have reported "Linux" and the tests would have passed)