### PR TITLE
Suggest Bugsnag plugin v7 if AGPv7 is used

### DIFF
--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -3,7 +3,7 @@ import logger from '../Logger'
 import { install as npmInstall, detectInstalled, guessPackageManager } from '../lib/Npm'
 import { install as podInstall } from '../lib/Pod'
 import onCancel from '../lib/OnCancel'
-import { findAndroidPluginVersion, modifyRootBuildGradle, modifyAppBuildGradle } from '../lib/Gradle'
+import { getSuggestedBugsnagGradleVersion, modifyRootBuildGradle, modifyAppBuildGradle } from '../lib/Gradle'
 
 export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
   try {
@@ -44,13 +44,12 @@ async function installJavaScriptPackage (projectRoot: string): Promise<void> {
 async function addGradlePluginDependency (projectRoot: string): Promise<void> {
   logger.info('Adding the Bugsnag Android Gradle Plugin')
 
-  const androidPluginVersion = await findAndroidPluginVersion(projectRoot)
-  const suggestedPluginVersion = androidPluginVersion?.startsWith('7.') ? '7+' : '5+'
+  const suggestedPluginVersion = await getSuggestedBugsnagGradleVersion(projectRoot, logger)
 
   const { gradlePluginVersion } = await prompts({
     type: 'text',
     name: 'gradlePluginVersion',
-    message: 'If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want',
+    message: 'Enter version of the Bugsnag Android Gradle plugin you want to use',
     initial: suggestedPluginVersion
   }, { onCancel })
 

--- a/packages/react-native-cli/src/commands/InstallCommand.ts
+++ b/packages/react-native-cli/src/commands/InstallCommand.ts
@@ -3,7 +3,7 @@ import logger from '../Logger'
 import { install as npmInstall, detectInstalled, guessPackageManager } from '../lib/Npm'
 import { install as podInstall } from '../lib/Pod'
 import onCancel from '../lib/OnCancel'
-import { modifyRootBuildGradle, modifyAppBuildGradle } from '../lib/Gradle'
+import { findAndroidPluginVersion, modifyRootBuildGradle, modifyAppBuildGradle } from '../lib/Gradle'
 
 export default async function run (argv: string[], projectRoot: string, opts: Record<string, unknown>): Promise<boolean> {
   try {
@@ -44,11 +44,14 @@ async function installJavaScriptPackage (projectRoot: string): Promise<void> {
 async function addGradlePluginDependency (projectRoot: string): Promise<void> {
   logger.info('Adding the Bugsnag Android Gradle Plugin')
 
+  const androidPluginVersion = await findAndroidPluginVersion(projectRoot)
+  const suggestedPluginVersion = androidPluginVersion?.startsWith('7.') ? '7+' : '5+'
+
   const { gradlePluginVersion } = await prompts({
     type: 'text',
     name: 'gradlePluginVersion',
     message: 'If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want',
-    initial: '5.+'
+    initial: suggestedPluginVersion
   }, { onCancel })
 
   await modifyRootBuildGradle(projectRoot, gradlePluginVersion, logger)

--- a/packages/react-native-cli/src/lib/Gradle.ts
+++ b/packages/react-native-cli/src/lib/Gradle.ts
@@ -6,11 +6,22 @@ const GRADLE_PLUGIN_IMPORT = (version: string) => `classpath("com.bugsnag:bugsna
 const GRADLE_PLUGIN_IMPORT_REGEX = /classpath\(["']com\.bugsnag:bugsnag-android-gradle-plugin:.*["']\)/
 const GRADLE_PLUGIN_APPLY = 'apply plugin: "com.bugsnag.android.gradle"'
 const GRADLE_PLUGIN_APPLY_REGEX = /apply plugin: ["']com\.bugsnag\.android\.gradle["']/
+const GRADLE_ANDROID_PLUGIN_REGEX = /classpath\(["']com.android.tools.build:gradle:[^0-9]*([^'"]+)["']\)/
 const DOCS_LINK = 'https://docs.bugsnag.com/build-integrations/gradle/#installation'
 const ENABLE_REACT_NATIVE_MAPPINGS = 'bugsnag {\n  uploadReactNativeMappings = true\n}\n'
 const ENABLE_REACT_NATIVE_MAPPINGS_REGEX = /^\s*bugsnag {[^}]*uploadReactNativeMappings[^}]*?}/m
 const UPLOAD_ENDPOINT_REGEX = /^\s*bugsnag {[^}]*endpoint[^}]*?}/m
 const BUILD_ENDPOINT_REGEX = /^\s*bugsnag {[^}]*releasesEndpoint[^}]*?}/m
+
+export async function findAndroidPluginVersion (projectRoot: string): Promise<string | null> {
+  try {
+    const fileContents = await fs.readFile(path.join(projectRoot, 'android', 'build.gradle'), 'utf8')
+    const versionMatchResult = fileContents.match(GRADLE_ANDROID_PLUGIN_REGEX)
+    return versionMatchResult?.[1] ?? null
+  } catch (e) {
+    return null
+  }
+}
 
 export async function modifyRootBuildGradle (projectRoot: string, pluginVersion: string, logger: Logger): Promise<void> {
   logger.debug('Looking for android/build.gradle')

--- a/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
@@ -1,4 +1,4 @@
-import { findAndroidPluginVersion, modifyAppBuildGradle, modifyRootBuildGradle, enableReactNativeMappings } from '../Gradle'
+import { getSuggestedBugsnagGradleVersion, modifyAppBuildGradle, modifyRootBuildGradle, enableReactNativeMappings } from '../Gradle'
 import logger from '../../Logger'
 import path from 'path'
 import { promises as fs } from 'fs'
@@ -513,32 +513,32 @@ test('enableReactNativeMappings(): success without initial bugsnag config and cu
   expect(writeFileMock).toHaveBeenNthCalledWith(3, '/random/path/android/app/build.gradle', expectedFinal, 'utf8')
 })
 
-test('findAndroidPluginVersion(): success', async () => {
+test('getSuggestedBugsnagGradleVersion(): success', async () => {
   const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'root-build-before.gradle'))
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockResolvedValueOnce(buildGradle)
 
-  const version = await findAndroidPluginVersion('/random/path')
-  expect(version).toBe('3.5.3')
+  const version = await getSuggestedBugsnagGradleVersion('/random/path', logger)
+  expect(version).toBe('5.+')
 })
 
-test('findAndroidPluginVersion(): null with wrong file', async () => {
+test('getSuggestedBugsnagGradleVersion(): null with wrong file', async () => {
   const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'app-build-before.gradle'))
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockResolvedValueOnce(buildGradle)
 
-  const version = await findAndroidPluginVersion('/random/path')
-  expect(version).toBeNull()
+  const version = await getSuggestedBugsnagGradleVersion('/random/path', logger)
+  expect(version).toBe('')
 })
 
-test('findAndroidPluginVersion(): success with bracketed AGP version', async () => {
+test('getSuggestedBugsnagGradleVersion(): success with bracketed AGP version', async () => {
   const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'root-build-before-with-prefixed-agp-version.gradle'))
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockResolvedValueOnce(buildGradle)
 
-  const version = await findAndroidPluginVersion('/random/path')
-  expect(version).toBe('7.0.0-alpha01')
+  const version = await getSuggestedBugsnagGradleVersion('/random/path', logger)
+  expect(version).toBe('7.+')
 })

--- a/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
@@ -1,4 +1,4 @@
-import { modifyAppBuildGradle, modifyRootBuildGradle, enableReactNativeMappings } from '../Gradle'
+import { findAndroidPluginVersion, modifyAppBuildGradle, modifyRootBuildGradle, enableReactNativeMappings } from '../Gradle'
 import logger from '../../Logger'
 import path from 'path'
 import { promises as fs } from 'fs'
@@ -511,4 +511,24 @@ test('enableReactNativeMappings(): success without initial bugsnag config and cu
   expect(writeFileMock).toHaveBeenNthCalledWith(1, '/random/path/android/app/build.gradle', expectedMappings, 'utf8')
   expect(writeFileMock).toHaveBeenNthCalledWith(2, '/random/path/android/app/build.gradle', expectedUploadEndpoint, 'utf8')
   expect(writeFileMock).toHaveBeenNthCalledWith(3, '/random/path/android/app/build.gradle', expectedFinal, 'utf8')
+})
+
+test('findAndroidPluginVersion(): success', async () => {
+  const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'root-build-before.gradle'))
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValueOnce(buildGradle)
+
+  const version = await findAndroidPluginVersion('/random/path')
+  expect(version).toBe('3.5.3')
+})
+
+test('findAndroidPluginVersion(): wrong file', async () => {
+  const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'app-build-before.gradle'))
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValueOnce(buildGradle)
+
+  const version = await findAndroidPluginVersion('/random/path')
+  expect(version).toBeNull()
 })

--- a/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Gradle.test.ts
@@ -523,7 +523,7 @@ test('findAndroidPluginVersion(): success', async () => {
   expect(version).toBe('3.5.3')
 })
 
-test('findAndroidPluginVersion(): wrong file', async () => {
+test('findAndroidPluginVersion(): null with wrong file', async () => {
   const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'app-build-before.gradle'))
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
@@ -531,4 +531,14 @@ test('findAndroidPluginVersion(): wrong file', async () => {
 
   const version = await findAndroidPluginVersion('/random/path')
   expect(version).toBeNull()
+})
+
+test('findAndroidPluginVersion(): success with bracketed AGP version', async () => {
+  const buildGradle = await loadFixture(path.join(__dirname, 'fixtures', 'root-build-before-with-prefixed-agp-version.gradle'))
+
+  const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
+  readFileMock.mockResolvedValueOnce(buildGradle)
+
+  const version = await findAndroidPluginVersion('/random/path')
+  expect(version).toBe('7.0.0-alpha01')
 })

--- a/packages/react-native-cli/src/lib/__test__/fixtures/root-build-before-with-prefixed-agp-version.gradle
+++ b/packages/react-native-cli/src/lib/__test__/fixtures/root-build-before-with-prefixed-agp-version.gradle
@@ -1,0 +1,37 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "29.0.2"
+        minSdkVersion = 16
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:[7.0.0-alpha01")
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("$rootDir/../node_modules/react-native/android")
+        }
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}

--- a/test/react-native-cli/features/cli-tests/install.feature
+++ b/test/react-native-cli/features/cli-tests/install.feature
@@ -65,7 +65,7 @@ Scenario: no git repo, run anyway, default version
     Then I wait for the current stdout line to match the regex "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
     When I input a return interactively
     Then I wait for the shell to output a match for the regex "\+ @bugsnag/react-native" to stdout
-    And I wait for the current stdout line to match the regex "If you want the latest version of the Bugsnag Android Gradle plugin hit enter\, otherwise type the version you want"
+    And I wait for the current stdout line to match the regex "Enter version of the Bugsnag Android Gradle plugin you want to use"
     When I input a return interactively
     And I wait for the shell to output a match for the regex "Detected platform is not macOS\, skipping" to stdout
     Then the last interactive command exited successfully
@@ -85,7 +85,7 @@ Scenario: clean git repo, run, version 7.5.0
     Then I wait for the current stdout line to match the regex "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
     When I input "7.5.0" interactively
     Then I wait for the shell to output a match for the regex "\+ @bugsnag/react-native" to stdout
-    And I wait for the current stdout line to match the regex "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+    And I wait for the current stdout line to match the regex "Enter version of the Bugsnag Android Gradle plugin you want to use"
     When I input a return interactively
     And I wait for the shell to output a match for the regex "Detected platform is not macOS, skipping" to stdout
     And the last interactive command exited successfully
@@ -107,7 +107,7 @@ Scenario: no git repo, run anyway, already installed
     And I wait for the current stdout line to match the regex "Do you want to continue anyway\?"
     When I input "y" interactively
     Then I wait for the shell to output a match for the regex "@bugsnag/react-native is already installed, skipping" to stdout
-    And I wait for the current stdout line to match the regex "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+    And I wait for the current stdout line to match the regex "Enter version of the Bugsnag Android Gradle plugin you want to use"
     When I input a return interactively
     And I wait for the current stdout line to match the regex "\/app #"
     And the last interactive command exited successfully

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -31,7 +31,7 @@ send -- http://localhost:9339/builds\r
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- $notifierVersion\r
 
-expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
+expect "Enter version of the Bugsnag Android Gradle plugin you want to use"
 send -- \r
 
 expect "What is your Bugsnag project API key?"

--- a/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-ios.sh
@@ -31,9 +31,8 @@ send -- http://localhost:9339/builds\r
 expect "If you want the latest version of @bugsnag/react-native hit enter, otherwise type the version you want"
 send -- $notifierVersion\r
 
-# TODO: Use latest once BAGP is released for real
-expect "If you want the latest version of the Bugsnag Android Gradle plugin hit enter, otherwise type the version you want"
-send -- "5.5.0-alpha01\r"
+expect "Enter version of the Bugsnag Android Gradle plugin you want to use"
+send -- \r
 
 expect "What is your Bugsnag project API key?"
 send -- "1234567890ABCDEF1234567890ABCDEF\r"


### PR DESCRIPTION
## Goal
When adding Bugsnag to an existing ReactNative project using the `react-native-cli` we should suggest `bugsnag-android:7+` if the ReactNative project is using the Android Gradle Plugin 7.

## Design
Before prompting the user to enter a version:
 - Read the project-level `build.gradle`
 - Attempt to detect the Android Build Plugin used
 - If successfully found - and the version number starts with `7.` suggest `7+`
 - Otherwise fallback to suggesting `5+`

## Testing
Included test coverage for the AGP version-number detection. These changes can also be manually tested by using the `cli` with ReactNative projects and adjusting the AGP version number.