### PR TITLE
[PLAT-6568] fix(browser): Loaded breadcrumb should have type state

### DIFF
--- a/packages/browser/src/notifier.js
+++ b/packages/browser/src/notifier.js
@@ -69,6 +69,7 @@ const Bugsnag = {
     bugsnag._setDelivery(window.XDomainRequest ? dXDomainRequest : dXMLHttpRequest)
 
     bugsnag._logger.debug('Loaded!')
+    bugsnag.leaveBreadcrumb('Bugsnag loaded', {}, 'state')
 
     return bugsnag._config.autoTrackSessions
       ? bugsnag.startSession()

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -64,7 +64,7 @@ describe('browser notifier', () => {
         done(err)
       }
       expect(event.breadcrumbs[0]).toStrictEqual(expect.objectContaining({
-        type: 'navigation',
+        type: 'state',
         message: 'Bugsnag loaded'
       }))
       expect(event.originalError.message).toBe('123')

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -33,8 +33,6 @@ module.exports = (win = window) => {
 
       if (win.history.replaceState) wrapHistoryFn(client, win.history, 'replaceState', win)
       if (win.history.pushState) wrapHistoryFn(client, win.history, 'pushState', win)
-
-      client.leaveBreadcrumb('Bugsnag loaded', {}, 'navigation')
     }
   }
 

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
@@ -28,7 +28,7 @@ describe('plugin: navigation breadcrumbs', () => {
     // then ensure that it works with `undefined` as the url parameter (IE11-specific issue)
     expect(c._breadcrumbs[c._breadcrumbs.length - 1].metadata.to).toMatch(/^\/?network-breadcrumb-test\.html$/)
 
-    expect(c._breadcrumbs.length).toBe(6)
+    expect(c._breadcrumbs.length).toBe(5)
 
     done()
   })
@@ -91,7 +91,7 @@ describe('plugin: navigation breadcrumbs', () => {
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
     window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
     window.history.replaceState({}, 'bar')
-    expect(c._breadcrumbs.length).toBe(5)
+    expect(c._breadcrumbs.length).toBe(4)
   })
 })
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->