### PR TITLE
Add native crash to Electron examples

### DIFF
--- a/examples/electron/electron-basic/src/index.html
+++ b/examples/electron/electron-basic/src/index.html
@@ -18,10 +18,12 @@
       <button type="button" id="rendererHandled">Send handled error</button>
       <button type="button" id="rendererUnhandled">Send unhandled error</button>
       <button type="button" id="rendererRejection">Send unhandled promise rejection</button>
+      <button type="button" id="rendererProcessCrash">Native Crash (process.crash)</button>
       <h4>Main process</h4>
       <button type="button" id="mainHandled">Send handled error</button>
       <button type="button" id="mainUnhandled">Send unhandled error</button>
       <button type="button" id="mainRejection">Send unhandled promise rejection</button>
+      <button type="button" id="mainProcessCrash">Native Crash (process.crash)</button>
     </div>
 
     <script src="renderer/app.js"></script>

--- a/examples/electron/electron-basic/src/index.js
+++ b/examples/electron/electron-basic/src/index.js
@@ -63,3 +63,7 @@ ipcMain.on('bugsnag-unhandled-error', () => {
 ipcMain.on('bugsnag-promise-rejection', () => {
   Promise.reject(new Error('unhandled promise rejection in main'))
 })
+
+ipcMain.on('bugsnag-process-crash', () => {
+  process.crash()
+})

--- a/examples/electron/electron-basic/src/renderer/app.js
+++ b/examples/electron/electron-basic/src/renderer/app.js
@@ -13,6 +13,10 @@ document.getElementById('rendererRejection').onclick = () => {
   Promise.reject(new Error('unhandled promise rejection in renderer'))
 }
 
+document.getElementById('rendererProcessCrash').onclick = () => {
+  process.crash()
+}
+
 const { ipcRenderer } = require('electron')
 
 document.getElementById('mainHandled').onclick = () => {
@@ -25,4 +29,8 @@ document.getElementById('mainUnhandled').onclick = () => {
 
 document.getElementById('mainRejection').onclick = () => {
   ipcRenderer.send('bugsnag-promise-rejection')
+}
+
+document.getElementById('mainProcessCrash').onclick = () => {
+  ipcRenderer.send('bugsnag-process-crash')
 }

--- a/examples/electron/electron-bundled/src/index.html
+++ b/examples/electron/electron-bundled/src/index.html
@@ -17,10 +17,12 @@
       <button type="button" id="rendererHandled">Send handled error</button>
       <button type="button" id="rendererUnhandled">Send unhandled error</button>
       <button type="button" id="rendererRejection">Send unhandled promise rejection</button>
+      <button type="button" id="rendererProcessCrash">Native Crash (process.crash)</button>
       <h4>Main process</h4>
       <button type="button" id="mainHandled">Send handled error</button>
       <button type="button" id="mainUnhandled">Send unhandled error</button>
       <button type="button" id="mainRejection">Send unhandled promise rejection</button>
+      <button type="button" id="mainProcessCrash">Native Crash (process.crash)</button>
     </div>
   </body>
 </html>

--- a/examples/electron/electron-bundled/src/main.js
+++ b/examples/electron/electron-bundled/src/main.js
@@ -62,3 +62,7 @@ ipcMain.on('bugsnag-unhandled-error', () => {
 ipcMain.on('bugsnag-promise-rejection', () => {
   Promise.reject(new Error('unhandled promise rejection in main'))
 })
+
+ipcMain.on('bugsnag-process-crash', () => {
+  process.crash()
+})

--- a/examples/electron/electron-bundled/src/preload.js
+++ b/examples/electron/electron-bundled/src/preload.js
@@ -9,5 +9,8 @@ contextBridge.exposeInMainWorld('__bugsnag_example_ipc__', {
   },
   sendMainRejection: () => {
     ipcRenderer.send('bugsnag-promise-rejection')
+  },
+  sendMainProcessCrash: () => {
+    ipcRenderer.send('bugsnag-process-crash')
   }
 })

--- a/examples/electron/electron-bundled/src/renderer.js
+++ b/examples/electron/electron-bundled/src/renderer.js
@@ -45,6 +45,10 @@ document.getElementById('rendererRejection').onclick = () => {
   Promise.reject(new Error('unhandled promise rejection in renderer'))
 }
 
+document.getElementById('rendererProcessCrash').onclick = () => {
+  process.crash()
+}
+
 document.getElementById('mainHandled').onclick = () => {
   __bugsnag_example_ipc__.sendMainHandled()
 }
@@ -55,4 +59,8 @@ document.getElementById('mainUnhandled').onclick = () => {
 
 document.getElementById('mainRejection').onclick = () => {
   __bugsnag_example_ipc__.sendMainRejection()
+}
+
+document.getElementById('mainProcessCrash').onclick = () => {
+  __bugsnag_example_ipc__.sendMainProcessCrash()
 }


### PR DESCRIPTION
## Goal
Add a Native Crash option to the Electron example applications. This covers crashing both the main and renderer process using the standard `process.crash()` method.

## Testing
Manual testing of the Electron example apps