### PR TITLE
test(react-native): Enable Hermes on iOS test fixture app

### DIFF
--- a/test/react-native/features/fixtures/rn0.64-hermes/ios/Podfile
+++ b/test/react-native/features/fixtures/rn0.64-hermes/ios/Podfile
@@ -9,7 +9,7 @@ target 'reactnative' do
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
-    :hermes_enabled => false
+    :hermes_enabled => true
   )
 
   target 'reactnativeTests' do


### PR DESCRIPTION
Enable Hermes on the the recently-added RN 0.64 test fixture.