### PR TITLE
[PLAT-5051] Expo: use device id as default user id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (plugin-console-breadcrumbs): Ensure console breadcrumbs do not run in Expo's dev environment and obscure log line numbers [#1453](https://github.com/bugsnag/bugsnag-js/pull/1453)
 
+### Added
+
+- (expo): User ID now defaults to `device.id` if no user is set [#1454](https://github.com/bugsnag/bugsnag-js/pull/1454)
+
 ## 7.10.4 (2021-06-28)
 
 ### Fixed

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -45,6 +45,7 @@ module.exports = {
     client.addOnSession(session => {
       session.device = { ...session.device, ...device }
       addDefaultAppType(session)
+      addDefaultUserId(session)
     })
 
     client.addOnError(event => {
@@ -54,6 +55,7 @@ module.exports = {
         appOwnership: Constants.appOwnership
       })
       addDefaultAppType(event)
+      addDefaultUserId(event)
     }, true)
   }
 }
@@ -66,5 +68,13 @@ function addDefaultAppType (eventOrSession) {
     if (!eventOrSession.app.type) {
       eventOrSession.app.type = eventOrSession.device.osName
     }
+  }
+}
+
+function addDefaultUserId (eventOrSession) {
+  // device id is also used to populate the user id field, if it's not already set
+  const user = eventOrSession.getUser()
+  if (!user || !user.id) {
+    eventOrSession.setUser(eventOrSession.device.id)
   }
 }

--- a/test/expo/features/fixtures/test-app/app/user.js
+++ b/test/expo/features/fixtures/test-app/app/user.js
@@ -14,6 +14,10 @@ export default class User extends Component {
     })
   }
 
+  userDefault = () => {
+    bugsnagClient.notify(new Error('UserDefaultError'))
+  }
+
   render() {
     return (
       <View>
@@ -24,6 +28,10 @@ export default class User extends Component {
         <Button accessibilityLabel="userCallbackButton"
           title="userCallback"
           onPress={this.userCallback}
+        />
+        <Button accessibilityLabel="userDefaultButton"
+          title="userDefault"
+          onPress={this.userDefault}
         />
       </View>
     )

--- a/test/expo/features/fixtures/test-app/app/user.js
+++ b/test/expo/features/fixtures/test-app/app/user.js
@@ -4,13 +4,13 @@ import { bugsnagClient } from './bugsnag'
 
 export default class User extends Component {
   userClient = () => {
-    bugsnagClient.setUser(null, null, "userClientName")
+    bugsnagClient.setUser('123', 'user@ema.il', "userClientName")
     bugsnagClient.notify(new Error('UserClientError'))
   }
 
   userCallback = () => {
     bugsnagClient.notify(new Error('UserCallbackError'), event => {
-      event.setUser(null, null, "userCallbackName")
+      event.setUser('123', 'user@ema.il', "userCallbackName")
     })
   }
 

--- a/test/expo/features/user.feature
+++ b/test/expo/features/user.feature
@@ -21,3 +21,12 @@ Scenario: User data can be set via a callback
   And the exception "message" equals "UserCallbackError"
   And the event "user.name" equals "userCallbackName"
   And the error Bugsnag-Integrity header is valid
+
+Scenario: User id defaults to device id
+  Given the element "userDefaultButton" is present
+  When I click the element "userDefaultButton"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "UserDefaultError"
+  And the event "user.id" is not null
+  And the error Bugsnag-Integrity header is valid


### PR DESCRIPTION
For the user stability feature, it is important for `user.id` to have a default value. As per the spec and as per the Electron implementation, we use `device.id` if no user id is set.