### PR TITLE
Dismiss any system (crash) dialog on app launch

### DIFF
--- a/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainActivity.java
+++ b/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn063example;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,5 +14,14 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn063example";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 }

--- a/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainActivity.java
+++ b/examples/reactnative/rn063example/android/app/src/main/java/com/rn063example/MainActivity.java
@@ -1,6 +1,6 @@
 package com.rn063example;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn0_60;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "rn0_60";
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+        Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+        sendBroadcast(closeDialog);
     }
 
     @Override

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainActivity.java
@@ -1,6 +1,6 @@
 package com.rn0_60;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainActivity.java
@@ -1,6 +1,6 @@
 package com.rn0_61;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn0_61;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_61";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 
   @Override

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn0_62;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_62";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 
   @Override

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainActivity.java
@@ -1,6 +1,6 @@
 package com.rn0_62;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/bugsnag/rn0_63_expo_ejected/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/bugsnag/rn0_63_expo_ejected/MainActivity.java
@@ -1,6 +1,6 @@
 package com.bugsnag.rn0_63_expo_ejected;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/bugsnag/rn0_63_expo_ejected/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/bugsnag/rn0_63_expo_ejected/MainActivity.java
@@ -1,5 +1,6 @@
 package com.bugsnag.rn0_63_expo_ejected;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -11,14 +12,18 @@ import expo.modules.splashscreen.singletons.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
 
 public class MainActivity extends ReactActivity {
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(null);
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
     SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class, false);
-  }
 
+    // Attempt to dismiss any system dialogs (such as "MazeRunner crashed")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript.

--- a/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainActivity.java
@@ -1,6 +1,6 @@
 package com.rn0_64;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn0_64;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_64";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 
   @Override

--- a/test/react-native-cli/features/fixtures/rn0_64_hermes/android/app/src/main/java/com/rn0_64_hermes/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_64_hermes/android/app/src/main/java/com/rn0_64_hermes/MainActivity.java
@@ -1,6 +1,6 @@
 package com.rn0_64_hermes;
 
-import android.content.Intent
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;

--- a/test/react-native-cli/features/fixtures/rn0_64_hermes/android/app/src/main/java/com/rn0_64_hermes/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_64_hermes/android/app/src/main/java/com/rn0_64_hermes/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn0_64_hermes;
 
+import android.content.Intent
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "rn0_64_hermes";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 
   @Override

--- a/test/react-native/features/fixtures/rn0.60/android/app/src/main/java/com/rn060/MainActivity.java
+++ b/test/react-native/features/fixtures/rn0.60/android/app/src/main/java/com/rn060/MainActivity.java
@@ -1,5 +1,6 @@
 package com.rn060;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "reactnative";
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+        Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+        sendBroadcast(closeDialog);
     }
 
     @Override

--- a/test/react-native/features/fixtures/rn0.63/android/app/src/main/java/com/reactnative/MainActivity.java
+++ b/test/react-native/features/fixtures/rn0.63/android/app/src/main/java/com/reactnative/MainActivity.java
@@ -1,5 +1,6 @@
 package com.reactnative;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "reactnative";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 
   @Override

--- a/test/react-native/features/fixtures/rn0.64-hermes/android/app/src/main/java/com/reactnative/MainActivity.java
+++ b/test/react-native/features/fixtures/rn0.64-hermes/android/app/src/main/java/com/reactnative/MainActivity.java
@@ -1,5 +1,6 @@
 package com.reactnative;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -13,6 +14,15 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "reactnative";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Attempt to dismiss any system dialogs (such as "reactnative keeps stopping")
+    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+    sendBroadcast(closeDialog);
   }
 
   @Override


### PR DESCRIPTION
## Goal

Avoid test flakes by dismissing system (crash) dialogs at app launch.

## Design

If a system dialog is present, it prevents Appium from locating elements on the screen.

## Testing

Covered by CI.