### PR TITLE
feat(react-native): Always upload JS version of bundle file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (react-native): Always upload JS bundle (rather than .hbc bundle) during Xcode source map upload build phase
+
 ## v7.10.0 (2021-05-18)
 
 This release adds [`@bugsnag/electron`](http://docs.bugsnag.com/platforms/electron), a notifier for use on apps that are built using Electron.

--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -17,7 +17,7 @@ fi
 
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 
-BUNDLE_FILE="$DEST/main.jsbundle"
+BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle"
 if [ ! -f "$BUNDLE_FILE" ]; then
   echo "Skipping source map upload because app has not been bundled."
   exit 0

--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -15,8 +15,6 @@ if [ -z "$API_KEY" ]; then
   exit 1
 fi
 
-DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
-
 BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle"
 if [ ! -f "$BUNDLE_FILE" ]; then
   echo "Skipping source map upload because app has not been bundled."


### PR DESCRIPTION
When Hermes is used, the final main.jsbundle is a precompiled binary format. This means that the Bugsnag backend can't
parse it as JS to find the original (precompiled) method name.

The JS bundle (which is fed into the Hermes compiler) always exists in this location, whether Hermes is in use or not.