### PR TITLE
Load surrounding code from paths relative the project root

### DIFF
--- a/packages/plugin-node-surrounding-code/surrounding-code.js
+++ b/packages/plugin-node-surrounding-code/surrounding-code.js
@@ -5,6 +5,7 @@ const { createReadStream } = require('fs')
 const { Writable } = require('stream')
 const pump = require('pump')
 const byline = require('byline')
+const path = require('path')
 
 module.exports = {
   load: client => {
@@ -13,12 +14,13 @@ module.exports = {
     const loadSurroundingCode = (stackframe, cache) => new Promise((resolve, reject) => {
       try {
         if (!stackframe.lineNumber || !stackframe.file) return resolve(stackframe)
-        const cacheKey = `${stackframe.file}@${stackframe.lineNumber}`
+        const file = path.resolve(client._config.projectRoot, stackframe.file)
+        const cacheKey = `${file}@${stackframe.lineNumber}`
         if (cacheKey in cache) {
           stackframe.code = cache[cacheKey]
           return resolve(stackframe)
         }
-        getSurroundingCode(stackframe.file, stackframe.lineNumber, (err, code) => {
+        getSurroundingCode(file, stackframe.lineNumber, (err, code) => {
           if (err) return resolve(stackframe)
           stackframe.code = cache[cacheKey] = code
           return resolve(stackframe)


### PR DESCRIPTION
## Goal

This allows the plugin to work if the project root has already been stripped before it runs. If there is no project root, or the file path is absolute, there should be no change in behaviour