### PR TITLE
Do not save Instance State in e2e test fixture

### DIFF
--- a/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainActivity.java
+++ b/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn063example;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn0_60;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "rn0_60";
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle SavedInstanceState) {
+        // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+        // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+        // the getConstantState method, causing another crash.
     }
 }

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn0_61;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_61";
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn0_62;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_62";
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/bugsnag/rn0_63_expo_ejected/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/bugsnag/rn0_63_expo_ejected/MainActivity.java
@@ -20,22 +20,29 @@ public class MainActivity extends ReactActivity {
   }
 
 
-    /**
-     * Returns the name of the main component registered from JavaScript.
-     * This is used to schedule rendering of the component.
-     */
-    @Override
-    protected String getMainComponentName() {
+  /**
+   * Returns the name of the main component registered from JavaScript.
+   * This is used to schedule rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
         return "main";
     }
 
-    @Override
-    protected ReactActivityDelegate createReactActivityDelegate() {
-        return new ReactActivityDelegate(this, getMainComponentName()) {
-            @Override
-            protected ReactRootView createRootView() {
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactRootView createRootView() {
                 return new RNGestureHandlerEnabledRootView(MainActivity.this);
             }
-        };
-    }
+    };
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
+  }
 }

--- a/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn0_64;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_64";
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_64_hermes/android/app/src/main/java/com/rn0_64_hermes/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_64_hermes/android/app/src/main/java/com/rn0_64_hermes/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn0_64_hermes;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_64_hermes";
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
   }
 }

--- a/test/react-native/features/fixtures/rn0.60/android/app/src/main/java/com/rn060/MainActivity.java
+++ b/test/react-native/features/fixtures/rn0.60/android/app/src/main/java/com/rn060/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rn060;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "reactnative";
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle SavedInstanceState) {
+        // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+        // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+        // the getConstantState method, causing another crash.
     }
 }

--- a/test/react-native/features/fixtures/rn0.63/android/app/src/main/java/com/reactnative/MainActivity.java
+++ b/test/react-native/features/fixtures/rn0.63/android/app/src/main/java/com/reactnative/MainActivity.java
@@ -1,5 +1,7 @@
 package com.reactnative;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "reactnative";
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
   }
 }

--- a/test/react-native/features/fixtures/rn0.64-hermes/android/app/src/main/java/com/reactnative/MainActivity.java
+++ b/test/react-native/features/fixtures/rn0.64-hermes/android/app/src/main/java/com/reactnative/MainActivity.java
@@ -1,5 +1,7 @@
 package com.reactnative;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +13,12 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "reactnative";
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle SavedInstanceState) {
+    // Do not write any state, to avoid crashes on relaunch after a crash.  If Android keeps the state Bundle from
+    // before the crash, passing it back into the application it can do so with a Drawable that does not implement
+    // the getConstantState method, causing another crash.
   }
 }


### PR DESCRIPTION
## Goal

Avoid a test flake caused by Android keeping the state Bundle from before a crash and passing it back into the application with a Drawable that does not implement the `getConstantState` method.  This resulted in the following exception in the Appium log:

```
Caught exception
java.lang.NullPointerException: Attempt to invoke virtual method 'android.graphics.drawable.Drawable android.graphics.drawable.Drawable$ConstantState.newDrawable(android.content.res.Resources)' on a null object reference
```

## Changeset

Override `onSaveInstanceState` in all `Activity` classes to prevent and Instance State being saved in the first place.

## Testing

Passing CI shows that the tests are no worse off than they were, although we can't really tell at this stage if the exception is truly resolved.