### PR TITLE
Allow merging falsy options in renderers and use plugin schema extensions

### DIFF
--- a/packages/electron/src/client/renderer.js
+++ b/packages/electron/src/client/renderer.js
@@ -9,11 +9,6 @@ Event.__type = 'electronrendererjs'
 
 module.exports = (rendererOpts) => {
   if (!window.__bugsnag_ipc__) throw new Error('Bugsnag was not loaded in the main process')
-  const opts = mergeOptions(window.__bugsnag_ipc__.config, rendererOpts)
-
-  // automatic error breadcrumbs will always be duplicates if created in renderers
-  // because both the renderers and main process create them for the same Event
-  opts.enabledBreadcrumbTypes = opts.enabledBreadcrumbTypes.filter(type => type !== 'error')
 
   const internalPlugins = [
     require('@bugsnag/plugin-electron-renderer-client-state-updates')(window.__bugsnag_ipc__),
@@ -28,6 +23,20 @@ module.exports = (rendererOpts) => {
     require('@bugsnag/plugin-stackframe-path-normaliser'),
     require('@bugsnag/plugin-electron-renderer-event-data')(window.__bugsnag_ipc__)
   ]
+
+  const additionalSchemaKeys = internalPlugins.reduce((schemaKeys, plugin) => {
+    if (plugin.configSchema) {
+      return schemaKeys.concat(Object.keys(plugin.configSchema))
+    }
+
+    return schemaKeys
+  }, [])
+
+  const opts = mergeOptions(additionalSchemaKeys, window.__bugsnag_ipc__.config, rendererOpts)
+
+  // automatic error breadcrumbs will always be duplicates if created in renderers
+  // because both the renderers and main process create them for the same Event
+  opts.enabledBreadcrumbTypes = opts.enabledBreadcrumbTypes.filter(type => type !== 'error')
 
   const bugsnag = new Client(opts, schema, internalPlugins, require('../id'))
 

--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -28,8 +28,8 @@ module.exports.schema = {
   }
 }
 
-module.exports.mergeOptions = (mainOpts, rendererOpts) => {
-  return Object.keys(module.exports.schema).reduce((accum, k) => {
+module.exports.mergeOptions = (additionalSchemaKeys, mainOpts, rendererOpts) => {
+  return Object.keys(module.exports.schema).concat(additionalSchemaKeys).reduce((accum, k) => {
     if (Object.prototype.hasOwnProperty.call(rendererOpts, k)) {
       if (ALLOWED_IN_RENDERER.includes(k)) {
         if (k === 'metadata') {

--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -30,7 +30,7 @@ module.exports.schema = {
 
 module.exports.mergeOptions = (mainOpts, rendererOpts) => {
   return Object.keys(module.exports.schema).reduce((accum, k) => {
-    if (rendererOpts[k]) {
+    if (Object.prototype.hasOwnProperty.call(rendererOpts, k)) {
       if (ALLOWED_IN_RENDERER.includes(k)) {
         if (k === 'metadata') {
           // ensure that metadata set in renderer config doesn't blow away all preexisting metadata


### PR DESCRIPTION
## Goal

Pulled some fixes from the now closed https://github.com/bugsnag/bugsnag-js/pull/1403. These aren't super important right now, but might bite us in future. The issues are:

1. falsy values can now be set, which allows disabling boolean options. Previously a boolean that defaults to `true` would be impossible to disable
1. plugins can now define schema in renderers. Previously only the main renderer schema was used when determining which properties to merge from the given config