### PR TITLE
refactor(electron): codeBundleId defaults to undefined

### DIFF
--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -22,9 +22,9 @@ module.exports.schema = {
     defaultValue: () => getPrefixedConsole()
   }),
   codeBundleId: {
-    defaultValue: () => null,
+    defaultValue: () => undefined,
     message: 'should be a string',
-    validate: val => (val === null || stringWithLength(val))
+    validate: val => (val === undefined || stringWithLength(val))
   }
 }
 

--- a/packages/electron/src/config/test/renderer.test.ts
+++ b/packages/electron/src/config/test/renderer.test.ts
@@ -1,0 +1,9 @@
+import { schema } from '../renderer'
+
+describe('renderer process client config schema', () => {
+  describe('codeBundleId', () => {
+    it('defaults to undefined', () => {
+      expect(schema.codeBundleId.defaultValue()).toBe(undefined)
+    })
+  })
+})


### PR DESCRIPTION
## Goal

`codeBundleId` should only show up in the payload if it has been explicitly set.

## Design

The default value was `null` which gets included in JSON serialisation. `undefined` doesn't and achieves exactly what we want.

## Changeset

Updated the default value to be `undefined` and added a test.

## Testing

Added a unit test because the end to end tests aren't set up to assert the lack of a field/property property in the payload.