### PR TITLE
Fix internal type definition for session delegates

### DIFF
--- a/packages/core/client.d.ts
+++ b/packages/core/client.d.ts
@@ -57,9 +57,9 @@ export default class ClientWithInternals<T extends Config = Config> extends Clie
   _pausedSession: Session | null
 
   _sessionDelegate: {
-    startSession: (client: ClientWithInternals, session: Session) => any
-    pauseSession: () => void
-    resumeSession: () => void
+    startSession: (client: ClientWithInternals, session: Session) => ClientWithInternals
+    pauseSession: (client: ClientWithInternals) => void
+    resumeSession: (client: ClientWithInternals) => ClientWithInternals
   }
 
   _addOnSessionPayload: (cb: (sessionPayload: Session) => void) => void

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -4,6 +4,9 @@ import Session from '../session'
 import breadcrumbTypes from '../lib/breadcrumb-types'
 import { BreadcrumbType } from '../types/common'
 
+const noop = () => {}
+const id = <T>(a: T) => a
+
 describe('@bugsnag/core/client', () => {
   describe('constructor', () => {
     it('can handle bad input', () => {
@@ -669,17 +672,15 @@ describe('@bugsnag/core/client', () => {
   describe('startSession()', () => {
     it('calls the provided session delegate and return delegate’s return value', () => {
       const client = new Client({ apiKey: 'API_KEY' })
-      let ret
       client._sessionDelegate = {
         startSession: c => {
           expect(c).toBe(client)
-          ret = {}
-          return ret
+          return c
         },
-        pauseSession: () => {},
-        resumeSession: () => {}
+        pauseSession: noop,
+        resumeSession: id
       }
-      expect(client.startSession()).toBe(ret)
+      expect(client.startSession()).toBe(client)
     })
 
     it('tracks error counts using the session delegate and sends them in error payloads', (done) => {
@@ -690,8 +691,8 @@ describe('@bugsnag/core/client', () => {
           client._session = new Session()
           return client
         },
-        pauseSession: () => {},
-        resumeSession: () => {}
+        pauseSession: noop,
+        resumeSession: id
       }
       client._setDelivery(client => ({
         sendSession: () => {},
@@ -720,9 +721,9 @@ describe('@bugsnag/core/client', () => {
     it('does not start the session if onSession returns false', () => {
       const client = new Client({ apiKey: 'API_KEY', onSession: () => false })
       const sessionDelegate = {
-        startSession: () => {},
-        pauseSession: () => {},
-        resumeSession: () => {}
+        startSession: id,
+        pauseSession: noop,
+        resumeSession: id
       }
       client._sessionDelegate = sessionDelegate
 
@@ -740,9 +741,9 @@ describe('@bugsnag/core/client', () => {
         }
       })
       const sessionDelegate = {
-        startSession: () => {},
-        pauseSession: () => {},
-        resumeSession: () => {}
+        startSession: id,
+        pauseSession: noop,
+        resumeSession: id
       }
       client._sessionDelegate = sessionDelegate
 
@@ -759,9 +760,9 @@ describe('@bugsnag/core/client', () => {
       c._setDelivery(client => ({ sendEvent: (p, cb) => cb(null), sendSession: (s: any, cb: any) => cb(null) }))
       c._logger = console
       const sessionDelegate = {
-        startSession: () => {},
-        pauseSession: () => {},
-        resumeSession: () => {}
+        startSession: id,
+        pauseSession: noop,
+        resumeSession: id
       }
       c._sessionDelegate = sessionDelegate
       const eSpy = jest.fn()
@@ -839,9 +840,9 @@ describe('@bugsnag/core/client', () => {
     it('forwards on calls to the session delegate', () => {
       const client = new Client({ apiKey: 'API_KEY' })
       const sessionDelegate = {
-        startSession: () => {},
-        pauseSession: () => {},
-        resumeSession: () => {}
+        startSession: id,
+        pauseSession: noop,
+        resumeSession: id
       }
       client._sessionDelegate = sessionDelegate
 

--- a/packages/in-flight/test/in-flight.test.ts
+++ b/packages/in-flight/test/in-flight.test.ts
@@ -7,6 +7,8 @@ import BugsnagInFlightJustForTypescript from '../types/bugsnag-in-flight'
 
 let bugsnagInFlight: BugsnagInFlightJustForTypescript
 jest.isolateModules(() => { bugsnagInFlight = require('../src/in-flight') })
+const noop = () => {}
+const id = <T>(a: T) => a
 
 describe('@bugsnag/in-flight', () => {
   it('tracks in-flight events', () => {
@@ -50,6 +52,8 @@ describe('@bugsnag/in-flight', () => {
     client._sessionDelegate = {
       startSession: jest.fn(function (client, session) {
         client._delivery.sendSession(session, callback)
+
+        return client
       }),
       pauseSession: jest.fn(),
       resumeSession: jest.fn()
@@ -89,6 +93,8 @@ describe('@bugsnag/in-flight', () => {
     client._sessionDelegate = {
       startSession: jest.fn(function (client, session) {
         client._delivery.sendSession(session, sessionCallback)
+
+        return client
       }),
       pauseSession: jest.fn(),
       resumeSession: jest.fn()
@@ -135,9 +141,11 @@ describe('@bugsnag/in-flight', () => {
     client._sessionDelegate = {
       startSession (client, session) {
         client._delivery.sendSession(session, () => {})
+
+        return client
       },
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
 
     client._setDelivery(() => ({
@@ -177,9 +185,11 @@ describe('@bugsnag/in-flight', () => {
     client._sessionDelegate = {
       startSession: (client, session) => {
         client._delivery.sendSession(session, () => {})
+
+        return client
       },
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
 
     client._setDelivery(() => ({
@@ -225,9 +235,11 @@ describe('@bugsnag/in-flight', () => {
     client._sessionDelegate = {
       startSession (client, session) {
         client._delivery.sendSession(session, () => {})
+
+        return client
       },
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
 
     client._setDelivery(() => ({

--- a/packages/plugin-browser-device/test/device.test.ts
+++ b/packages/plugin-browser-device/test/device.test.ts
@@ -12,6 +12,8 @@ declare class SessionWithDevice extends Session { public device: Device }
 
 const navigator = { language: 'en-GB', userAgent: 'testing browser 1.2.3' } as unknown as Navigator
 const screen = { orientation: { type: 'landscape-primary' } } as unknown as Screen
+const noop = () => {}
+const id = <T>(a: T) => a
 
 describe('plugin: device', () => {
   it('should add an onError callback which captures device information', () => {
@@ -56,9 +58,11 @@ describe('plugin: device', () => {
     client._sessionDelegate = {
       startSession: (client, session) => {
         client._delivery.sendSession(session, () => {})
+
+        return client
       },
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
 
     expect(client._cbs.s).toHaveLength(1)
@@ -80,9 +84,11 @@ describe('plugin: device', () => {
     client._sessionDelegate = {
       startSession: (client, session) => {
         client._delivery.sendSession(session, () => {})
+
+        return client
       },
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
 
     expect(client._cbs.s).toHaveLength(1)
@@ -119,9 +125,11 @@ describe('plugin: device', () => {
             { sessions: [session] },
             (err) => { if (err) throw err }
           )
+
+          return client
         },
-        pauseSession: () => {},
-        resumeSession: () => {}
+        pauseSession: noop,
+        resumeSession: id
       }
 
       client._setDelivery((client) => ({

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
@@ -2,14 +2,17 @@ import plugin from '../navigation-breadcrumbs'
 
 import Client from '@bugsnag/core/client'
 
+const noop = () => {}
+const id = <T>(a: T) => a
+
 describe('plugin: navigation breadcrumbs', () => {
   it('should drop breadcrumb for navigational activity', done => {
     const { winHandlers, docHandlers, window } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin(window)] })
     c._sessionDelegate = {
-      startSession: () => {},
-      pauseSession: () => {},
-      resumeSession: () => {}
+      startSession: id,
+      pauseSession: noop,
+      resumeSession: id
     }
 
     winHandlers.load.forEach((h) => h.call(window))
@@ -37,9 +40,9 @@ describe('plugin: navigation breadcrumbs', () => {
     const { winHandlers, docHandlers, window } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [], plugins: [plugin(window)] })
     c._sessionDelegate = {
-      startSession: () => {},
-      pauseSession: () => {},
-      resumeSession: () => {}
+      startSession: id,
+      pauseSession: noop,
+      resumeSession: id
     }
     winHandlers.load.forEach((h) => h.call(window))
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
@@ -53,8 +56,8 @@ describe('plugin: navigation breadcrumbs', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin(window)] })
     c._sessionDelegate = {
       startSession: jest.fn(),
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
     winHandlers.load.forEach((h) => h.call(window))
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
@@ -70,8 +73,8 @@ describe('plugin: navigation breadcrumbs', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoTrackSessions: false, plugins: [plugin(window)] })
     c._sessionDelegate = {
       startSession: jest.fn(),
-      pauseSession: () => {},
-      resumeSession: () => {}
+      pauseSession: noop,
+      resumeSession: id
     }
     winHandlers.load.forEach((h) => h.call(window))
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
@@ -83,9 +86,9 @@ describe('plugin: navigation breadcrumbs', () => {
     const { winHandlers, docHandlers, window } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['navigation'], plugins: [plugin(window)] })
     c._sessionDelegate = {
-      startSession: () => {},
-      pauseSession: () => {},
-      resumeSession: () => {}
+      startSession: id,
+      pauseSession: noop,
+      resumeSession: id
     }
     winHandlers.load.forEach((h) => h.call(window))
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
@@ -98,9 +101,9 @@ describe('plugin: navigation breadcrumbs', () => {
     const { winHandlers, docHandlers, window } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
     c._sessionDelegate = {
-      startSession: () => {},
-      pauseSession: () => {},
-      resumeSession: () => {}
+      startSession: id,
+      pauseSession: noop,
+      resumeSession: id
     }
     winHandlers.load.forEach((h) => h.call(window))
     docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))


### PR DESCRIPTION
## Goal

The internal type definition for session delegates was wrong in a few ways:

- `startSession` returned `any` when it should always return a client
- `pauseSession` took no parameters when it actually takes a client
- `resumeSession` took no parameters and returned void when it actually takes and returns a client

This can be verified by checking the session implementations:

- [`plugin-browser-session`](https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-browser-session/session.js) ([`plugin-electron-session`](https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-electron-session/session.js) uses this implementation internally)
- [`plugin-react-native-session`](https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-react-native-session/session.js)
- [`plugin-server-session`](https://github.com/bugsnag/bugsnag-js/blob/next/packages/plugin-server-session/session.js)

There are no BC concerns here as we don't ship this type definition file in the NPM package, it's purely used internally:

https://github.com/bugsnag/bugsnag-js/blob/ce9d8dcc2fb6ffd32bbfdeb76b97df8e6ae85cbe/packages/core/package.json#L15-L19