### PR TITLE
feat(electron): Use page title/window location for default context in renderers

### DIFF
--- a/packages/plugin-electron-renderer-event-data/package.json
+++ b/packages/plugin-electron-renderer-event-data/package.json
@@ -20,9 +20,11 @@
   ],
   "devDependencies": {
     "@bugsnag/core": "^7.10.0-alpha.0",
-    "@bugsnag/electron-test-helpers": "^7.10.0-alpha.1"
+    "@bugsnag/electron-test-helpers": "^7.10.0-alpha.1",
+    "@bugsnag/plugin-electron-renderer-strip-project-root": "^7.10.0-alpha.1"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^7.9.2",
+    "@bugsnag/plugin-electron-renderer-strip-project-root": "^7.10.0-alpha.1"
   }
 }

--- a/packages/plugin-electron-renderer-event-data/renderer-event-data.js
+++ b/packages/plugin-electron-renderer-event-data/renderer-event-data.js
@@ -1,3 +1,5 @@
+const { stripProjectRoot } = require('@bugsnag/plugin-electron-renderer-strip-project-root')
+
 module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
   load: client => {
     client.addOnError(async (event) => {
@@ -13,7 +15,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
 
       if (shouldSend === false) return false
 
-      event.context = event.context || context
+      event.context = event.context || context || getDefaultContext()
       event.breadcrumbs = breadcrumbs
       event.app = { ...event.app, ...app, codeBundleId: client._config.codeBundleId }
       event.device = { ...event.device, ...device }
@@ -34,5 +36,9 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
         event.app.type = client._config.appType
       }
     }, true)
+
+    const getDefaultContext = () => {
+      return window.document.title || stripProjectRoot(client._config.projectRoot, window.location.pathname)
+    }
   }
 })

--- a/packages/plugin-electron-renderer-strip-project-root/strip-project-root.js
+++ b/packages/plugin-electron-renderer-strip-project-root/strip-project-root.js
@@ -1,24 +1,39 @@
 module.exports = {
   load: client => {
     const projectRoot = client._config.projectRoot
-    const normalizedRoot = projectRoot ? projectRoot.replace(/\\/g, '/') : null
 
     client.addOnError(event => {
       const allFrames = event.errors.reduce((accum, er) => accum.concat(er.stacktrace), [])
       allFrames.forEach(stackframe => {
         if (typeof stackframe.file !== 'string') return
-        stackframe.file = decodeURI(stackframe.file).replace(/^file:\/\//, '')
-        if (stackframe.file.match('^/[A-Z]:/')) {
-          stackframe.file = stackframe.file.slice(1) // strip extra leading slash on windows
-        }
-        if (!projectRoot) return
-        if (stackframe.file.indexOf(projectRoot) === 0) {
-          stackframe.file = stackframe.file.slice(projectRoot.length)
-        } else if (stackframe.file.indexOf(normalizedRoot) === 0) {
-          // normalize path if needed - renderer paths on windows use '/' as a separator
-          stackframe.file = stackframe.file.slice(normalizedRoot.length)
-        }
+        stackframe.file = stripProjectRoot(projectRoot, stackframe.file)
       })
     })
   }
+}
+
+const stripProjectRoot = module.exports.stripProjectRoot = (projectRoot, path) => {
+  // decode URI escaped chars
+  let p = decodeURI(path)
+
+  // strip file protocol
+  p = p.replace(/^file:\/\//, '')
+
+  // strip extra leading slash on windows
+  if (p.match('^/[A-Z]:/')) {
+    p = p.slice(1)
+  }
+
+  // only continue with the next steps if we have a project root
+  if (!projectRoot) return p
+
+  const normalizedRoot = projectRoot ? projectRoot.replace(/\\/g, '/') : null
+  if (p.indexOf(projectRoot) === 0) {
+    p = p.slice(projectRoot.length)
+  } else if (p.indexOf(normalizedRoot) === 0) {
+    // normalize path if needed - renderer paths on windows use '/' as a separator
+    p = p.slice(normalizedRoot.length)
+  }
+
+  return p
 }

--- a/test/electron/features/automatic-context.feature
+++ b/test/electron/features/automatic-context.feature
@@ -1,0 +1,22 @@
+Feature: Automatic context
+
+    Scenario Outline: Automatic config in renderers
+        Given I launch an app with configuration:
+            | bugsnag | <config> |
+        And I click "<case>"
+        And I click "renderer-notify"
+        Then the total requests received by the server matches:
+            | events  | 1        |
+        Then the headers of every event request contains:
+            | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+            | Content-Type      | application/json                 |
+            | Bugsnag-Integrity | {BODY_SHA1}                      |
+        Then the contents of an event request matches "renderer/context/<case>-<config>.json"
+
+        Examples:
+            | config         | case               |
+            | default        | page-title-clear   |
+            | default        | page-title-update  |
+            | default        | set-context        |
+            | complex-config | page-title-clear   |
+            | complex-config | page-title-update  |

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -41,7 +41,12 @@
         <li><a href="#" id="performance-metrics">Send an error with performance metrics</a></li>
     </ul>
     <ul>
-        <li><a href="#" id="mark-launch-complete" onclick="RunnerAPI.markLaunchComplete()"> Call Bugsnag.markLaunchCompolete() in the main process</a></li>
+        <li><a href="#" id="mark-launch-complete" onclick="RunnerAPI.markLaunchComplete()">Call Bugsnag.markLaunchCompolete() in the main process</a></li>
+    </ul>
+    <ul>
+        <li><a href="#" id="page-title-update" onclick="document.title = 'A different title'">Update the page title</a></li>
+        <li><a href="#" id="page-title-clear" onclick="document.title = ''">Clear the page title</a></li>
+        <li><a href="#" id="set-context">Manually call setContext() in renderer</a></li>
     </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -48,3 +48,5 @@ document.getElementById('renderer-cancel-breadcrumbs').onclick = () => Bugsnag.a
 document.getElementById('performance-metrics').onclick = () => Bugsnag.notify(new Error('startup perf budget'), (event) => {
   event.addMetadata('performance', 'startupTime', startupTimestamp - window.RunnerAPI.preloadStart)
 })
+
+document.getElementById('set-context').onclick = () => Bugsnag.setContext('Another context')

--- a/test/electron/fixtures/events/renderer/context/page-title-clear-complex-config.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-clear-complex-config.json
@@ -10,12 +10,13 @@
       "payloadVersion": "4",
       "app": {
         "duration": "{TYPE:number}",
-        "releaseStage": "production",
+        "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
-        "version": "1.0.2"
+        "type": "complicated",
+        "version": "2.0.83-beta3"
       },
+      "context": "shopping cart",
       "device": {
         "runtimeVersions": {
           "node": "{TYPE:string}",
@@ -28,13 +29,13 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
-      "user": {
-        "id": "{REGEX:[0-9a-f]{64}}"
-      },
-      "context": "Runner",
       "metaData": {
+        "account": {
+          "type": "pro"
+        },
         "app": {
           "name": "Runner",
+          "part": 3,
           "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
@@ -44,6 +45,9 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "site": {
+          "name": "shop co"
         },
         "process": {
           "type": "renderer",
@@ -56,6 +60,11 @@
       "unhandled": false,
       "severityReason": {
         "type": "handledException"
+      },
+      "user": {
+        "id": "3",
+        "email": "elia@example.com",
+        "name": "Elia"
       },
       "breadcrumbs": [
         {
@@ -78,14 +87,6 @@
           "metaData": {
             "id": 1,
             "title": "Runner"
-          }
-        },
-        {
-          "type": "manual",
-          "name": "missing auth token",
-          "timestamp": "{TIMESTAMP}",
-          "metaData": {
-            "session": "two-two"
           }
         }
       ],

--- a/test/electron/fixtures/events/renderer/context/page-title-clear-default.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-clear-default.json
@@ -13,8 +13,8 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
-        "version": "1.0.2"
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
       },
       "device": {
         "runtimeVersions": {
@@ -28,10 +28,10 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "context": ".webpack/renderer/main_window/index.html",
       "user": {
         "id": "{REGEX:[0-9a-f]{64}}"
       },
-      "context": "Runner",
       "metaData": {
         "app": {
           "name": "Runner",
@@ -44,12 +44,6 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
-        },
-        "process": {
-          "type": "renderer",
-          "sandboxed": true,
-          "isMainFrame": true,
-          "heapStatistics": {}
         }
       },
       "severity": "warning",
@@ -78,14 +72,6 @@
           "metaData": {
             "id": 1,
             "title": "Runner"
-          }
-        },
-        {
-          "type": "manual",
-          "name": "missing auth token",
-          "timestamp": "{TIMESTAMP}",
-          "metaData": {
-            "session": "two-two"
           }
         }
       ],

--- a/test/electron/fixtures/events/renderer/context/page-title-update-complex-config.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-update-complex-config.json
@@ -10,12 +10,13 @@
       "payloadVersion": "4",
       "app": {
         "duration": "{TYPE:number}",
-        "releaseStage": "production",
+        "releaseStage": "beta",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
-        "version": "1.0.2"
+        "type": "complicated",
+        "version": "2.0.83-beta3"
       },
+      "context": "shopping cart",
       "device": {
         "runtimeVersions": {
           "node": "{TYPE:string}",
@@ -28,13 +29,13 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
-      "user": {
-        "id": "{REGEX:[0-9a-f]{64}}"
-      },
-      "context": "Runner",
       "metaData": {
+        "account": {
+          "type": "pro"
+        },
         "app": {
           "name": "Runner",
+          "part": 3,
           "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
         },
         "device": {
@@ -44,6 +45,9 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
+        },
+        "site": {
+          "name": "shop co"
         },
         "process": {
           "type": "renderer",
@@ -56,6 +60,11 @@
       "unhandled": false,
       "severityReason": {
         "type": "handledException"
+      },
+      "user": {
+        "id": "3",
+        "email": "elia@example.com",
+        "name": "Elia"
       },
       "breadcrumbs": [
         {
@@ -78,14 +87,6 @@
           "metaData": {
             "id": 1,
             "title": "Runner"
-          }
-        },
-        {
-          "type": "manual",
-          "name": "missing auth token",
-          "timestamp": "{TIMESTAMP}",
-          "metaData": {
-            "session": "two-two"
           }
         }
       ],

--- a/test/electron/fixtures/events/renderer/context/page-title-update-default.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-update-default.json
@@ -13,8 +13,8 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
-        "version": "1.0.2"
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
       },
       "device": {
         "runtimeVersions": {
@@ -28,10 +28,10 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "context": "A different title",
       "user": {
         "id": "{REGEX:[0-9a-f]{64}}"
       },
-      "context": "Runner",
       "metaData": {
         "app": {
           "name": "Runner",
@@ -44,12 +44,6 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
-        },
-        "process": {
-          "type": "renderer",
-          "sandboxed": true,
-          "isMainFrame": true,
-          "heapStatistics": {}
         }
       },
       "severity": "warning",
@@ -78,14 +72,6 @@
           "metaData": {
             "id": 1,
             "title": "Runner"
-          }
-        },
-        {
-          "type": "manual",
-          "name": "missing auth token",
-          "timestamp": "{TIMESTAMP}",
-          "metaData": {
-            "session": "two-two"
           }
         }
       ],

--- a/test/electron/fixtures/events/renderer/context/set-context-default.json
+++ b/test/electron/fixtures/events/renderer/context/set-context-default.json
@@ -13,8 +13,8 @@
         "releaseStage": "production",
         "inForeground": "{TYPE:boolean}",
         "isLaunching": "{TYPE:boolean}",
-        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
-        "version": "1.0.2"
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
       },
       "device": {
         "runtimeVersions": {
@@ -28,10 +28,10 @@
         "totalMemory": "{TYPE:number}",
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
+      "context": "Another context",
       "user": {
         "id": "{REGEX:[0-9a-f]{64}}"
       },
-      "context": "Runner",
       "metaData": {
         "app": {
           "name": "Runner",
@@ -44,12 +44,6 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
-        },
-        "process": {
-          "type": "renderer",
-          "sandboxed": true,
-          "isMainFrame": true,
-          "heapStatistics": {}
         }
       },
       "severity": "warning",
@@ -78,14 +72,6 @@
           "metaData": {
             "id": 1,
             "title": "Runner"
-          }
-        },
-        {
-          "type": "manual",
-          "name": "missing auth token",
-          "timestamp": "{TIMESTAMP}",
-          "metaData": {
-            "session": "two-two"
           }
         }
       ],


### PR DESCRIPTION
## Goal

Renderer events should have a default context.

## Design

This implementation takes the page title, and falls back to the window location.

## Changeset

Since the amount of logic required was so small I felt comfortable augmenting the renderer event data plugin, rather than creating an entire new plugin.

For packaged apps, `window.location.pathname` is an absolute file path (like stacktraces). I tweaked logic for stackframe project root stripping so it could be referenced from the renderer event plugin rather than duplicated.

## Testing

End to end tests added for all the cases I could think of. `config.context` and `setContext()` should take precedence.