### PR TITLE
scan all minidumps in crash dir

### DIFF
--- a/packages/electron-filestore/filestore.js
+++ b/packages/electron-filestore/filestore.js
@@ -8,13 +8,12 @@ const { getIdentifier, createIdentifier, identifierKey } = require('./lib/minidu
 class FileStore {
   constructor (apiKey, storageDir, crashDir) {
     const base = join(storageDir, 'bugsnag', apiKey)
-    const isMac = process.platform === 'darwin'
     this._paths = {
       events: join(base, 'events'),
       sessions: join(base, 'sessions'),
       runinfo: join(base, 'runinfo'),
       device: join(base, 'device.json'),
-      minidumps: join(crashDir, isMac ? 'pending' : 'reports')
+      minidumps: crashDir
     }
   }
 
@@ -30,13 +29,10 @@ class FileStore {
   }
 
   async listMinidumps () {
-    const basepath = this._paths.minidumps
-    return readdir(basepath, { withFileTypes: true })
-      .then(async entries => {
-        const minidumps = entries
-          .filter(entry => entry.isFile() && entry.name.match(/\.dmp$/))
-          .map(async entry => {
-            const minidumpPath = join(basepath, entry.name)
+    return this._listMinidumpFiles()
+      .then(minidumpPaths => {
+        const minidumps = minidumpPaths
+          .map(async minidumpPath => {
             const eventPath = await getIdentifier(minidumpPath)
               .then(async id => {
                 const path = this.getEventInfoPath(id)
@@ -52,6 +48,24 @@ class FileStore {
         console.log(e)
         return []
       })
+  }
+
+  async _listMinidumpFiles () {
+    const dirs = [this._paths.minidumps]
+    const minidumpFiles = []
+    while (dirs.length) {
+      const dir = dirs.pop()
+      const entries = await readdir(dir, { withFileTypes: true })
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.match(/\.dmp$/)) {
+          minidumpFiles.push(join(dir, entry.name))
+        } else if (entry.isDirectory()) {
+          dirs.push(join(dir, entry.name))
+        }
+      }
+    }
+
+    return minidumpFiles
   }
 
   getEventInfoPath (appRunID) {

--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -29,7 +29,7 @@ describe('FileStore', () => {
       expect(paths.sessions).toEqual(join(base, 'sessions'))
       expect(paths.device).toEqual(join(base, 'device.json'))
       expect(paths.runinfo).toEqual(join(base, 'runinfo'))
-      expect(dirname(paths.minidumps)).toEqual(crashes)
+      expect(paths.minidumps).toEqual(crashes)
     })
   })
 
@@ -147,6 +147,21 @@ describe('FileStore', () => {
       expect(dumps[0].eventPath).toBeNull()
       expect(dumps[1].minidumpPath).toEqual(join(base, 'report02.dmp'))
       expect(dumps[1].eventPath).toEqual(join(store.getPaths().runinfo, id))
+    })
+
+    it('scans subdirectories', async () => {
+      const base = store.getPaths().minidumps
+
+      await writeFile(join(base, 'some-other-thing.ps'), 'not a crash')
+      await createMinidump('report01.dmp', '')
+      await createMinidump(join('reports', 'report02.dmp'), id)
+      await createMinidump(join('pending', 'report03.dmp'), id)
+
+      const dumps = await store.listMinidumps() as any[]
+      const dumpPaths = dumps.map(d => d.minidumpPath)
+      expect(dumpPaths).toContain(join(base, 'report01.dmp'))
+      expect(dumpPaths).toContain(join(base, 'reports', 'report02.dmp'))
+      expect(dumpPaths).toContain(join(base, 'pending', 'report03.dmp'))
     })
   })
 

--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -159,9 +159,11 @@ describe('FileStore', () => {
 
       const dumps = await store.listMinidumps() as any[]
       const dumpPaths = dumps.map(d => d.minidumpPath)
-      expect(dumpPaths).toContain(join(base, 'report01.dmp'))
-      expect(dumpPaths).toContain(join(base, 'reports', 'report02.dmp'))
-      expect(dumpPaths).toContain(join(base, 'pending', 'report03.dmp'))
+      expect(dumpPaths.sort()).toEqual([
+        join(base, 'report01.dmp'),
+        join(base, 'reports', 'report02.dmp'),
+        join(base, 'pending', 'report03.dmp')
+      ].sort())
     })
   })
 


### PR DESCRIPTION
## Goal
Electron uses different directory layouts for minidumps depending on both platform and how the crash reporter has been configured. To keep things simple: scan all minidump files under the `crashDumps` directory. 

## Testing
Mostly relied on the existing testing (unit tests and integration tests). The filestore unit test now checks that the minidump path is the `crashDumps` directory rather than a subdirectory of it.