### PR TITLE
use new minidump endpoint

### DIFF
--- a/packages/electron/src/config/common.js
+++ b/packages/electron/src/config/common.js
@@ -25,7 +25,7 @@ module.exports.schema = {
     defaultValue: () => ({
       notify: 'https://notify.bugsnag.com',
       sessions: 'https://sessions.bugsnag.com',
-      minidumps: 'https://notify.bugsnag.com/minidumps'
+      minidumps: 'https://notify.bugsnag.com'
     }),
     message: 'should be an object containing endpoint URLs { notify, sessions, minidumps }',
     validate: val =>

--- a/packages/plugin-electron-deliver-minidumps/send-minidump.js
+++ b/packages/plugin-electron-deliver-minidumps/send-minidump.js
@@ -32,6 +32,7 @@ module.exports = (net, client) => {
 
   const sendMinidump = async (minidumpPath, event) => {
     const url = new URL(client._config.endpoints.minidumps)
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/minidump`
     url.searchParams.set('api_key', client._config.apiKey)
 
     const minidumpStream = createReadStream(minidumpPath).pipe(createGzip())

--- a/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
@@ -9,7 +9,7 @@ const client = {
     apiKey: 'test-api-key',
     redactedKeys: [],
     endpoints: {
-      minidumps: 'http://localhost/test-minidump-endpoint'
+      minidumps: 'http://localhost/test-minidump-endpoint/'
     }
   }
 }
@@ -39,7 +39,9 @@ describe('electron-minidump-delivery: sendMinidump', () => {
     expect(net.request).toBeCalledTimes(1)
 
     const { url, method, headers } = net.request.mock.calls[0][0]
-    expect(url).toMatch(/\?api_key=test-api-key/)
+    const parsedUrl = new URL(url)
+    expect(parsedUrl.pathname).toBe('/test-minidump-endpoint/minidump')
+    expect(parsedUrl.searchParams.get('api_key')).toBe('test-api-key')
     expect(method).toBe('POST')
     expect(headers['content-type']).toMatch(/^multipart\/form-data/)
     expect(headers['Bugsnag-Sent-At']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)

--- a/test/electron/features/support/server.js
+++ b/test/electron/features/support/server.js
@@ -11,7 +11,7 @@ class MockServer {
     this.minidumpUploads = []
 
     const router = new Router()
-    router.register('/minidumps', 'POST', this.uploadMinidump.bind(this))
+    router.register('/minidump', 'POST', this.uploadMinidump.bind(this))
     router.register('/events', 'POST', this.sendEvent.bind(this))
     router.register('/sessions', 'POST', this.sendSession.bind(this))
 
@@ -110,7 +110,7 @@ class MockServer {
     for (let i = 0; i < this.minidumpUploads.length; i++) {
       const upload = this.minidumpUploads[i]
       const handle = await open(join(directory, `minidump-${i}.log`), 'w+')
-      await this.writeHeaders(handle, upload, '/minidumps')
+      await this.writeHeaders(handle, upload, '/minidump')
       for (const field in upload.fields) {
         await handle.write(`${upload.boundary}\nContent-Disposition: form-data; name="${field}"\n\n${upload.fields[field]}`)
       }

--- a/test/electron/features/support/world.js
+++ b/test/electron/features/support/world.js
@@ -18,7 +18,7 @@ BeforeAll({ timeout: 420 * 1000 }, async () => {
 
   const address = `http://localhost:${global.server.port}`
   const endpoints = {
-    minidumps: `${address}/minidumps`,
+    minidumps: `${address}/minidump`,
     notify: `${address}/events`,
     sessions: `${address}/sessions`
   }


### PR DESCRIPTION
## Goal
The notifier address for minidumps is located at `/minidump` (and not `/minidumps`). This should always be appended to the configured endpoint.

## Testing
Relied on existing tests - having changed their endpoints from `"/minidumps"` to `"/minidump"`.