### PR TITLE
Fix RN 0.63 navigation CI

### DIFF
--- a/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
@@ -6,7 +6,7 @@ if [ "$REACT_NATIVE_VERSION" == "rn0.60" ];
 then
    npm i react-native-navigation@7.0.0
 else
-   npm i react-native-navigation@7.14.0
+   npm i react-native-navigation@^7.15.0
 fi
 
 npx rnn-link

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
@@ -6,7 +6,7 @@ if [ "$REACT_NATIVE_VERSION" == "rn0.60" ];
 then
    npm i react-native-navigation@7.0.0
 else
-   npm i react-native-navigation@^7.0.0
+   npm i react-native-navigation@7.14.0
 fi
 
 npx rnn-link

--- a/test/react-native/features/fixtures/rn0.63/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.63/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlin_version = "1.3.61"
+        kotlin_version = "1.4.30"
         RNNKotlinVersion = kotlin_version
         buildToolsVersion = "29.0.2"
         minSdkVersion = 16


### PR DESCRIPTION
A recent version of `react-native-navigation` introduced some Kotlin code that wasn't compatible with the version of the Kotlin compiler we were using. This bumps the version of the compiler on the fixture app and moves along the minimum version of RNN required (to ensure a cached version of e.g. 7.0.0 was installed, giving me a false positive).