### PR TITLE
Electron: reduce filestore startup latency

### DIFF
--- a/packages/electron-filestore/filestore.js
+++ b/packages/electron-filestore/filestore.js
@@ -16,7 +16,6 @@ class FileStore {
       device: join(base, 'device.json'),
       minidumps: join(crashDir, isMac ? 'completed' : 'reports')
     }
-    this._deviceInfoPromise = null
   }
 
   // Create directory layout
@@ -103,8 +102,7 @@ class FileStore {
       // attempt to create or update the device.json file with
       // a) the device data we retrieved or
       // b) a new auto generated id
-      device = this.setDeviceInfo(device)
-      return device
+      return this.setDeviceInfo(device)
     } catch (e) {
       // in the event of a failure we don't want to return the device
       // id we have in memory because it won't have been persisted,

--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -71,11 +71,11 @@ describe('FileStore', () => {
   })
 
   describe('getDeviceInfo()', () => {
-    it('returns an empty object if something goes wrong', async () => {
+    it('returns a device id even if something goes wrong', async () => {
       const dir = process.platform === 'win32' ? '6:\\non\\existent' : '/dev/null/non/existent'
       store = new FileStore('mykey', dir, crashes)
       const contents = await store.getDeviceInfo()
-      expect(contents).toEqual({})
+      expect(typeof contents.id).toBe('string')
     })
 
     it('returns an ID after initialization', async () => {

--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -71,16 +71,16 @@ describe('FileStore', () => {
   })
 
   describe('getDeviceInfo()', () => {
-    it('returns a device id even if something goes wrong', async () => {
+    it('returns an empty object if something goes wrong', async () => {
       const dir = process.platform === 'win32' ? '6:\\non\\existent' : '/dev/null/non/existent'
       store = new FileStore('mykey', dir, crashes)
-      const contents = await store.getDeviceInfo()
-      expect(typeof contents.id).toBe('string')
+      const contents = store.getDeviceInfo()
+      expect(contents).toEqual({})
     })
 
     it('returns an ID after initialization', async () => {
       await store.init()
-      const contents = await store.getDeviceInfo()
+      const contents = store.getDeviceInfo()
       expect(typeof contents.id).toBe('string')
     })
 
@@ -88,7 +88,7 @@ describe('FileStore', () => {
       const base = join(fixtures, 'bugsnag', 'mykey')
       await mkdir(base, { recursive: true })
       await writeFile(join(base, 'device.json'), '')
-      const contents = await store.getDeviceInfo()
+      const contents = store.getDeviceInfo()
       expect(typeof contents.id).toBe('string')
     })
 
@@ -96,19 +96,19 @@ describe('FileStore', () => {
       const base = join(fixtures, 'bugsnag', 'mykey')
       await mkdir(base, { recursive: true })
       await writeFile(join(base, 'device.json'), '{"id":')
-      const contents = await store.getDeviceInfo()
+      const contents = store.getDeviceInfo()
       expect(typeof contents.id).toBe('string')
     })
 
     it('returns the object sent to setDeviceInfo()', async () => {
-      await store.setDeviceInfo({ id: 'a684c' })
-      const contents = await store.getDeviceInfo()
+      store.setDeviceInfo({ id: 'a684c' })
+      const contents = store.getDeviceInfo()
       expect(contents).toEqual({ id: 'a684c' })
     })
 
     it('returns an object with an ID if none given to setDeviceInfo()', async () => {
-      await store.setDeviceInfo({ name: 'jeanne' })
-      const contents = await store.getDeviceInfo()
+      store.setDeviceInfo({ name: 'jeanne' })
+      const contents = store.getDeviceInfo()
       expect(contents.name).toEqual('jeanne')
       expect(typeof contents.id).toBe('string')
     })
@@ -116,14 +116,14 @@ describe('FileStore', () => {
 
   describe('setDeviceInfo()', () => {
     it('serializes device info to disk', async () => {
-      await store.setDeviceInfo({ id: 'df40a811e2' })
+      store.setDeviceInfo({ id: 'df40a811e2' })
       const base = join(fixtures, 'bugsnag', 'mykey')
       const contents = await readFile(join(base, 'device.json'))
       expect(JSON.parse(contents.toString())).toEqual({ id: 'df40a811e2' })
     })
 
     it('inserts a unique identifier if none given', async () => {
-      await store.setDeviceInfo({ color: 'cyan' })
+      store.setDeviceInfo({ color: 'cyan' })
       const base = join(fixtures, 'bugsnag', 'mykey')
       const contents = await readFile(join(base, 'device.json'))
       const device = JSON.parse(contents.toString())

--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -22,9 +22,9 @@ module.exports.schema = {
     defaultValue: () => getPrefixedConsole()
   }),
   codeBundleId: {
-    defaultValue: () => null,
+    defaultValue: () => undefined,
     message: 'should be a string',
-    validate: val => (val === null || stringWithLength(val))
+    validate: val => (val === undefined || stringWithLength(val))
   }
 }
 

--- a/packages/electron/src/config/test/renderer.test.ts
+++ b/packages/electron/src/config/test/renderer.test.ts
@@ -1,0 +1,9 @@
+import { schema } from '../renderer'
+
+describe('renderer process client config schema', () => {
+  describe('codeBundleId', () => {
+    it('defaults to undefined', () => {
+      expect(schema.codeBundleId.defaultValue()).toBe(undefined)
+    })
+  })
+})

--- a/packages/plugin-electron-session/session.js
+++ b/packages/plugin-electron-session/session.js
@@ -2,7 +2,7 @@ const sessionDelegate = require('@bugsnag/plugin-browser-session')
 
 const SESSION_TIMEOUT_MS = 60 * 1000
 
-module.exports = (app, BrowserWindow, filestore) => ({
+module.exports = (app, BrowserWindow) => ({
   load (client) {
     // load the actual session delegate from plugin-browser-session
     sessionDelegate.load(client)
@@ -10,7 +10,7 @@ module.exports = (app, BrowserWindow, filestore) => ({
     if (!client._config.autoTrackSessions) {
       return
     }
-
+    // ensure the session gets started _after_ we have a device id
     app.whenReady()
       .then(() => client.startSession())
       .catch(() => {})

--- a/packages/plugin-electron-session/session.js
+++ b/packages/plugin-electron-session/session.js
@@ -11,9 +11,8 @@ module.exports = (app, BrowserWindow, filestore) => ({
       return
     }
 
-    // jump through hoops to ensure the session gets started _after_ we have a device id
-    Promise.all([filestore.getDeviceInfo(), app.whenReady()])
-      .then(() => { setTimeout(() => client.startSession(), 10) })
+    app.whenReady()
+      .then(() => client.startSession())
       .catch(() => {})
 
     let lastInBackground = null

--- a/packages/plugin-electron-session/test/session.test.ts
+++ b/packages/plugin-electron-session/test/session.test.ts
@@ -4,9 +4,6 @@ import { makeApp, makeBrowserWindow } from '@bugsnag/electron-test-helpers'
 import plugin from '../'
 
 const expectCuid = expect.stringMatching(/^c[a-z0-9]{20,30}$/)
-const mockFileStore = {
-  getDeviceInfo: () => Promise.resolve()
-}
 
 describe('plugin: electron sessions', () => {
   beforeEach(() => { jest.useRealTimers() })
@@ -18,7 +15,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f' },
       undefined,
-      [plugin(app, BrowserWindow, mockFileStore)]
+      [plugin(app, BrowserWindow)]
     )
 
     const payload = await createSession(client)
@@ -63,7 +60,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f' },
       undefined,
-      [plugin(app, BrowserWindow, mockFileStore)]
+      [plugin(app, BrowserWindow)]
     )
 
     const window = new BrowserWindow(123, 'hello world')
@@ -113,7 +110,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f' },
       undefined,
-      [plugin(app, BrowserWindow, mockFileStore)]
+      [plugin(app, BrowserWindow)]
     )
 
     const window = new BrowserWindow(123, 'hello world')
@@ -169,7 +166,7 @@ describe('plugin: electron sessions', () => {
     const client = new Client(
       { apiKey: 'abcabcabcabcabcabcabc1234567890f', autoTrackSessions: false },
       undefined,
-      [plugin(app, BrowserWindow, mockFileStore)]
+      [plugin(app, BrowserWindow)]
     )
 
     const window = new BrowserWindow(123, 'hello world')


### PR DESCRIPTION
Because the async file read to pick up device id happens during the app start up, it loses out to other blocking io and takes almost half a second to return device id. By switching to a sync fs read, it takes 1ms.

Clearly this blocks the process itself, but the file will always be tiny, and Bugsnag can't send any events/sessions until it has generated/retrieved a device id, so is deemed an acceptable trade off.