### PR TITLE
refactor(plugin-react): Make plugin Yarn PnP compatible

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -26,8 +26,5 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.10.0"
-  },
-  "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
   }
 }

--- a/packages/plugin-react/types/bugsnag-plugin-react.d.ts
+++ b/packages/plugin-react/types/bugsnag-plugin-react.d.ts
@@ -1,11 +1,22 @@
-import { Plugin, OnErrorCallback } from '@bugsnag/core'
 import React from 'react'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface BugsnagPluginReact extends Plugin { }
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+type OnErrorCallback = (event: any, cb: (err: null | Error, shouldSend?: boolean) => void) => void | boolean | Promise<void | boolean>
+type NotifiableError = Error
+| { errorClass: string, errorMessage: string }
+| { name: string, message: string }
+| string
+
+interface ClientThatReactNeeds {
+  notify(
+    error: NotifiableError,
+    onError?: OnErrorCallback,
+    cb?: (err: any, event: any) => void
+  ): void
+}
+
 declare class BugsnagPluginReact {
   constructor(react?: typeof React)
+  load(client: ClientThatReactNeeds): BugsnagPluginReactResult
 }
 
 export type BugsnagErrorBoundary = React.ComponentType<{


### PR DESCRIPTION
Currently, Yarn PnP mode is not supported by `@bugsnag/plugin-react`'s types.

This change is a draft for PnP + TypeScript support by breaking the hard dependency on `@bugsnag/core`'s types, and constructing the required types explicitly within the plugin. This dependency was previously expressed as a "peerDependency" because it was not a requirement for non-TypeScript users. However, with the Yarn PnP system, despite `@bugsnag/core` being installed elsewhere – it is not visible from `@bugsnag/plugin-react`.