### PR TITLE
Use MazeRunner v5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       BUILDKITE:
       BUILDKITE_PIPELINE_NAME:
       DEBUG:
-      MAZE_DEVICE_FARM_USERNAME:
-      MAZE_DEVICE_FARM_ACCESS_KEY:
+      BROWSER_STACK_USERNAME:
+      BROWSER_STACK_ACCESS_KEY:
       HOST: "${HOST:-maze-runner}"
       API_HOST: "${API_HOST:-maze-runner}"
     networks:

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -45,7 +45,7 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 RUN rm -fr **/*/node_modules/
 
 # The maze-runner browser tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v4-cli as browser-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v5-cli as browser-maze-runner
 
 COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
 WORKDIR /app/test/browser

--- a/test/browser/Gemfile
+++ b/test/browser/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.8.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.9.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../../../maze-runner'

--- a/test/browser/Gemfile.lock
+++ b/test/browser/Gemfile.lock
@@ -1,11 +1,10 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 7ff68102cc9265e08e81b331a51d95fb220c2581
-  tag: v4.8.0
+  revision: d5b89bf37ab121da24d1ec69931c1da21de83591
+  tag: v5.9.0
   specs:
-    bugsnag-maze-runner (4.8.0)
+    bugsnag-maze-runner (5.9.0)
       appium_lib (~> 11.2.0)
-      boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -14,6 +13,7 @@ GIT
       optimist (~> 3.0.1)
       os (~> 1.0.0)
       rake (~> 12.3.3)
+      rubyzip (~> 2.3.2)
       selenium-webdriver (~> 3.11)
       test-unit (~> 3.3.0)
 
@@ -24,11 +24,10 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.3.1)
+    appium_lib_core (4.7.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.20.2)
-    boring (0.1.0)
+    backports (3.21.0)
     builder (3.2.4)
     childprocess (3.0.0)
     cucumber (3.1.2)
@@ -50,15 +49,15 @@ GEM
     curb (0.9.11)
     diff-lcs (1.4.4)
     eventmachine (1.2.7)
-    faye-websocket (0.11.0)
+    faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    mini_portile2 (2.5.3)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)
@@ -66,14 +65,14 @@ GEM
     power_assert (2.0.0)
     racc (1.5.2)
     rake (12.3.3)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 
@@ -84,4 +83,4 @@ DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.1.4
+   2.2.20

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -26,7 +26,7 @@ def get_test_url path
 end
 
 def get_error_message id
-  browser = Maze.config.bs_browser
+  browser = Maze.config.browser
   raise "The browser '#{browser}' does not exist in 'browser_errors.yml'" unless ERRORS.has_key?(browser)
 
   ERRORS[browser][id]


### PR DESCRIPTION
## Goal

Update the Browser e2e tests to use the latest version of MazeRunner.

## Changeset

Minimal changes were needed.

## Testing

Covered by CI.