### PR TITLE
Add `_isBreadcrumbTypeEnabled` helper to core

### DIFF
--- a/packages/core/client.d.ts
+++ b/packages/core/client.d.ts
@@ -72,4 +72,6 @@ export default class ClientWithInternals<T extends Config = Config> extends Clie
   }
 
   _loadPlugin(plugin: Plugin): void
+
+  _isBreadcrumbTypeEnabled(type: string): boolean
 }

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -257,6 +257,12 @@ class Client {
     }
   }
 
+  _isBreadcrumbTypeEnabled (type) {
+    const types = this._config.enabledBreadcrumbTypes
+
+    return types === null || includes(types, type)
+  }
+
   notify (maybeError, onError, cb = noop) {
     const event = Event.create(maybeError, true, undefined, 'notify()', this._depth + 1, this._logger)
     this._notify(event, onError, cb)

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -302,9 +302,7 @@ class Client {
         return cb(null, event)
       }
 
-      const types = this._config.enabledBreadcrumbTypes
-
-      if (!types || includes(types, 'error')) {
+      if (this._isBreadcrumbTypeEnabled('error')) {
         // only leave a crumb for the error if actually got sent
         Client.prototype.leaveBreadcrumb.call(this, event.errors[0].errorClass, {
           errorClass: event.errors[0].errorClass,

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -1,6 +1,8 @@
 import Client from '../client'
 import Event from '../event'
 import Session from '../session'
+import breadcrumbTypes from '../lib/breadcrumb-types'
+import { BreadcrumbType } from '../types/common'
 
 describe('@bugsnag/core/client', () => {
   describe('constructor', () => {
@@ -624,6 +626,43 @@ describe('@bugsnag/core/client', () => {
         expect(client._breadcrumbs.length).toBe(0)
         done()
       })
+    })
+  })
+
+  describe('_isBreadcrumbTypeEnabled()', () => {
+    it.each(breadcrumbTypes)('returns true for "%s" when enabledBreadcrumbTypes is not configured', (type) => {
+      const client = new Client({ apiKey: 'API_KEY_YEAH' })
+
+      expect(client._isBreadcrumbTypeEnabled(type)).toBe(true)
+    })
+
+    it.each(breadcrumbTypes)('returns true for "%s" when enabledBreadcrumbTypes=null', (type) => {
+      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledBreadcrumbTypes: null })
+
+      expect(client._isBreadcrumbTypeEnabled(type)).toBe(true)
+    })
+
+    it.each(breadcrumbTypes)('returns false for "%s" when enabledBreadcrumbTypes=[]', (type) => {
+      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledBreadcrumbTypes: [] })
+
+      expect(client._isBreadcrumbTypeEnabled(type)).toBe(false)
+    })
+
+    it.each(breadcrumbTypes)('returns true for "%s" when enabledBreadcrumbTypes only contains it', (type) => {
+      const client = new Client({ apiKey: 'API_KEY_YEAH', enabledBreadcrumbTypes: [type as BreadcrumbType] })
+
+      expect(client._isBreadcrumbTypeEnabled(type)).toBe(true)
+    })
+
+    it.each(breadcrumbTypes)('returns false for "%s" when enabledBreadcrumbTypes does not contain it', (type) => {
+      const enabledBreadcrumbTypes = breadcrumbTypes.filter(enabledType => enabledType !== type)
+
+      const client = new Client({
+        apiKey: 'API_KEY_YEAH',
+        enabledBreadcrumbTypes: enabledBreadcrumbTypes as BreadcrumbType[]
+      })
+
+      expect(client._isBreadcrumbTypeEnabled(type)).toBe(false)
     })
   })
 

--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -68,7 +68,7 @@ module.exports = (opts) => {
   bugsnag.markLaunchComplete = markLaunchComplete
 
   bugsnag._logger.debug('Loaded! In main process.')
-  if (bugsnag._config.enabledBreadcrumbTypes === null || bugsnag._config.enabledBreadcrumbTypes.includes('state')) {
+  if (bugsnag._isBreadcrumbTypeEnabled('state')) {
     bugsnag.leaveBreadcrumb('Bugsnag loaded', {}, 'state')
   }
 

--- a/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
+++ b/packages/plugin-console-breadcrumbs/console-breadcrumbs.js
@@ -1,7 +1,6 @@
 const map = require('@bugsnag/core/lib/es-utils/map')
 const reduce = require('@bugsnag/core/lib/es-utils/reduce')
 const filter = require('@bugsnag/core/lib/es-utils/filter')
-const includes = require('@bugsnag/core/lib/es-utils/includes')
 
 /*
  * Leaves breadcrumbs when console log methods are called
@@ -9,7 +8,7 @@ const includes = require('@bugsnag/core/lib/es-utils/includes')
 exports.load = (client) => {
   const isDev = /^(local-)?dev(elopment)?$/.test(client._config.releaseStage)
 
-  if (isDev || (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'log'))) return
+  if (isDev || !client._isBreadcrumbTypeEnabled('log')) return
 
   map(CONSOLE_LOG_METHODS, method => {
     const original = console[method]

--- a/packages/plugin-electron-app-breadcrumbs/app-breadcrumbs.js
+++ b/packages/plugin-electron-app-breadcrumbs/app-breadcrumbs.js
@@ -5,7 +5,7 @@ const BREADCRUMB_STATE = 'state'
 
 module.exports = (app, BrowserWindow) => ({
   load (client) {
-    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
+    if (!client._isBreadcrumbTypeEnabled(BREADCRUMB_STATE)) {
       return
     }
 

--- a/packages/plugin-electron-ipc/bugsnag-ipc-main.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-main.js
@@ -60,7 +60,7 @@ module.exports = class BugsnagIpcMain {
         return
       }
 
-      if (this.client._config.enabledBreadcrumbTypes && this.client._config.enabledBreadcrumbTypes.includes('error')) {
+      if (this.client._isBreadcrumbTypeEnabled('error')) {
         // only leave a crumb for the error if actually got sent
         this.client.leaveBreadcrumb(event.errors[0].errorClass, {
           errorClass: event.errors[0].errorClass,

--- a/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
+++ b/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
@@ -2,7 +2,7 @@ const BREADCRUMB_REQUEST = 'request'
 
 module.exports = net => ({
   load (client) {
-    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_REQUEST)) {
+    if (!client._isBreadcrumbTypeEnabled(BREADCRUMB_REQUEST)) {
       return
     }
 

--- a/packages/plugin-electron-power-monitor-breadcrumbs/power-monitor-breadcrumbs.js
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/power-monitor-breadcrumbs.js
@@ -2,7 +2,7 @@ const BREADCRUMB_STATE = 'state'
 
 module.exports = (powerMonitor) => ({
   load (client) {
-    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
+    if (!client._isBreadcrumbTypeEnabled(BREADCRUMB_STATE)) {
       return
     }
 

--- a/packages/plugin-electron-screen-breadcrumbs/screen-breadcrumbs.js
+++ b/packages/plugin-electron-screen-breadcrumbs/screen-breadcrumbs.js
@@ -15,7 +15,7 @@ module.exports = screen => {
 
   return {
     load (client) {
-      if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes(BREADCRUMB_STATE)) {
+      if (!client._isBreadcrumbTypeEnabled(BREADCRUMB_STATE)) {
         return
       }
 

--- a/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
+++ b/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
@@ -1,13 +1,10 @@
-const includes = require('@bugsnag/core/lib/es-utils/includes')
-
 /*
  * Leaves breadcrumbs when the user interacts with the DOM
  */
 module.exports = (win = window) => ({
   load: (client) => {
     if (!('addEventListener' in win)) return
-
-    if (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'user')) return
+    if (!client._isBreadcrumbTypeEnabled('user')) return
 
     win.addEventListener('click', (event) => {
       let targetText, targetSelector

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -1,5 +1,3 @@
-const includes = require('@bugsnag/core/lib/es-utils/includes')
-
 /*
 * Leaves breadcrumbs when navigation methods are called or events are emitted
 */
@@ -7,8 +5,7 @@ module.exports = (win = window) => {
   const plugin = {
     load: (client) => {
       if (!('addEventListener' in win)) return
-
-      if (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'navigation')) return
+      if (!client._isBreadcrumbTypeEnabled('navigation')) return
 
       // returns a function that will drop a breadcrumb with a given name
       const drop = name => () => client.leaveBreadcrumb(name, {}, 'navigation')

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -14,7 +14,7 @@ module.exports = (_ignoredUrls = [], win = window) => {
   let restoreFunctions = []
   const plugin = {
     load: client => {
-      if (client._config.enabledBreadcrumbTypes && !includes(client._config.enabledBreadcrumbTypes, 'request')) return
+      if (!client._isBreadcrumbTypeEnabled('request')) return
 
       const ignoredUrls = [
         client._config.endpoints.notify,

--- a/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
+++ b/packages/plugin-react-native-app-state-breadcrumbs/app-state.js
@@ -2,7 +2,7 @@ const { AppState } = require('react-native')
 
 module.exports = {
   load: client => {
-    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('state')) return
+    if (!client._isBreadcrumbTypeEnabled('state')) return
 
     AppState.addEventListener('change', state => {
       client.leaveBreadcrumb('App state changed', { state }, 'state')

--- a/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
+++ b/packages/plugin-react-native-connectivity-breadcrumbs/connectivity.js
@@ -2,7 +2,7 @@ const NetInfo = require('@react-native-community/netinfo')
 
 module.exports = {
   load: client => {
-    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('state')) return
+    if (!client._isBreadcrumbTypeEnabled('state')) return
 
     NetInfo.addEventListener(({ isConnected, isInternetReachable, type }) => {
       client.leaveBreadcrumb(

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -15,13 +15,7 @@ module.exports = class BugsnagPluginReactNativeNavigation {
     this.Navigation.events().registerComponentDidAppearListener(event => {
       client.setContext(event.componentName)
 
-      if (
-        lastComponent !== event.componentName &&
-        (
-          client._config.enabledBreadcrumbTypes === null ||
-          client._config.enabledBreadcrumbTypes.includes('navigation')
-        )
-      ) {
+      if (lastComponent !== event.componentName && client._isBreadcrumbTypeEnabled('navigation')) {
         client.leaveBreadcrumb(
           'React Native Navigation componentDidAppear',
           { to: event.componentName, from: lastComponent },

--- a/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
+++ b/packages/plugin-react-native-navigation/test/react-native-navigation.test.ts
@@ -103,44 +103,6 @@ describe('plugin-react-native-navigation', () => {
     expect(breadcrumbs[1].type).toBe('navigation')
   })
 
-  it('leaves a breadcrumb when enabledBreadcrumbTypes=null', () => {
-    let listener = (event: Event) => {
-      throw new Error(`This function was not supposed to be called! ${event.componentName}`)
-    }
-
-    const Navigation = {
-      events () {
-        return {
-          registerComponentDidAppearListener (callback: (event: Event) => never) {
-            listener = callback
-          }
-        }
-      }
-    }
-
-    const breadcrumbs: Breadcrumb[] = []
-
-    const plugin = new Plugin(Navigation)
-    const client = new Client({ apiKey: 'API_KEY_YEAH', plugins: [plugin], enabledBreadcrumbTypes: null })
-    client.addOnBreadcrumb(breadcrumb => { breadcrumbs.push(breadcrumb) })
-
-    expect(breadcrumbs).toHaveLength(0)
-
-    listener({ componentId: 1, componentName: 'abc xyz', passProps: {} })
-
-    expect(breadcrumbs).toHaveLength(1)
-    expect(breadcrumbs[0].message).toBe('React Native Navigation componentDidAppear')
-    expect(breadcrumbs[0].metadata).toStrictEqual({ to: 'abc xyz', from: undefined })
-    expect(breadcrumbs[0].type).toBe('navigation')
-
-    listener({ componentId: 2, componentName: 'xyz abc', passProps: {} })
-
-    expect(breadcrumbs).toHaveLength(2)
-    expect(breadcrumbs[1].message).toBe('React Native Navigation componentDidAppear')
-    expect(breadcrumbs[1].metadata).toStrictEqual({ to: 'xyz abc', from: 'abc xyz' })
-    expect(breadcrumbs[1].type).toBe('navigation')
-  })
-
   it('does not leave a breadcrumb when the component has not changed', () => {
     let listener = (event: Event) => {
       throw new Error(`This function was not supposed to be called! ${event.componentName}`)

--- a/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
+++ b/packages/plugin-react-native-orientation-breadcrumbs/orientation.js
@@ -2,7 +2,7 @@ const { Dimensions } = require('react-native')
 
 module.exports = {
   load: client => {
-    if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('state')) return
+    if (!client._isBreadcrumbTypeEnabled('state')) return
 
     let lastOrientation
 

--- a/packages/plugin-react-navigation/react-navigation.js
+++ b/packages/plugin-react-navigation/react-navigation.js
@@ -7,7 +7,7 @@ class BugsnagPluginReactNavigation {
 
   load (client) {
     const leaveBreadcrumb = (event, currentRouteName, previousRouteName) => {
-      if (client._config.enabledBreadcrumbTypes && !client._config.enabledBreadcrumbTypes.includes('navigation')) return
+      if (!client._isBreadcrumbTypeEnabled('navigation')) return
 
       client.leaveBreadcrumb(
         `React Navigation ${event}`,


### PR DESCRIPTION
## Goal

Building on #1467, this PR adds a new helper method to the core Client: `_isBreadcrumbTypeEnabled`

This can be used by plugins to avoid having to check for null everywhere, which saves duplication and should make this kind of error much less likely to happen again

The de-duplication also saves a few bytes in the browser bundle

## Testing

Tests added for the new helper and existing tests cover the plugins still work