### PR TITLE
fix(react-native): Only include codeBundleId in payload when it has a value

### DIFF
--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -19,9 +19,9 @@ module.exports.schema = {
     defaultValue: () => getPrefixedConsole()
   },
   codeBundleId: {
-    defaultValue: () => null,
+    defaultValue: () => undefined,
     message: 'should be a string',
-    validate: val => (val === null || stringWithLength(val))
+    validate: val => (val === undefined || stringWithLength(val))
   },
   enabledErrorTypes: {
     ...schema.enabledErrorTypes,


### PR DESCRIPTION
Makes the behaviour of this field consistent with Electron in that it only appears in the payload if it has a value.