### PR TITLE
[PLAT-5961] feat(browser,node): Add default appType config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (react-native): Update bugsnag-cocoa to v6.9.2
   - Add a mechanism for reporting errors that occur within the notifier. [bugsnag-cocoa#1089](https://github.com/bugsnag/bugsnag-cocoa/pull/1089)
   - Fix compiler warnings when additional warning flags are enabled. [bugsnag-cocoa#1092](https://github.com/bugsnag/bugsnag-cocoa/pull/1092) [bugsnag-cocoa#1094](https://github.com/bugsnag/bugsnag-cocoa/pull/1094)
+- (browser,node): Add default `appType`
 
 ### Fixed
 

--- a/packages/browser/src/config.js
+++ b/packages/browser/src/config.js
@@ -9,6 +9,10 @@ module.exports = {
       return 'production'
     }
   }),
+  appType: {
+    ...schema.appType,
+    defaultValue: () => 'browser'
+  },
   logger: assign({}, schema.logger, {
     defaultValue: () =>
       // set logger based on browser capability

--- a/packages/node/src/config.js
+++ b/packages/node/src/config.js
@@ -4,6 +4,10 @@ const os = require('os')
 const { inspect } = require('util')
 
 module.exports = {
+  appType: {
+    ...schema.appType,
+    defaultValue: () => 'node'
+  },
   projectRoot: {
     defaultValue: () => process.cwd(),
     validate: value => value === null || stringWithLength(value),

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -8,6 +8,7 @@ Scenario Outline: calling notify() with Error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "bad things"
   And the exception "type" equals "browserjs"
+  And the error payload field "events.0.app.type" equals "browser"
   And event 0 is handled
 
   Examples:

--- a/test/browser/features/unhandled_errors.feature
+++ b/test/browser/features/unhandled_errors.feature
@@ -6,6 +6,7 @@ Scenario: syntax errors
   Then I wait to receive an error
   And the error is a valid browser payload for the error reporting API
   And the exception matches the "unhandled_syntax" values for the current browser
+  And the error payload field "events.0.app.type" equals "browser"
   And event 0 is unhandled
 
 Scenario: thrown errors

--- a/test/node/features/handled_errors.feature
+++ b/test/node/features/handled_errors.feature
@@ -9,6 +9,7 @@ Scenario: calling notify() with an error
   And I run the service "handled" with the command "node scenarios/notify"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the error payload field "events.0.app.type" equals "node"
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"

--- a/test/node/features/unhandled_errors.feature
+++ b/test/node/features/unhandled_errors.feature
@@ -9,6 +9,7 @@ Scenario: reporting thrown exception which is not caught
   And I run the service "unhandled" with the command "node scenarios/thrown-error-not-caught"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the error payload field "events.0.app.type" equals "node"
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledException"


### PR DESCRIPTION
## Goal

App type is given visual prominence in the dashboard, so populate it with reasonable default values for browser and Node.js events.