### PR TITLE
fix(plugin-console-breadcrumbs): Ensure off by default in Expo dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBC
+
+### Fixed
+
+- (plugin-console-breadcrumbs): Ensure console breadcrumbs do not run in Expo's dev environment and obscure log line numbers [#1453](https://github.com/bugsnag/bugsnag-js/pull/1453)
+
 ## 7.10.4 (2021-06-28)
 
 ### Fixed

--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -7,7 +7,7 @@ const includes = require('@bugsnag/core/lib/es-utils/includes')
  * Leaves breadcrumbs when console log methods are called
  */
 exports.load = (client) => {
-  const isDev = /^dev(elopment)?$/.test(client._config.releaseStage)
+  const isDev = /^(local-)?dev(elopment)?$/.test(client._config.releaseStage)
 
   if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'log') || isDev) return
 

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.ts
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.ts
@@ -59,4 +59,18 @@ describe('plugin: console breadcrumbs', () => {
     expect(c._breadcrumbs.length).toBe(0)
     plugin.destroy()
   })
+
+  it('should be not enabled by default when releaseStage=dev', () => {
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'dev', plugins: [plugin] })
+    console.log(123)
+    expect(c._breadcrumbs.length).toBe(0)
+    plugin.destroy()
+  })
+
+  it('should be not enabled by default when releaseStage=local-dev', () => {
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', releaseStage: 'local-dev', plugins: [plugin] })
+    console.log(123)
+    expect(c._breadcrumbs.length).toBe(0)
+    plugin.destroy()
+  })
 })


### PR DESCRIPTION
Console breadcrumbs should be disabled in dev environments because they have a known side-effect of obscuring line number (all logs appear to come from Bugsnag's own code).

We call Expo's dev environment `local-dev` so this updates the plugin's regex `releaseStage` check to ensure it matches.