### PR TITLE
Fix crashes when `enabledBreadcrumbTypes` is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Breadcrumbs will now be left when `enabledBreadcrumbTypes` is `null` [#1466](https://github.com/bugsnag/bugsnag-js/pull/1466)
+- Avoid crash when `enabledBreadcrumbTypes` is `null` [#1467](https://github.com/bugsnag/bugsnag-js/pull/1467)
 
 ## 7.10.5 (2021-07-05)
 

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -296,7 +296,9 @@ class Client {
         return cb(null, event)
       }
 
-      if (includes(this._config.enabledBreadcrumbTypes, 'error')) {
+      const types = this._config.enabledBreadcrumbTypes
+
+      if (!types || includes(types, 'error')) {
         // only leave a crumb for the error if actually got sent
         Client.prototype.leaveBreadcrumb.call(this, event.errors[0].errorClass, {
           errorClass: event.errors[0].errorClass,

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -396,6 +396,19 @@ describe('@bugsnag/core/client', () => {
       expect(payloads[0].events[0].breadcrumbs.length).toBe(0)
     })
 
+    it('leaves a breadcrumb of the error when enabledBreadcrumbTypes=null', () => {
+      const payloads: any[] = []
+      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledBreadcrumbTypes: null })
+      client._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload), sendSession: () => {} }))
+      client.notify(new Error('foobar'))
+      expect(client._breadcrumbs).toHaveLength(1)
+      expect(client._breadcrumbs[0].type).toBe('error')
+      expect(client._breadcrumbs[0].message).toBe('Error')
+      expect(client._breadcrumbs[0].metadata.stacktrace).toBe(undefined)
+      // the error shouldn't appear as a breadcrumb for itself
+      expect(payloads[0].events[0].breadcrumbs).toHaveLength(0)
+    })
+
     it('doesn’t modify global client.metadata when using addMetadata() method', () => {
       const client = new Client({ apiKey: 'API_KEY_YEAH' })
       client.addMetadata('foo', 'bar', [1, 2, 3])

--- a/packages/electron/src/client/renderer.js
+++ b/packages/electron/src/client/renderer.js
@@ -36,7 +36,9 @@ module.exports = (rendererOpts) => {
 
   // automatic error breadcrumbs will always be duplicates if created in renderers
   // because both the renderers and main process create them for the same Event
-  opts.enabledBreadcrumbTypes = opts.enabledBreadcrumbTypes.filter(type => type !== 'error')
+  if (opts.enabledBreadcrumbTypes !== null) {
+    opts.enabledBreadcrumbTypes = opts.enabledBreadcrumbTypes.filter(type => type !== 'error')
+  }
 
   const bugsnag = new Client(opts, schema, internalPlugins, require('../id'))
 

--- a/packages/plugin-electron-app-breadcrumbs/app-breadcrumbs.js
+++ b/packages/plugin-electron-app-breadcrumbs/app-breadcrumbs.js
@@ -5,7 +5,7 @@ const BREADCRUMB_STATE = 'state'
 
 module.exports = (app, BrowserWindow) => ({
   load (client) {
-    if (!client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
+    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
       return
     }
 

--- a/packages/plugin-electron-app-breadcrumbs/test/app-breadcrumbs.test.ts
+++ b/packages/plugin-electron-app-breadcrumbs/test/app-breadcrumbs.test.ts
@@ -483,6 +483,18 @@ describe('plugin: electron app breadcrumbs', () => {
     browserWindowEvents.forEach(windowEvent => window._emit(windowEvent, window))
     expect(client._breadcrumbs).toHaveLength(0)
   })
+
+  it('leaves a breadcrumb when enabledBreadcrumbTypes=null', () => {
+    const BrowserWindow = makeBrowserWindow()
+    const app = makeApp({ BrowserWindow })
+
+    const client = makeClient({ app, BrowserWindow, config: { enabledBreadcrumbTypes: null } })
+
+    const appEvents = ['ready', 'will-quit']
+    appEvents.forEach(appEvent => app._emit(appEvent, {}))
+
+    expect(client._breadcrumbs).toHaveLength(2)
+  })
 })
 
 function makeClient ({

--- a/packages/plugin-electron-ipc/bugsnag-ipc-main.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-main.js
@@ -60,7 +60,7 @@ module.exports = class BugsnagIpcMain {
         return
       }
 
-      if (this.client._config.enabledBreadcrumbTypes.includes('error')) {
+      if (this.client._config.enabledBreadcrumbTypes && this.client._config.enabledBreadcrumbTypes.includes('error')) {
         // only leave a crumb for the error if actually got sent
         this.client.leaveBreadcrumb(event.errors[0].errorClass, {
           errorClass: event.errors[0].errorClass,

--- a/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
+++ b/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
@@ -2,7 +2,7 @@ const BREADCRUMB_REQUEST = 'request'
 
 module.exports = net => ({
   load (client) {
-    if (!client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_REQUEST)) {
+    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_REQUEST)) {
       return
     }
 

--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -133,6 +133,29 @@ describe('plugin: electron net breadcrumbs', () => {
     expect(client._breadcrumbs[0]).toMatchBreadcrumb(expected)
   })
 
+  it('it leaves breadcrumbs when enabledBreadcrumbTypes=null', async () => {
+    const client = makeClient({ enabledBreadcrumbTypes: null })
+
+    currentServer = await startServer(200)
+
+    const url = `http://localhost:${currentServer.port}`
+    const request = net.request(url)
+
+    await new Promise(resolve => {
+      request.on('close', resolve)
+      request.abort()
+    })
+
+    const expected = new Breadcrumb(
+      'net.request aborted',
+      { request: `GET ${url}/` },
+      'request'
+    )
+
+    expect(client._breadcrumbs).toHaveLength(1)
+    expect(client._breadcrumbs[0]).toMatchBreadcrumb(expected)
+  })
+
   it('it leaves a breadcrumb when the request errors', async () => {
     const client = makeClient()
 

--- a/packages/plugin-electron-power-monitor-breadcrumbs/power-monitor-breadcrumbs.js
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/power-monitor-breadcrumbs.js
@@ -2,7 +2,7 @@ const BREADCRUMB_STATE = 'state'
 
 module.exports = (powerMonitor) => ({
   load (client) {
-    if (!client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
+    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
       return
     }
 

--- a/packages/plugin-electron-power-monitor-breadcrumbs/test/power-monitor-breadcrumbs.test.ts
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/test/power-monitor-breadcrumbs.test.ts
@@ -36,4 +36,16 @@ describe('plugin: electron power monitor breadcrumbs', () => {
 
     expect(client._breadcrumbs).toHaveLength(0)
   })
+
+  it.each(events)('works when enabledBreadcrumbTypes=null for "%s"', (event, expectedMessage) => {
+    const powerMonitor = makePowerMonitor()
+    const { client } = makeClientForPlugin({
+      plugin: plugin(powerMonitor),
+      config: { enabledBreadcrumbTypes: null }
+    })
+
+    powerMonitor._emit(event)
+
+    expect(client._breadcrumbs).toHaveLength(1)
+  })
 })

--- a/packages/plugin-electron-screen-breadcrumbs/screen-breadcrumbs.js
+++ b/packages/plugin-electron-screen-breadcrumbs/screen-breadcrumbs.js
@@ -15,7 +15,7 @@ module.exports = screen => {
 
   return {
     load (client) {
-      if (!client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
+      if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
         return
       }
 

--- a/packages/plugin-electron-screen-breadcrumbs/test/screen-breadcrumbs.test.ts
+++ b/packages/plugin-electron-screen-breadcrumbs/test/screen-breadcrumbs.test.ts
@@ -74,6 +74,22 @@ describe('plugin: electron screen breadcrumbs', () => {
     expect(client._breadcrumbs).toHaveLength(0)
   })
 
+  it('works when enabledBreadcrumbTypes=null', () => {
+    const screen = makeScreen()
+    const { client } = makeClientForPlugin({
+      plugin: plugin(screen),
+      config: { enabledBreadcrumbTypes: null }
+    })
+
+    const display = makeDisplay({ id: 1234 })
+
+    screen._emit('display-added', display)
+    screen._emit('display-removed', display)
+    screen._emit('display-metrics-changed', display, ['bounds'])
+
+    expect(client._breadcrumbs).toHaveLength(3)
+  })
+
   it('anonymises IDs correctly', () => {
     const screen = makeScreen()
     const { client } = makeClientForPlugin({ plugin: plugin(screen) })

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -66,7 +66,9 @@ const _createClient = (opts, jsOpts) => {
   const bugsnag = new Client(opts, schema, internalPlugins, { name, version, url })
 
   // if we let JS keep error breadcrumbs, it results in an error containing itself as a breadcrumb
-  bugsnag._config.enabledBreadcrumbTypes = bugsnag._config.enabledBreadcrumbTypes.filter(t => t !== 'error')
+  if (bugsnag._config.enabledBreadcrumbTypes !== null) {
+    bugsnag._config.enabledBreadcrumbTypes = bugsnag._config.enabledBreadcrumbTypes.filter(t => t !== 'error')
+  }
 
   bugsnag._setDelivery(client => delivery(client, NativeClient))
 

--- a/test/electron/features/breadcrumbs.feature
+++ b/test/electron/features/breadcrumbs.feature
@@ -13,12 +13,13 @@ Feature: Automatic breadcrumbs
             | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
             | Content-Type      | application/json                 |
             | Bugsnag-Integrity | {BODY_SHA1}                      |
-        Then the contents of an event request matches "main/breadcrumbs/<config>.json"
+        Then the contents of an event request matches "main/breadcrumbs/<expected>.json"
 
         Examples:
-            | config          |
-            | default         |
-            | complex-config  |
+            | config                        | expected       |
+            | default                       | default        |
+            | null-enabled-breadcrumb-types | default        |
+            | complex-config                | complex-config |
 
     Scenario: Breadcrumbs can be cancelled in renderer and not synced to main
         Given I launch an app with configuration:

--- a/test/electron/fixtures/app/configs/null-enabled-breadcrumb-types.js
+++ b/test/electron/fixtures/app/configs/null-enabled-breadcrumb-types.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+  return {
+    enabledBreadcrumbTypes: null
+  }
+}

--- a/test/react-native/features/breadcrumbs.feature
+++ b/test/react-native/features/breadcrumbs.feature
@@ -19,6 +19,19 @@ Scenario: Automatic breadcrumb for errors
   And the exception "message" equals "BreadcrumbsAutomaticErrorScenarioB"
   And the event has a "error" breadcrumb named "Error"
 
+Scenario: Automatic breadcrumbs when enabledBreadcrumbTypes is null
+  When I run "BreadcrumbsNullEnabledBreadcrumbTypesScenario"
+  Then I wait to receive 2 errors
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "BreadcrumbsNullEnabledBreadcrumbTypesScenarioA"
+  And the event has a "state" breadcrumb named "Bugsnag loaded"
+  And the event does not have a "error" breadcrumb
+  And I discard the oldest error
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "BreadcrumbsNullEnabledBreadcrumbTypesScenarioB"
+  And the event has a "state" breadcrumb named "Bugsnag loaded"
+  And the event has a "error" breadcrumb named "Error"
+
 Scenario: Manual breadcrumbs (JS)
   When I run "BreadcrumbsJsManualScenario"
   Then I wait to receive an error

--- a/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
@@ -31,6 +31,7 @@ export { BreadcrumbsAutomaticLoadedScenario } from './scenarios/BreadcrumbsAutom
 export { BreadcrumbsAutomaticErrorScenario } from './scenarios/BreadcrumbsAutomaticErrorScenario'
 export { BreadcrumbsJsManualScenario } from './scenarios/BreadcrumbsJsManualScenario'
 export { BreadcrumbsNativeManualScenario } from './scenarios/BreadcrumbsNativeManualScenario'
+export { BreadcrumbsNullEnabledBreadcrumbTypesScenario } from './scenarios/BreadcrumbsNullEnabledBreadcrumbTypesScenario'
 
 // device.feature
 export { DeviceJsHandledScenario } from './scenarios/DeviceJsHandledScenario'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/BreadcrumbsNullEnabledBreadcrumbTypesScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/BreadcrumbsNullEnabledBreadcrumbTypesScenario.js
@@ -1,0 +1,22 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+
+export class BreadcrumbsNullEnabledBreadcrumbTypesScenario extends Scenario {
+  constructor (configuration, extraData, jsConfig) {
+    super()
+    configuration.enabledBreadcrumbTypes = null
+  }
+
+  run () {
+    Bugsnag.notify(
+      new Error('BreadcrumbsNullEnabledBreadcrumbTypesScenarioA'),
+      () => {},
+      () => {
+        setTimeout(
+          () => Bugsnag.notify(new Error('BreadcrumbsNullEnabledBreadcrumbTypesScenarioB')),
+          2000
+        )
+      }
+    )
+  }
+}

--- a/test/react-native/features/fixtures/ios-module/BugsnagModule.m
+++ b/test/react-native/features/fixtures/ios-module/BugsnagModule.m
@@ -61,7 +61,7 @@ BugsnagConfiguration *createConfiguration(NSDictionary * options) {
   if (options[@"enabledReleaseStages"] != nil) {
     [config setEnabledReleaseStages:[NSSet setWithArray:options[@"enabledReleaseStages"]]];
   }
-  if (options[@"enabledBreadcrumbTypes"] != nil) {
+  if (options[@"enabledBreadcrumbTypes"] && ![options[@"enabledBreadcrumbTypes"] isEqual:[NSNull null]]) {
     [config setEnabledBreadcrumbTypes:[NSSet setWithArray:options[@"enabledBreadcrumbTypes"]]];
   }
   if (options[@"configMetaData"] != nil) {

--- a/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
+++ b/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
@@ -133,10 +133,14 @@ public class BugsnagModule extends ReactContextBaseJavaModule {
       }
 
       if (options.hasKey("enabledBreadcrumbTypes")) {
-        Set<BreadcrumbType> enabledBreadcrumbTypes = new HashSet<BreadcrumbType>();
-        ReadableArray ar = options.getArray("enabledBreadcrumbTypes");
-        for (int i = 0; i < ar.size(); i++) enabledBreadcrumbTypes.add(BreadcrumbType.valueOf(ar.getString(i)));
-        config.setEnabledBreadcrumbTypes(enabledBreadcrumbTypes);
+        if (options.isNull("enabledBreadcrumbTypes")) {
+            config.setEnabledBreadcrumbTypes(null);
+        } else {
+            Set<BreadcrumbType> enabledBreadcrumbTypes = new HashSet<BreadcrumbType>();
+            ReadableArray ar = options.getArray("enabledBreadcrumbTypes");
+            for (int i = 0; i < ar.size(); i++) enabledBreadcrumbTypes.add(BreadcrumbType.valueOf(ar.getString(i)));
+            config.setEnabledBreadcrumbTypes(enabledBreadcrumbTypes);
+        }
       }
 
       if (options.hasKey("redactedKeys")) {


### PR DESCRIPTION
## Goal

Following on from https://github.com/bugsnag/bugsnag-js/pull/1466, this PR fixes crashes in various plugins that assumed `enabledBreadcrumbTypes` must always be an array. They now allow for the case where it may be null and handle it accordingly

## Testing

Existing tests & new unit tests. Manually tested in browser, ~~electron~~ and ~~react native~~ projects