### PR TITLE
Fix the Koa plugin suppressing other error handlers

### DIFF
--- a/.buildkite/node-pipeline.yml
+++ b/.buildkite/node-pipeline.yml
@@ -25,7 +25,7 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "koa_disabled.feature", "-e", "webpack.feature"]
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "koa_disabled.feature", "-e", "koa-1x_disabled.feature", "-e", "webpack.feature"]
     env:
       NODE_VERSION: "4"
 
@@ -37,7 +37,7 @@ steps:
         run: node-maze-runner
         use-aliases: true
         verbose: true
-        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "koa_disabled.feature"]
+        command: ["-e", "koa.feature", "-e", "koa-1x.feature", "-e", "koa_disabled.feature", "-e", "koa-1x_disabled.feature"]
     env:
       NODE_VERSION: "6"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 - Breadcrumbs will now be left when `enabledBreadcrumbTypes` is `null` [#1466](https://github.com/bugsnag/bugsnag-js/pull/1466)
 - Avoid crash when `enabledBreadcrumbTypes` is `null` [#1467](https://github.com/bugsnag/bugsnag-js/pull/1467)
+- (plugin-koa): Fix the Koa plugin suppressing other error handlers [#1482](https://github.com/bugsnag/bugsnag-js/pull/1482)
 
 ## 7.10.5 (2021-07-05)
 

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -75,6 +75,16 @@ module.exports = {
 
         client._notify(event)
       }
+
+      const app = ctx.app
+
+      // call Koa's built in onerror if we're the only registered error handler
+      // Koa will not add its own error handler if one has already been added,
+      // but we want to ensure the default handler still runs after adding Bugsnag
+      // unless another handler has also been added
+      if (app && typeof app.listenerCount === 'function' && app.listenerCount('error') === 1) {
+        app.onerror(err)
+      }
     }
 
     return { requestHandler, errorHandler }

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -62,14 +62,17 @@ module.exports = {
 
       const event = client.Event.create(err, false, handledState, 'koa middleware', 1)
 
-      const { metadata, request } = getRequestAndMetadataFromCtx(ctx)
-      event.request = { ...event.request, ...request }
-      event.addMetadata('request', metadata)
-
       if (ctx.bugsnag) {
         ctx.bugsnag._notify(event)
       } else {
         client._logger.warn('ctx.bugsnag is not defined. Make sure the @bugsnag/plugin-koa requestHandler middleware is added first.')
+
+        // the request metadata should be added by the requestHandler, but as there's
+        // no "ctx.bugsnag" we have to assume the requestHandler has not run
+        const { metadata, request } = getRequestAndMetadataFromCtx(ctx)
+        event.request = { ...event.request, ...request }
+        event.addMetadata('request', metadata)
+
         client._notify(event)
       }
     }

--- a/packages/plugin-koa/src/koa.js
+++ b/packages/plugin-koa/src/koa.js
@@ -27,24 +27,7 @@ module.exports = {
         event.addMetadata('request', metadata)
       }, true)
 
-      if (!client._config.autoDetectErrors) return next()
-
-      try {
-        await next()
-      } catch (err) {
-        if (err.status === undefined || err.status >= 500) {
-          const event = client.Event.create(err, false, handledState, 'koa middleware', 1)
-          ctx.bugsnag._notify(event)
-        }
-        if (!ctx.response.headerSent) ctx.response.status = err.status || 500
-        try {
-          // this function will throw if you give it a non-error, but we still want
-          // to output that, so if it throws, pass it back what it threw (a TypeError)
-          ctx.app.onerror(err)
-        } catch (e) {
-          ctx.app.onerror(e)
-        }
-      }
+      await next()
     }
 
     requestHandler.v1 = function * (next) {

--- a/packages/plugin-koa/test/koa.test.ts
+++ b/packages/plugin-koa/test/koa.test.ts
@@ -1,5 +1,16 @@
 import Client from '@bugsnag/core/client'
 import plugin from '../src/koa'
+import { EventPayload } from '@bugsnag/core'
+import Event from '@bugsnag/core/event'
+
+const noop = () => {}
+const id = <T>(a: T) => a
+const logger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+})
 
 describe('plugin: koa', () => {
   it('exports two middleware functions', () => {
@@ -9,8 +20,13 @@ describe('plugin: koa', () => {
       pauseSession: () => {},
       resumeSession: () => c
     }
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const middleware = c.getPlugin('koa')!
+
+    const middleware = c.getPlugin('koa')
+
+    if (!middleware) {
+      throw new Error('getPlugin("koa") failed')
+    }
+
     expect(typeof middleware.requestHandler).toBe('function')
     expect(middleware.requestHandler.length).toBe(2)
     expect(typeof middleware.errorHandler).toBe('function')
@@ -18,29 +34,213 @@ describe('plugin: koa', () => {
   })
 
   describe('requestHandler', () => {
-    it('should call through to app.onerror to ensure the error is logged out', (done) => {
-      const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
-      c._sessionDelegate = {
-        startSession: () => c,
-        pauseSession: () => {},
-        resumeSession: () => c
+    it('should start a session and attach a client to the context', async () => {
+      const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+      const startSession = jest.fn().mockReturnValue(client)
+      const pauseSession = jest.fn()
+      const resumeSession = jest.fn().mockReturnValue(client)
+
+      client._sessionDelegate = { startSession, pauseSession, resumeSession }
+      client._logger = logger()
+
+      const middleware = client.getPlugin('koa')
+
+      if (!middleware) {
+        throw new Error('getPlugin("koa") failed')
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const middleware = c.getPlugin('koa')!
-      const mockCtx = {
-        req: { connection: { address: () => ({ port: 1234 }) }, headers: {} },
-        request: { query: {} },
-        res: {},
-        response: { headerSent: false },
-        app: {
-          onerror: (err: Error) => {
-            expect(err).toStrictEqual(new Error('oops'))
-            done()
+      const context = {} as any
+      const next = jest.fn()
+
+      await middleware.requestHandler(context, next)
+
+      expect(client._logger.warn).not.toHaveBeenCalled()
+      expect(client._logger.error).not.toHaveBeenCalled()
+      expect(startSession).not.toHaveBeenCalled()
+      expect(pauseSession).not.toHaveBeenCalled()
+      expect(resumeSession).toHaveBeenCalledTimes(1)
+      expect(context.bugsnag).toBe(client)
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+
+    it('should record metadata from the request', async () => {
+      const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+      client._sessionDelegate = { startSession: id, pauseSession: noop, resumeSession: id }
+      client._logger = logger()
+      client._setDelivery(() => ({
+        sendEvent (payload: EventPayload, cb: (err: Error|null, obj: unknown) => void) {
+          expect(payload.events).toHaveLength(1)
+          cb(null, payload.events[0])
+        },
+        sendSession: noop
+      }))
+
+      const middleware = client.getPlugin('koa')
+
+      if (!middleware) {
+        throw new Error('getPlugin("koa") failed')
+      }
+
+      const context = {
+        req: {
+          headers: { referer: '/abc' },
+          httpVersion: '1.0',
+          method: 'GET',
+          url: '/xyz',
+          connection: {
+            remoteAddress: '123.456.789.0',
+            remotePort: 9876,
+            bytesRead: 192837645,
+            bytesWritten: 918273465,
+            address: () => ({ port: 1234, family: 'IPv4', address: '127.0.0.1' })
           }
-        }
+        },
+        res: {},
+        request: {
+          href: 'http://localhost:8080/xyz?a=1&b=2',
+          query: { a: 1, b: 2 },
+          body: 'the request body'
+        },
+        ip: '1.2.3.4'
       } as any
-      middleware.requestHandler(mockCtx, async () => { throw new Error('oops') })
+
+      const next = jest.fn()
+
+      await middleware.requestHandler(context, next)
+
+      expect(next).toHaveBeenCalledTimes(1)
+
+      const event: Event = await new Promise(resolve => {
+        client.notify(new Error('abc'), noop, (_, event) => resolve(event as Event))
+      })
+
+      expect(client._logger.warn).not.toHaveBeenCalled()
+      expect(client._logger.error).not.toHaveBeenCalled()
+
+      expect(event.request).toEqual({
+        body: 'the request body',
+        clientIp: '1.2.3.4',
+        headers: { referer: '/abc' },
+        httpMethod: 'GET',
+        httpVersion: '1.0',
+        url: 'http://localhost:8080/xyz?a=1&b=2',
+        referer: '/abc'
+      })
+
+      expect(event._metadata.request).toEqual({
+        clientIp: '1.2.3.4',
+        connection: {
+          remoteAddress: '123.456.789.0',
+          remotePort: 9876,
+          bytesRead: 192837645,
+          bytesWritten: 918273465,
+          localPort: 1234,
+          localAddress: '127.0.0.1',
+          IPVersion: 'IPv4'
+        },
+        headers: { referer: '/abc' },
+        httpMethod: 'GET',
+        httpVersion: '1.0',
+        path: '/xyz',
+        query: { a: 1, b: 2 },
+        url: 'http://localhost:8080/xyz?a=1&b=2',
+        referer: '/abc'
+      })
+    })
+
+    it('should not throw when no request data is available', async () => {
+      const client = new Client({ apiKey: 'api_key', plugins: [plugin] })
+      client._sessionDelegate = { startSession: id, pauseSession: noop, resumeSession: id }
+      client._logger = logger()
+      client._setDelivery(() => ({
+        sendEvent (payload: EventPayload, cb: (err: Error|null, obj: unknown) => void) {
+          expect(payload.events).toHaveLength(1)
+          cb(null, payload.events[0])
+        },
+        sendSession: noop
+      }))
+
+      const middleware = client.getPlugin('koa')
+
+      if (!middleware) {
+        throw new Error('getPlugin("koa") failed')
+      }
+
+      const context = {
+        req: { headers: {} },
+        res: {},
+        request: {}
+      } as any
+
+      const next = jest.fn()
+
+      await middleware.requestHandler(context, next)
+
+      expect(next).toHaveBeenCalledTimes(1)
+
+      const event: Event = await new Promise(resolve => {
+        client.notify(new Error('abc'), noop, (_, event) => resolve(event as Event))
+      })
+
+      expect(client._logger.warn).not.toHaveBeenCalled()
+      expect(client._logger.error).not.toHaveBeenCalled()
+
+      expect(event.request).toEqual({
+        body: undefined,
+        clientIp: undefined,
+        headers: {},
+        httpMethod: undefined,
+        httpVersion: undefined,
+        url: 'undefined',
+        referer: undefined
+      })
+
+      expect(event._metadata.request).toEqual({
+        clientIp: undefined,
+        connection: undefined,
+        headers: {},
+        httpMethod: undefined,
+        httpVersion: undefined,
+        path: undefined,
+        query: undefined,
+        url: 'undefined',
+        referer: undefined
+      })
+    })
+
+    it('should not track a session when "autoTrackSessions" is disabled', async () => {
+      const client = new Client({ apiKey: 'api_key', plugins: [plugin], autoTrackSessions: false })
+
+      const startSession = jest.fn().mockReturnValue(client)
+      const pauseSession = jest.fn()
+      const resumeSession = jest.fn().mockReturnValue(client)
+
+      client._sessionDelegate = { startSession, pauseSession, resumeSession }
+      client._logger = logger()
+
+      const middleware = client.getPlugin('koa')
+
+      if (!middleware) {
+        throw new Error('getPlugin("koa") failed')
+      }
+
+      const context = {} as any
+      const next = jest.fn()
+
+      await middleware.requestHandler(context, next)
+
+      expect(client._logger.warn).not.toHaveBeenCalled()
+      expect(client._logger.error).not.toHaveBeenCalled()
+      expect(startSession).not.toHaveBeenCalled()
+      expect(pauseSession).not.toHaveBeenCalled()
+      expect(resumeSession).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledTimes(1)
+
+      // the Client should be cloned to ensure any manually started sessions
+      // do not leak between requests
+      expect(context.bugsnag).not.toBe(client)
+      expect(context.bugsnag).toBeInstanceOf(Client)
     })
   })
 })

--- a/test/node/features/fixtures/docker-compose.yml
+++ b/test/node/features/fixtures/docker-compose.yml
@@ -184,6 +184,22 @@ services:
           - koa-1x
     restart: "no"
 
+  koa-1x-disabled:
+    build:
+      context: koa-1x
+      args:
+        - NODE_VERSION
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_SESSIONS_ENDPOINT
+    networks:
+      default:
+        aliases:
+          - koa-1x-disabled
+    restart: "no"
+    entrypoint: "node scenarios/app-disabled"
+
   proxy:
     build:
       context: proxy

--- a/test/node/features/fixtures/koa-1x/scenarios/app-disabled.js
+++ b/test/node/features/fixtures/koa-1x/scenarios/app-disabled.js
@@ -1,0 +1,63 @@
+const Bugsnag = require('@bugsnag/node')
+const bugsnagKoa = require('@bugsnag/plugin-koa')
+const Koa = require('koa')
+
+Bugsnag.start({
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_NOTIFY_ENDPOINT,
+    sessions: process.env.BUGSNAG_SESSIONS_ENDPOINT
+  },
+  autoDetectErrors: false,
+  plugins: [bugsnagKoa]
+})
+
+
+const middleware = Bugsnag.getPlugin('koa')
+
+const app = new Koa()
+
+// If the server hasn't started sending something within 2 seconds
+// it probably won't. So end the request and hurry the failing test
+// along.
+app.use(function * (next) {
+  console.log('[req]', this.url, this.path)
+  var ctx = this
+  setTimeout(function () {
+    if (!ctx.headerSent) ctx.status = 500
+  }, 2000)
+  yield next
+})
+
+app.use(function * (next) {
+  if (this.path === '/error-before-handler') {
+    throw new Error('nope')
+  } else {
+    yield next
+  }
+})
+
+app.use(middleware.requestHandler.v1)
+
+app.use(function * (next) {
+  if (this.path === '/') {
+    this.body = 'ok'
+  } else if (this.path === '/err') {
+    throw new Error('noooop')
+  } else if (this.path === '/ctx-throw') {
+    this.throw(500, 'thrown')
+  } else if (this.path === '/ctx-throw-400') {
+    this.throw(400, 'thrown')
+  } else if (this.path === '/throw-non-error') {
+    throw 'error' // eslint-disable-line
+  } else if (this.path === '/handled') {
+    this.bugsnag.notify(new Error('handled'))
+    yield next
+  } else {
+    yield next
+  }
+})
+
+app.on('error', middleware.errorHandler)
+
+app.listen(80)

--- a/test/node/features/fixtures/koa/scenarios/app.js
+++ b/test/node/features/fixtures/koa/scenarios/app.js
@@ -64,6 +64,23 @@ app.use(async (ctx, next) => {
   }
 })
 
+app.on('error', (err, ctx) => {
+  // in the "error-before-handler" test ctx.bugsnag won't exist
+  const bugsnag = ctx.bugsnag || Bugsnag
+
+  bugsnag.addMetadata('error_handler', 'before', true)
+})
+
 app.on('error', middleware.errorHandler)
+
+app.on('error', (err, ctx) => {
+  // in the "error-before-handler" test ctx.bugsnag won't exist
+  const bugsnag = ctx.bugsnag || Bugsnag
+
+  // this should not be added to events as error handlers run in the order they
+  // were added, so at this point the event has already been sent by the Bugsnag
+  // errorHandler
+  bugsnag.addMetadata('error_handler', 'after', true)
+})
 
 app.listen(80)

--- a/test/node/features/koa-1x.feature
+++ b/test/node/features/koa-1x.feature
@@ -53,8 +53,8 @@ Scenario: throwing non-Error error
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledErrorMiddleware"
-  And the exception "errorClass" equals "InvalidError"
-  And the exception "message" matches "^koa middleware received a non-error\."
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "non-error thrown: error"
   And the exception "type" equals "nodejs"
 
 Scenario: A non-5XX error created with ctx.throw()

--- a/test/node/features/koa-1x_disabled.feature
+++ b/test/node/features/koa-1x_disabled.feature
@@ -1,0 +1,46 @@
+Feature: @bugsnag/plugin-koa (koa v1.x support) autoDetectErrors=false
+
+Background:
+  Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+  And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
+  And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+  And I start the service "koa-1x-disabled"
+  And I wait for the host "koa-1x-disabled" to open port "80"
+
+Scenario: a synchronous thrown error in a route
+  Given I open the URL "http://koa-1x-disabled/err"
+  Then I should receive no errors
+
+Scenario: An error created with with ctx.throw()
+  Given I open the URL "http://koa-1x-disabled/ctx-throw"
+  Then I should receive no errors
+
+Scenario: an error thrown before the requestHandler middleware
+  Given I open the URL "http://koa-1x-disabled/error-before-handler"
+  Then I should receive no errors
+
+Scenario: throwing non-Error error
+  Given I open the URL "http://koa-1x-disabled/throw-non-error"
+  Then I should receive no errors
+
+Scenario: A non-5XX error created with ctx.throw()
+  Given I open the URL "http://koa-1x-disabled/ctx-throw-400"
+  Then I should receive no errors
+  When I wait to receive a session
+  Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+  And the session payload has a valid sessions array
+  And the sessionCount "sessionsStarted" equals 1
+
+Scenario: A handled error with ctx.bugsnag.notify()
+  Given I open the URL "http://koa-1x-disabled/handled"
+  When I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "handled"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app-disabled.js"
+  And the event "request.url" equals "http://koa-1x-disabled/handled"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -8,7 +8,7 @@ Background:
   And I wait for the host "koa" to open port "80"
 
 Scenario: a synchronous thrown error in a route
-  Then I open the URL "http://koa/err"
+  Then I open the URL "http://koa/err" and get a 500 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -23,7 +23,7 @@ Scenario: a synchronous thrown error in a route
   And the event "request.clientIp" is not null
 
 Scenario: an asynchronous thrown error in a route
-  Then I open the URL "http://koa/async-err"
+  Then I open the URL "http://koa/async-err" and get a 500 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -35,7 +35,7 @@ Scenario: an asynchronous thrown error in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
 
 Scenario: An error created with with ctx.throw()
-  Then I open the URL "http://koa/ctx-throw"
+  Then I open the URL "http://koa/ctx-throw" and get a 500 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -48,7 +48,7 @@ Scenario: An error created with with ctx.throw()
   And the "file" of stack frame 1 equals "scenarios/app.js"
 
 Scenario: an error thrown before the requestHandler middleware
-  Then I open the URL "http://koa/error-before-handler"
+  Then I open the URL "http://koa/error-before-handler" and get a 500 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -60,7 +60,7 @@ Scenario: an error thrown before the requestHandler middleware
   And the "file" of stack frame 0 equals "scenarios/app.js"
 
 Scenario: throwing non-Error error
-  Then I open the URL "http://koa/throw-non-error"
+  Then I open the URL "http://koa/throw-non-error" and get a 500 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -71,14 +71,14 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
 
 Scenario: A non-5XX error created with ctx.throw()
-  When I open the URL "http://koa/ctx-throw-400"
+  When I open the URL "http://koa/ctx-throw-400" and get a 400 response
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
   And the session payload has a valid sessions array
   And the sessionCount "sessionsStarted" equals 1
 
 Scenario: A handled error with ctx.bugsnag.notify()
-  Then I open the URL "http://koa/handled"
+  Then I open the URL "http://koa/handled" and get a 404 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is false

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -66,8 +66,8 @@ Scenario: throwing non-Error error
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledErrorMiddleware"
-  And the exception "errorClass" equals "InvalidError"
-  And the exception "message" matches "^koa middleware received a non-error\."
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals 'non-error thrown: \\"error\\"'
   And the exception "type" equals "nodejs"
 
 Scenario: A non-5XX error created with ctx.throw()

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -81,8 +81,9 @@ Scenario: throwing non-Error error
   And the event "metaData.error_handler.after" is null
 
 Scenario: A non-5XX error created with ctx.throw()
-  When I open the URL "http://koa/ctx-throw-400" and get a 400 response
-  And I wait to receive a session
+  Given I open the URL "http://koa/ctx-throw-400" and get a 400 response
+  Then I should receive no errors
+  When I wait to receive a session
   Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
   And the session payload has a valid sessions array
   And the sessionCount "sessionsStarted" equals 1

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -21,6 +21,8 @@ Scenario: a synchronous thrown error in a route
   And the event "request.url" equals "http://koa/err"
   And the event "request.httpMethod" equals "GET"
   And the event "request.clientIp" is not null
+  And the event "metaData.error_handler.before" is true
+  And the event "metaData.error_handler.after" is null
 
 Scenario: an asynchronous thrown error in a route
   Then I open the URL "http://koa/async-err" and get a 500 response
@@ -33,6 +35,8 @@ Scenario: an asynchronous thrown error in a route
   And the exception "message" equals "async noooop"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "metaData.error_handler.before" is true
+  And the event "metaData.error_handler.after" is null
 
 Scenario: An error created with with ctx.throw()
   Then I open the URL "http://koa/ctx-throw" and get a 500 response
@@ -46,6 +50,8 @@ Scenario: An error created with with ctx.throw()
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "node_modules/koa/lib/context.js"
   And the "file" of stack frame 1 equals "scenarios/app.js"
+  And the event "metaData.error_handler.before" is true
+  And the event "metaData.error_handler.after" is null
 
 Scenario: an error thrown before the requestHandler middleware
   Then I open the URL "http://koa/error-before-handler" and get a 500 response
@@ -58,6 +64,8 @@ Scenario: an error thrown before the requestHandler middleware
   And the exception "message" equals "nope"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "metaData.error_handler.before" is true
+  And the event "metaData.error_handler.after" is null
 
 Scenario: throwing non-Error error
   Then I open the URL "http://koa/throw-non-error" and get a 500 response
@@ -69,6 +77,8 @@ Scenario: throwing non-Error error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals 'non-error thrown: \\"error\\"'
   And the exception "type" equals "nodejs"
+  And the event "metaData.error_handler.before" is true
+  And the event "metaData.error_handler.after" is null
 
 Scenario: A non-5XX error created with ctx.throw()
   When I open the URL "http://koa/ctx-throw-400" and get a 400 response
@@ -90,6 +100,8 @@ Scenario: A handled error with ctx.bugsnag.notify()
   And the event "request.url" equals "http://koa/handled"
   And the event "request.httpMethod" equals "GET"
   And the event "request.clientIp" is not null
+  And the event "metaData.error_handler.before" is null
+  And the event "metaData.error_handler.after" is null
 
 Scenario: adding body to request metadata
   When I POST the data "data=in_request_body" to the URL "http://koa/bodytest"
@@ -104,3 +116,5 @@ Scenario: adding body to request metadata
   And the event "request.body.data" equals "in_request_body"
   And the event "request.httpMethod" equals "POST"
   And the event "request.httpVersion" equals "1.1"
+  And the event "metaData.error_handler.before" is true
+  And the event "metaData.error_handler.after" is null

--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -8,11 +8,28 @@ When("I POST the data {string} to the URL {string}") do |reqbody, url|
   Net::HTTP.post(URI(url), reqbody)
 end
 
-
 When('I open the URL {string} tolerating any error') do |url|
   begin
     open(url, &:read)
   rescue
     $logger.debug $!.inspect
   end
+end
+
+When('I open the URL {string} and get a {int} response') do |url, expected_response_code|
+  begin
+    response = Net::HTTP.get_response(URI(url))
+  rescue
+    $logger.debug $!.inspect
+  end
+
+  assert_same(
+    expected_response_code,
+    response.code.to_i,
+    <<~TEXT
+      Unexpected response code "#{response.code}" received. Response body:
+
+      #{response.body}
+    TEXT
+  )
 end


### PR DESCRIPTION
## Goal

The Koa plugin currently works by catching exceptions in the request handler and notifying Bugsnag. This works but prevents Koa from detecting that there was an error and so it doesn't trigger error handlers to run. This also means that Bugsnag's error handler will never be called

This PR overhauls the plugin so that it works primarily through the error handler, not the request handler. The request handler still exists to attach request data as metadata and create `ctx.bugsnag`, but does nothing else. The error handler will then be triggered by Koa when an error is thrown and Koa will then ensure all other error handlers also run

The error handler is now more complicated as logic from the request handler has been moved into it. Specifically:

- it now checks the error status code and only notifies if the code is a 5xx (originally https://github.com/bugsnag/bugsnag-js/pull/541)
- it will delegate to the default Koa error handler if there are no other error handlers. This ensures we don't change the default behaviour of Koa, as it does not attach its internal error handler if any other error handler has been added (originally https://github.com/bugsnag/bugsnag-js/pull/614)

Finally we no longer set the status code ourselves as Koa's default error handling does that already. Assertions against the status code have been added to the MazeRunner tests

## Testing

Unit tests have been added for most functionality (where it makes sense) and the Maze Runner tests have been updated to ensure other error handlers run