### PR TITLE
Add surrounding code plugin to Electron

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -36,6 +36,7 @@
     "@bugsnag/plugin-interaction-breadcrumbs": "^7.10.0-alpha.0",
     "@bugsnag/plugin-internal-callback-marker": "^7.10.0-alpha.1",
     "@bugsnag/plugin-network-breadcrumbs": "^7.10.0-alpha.0",
+    "@bugsnag/plugin-node-surrounding-code": "^7.10.0-alpha.0",
     "@bugsnag/plugin-node-uncaught-exception": "^7.10.0-alpha.0",
     "@bugsnag/plugin-node-unhandled-rejection": "^7.10.0-alpha.0",
     "@bugsnag/plugin-stackframe-path-normaliser": "^7.10.0-alpha.2",

--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -33,7 +33,8 @@ module.exports = (opts) => {
 
   // main internal plugins go here
   const internalPlugins = [
-    // THIS PLUGIN MUST BE FIRST!
+    // Plugins after the "FirstPlugin" will run in the main process for renderer
+    // errors before any renderer onError callbacks are called
     require('@bugsnag/plugin-internal-callback-marker').FirstPlugin,
     require('@bugsnag/plugin-electron-client-state-manager'),
     require('@bugsnag/plugin-electron-ipc'),
@@ -49,8 +50,12 @@ module.exports = (opts) => {
     require('@bugsnag/plugin-electron-preload-error')(electron.app),
     require('@bugsnag/plugin-electron-net-breadcrumbs')(electron.net),
     require('@bugsnag/plugin-stackframe-path-normaliser'),
-    // THIS PLUGIN MUST BE LAST!
-    require('@bugsnag/plugin-internal-callback-marker').LastPlugin
+    // Plugins after the "LastPlugin" will run in the main process for renderer
+    // errors after all renderer onError callbacks have been called
+    require('@bugsnag/plugin-internal-callback-marker').LastPlugin,
+    // The surrounding code plugin must run here because the stacktrace is not
+    // present on renderer errors in the first round of callbacks
+    require('@bugsnag/plugin-node-surrounding-code')
   ]
 
   const bugsnag = new Client(opts, schema, internalPlugins, require('../id'))

--- a/packages/electron/test/type.test.ts
+++ b/packages/electron/test/type.test.ts
@@ -90,7 +90,8 @@ describe.skip('@bugsnag/electron types', () => {
         redactedKeys: ['b'],
         releaseStage: 'vOv',
         user: { id: '1234-abcd' },
-        launchDurationMillis: 100
+        launchDurationMillis: 100,
+        sendCode: false
       })
       Bugsnag.markLaunchComplete()
     })

--- a/packages/electron/types/notifier.d.ts
+++ b/packages/electron/types/notifier.d.ts
@@ -24,6 +24,7 @@ interface MainConfig extends Config {
   onUnhandledRejection?: AfterErrorCallback
   projectRoot?: string
   launchDurationMillis?: number
+  sendCode?: boolean
 }
 
 // a renderer is only allowed a subset of properties from Config

--- a/test/electron/features/error-handling.feature
+++ b/test/electron/features/error-handling.feature
@@ -55,6 +55,7 @@ Feature: Detecting and reporting errors
             | config          |
             | default         |
             | complex-config  |
+            | dont-send-code  |
 
     Scenario Outline: An event occurs when reporting is disabled
         Given I launch an app with configuration:

--- a/test/electron/features/support/utils/payload-matchers.js
+++ b/test/electron/features/support/utils/payload-matchers.js
@@ -91,13 +91,24 @@ const compareArray = (expected, actual, path) => {
   }]
 }
 
+// Check if this expected value allows "undefined". This is either a platform
+// specific matcher (some platforms may not have values for fields that are
+// specific to other platforms) or the expected value is undefined
+const canBeUndefined = expected => {
+  if (typeof expected === 'string') {
+    return expected.match(platformMatcher) || expected === '{TYPE:undefined}'
+  }
+
+  return false
+}
+
 /* Assert some variety of value matches an expected thing (of some variety) */
 const compare = (expected, actual, path = '') => {
-  // Ensure there's an actual value, unless this is a platform specific matcher
-  // Some platforms may not have values for fields that are specific to other platforms
-  if (typeof actual === 'undefined' && !expected.match(platformMatcher)) {
+  // Ensure there's an actual value unless this expectation allows "undefined"
+  if (typeof actual === 'undefined' && !canBeUndefined(expected)) {
     return [{ path, expected, actual, message: 'Expected a value but was undefined' }]
   }
+
   switch (typeof expected) {
     case 'object': {
       if (expected === null) {

--- a/test/electron/fixtures/app/configs/dont-send-code.js
+++ b/test/electron/fixtures/app/configs/dont-send-code.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+  return {
+    sendCode: false
+  }
+}

--- a/test/electron/fixtures/events/main/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/main/handled-error/complex-config.json
@@ -102,7 +102,10 @@
           "errorClass": "ReferenceError",
           "stacktrace": [{
             "file": "./src/errors.js",
-            "lineNumber": 18
+            "lineNumber": 18,
+            "code": {
+              "1": "{TYPE:string}"
+            }
           }],
           "type": "electronnodejs"
         }

--- a/test/electron/fixtures/events/main/handled-error/default.json
+++ b/test/electron/fixtures/events/main/handled-error/default.json
@@ -92,7 +92,10 @@
           "errorClass": "ReferenceError",
           "stacktrace": [{
             "file": "./src/errors.js",
-            "lineNumber": 18
+            "lineNumber": 18,
+            "code": {
+              "1": "{TYPE:string}"
+            }
           }],
           "type": "electronnodejs"
         }

--- a/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/complex-config.json
@@ -104,7 +104,10 @@
           "errorMessage": "foo is not defined",
           "stacktrace": [{
             "file": "./src/errors.js",
-            "lineNumber": 6
+            "lineNumber": 6,
+            "code": {
+              "1": "{TYPE:string}"
+            }
           }],
           "type": "electronnodejs"
         }

--- a/test/electron/fixtures/events/main/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/default.json
@@ -94,7 +94,10 @@
           "errorMessage": "foo is not defined",
           "stacktrace": [{
             "file": "./src/errors.js",
-            "lineNumber": 6
+            "lineNumber": 6,
+            "code": {
+              "1": "{TYPE:string}"
+            }
           }],
           "type": "electronnodejs"
         }

--- a/test/electron/fixtures/events/main/uncaught-exception/dont-send-code.json
+++ b/test/electron/fixtures/events/main/uncaught-exception/dont-send-code.json
@@ -1,0 +1,105 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
+        "version": "1.0.2"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
+        }
+      },
+      "severity": "error",
+      "unhandled": true,
+      "severityReason": {
+        "type": "unhandledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        },
+        {
+            "type": "user",
+            "name": "UI click",
+            "timestamp": "{TIMESTAMP}",
+            "metaData": {
+                "targetText": "Uncaught exception in main process",
+                "targetSelector": "A#main-process-uncaught-exception"
+            }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorClass": "ReferenceError",
+          "errorMessage": "foo is not defined",
+          "stacktrace": [{
+            "file": "./src/errors.js",
+            "lineNumber": 6,
+            "code": "{TYPE:undefined}"
+          }],
+          "type": "electronnodejs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/complex-config.json
@@ -104,7 +104,10 @@
           "errorMessage": "invalid",
           "stacktrace": [{
             "file": "./src/errors.js",
-            "lineNumber": 10
+            "lineNumber": 10,
+            "code": {
+              "1": "{TYPE:string}"
+            }
           }],
           "type": "electronnodejs"
         }

--- a/test/electron/fixtures/events/main/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/main/unhandled-rejection/default.json
@@ -94,7 +94,10 @@
           "errorMessage": "invalid",
           "stacktrace": [{
             "file": "./src/errors.js",
-            "lineNumber": 10
+            "lineNumber": 10,
+            "code": {
+              "1": "{TYPE:string}"
+            }
           }],
           "type": "electronnodejs"
         }

--- a/test/electron/fixtures/events/renderer/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/renderer/handled-error/complex-config.json
@@ -105,7 +105,10 @@
           "stacktrace": [
             {
               "lineNumber": 20,
-              "file": "./renderer.js"
+              "file": "./renderer.js",
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronrendererjs"

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -96,7 +96,10 @@
           "stacktrace": [
             {
               "lineNumber": 20,
-              "file": "./renderer.js"
+              "file": "./renderer.js",
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronrendererjs"

--- a/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
@@ -98,7 +98,10 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 16
+              "lineNumber": 16,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronrendererjs"

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -88,7 +88,10 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 16
+              "lineNumber": 16,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronrendererjs"

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
@@ -98,7 +98,10 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 12
+              "lineNumber": 12,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronrendererjs"

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -88,7 +88,10 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 12
+              "lineNumber": 12,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronrendererjs"


### PR DESCRIPTION
## Goal

Adds `plugin-node-surrounding-code` to the Electron main process notifier. This works for errors in JS and HTML files

Notably this must be after the internal callback marker "LastPlugin" as renderer errors don't have the correct stacktrace until they are sent to the main process (i.e. when `getPayloadInfo` runs, the stacktrace is missing

## Testing

I've added tests for this but the result is a bit weird as our test fixture app is minified, so the extracted code is just the first 200 characters of a webpack bundle. This still tests the plugin is running for Electron

I've also added a test with `sendCode = false` to make sure the plugin can be disabled. This required a small change to allow `{TYPE:undefined}` to be used to assert a property is missing (`undefined` isn't a valid JSON value so `typeof value === 'undefined'` must mean the property is missing)