### PR TITLE
Correctly encode events delivered alongside minidumps

### DIFF
--- a/packages/plugin-electron-deliver-minidumps/send-minidump.js
+++ b/packages/plugin-electron-deliver-minidumps/send-minidump.js
@@ -43,7 +43,12 @@ module.exports = (net, client) => {
     })
 
     if (event) {
-      const eventBody = payload.event(event, client._config.redactedKeys)
+      const eventPayload = {
+        notifier: client._notifier,
+        payloadVersion: '5',
+        events: [event]
+      }
+      const eventBody = payload.event(eventPayload, client._config.redactedKeys)
       formData.append('event', eventBody)
     }
 

--- a/test/electron/fixtures/events/minidump-event.json
+++ b/test/electron/fixtures/events/minidump-event.json
@@ -1,49 +1,59 @@
 {
-  "app": {
-    "releaseStage": "production",
-    "inForeground": "{TYPE:boolean}",
-    "isLaunching": "{TYPE:boolean}",
-    "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
-    "version": "1.0.2"
+  "payloadVersion": "5",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "version": "{TYPE:string}",
+    "url": "https://github.com/bugsnag/bugsnag-electron"
   },
-  "breadcrumbs": [
+  "events": [
     {
-      "type": "state",
-      "name": "App became ready",
-      "timestamp": "{TIMESTAMP}",
-      "metaData": {}
-    },
-    {
-      "name": "Browser window 1 created",
-      "timestamp": "{TIMESTAMP}",
-      "type": "state",
-      "metaData": {
-        "id": "{TYPE:number}",
-        "title": "{TYPE:string}"
+      "app": {
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
+        "version": "1.0.2"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {}
+        },
+        {
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "type": "state",
+          "metaData": {
+            "id": "{TYPE:number}",
+            "title": "{TYPE:string}"
+          }
+        }
+      ],
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "metadata": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
       }
     }
-  ],
-  "device": {
-    "runtimeVersions": {
-      "node": "{TYPE:string}",
-      "chrome": "{TYPE:string}",
-      "electron": "{TYPE:string}"
-    },
-    "id": "{REGEX:[0-9a-f]{64}}",
-    "locale": "{REGEX:^[a-z]{2}(-[A-Z]{2})?$}",
-    "osVersion": "{REGEX:\\d+\\.\\d+}"
-  },
-  "metadata": {
-    "app": {
-      "name": "Runner",
-      "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
-    },
-    "device": {
-      "online": "{TYPE:boolean}",
-      "screenResolution": {
-        "width": "{TYPE:number}",
-        "height": "{TYPE:number}"
-      }
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Goal
Correct the encapsulation of events that are delivered along-side minidump files to be inline with the error reporting API, and the `/minidump` endpoint.

## Testing
Relied on existing tests with modified expected values.