### PR TITLE
Leave autotomatic breadcrumbs when `enabledBreadcrumbTypes` is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   - Fix `NSNull` handling in `+[BugsnagError errorFromJson:]` and `+[BugsnagStackframe frameFromJson:]`. [bugsnag-cocoa#1143](https://github.com/bugsnag/bugsnag-cocoa/pull/1143)
   - Fix a rare crash in `bsg_ksmachgetThreadQueueName`. [bugsnag-cocoa#1147](https://github.com/bugsnag/bugsnag-cocoa/pull/1147)
 
+### Fixed
+
+- Breadcrumbs will now be left when `enabledBreadcrumbTypes` is `null` [#1466](https://github.com/bugsnag/bugsnag-js/pull/1466)
+
 ## 7.10.5 (2021-07-05)
 
 ### Fixed

--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -68,7 +68,7 @@ module.exports = (opts) => {
   bugsnag.markLaunchComplete = markLaunchComplete
 
   bugsnag._logger.debug('Loaded! In main process.')
-  if (bugsnag._config.enabledBreadcrumbTypes && bugsnag._config.enabledBreadcrumbTypes.includes('state')) {
+  if (bugsnag._config.enabledBreadcrumbTypes === null || bugsnag._config.enabledBreadcrumbTypes.includes('state')) {
     bugsnag.leaveBreadcrumb('Bugsnag loaded', {}, 'state')
   }
 

--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -9,7 +9,7 @@ const includes = require('@bugsnag/core/lib/es-utils/includes')
 exports.load = (client) => {
   const isDev = /^(local-)?dev(elopment)?$/.test(client._config.releaseStage)
 
-  if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'log') || isDev) return
+  if (isDev || (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'log'))) return
 
   map(CONSOLE_LOG_METHODS, method => {
     const original = console[method]

--- a/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.ts
+++ b/packages/plugin-console-breadcrumbs/test/console-breadcrumbs.test.ts
@@ -46,6 +46,13 @@ describe('plugin: console breadcrumbs', () => {
     plugin.destroy()
   })
 
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin] })
+    console.log(123)
+    expect(c._breadcrumbs).toHaveLength(1)
+    plugin.destroy()
+  })
+
   it('should be enabled when enabledBreadcrumbTypes=["log"]', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['log'], plugins: [plugin] })
     console.log(123)

--- a/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
+++ b/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
@@ -7,7 +7,7 @@ module.exports = (win = window) => ({
   load: (client) => {
     if (!('addEventListener' in win)) return
 
-    if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'user')) return
+    if (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'user')) return
 
     win.addEventListener('click', (event) => {
       let targetText, targetSelector

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
@@ -23,6 +23,13 @@ describe('plugin: interaction breadcrumbs', () => {
     winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
     expect(c._breadcrumbs.length).toBe(1)
   })
+
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
+    const { window, winHandlers, els } = getMockWindow()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+    winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
+    expect(c._breadcrumbs.length).toBe(1)
+  })
 })
 
 const getMockWindow = () => {

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -8,7 +8,7 @@ module.exports = (win = window) => {
     load: (client) => {
       if (!('addEventListener' in win)) return
 
-      if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'navigation')) return
+      if (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'navigation')) return
 
       // returns a function that will drop a breadcrumb with a given name
       const drop = name => () => client.leaveBreadcrumb(name, {}, 'navigation')

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
@@ -79,9 +79,24 @@ describe('plugin: navigation breadcrumbs', () => {
     expect(c._sessionDelegate.startSession).not.toHaveBeenCalled()
   })
 
-  it('should be enabled when enabledReleaseStages=["navigation"]', () => {
+  it('should be enabled when enabledBreadcrumbTypes=["navigation"]', () => {
     const { winHandlers, docHandlers, window } = getMockWindow()
-    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledReleaseStages: ['navigation'], plugins: [plugin(window)] })
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['navigation'], plugins: [plugin(window)] })
+    c._sessionDelegate = {
+      startSession: () => {},
+      pauseSession: () => {},
+      resumeSession: () => {}
+    }
+    winHandlers.load.forEach((h) => h.call(window))
+    docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
+    window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
+    window.history.replaceState({}, 'bar')
+    expect(c._breadcrumbs.length).toBe(4)
+  })
+
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
+    const { winHandlers, docHandlers, window } = getMockWindow()
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
     c._sessionDelegate = {
       startSession: () => {},
       pauseSession: () => {},

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -14,7 +14,7 @@ module.exports = (_ignoredUrls = [], win = window) => {
   let restoreFunctions = []
   const plugin = {
     load: client => {
-      if (!client._config.enabledBreadcrumbTypes || !includes(client._config.enabledBreadcrumbTypes, 'request')) return
+      if (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'request')) return
 
       const ignoredUrls = [
         client._config.endpoints.notify,

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -447,6 +447,19 @@ describe('plugin: network breadcrumbs', () => {
     expect(client._breadcrumbs.length).toBe(1)
   })
 
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
+    const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
+
+    p = plugin([], window)
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [p] })
+
+    const request = new XMLHttpRequest()
+    request.open('GET', '/')
+    request.send(false, 200)
+
+    expect(client._breadcrumbs.length).toBe(1)
+  })
+
   it('should strip query string data before checking a url is ignored', () => {
     const window = { XMLHttpRequest } as unknown as Window & typeof globalThis
 

--- a/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
@@ -2,7 +2,7 @@ const { AppState } = require('react-native')
 
 module.exports = {
   load: client => {
-    if (!client._config.enabledBreadcrumbTypes || !client._config.enabledBreadcrumbTypes.includes('state')) return
+    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('state')) return
 
     AppState.addEventListener('change', state => {
       client.leaveBreadcrumb('App state changed', { state }, 'state')

--- a/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.ts
+++ b/packages/plugin-react-native-app-state-breadcrumbs/test/app-state.test.ts
@@ -41,10 +41,10 @@ describe('plugin: react native app state breadcrumbs', () => {
     expect(client._breadcrumbs[1].metadata).toEqual({ state: 'active' })
   })
 
-  it('should not be enabled when enabledBreadcrumbTypes=null', () => {
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin] })
     expect(client).toBe(client)
-    expect(AppState.addEventListener).not.toHaveBeenCalled()
+    expect(AppState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {

--- a/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
@@ -2,7 +2,7 @@ const NetInfo = require('@react-native-community/netinfo')
 
 module.exports = {
   load: client => {
-    if (!client._config.enabledBreadcrumbTypes || !client._config.enabledBreadcrumbTypes.includes('state')) return
+    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('state')) return
 
     NetInfo.addEventListener(({ isConnected, isInternetReachable, type }) => {
       client.leaveBreadcrumb(

--- a/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.ts
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/test/connectivity.test.ts
@@ -35,11 +35,11 @@ describe('plugin: react native connectivity breadcrumbs', () => {
     expect(client._breadcrumbs[1].metadata).toEqual({ type: 'none', isConnected: false, isInternetReachable: false })
   })
 
-  it('should not be enabled when enabledBreadcrumbTypes=null', () => {
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin] })
     expect(client).toBe(client)
 
-    expect(NetInfo.addEventListener).not.toHaveBeenCalled()
+    expect(NetInfo.addEventListener).toHaveBeenCalledWith(expect.any(Function))
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -16,9 +16,11 @@ module.exports = class BugsnagPluginReactNativeNavigation {
       client.setContext(event.componentName)
 
       if (
-        client._config.enabledBreadcrumbTypes &&
-        client._config.enabledBreadcrumbTypes.includes('navigation') &&
-        lastComponent !== event.componentName
+        lastComponent !== event.componentName &&
+        (
+          client._config.enabledBreadcrumbTypes === null ||
+          client._config.enabledBreadcrumbTypes.includes('navigation')
+        )
       ) {
         client.leaveBreadcrumb(
           'React Native Navigation componentDidAppear',

--- a/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
+++ b/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
@@ -103,6 +103,44 @@ describe('plugin-react-native-navigation', () => {
     expect(breadcrumbs[1].type).toBe('navigation')
   })
 
+  it('leaves a breadcrumb when enabledBreadcrumbTypes=null', () => {
+    let listener = (event: Event) => {
+      throw new Error(`This function was not supposed to be called! ${event.componentName}`)
+    }
+
+    const Navigation = {
+      events () {
+        return {
+          registerComponentDidAppearListener (callback: (event: Event) => never) {
+            listener = callback
+          }
+        }
+      }
+    }
+
+    const breadcrumbs: Breadcrumb[] = []
+
+    const plugin = new Plugin(Navigation)
+    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin], enabledBreadcrumbTypes: null })
+    client.addOnBreadcrumb(breadcrumb => { breadcrumbs.push(breadcrumb) })
+
+    expect(breadcrumbs).toHaveLength(0)
+
+    listener({ componentId: 1, componentName: 'abc xyz', passProps: {} })
+
+    expect(breadcrumbs).toHaveLength(1)
+    expect(breadcrumbs[0].message).toBe('React Native Navigation componentDidAppear')
+    expect(breadcrumbs[0].metadata).toStrictEqual({ to: 'abc xyz', from: undefined })
+    expect(breadcrumbs[0].type).toBe('navigation')
+
+    listener({ componentId: 2, componentName: 'xyz abc', passProps: {} })
+
+    expect(breadcrumbs).toHaveLength(2)
+    expect(breadcrumbs[1].message).toBe('React Native Navigation componentDidAppear')
+    expect(breadcrumbs[1].metadata).toStrictEqual({ to: 'xyz abc', from: 'abc xyz' })
+    expect(breadcrumbs[1].type).toBe('navigation')
+  })
+
   it('does not leave a breadcrumb when the component has not changed', () => {
     let listener = (event: Event) => {
       throw new Error(`This function was not supposed to be called! ${event.componentName}`)

--- a/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
@@ -2,7 +2,7 @@ const { Dimensions } = require('react-native')
 
 module.exports = {
   load: client => {
-    if (!client._config.enabledBreadcrumbTypes || !client._config.enabledBreadcrumbTypes.includes('state')) return
+    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('state')) return
 
     let lastOrientation
 

--- a/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.ts
+++ b/packages/plugin-react-native-orientation-breadcrumbs/test/orientation.test.ts
@@ -46,10 +46,12 @@ describe('plugin: react native orientation breadcrumbs', () => {
     expect(client._breadcrumbs[1].metadata).toEqual({ from: 'portrait', to: 'landscape' })
   })
 
-  it('should not be enabled when enabledBreadcrumbTypes=null', () => {
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
+    MockDimensions.get = () => ({ height: 100, width: 200 })
+
     const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin] })
 
-    expect(MockDimensions.addEventListener).not.toHaveBeenCalled()
+    expect(MockDimensions.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
     expect(client).toBe(client)
   })
 

--- a/packages/plugin-react-navigation/react-navigation.js
+++ b/packages/plugin-react-navigation/react-navigation.js
@@ -7,13 +7,13 @@ class BugsnagPluginReactNavigation {
 
   load (client) {
     const leaveBreadcrumb = (event, currentRouteName, previousRouteName) => {
-      if (client._config.enabledBreadcrumbTypes && client._config.enabledBreadcrumbTypes.includes('navigation')) {
-        client.leaveBreadcrumb(
-          `React Navigation ${event}`,
-          { to: currentRouteName, from: previousRouteName },
-          'navigation'
-        )
-      }
+      if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('navigation')) return
+
+      client.leaveBreadcrumb(
+        `React Navigation ${event}`,
+        { to: currentRouteName, from: previousRouteName },
+        'navigation'
+      )
     }
 
     const createNavigationContainer = (NavigationContainer) => React.forwardRef((props, ref) => {

--- a/packages/plugin-react-navigation/test/react-navigation.test.tsx
+++ b/packages/plugin-react-navigation/test/react-navigation.test.tsx
@@ -138,6 +138,45 @@ describe('plugin: react navigation', () => {
     expect(c._breadcrumbs[3].metadata.to).toBe('details')
   })
 
+  it('should leave breacrumbs when enabledBreadcrumbTypes=null', () => {
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [new Plugin()], enabledBreadcrumbTypes: null })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const BugsnagNavigationContainer = c.getPlugin('reactNavigation')!.createNavigationContainer(NavigationContainer)
+    let ref
+    let currentRouteName = 'home'
+    const App = () => {
+      ref = React.useRef({
+        getCurrentRoute: () => {
+          return { name: currentRouteName }
+        }
+      })
+      return (
+        <BugsnagNavigationContainer ref={ref as unknown as React.RefObject<NavigationContainerRef>}>
+          Testing 123
+        </BugsnagNavigationContainer>
+      )
+    }
+
+    const MockedNavigationContainerRender = (NavigationContainer as any).render as jest.MockedFunction<React.ForwardRefRenderFunction<any, any>>
+    TestRenderer.create(<App/>)
+
+    expect(MockedNavigationContainerRender).toBeCalledTimes(1)
+
+    expect(c._breadcrumbs).toHaveLength(0)
+
+    const navigationProps = MockedNavigationContainerRender.mock.calls[0][0]
+
+    navigationProps.onReady()
+    currentRouteName = 'details'
+    navigationProps.onStateChange()
+    currentRouteName = 'settings'
+    navigationProps.onStateChange()
+    currentRouteName = 'details'
+    navigationProps.onStateChange()
+
+    expect(c._breadcrumbs).toHaveLength(4)
+  })
+
   it('should leave no breacrumbs when navigation breadcrumbs are disabled', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [new Plugin()], enabledBreadcrumbTypes: [] })
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## Goal

The intended behaviour of `enabledBreadcrumbTypes` is for breadcrumbs to be left when it is null. This allows notifiers to avoid creating a set of breadcrumb types when it is not necessary

The latest Android release changed `enabledBreadcrumbTypes` to null by default for performance reasons and uncovered this bug via the RN tests

Note that this PR doesn't fix the problem alone as some parts of the code do not handle the case where `enabledBreadcrumbTypes` is null and so will crash when `notify` is called. This will be fixed in https://github.com/bugsnag/bugsnag-js/pull/1467

## Testing

Covered by existing tests and new unit tests for the `null` case. This cannot be manually tested yet as `notify` fails when `enabledBreadcrumbTypes` is null