### PR TITLE
Change console-breadcrumbs.js - support  lower case and other dev env…

### DIFF
--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -7,7 +7,7 @@ const includes = require('@bugsnag/core/lib/es-utils/includes')
  * Leaves breadcrumbs when console log methods are called
  */
 exports.load = (client) => {
-  const isDev = /^dev(elopment)?$/.test(client._config.releaseStage)
+  const isDev = !/^prod(uction)?$/.test(client._config.releaseStage.toLowerCase())
 
   if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'log') || isDev) return
 


### PR DESCRIPTION
Without this change, we get `console-breadcrumbs.js` in the source (when I in DEVELOPMENT or 'test' environment)

## Goal

- Support lower case (for example 'DEVELOPMENT')
- Support other dev environments (for example - 'stage', 'test'...)

## Changeset

Check `isDev` with not production environment 

## Testing

manual with react native debugger


@imjoehaines @bengourley 
