### PR TITLE
Add inline script plugin to renderer notifier

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -33,6 +33,7 @@
     "@bugsnag/plugin-electron-renderer-event-data": "^7.10.0-alpha.2",
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^7.10.0-alpha.1",
     "@bugsnag/plugin-electron-session": "^7.10.0-alpha.1",
+    "@bugsnag/plugin-inline-script-content": "^7.10.0-alpha.0",
     "@bugsnag/plugin-interaction-breadcrumbs": "^7.10.0-alpha.0",
     "@bugsnag/plugin-internal-callback-marker": "^7.10.0-alpha.1",
     "@bugsnag/plugin-network-breadcrumbs": "^7.10.0-alpha.0",

--- a/packages/electron/src/client/renderer.js
+++ b/packages/electron/src/client/renderer.js
@@ -26,7 +26,11 @@ module.exports = (rendererOpts) => {
     require('@bugsnag/plugin-electron-process-info')(window.__bugsnag_ipc__.process),
     require('@bugsnag/plugin-electron-renderer-strip-project-root'),
     require('@bugsnag/plugin-stackframe-path-normaliser'),
-    require('@bugsnag/plugin-electron-renderer-event-data')(window.__bugsnag_ipc__)
+    require('@bugsnag/plugin-electron-renderer-event-data')(window.__bugsnag_ipc__),
+
+    // plugin-inline-script-content must be the last plugin in order for it to
+    // be able to grab the currently executing script's contents
+    require('@bugsnag/plugin-inline-script-content')()
   ]
 
   const bugsnag = new Client(opts, schema, internalPlugins, require('../id'))

--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -28,8 +28,8 @@ module.exports.schema = {
   }
 }
 
-module.exports.mergeOptions = (mainOpts, rendererOpts) => {
-  return Object.keys(module.exports.schema).reduce((accum, k) => {
+module.exports.mergeOptions = (additionalSchemaKeys, mainOpts, rendererOpts) => {
+  return Object.keys(module.exports.schema).concat(additionalSchemaKeys).reduce((accum, k) => {
     if (Object.prototype.hasOwnProperty.call(rendererOpts, k)) {
       if (ALLOWED_IN_RENDERER.includes(k)) {
         if (k === 'metadata') {

--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -4,7 +4,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 const ALLOWED_IN_RENDERER = [
   // a list of config keys that are allowed to be supplied to the renderer client
   // this must be kept in sync with the typescript "AllowedRendererConfig" type
-  'onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins', 'appType'
+  'onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins', 'appType', 'trackInlineScripts'
 ]
 
 module.exports.schema = {

--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -30,7 +30,7 @@ module.exports.schema = {
 
 module.exports.mergeOptions = (mainOpts, rendererOpts) => {
   return Object.keys(module.exports.schema).reduce((accum, k) => {
-    if (rendererOpts[k]) {
+    if (Object.prototype.hasOwnProperty.call(rendererOpts, k)) {
       if (ALLOWED_IN_RENDERER.includes(k)) {
         if (k === 'metadata') {
           // ensure that metadata set in renderer config doesn't blow away all preexisting metadata

--- a/packages/electron/test/type.test.ts
+++ b/packages/electron/test/type.test.ts
@@ -32,7 +32,8 @@ describe.skip('@bugsnag/electron types', () => {
         plugins: [],
         user: { id: '1234-abcd' },
         appType: 'good',
-        codeBundleId: '1245'
+        codeBundleId: '1245',
+        trackInlineScripts: true
       })
     })
   })

--- a/packages/electron/types/notifier.d.ts
+++ b/packages/electron/types/notifier.d.ts
@@ -32,6 +32,7 @@ type AllowedRendererConfig = Pick<Config, 'onError'|'onBreadcrumb'|'logger'|'met
 
 interface RendererConfig extends AllowedRendererConfig {
   codeBundleId?: string
+  trackInlineScripts?: boolean
 }
 
 declare class ElectronClient extends Client {

--- a/test/electron/features/error-handling.feature
+++ b/test/electron/features/error-handling.feature
@@ -104,3 +104,21 @@ Feature: Detecting and reporting errors
             | config          |
             | default         |
             | complex-config  |
+
+    Scenario Outline: An exception in an inline script tag in a renderer
+        Given I launch an app with configuration:
+            | bugsnag | <config> |
+        When I click "inline-script-exception"
+        Then the total requests received by the server matches:
+            | events   | 1        |
+            | sessions | 1        |
+        Then the headers of every event request contains:
+            | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+            | Content-Type      | application/json                 |
+            | Bugsnag-Integrity | {BODY_SHA1}                      |
+        Then the contents of an event request matches "renderer/inline-script-exception/<config>.json"
+
+        Examples:
+            | config         |
+            | default        |
+            | complex-config |

--- a/test/electron/features/renderer-config.feature
+++ b/test/electron/features/renderer-config.feature
@@ -16,3 +16,16 @@ Feature: Setting config options in renderers
             | property | config                      |
             | appType  | { "appType": "real great" } |
             | codeBundleId  | { "codeBundleId": "1.0.0-r0123" } |
+
+    Scenario: An exception in an inline script tag in a renderer
+        Given I launch an app with configuration:
+            | renderer_config | { "trackInlineScripts": false } |
+        When I click "inline-script-exception"
+        Then the total requests received by the server matches:
+            | events   | 1 |
+            | sessions | 1 |
+        Then the headers of every event request contains:
+            | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+            | Content-Type      | application/json                 |
+            | Bugsnag-Integrity | {BODY_SHA1}                      |
+        Then the contents of an event request matches "renderer/inline-script-exception/disable-track-inline-scripts.json"

--- a/test/electron/features/support/utils/payload-matchers.js
+++ b/test/electron/features/support/utils/payload-matchers.js
@@ -93,9 +93,10 @@ const compareArray = (expected, actual, path) => {
 
 /* Assert some variety of value matches an expected thing (of some variety) */
 const compare = (expected, actual, path = '') => {
-  // Ensure there's an actual value, unless this is a platform specific matcher
-  // Some platforms may not have values for fields that are specific to other platforms
-  if (typeof actual === 'undefined' && !expected.match(platformMatcher)) {
+  // Ensure there's an actual value unless this is a platform specific matcher
+  // or the expected value is "undefined". Some platforms may not have values
+  // for fields that are specific to other platforms
+  if (typeof actual === 'undefined' && !expected.match(platformMatcher) && expected !== '{TYPE:undefined}') {
     return [{ path, expected, actual, message: 'Expected a value but was undefined' }]
   }
   switch (typeof expected) {

--- a/test/electron/fixtures/app/forge.config.js
+++ b/test/electron/fixtures/app/forge.config.js
@@ -5,11 +5,18 @@ module.exports = {
       mainConfig: './webpack.main.config.js',
       renderer: {
         config: './webpack.renderer.config.js',
-        entryPoints: [{
-          html: './index.html',
-          js: './renderer.js',
-          name: 'main_window'
-        }]
+        entryPoints: [
+          {
+            html: './index.html',
+            js: './renderer.js',
+            name: 'main_window'
+          },
+          {
+            html: './inline-script-exception.html',
+            js: './inline-script-exception.js',
+            name: 'inline_script_exception'
+          }
+        ]
       }
     }]
   ],

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -19,6 +19,7 @@
         <li><a href="#" id="renderer-unhandled-promise-rejection">Unhandled promise rejection in renderer</a></li>
         <li><a href="#" id="renderer-notify">Handled error in renderer</a></li>
         <li><a href="#" id="renderer-notify-on-error">notify with onError in renderer</a></li>
+        <li><a href="../inline_script_exception/index.html" id="inline-script-exception">Unhandled exception in an inline script</a></li>
     </ul>
     <ul>
         <li><a href="#" id="custom-breadcrumb">Leave a custom breadcrumb</a>

--- a/test/electron/fixtures/app/inline-script-exception.html
+++ b/test/electron/fixtures/app/inline-script-exception.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Runner</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
+</head>
+<body style="background: white;">
+    <p style="font-family: 'Comic Sans MS'; font-size: 72px">sample text</p>
+
+    <script src="../inline_script_exception.js"></script>
+
+    <script>
+        const someCode = 'goes here'
+
+        throw new Error('inline script broke!')
+        let moreCode = 'here'
+
+        moreCode += ' also here'
+    </script>
+</body>
+</html>

--- a/test/electron/fixtures/app/inline-script-exception.js
+++ b/test/electron/fixtures/app/inline-script-exception.js
@@ -1,0 +1,3 @@
+const Bugsnag = require('@bugsnag/electron')
+
+Bugsnag.start(window.RunnerAPI.rendererConfig)

--- a/test/electron/fixtures/events/renderer/inline-script-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/inline-script-exception/complex-config.json
@@ -1,0 +1,120 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "beta",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "complicated",
+        "version": "2.0.83-beta3"
+      },
+      "context": "shopping cart",
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "metaData": {
+        "script": {
+          "content": "const someCode = 'goes here'\n\n        throw new Error('inline script broke!')\n        let moreCode = 'here'\n\n        moreCode += ' also here'"
+        },
+        "account": {
+          "type": "pro"
+        },
+        "app": {
+          "name": "Runner",
+          "part": 3,
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "site": {
+          "name": "shop co"
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
+        }
+      },
+      "severity": "error",
+      "unhandled": true,
+      "severityReason": {
+        "type": "unhandledException"
+      },
+      "user": {
+        "id": "3",
+        "email": "elia@example.com",
+        "name": "Elia"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorClass": "Error",
+          "errorMessage": "inline script broke!",
+          "stacktrace": [
+            {
+              "file": ".webpack/renderer/inline_script_exception/index.html",
+              "lineNumber": 3,
+              "columnNumber": 15,
+              "code": {
+                "1": "<!-- DOC START -->",
+                "2": "<html><head><meta charset=\"UTF-8\"><title>Runner</title><meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'self' 'unsafe-inline';\"></head><body style=\"background: white;\"><p style=\"font-fa",
+                "3": "",
+                "4": "        throw new Error('inline script broke!')",
+                "5": "        let moreCode = 'here'"
+              }
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/inline-script-exception/default.json
+++ b/test/electron/fixtures/events/renderer/inline-script-exception/default.json
@@ -1,0 +1,110 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
+        "version": "1.0.2"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "script": {
+          "content": "const someCode = 'goes here'\n\n        throw new Error('inline script broke!')\n        let moreCode = 'here'\n\n        moreCode += ' also here'"
+        },
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
+        }
+      },
+      "severity": "error",
+      "unhandled": true,
+      "severityReason": {
+        "type": "unhandledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorClass": "Error",
+          "errorMessage": "inline script broke!",
+          "stacktrace": [
+            {
+              "file": ".webpack/renderer/inline_script_exception/index.html",
+              "lineNumber": 3,
+              "columnNumber": 15,
+              "code": {
+                "1": "<!-- DOC START -->",
+                "2": "<html><head><meta charset=\"UTF-8\"><title>Runner</title><meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'self' 'unsafe-inline';\"></head><body style=\"background: white;\"><p style=\"font-fa",
+                "3": "",
+                "4": "        throw new Error('inline script broke!')",
+                "5": "        let moreCode = 'here'"
+              }
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/inline-script-exception/disable-track-inline-scripts.json
+++ b/test/electron/fixtures/events/renderer/inline-script-exception/disable-track-inline-scripts.json
@@ -1,0 +1,102 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
+        "version": "1.0.2"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "script": "{TYPE:undefined}",
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "process": {
+          "type": "renderer",
+          "sandboxed": true,
+          "isMainFrame": true,
+          "heapStatistics": {}
+        }
+      },
+      "severity": "error",
+      "unhandled": true,
+      "severityReason": {
+        "type": "unhandledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorClass": "Error",
+          "errorMessage": "inline script broke!",
+          "stacktrace": [
+            {
+              "file": ".webpack/renderer/inline_script_exception/index.html",
+              "lineNumber": 3,
+              "columnNumber": 15,
+              "code": "{TYPE:undefined}"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Adds `plugin-inline-script-content` to the Electron renderer notifier. This allows reporting the code of script tags that throw errors

This required a couple of changes to the merging of renderer options:

1. falsy values can now be set, which allows disabling the `trackInlineScripts` option
2. plugins can now define schema in renderers. Previously only the main renderer schema was used when determining which properties to merge from the given config

## Testing

Integration tests have been added that test this works

I also added the ability to assert object keys are missing by using `{TYPE:undefined}`, which allows testing when `trackInlineScripts` is `false`