### PR TITLE
feat(electron): Set process.type=preload for errors in preload scripts

### DIFF
--- a/packages/plugin-electron-preload-error/preload-error.js
+++ b/packages/plugin-electron-preload-error/preload-error.js
@@ -27,6 +27,8 @@ module.exports = app => ({
 
         event.context = context
 
+        event._isPreloadError = true
+
         client._notify(event)
       })
     })

--- a/packages/plugin-electron-preload-error/preload-error.js
+++ b/packages/plugin-electron-preload-error/preload-error.js
@@ -27,7 +27,7 @@ module.exports = app => ({
 
         event.context = context
 
-        event._isPreloadError = true
+        event.addMetadata('process', 'type', 'preload')
 
         client._notify(event)
       })

--- a/packages/plugin-electron-process-info/procinfo.js
+++ b/packages/plugin-electron-process-info/procinfo.js
@@ -14,9 +14,9 @@ module.exports = (source = process) => ({
         info.heapStatistics = source.getHeapStatistics()
       }
 
-      if (isPreload || event._isPreloadError) {
+      if (isPreload) {
         info.type = 'preload'
-      } else if (typeof source.type === 'string') {
+      } else if (event.getMetadata('process', 'type') !== 'preload' && typeof source.type === 'string') {
         // type should always be available
         info.type = source.type
       }

--- a/packages/plugin-electron-process-info/procinfo.js
+++ b/packages/plugin-electron-process-info/procinfo.js
@@ -1,5 +1,9 @@
-// eslint-disable-next-line no-eval
-const isPreload = !!eval('typeof global !== "undefined"') && !!eval('typeof window !== "undefined"')
+const isPreload =
+  // is the process actually node-like (webpack defines a "global" variable when bundling, but node's
+  // global contains a circular reference to itself global.global)
+  typeof global !== 'undefined' && typeof global.global !== 'undefined' && global.global === global &&
+  // AND is the process browser-like (does the process have a window and a document?)
+  typeof window !== 'undefined' && typeof document !== 'undefined'
 
 module.exports = (source = process) => ({
   load: (client) => {

--- a/packages/plugin-electron-process-info/procinfo.js
+++ b/packages/plugin-electron-process-info/procinfo.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line no-eval
+const isPreload = !!eval('typeof global !== "undefined"') && !!eval('typeof window !== "undefined"')
+
 module.exports = (source = process) => ({
   load: (client) => {
     client.addOnError(function (event) {
@@ -7,7 +10,9 @@ module.exports = (source = process) => ({
         info.heapStatistics = source.getHeapStatistics()
       }
 
-      if (typeof source.type === 'string') {
+      if (isPreload || event._isPreloadError) {
+        info.type = 'preload'
+      } else if (typeof source.type === 'string') {
         // type should always be available
         info.type = source.type
       }

--- a/packages/plugin-electron-process-info/test/procinfo.test.ts
+++ b/packages/plugin-electron-process-info/test/procinfo.test.ts
@@ -22,6 +22,18 @@ describe('plugin: electron process info', () => {
     client._notify(new Event('Error', 'incorrect lambda type', []))
   })
 
+  it('does not overwrite process type if already set to preload', (done) => {
+    const processInfo = { type: 'worker' }
+    const client = makeClient((payload: any) => {
+      const metadata = payload.events[0]._metadata
+      expect(metadata.process.type).toEqual('preload')
+      done()
+    }, processInfo)
+    const event = new Event('Error', 'incorrect lambda type', [])
+    event.addMetadata('process', 'type', 'preload')
+    client._notify(event)
+  })
+
   it('attaches heap stats', (done) => {
     const processInfo = {
       getHeapStatistics: () => {


### PR DESCRIPTION
## Goal

Set `process.type = "preload"` for handled and unhandled errors in preload scripts.

## Design

Handled and unhandled errors are surfaced differently in preload scripts.

#### Unhandled errors
Unhandled errors are surfaced to the main process and are dealt with using the `plugin-electron-preload-error` module. The solution for that, though a little untidy, is pretty straightforward – annotate the Bugsnag `event` object and detect that annotation in the `procinfo` `onerror` callback. Before the the changes in this PR, these events had `process.type = "browser"` because they were captured in the main process.

#### Handled errors
For handled errors, these are dealt with in process and are routed through a client instance with the preload script context. It is hard to reliably determine whether the notifier is executing in the context of a preload script or not. Before this PR these events had `process.type = "renderer"` because they were handled by the renderer notifier. To determine whether the notifier is running in a preload script, the best test I could think of was to detect the presence a global variable that is present in Node, but not in the browser. This works when the script is not bundled, however, when bundled by webpack (or similar), attempting to use the `process` or `require` variables, results in a false positive in the browser because it defines them. To prevent the false positives, I attempted to `eval()` these checks, which works (because webpack doesn't parse the code in eval), but it is prevented from running when a sensible CSP is used. This is why the automated tests fail.