### PR TITLE
fix(react-native): Ensure source maps are uploaded on iOS RN<0.64

### DIFF
--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -208,6 +208,8 @@ steps:
 
   - label: ':ios: Init and build RN 0.63 Expo (ejected) ipa'
     key: 'rn-0-63-expo-ejected-ipa'
+    # TODO: Skip pending PLAT-6449
+    skip: PLAT-6449
     timeout_in_minutes: 30
     agents:
       queue: 'opensource-mac-rn'

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -163,8 +163,6 @@ steps:
     skip: To be fixed and enabled via PLAT-6449
 
   - label: ':ios: Init and build RN 0.60 ipa'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     key: 'rn-0-60-ipa'
     timeout_in_minutes: 30
     agents:
@@ -176,8 +174,6 @@ steps:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_60
 
   - label: ':ios: Init and build RN 0.61 ipa'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     key: 'rn-0-61-ipa'
     timeout_in_minutes: 30
     agents:
@@ -189,8 +185,6 @@ steps:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_61
 
   - label: ':ios: Init and build RN 0.62 ipa'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     key: 'rn-0-62-ipa'
     timeout_in_minutes: 30
     agents:
@@ -202,8 +196,6 @@ steps:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_62
 
   - label: ':ios: Init and build RN 0.63 ipa'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     key: 'rn-0-63-ipa'
     timeout_in_minutes: 30
     agents:
@@ -215,8 +207,6 @@ steps:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_63
 
   - label: ':ios: Init and build RN 0.63 Expo (ejected) ipa'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     key: 'rn-0-63-expo-ejected-ipa'
     timeout_in_minutes: 30
     agents:
@@ -327,8 +317,6 @@ steps:
     skip: To be fixed and enabled via PLAT-6449
 
   - label: ':runner: RN 0.60 iOS end-to-end tests'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     depends_on: "rn-0-60-ipa"
     timeout_in_minutes: 10
     plugins:
@@ -348,8 +336,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: RN 0.61 iOS end-to-end tests'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     depends_on: "rn-0-61-ipa"
     timeout_in_minutes: 10
     plugins:
@@ -369,8 +355,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: RN 0.62 iOS end-to-end tests'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     depends_on: "rn-0-62-ipa"
     timeout_in_minutes: 10
     plugins:
@@ -390,8 +374,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: RN 0.63 iOS end-to-end tests'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     depends_on: "rn-0-63-ipa"
     timeout_in_minutes: 10
     plugins:
@@ -411,8 +393,6 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':runner: RN 0.63 Expo (ejected) iOS end-to-end tests'
-    # TODO: Skip pending PLAT-6764
-    skip: Pending PLAT-6764
     depends_on: "rn-0-63-expo-ejected-ipa"
     timeout_in_minutes: 10
     plugins:

--- a/packages/react-native/bugsnag-react-native-xcode.sh
+++ b/packages/react-native/bugsnag-react-native-xcode.sh
@@ -15,9 +15,14 @@ if [ -z "$API_KEY" ]; then
   exit 1
 fi
 
+# in RN 0.64+ the JS bundle is in this location
 BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle"
 if [ ! -f "$BUNDLE_FILE" ]; then
-  echo "Skipping source map upload because app has not been bundled."
+  # in RN <0.64 it's in this location
+  BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/main.jsbundle"
+fi
+if [ ! -f "$BUNDLE_FILE" ]; then
+  echo "Skipping source map upload because app bundle could not be found."
   exit 0
 fi
 


### PR DESCRIPTION
An update that fixed RN source map uploads for Hermes on iOS (v0.64+) inadvertently broke uploads for RN <0.64 on iOS due to the combination of the JS bundle location changing, and some false +ves in the end to end tests.

This fix looks in both possible locations before skipping the upload.