### PR TITLE
Allow the apiKey to be set by event callbacks

### DIFF
--- a/packages/plugin-electron-deliver-minidumps/send-minidump.js
+++ b/packages/plugin-electron-deliver-minidumps/send-minidump.js
@@ -4,6 +4,18 @@ const { basename } = require('path')
 const payload = require('@bugsnag/core/lib/json-payload')
 const FormData = require('form-data')
 
+const isValidApiKey = (apiKey, logger) => {
+  if (apiKey) {
+    if (!/^[0-9a-f]{32}$/i.test(apiKey)) {
+      logger.warn(`Ignoring invalid event-specific apiKey\n  - apiKey should be a string of 32 hexadecimal characters, got ${apiKey}`)
+    } else {
+      return true
+    }
+  }
+
+  return false
+}
+
 module.exports = (net, client) => {
   const send = (opts, formData) => {
     return new Promise((resolve, reject) => {
@@ -31,9 +43,12 @@ module.exports = (net, client) => {
   }
 
   const sendMinidump = async (minidumpPath, event) => {
+    const apiKey = event && isValidApiKey(event.apiKey, client._logger)
+      ? event.apiKey
+      : client._config.apiKey
     const url = new URL(client._config.endpoints.minidumps)
     url.pathname = `${url.pathname.replace(/\/$/, '')}/minidump`
-    url.searchParams.set('api_key', client._config.apiKey)
+    url.searchParams.set('api_key', apiKey)
 
     const minidumpStream = createReadStream(minidumpPath).pipe(createGzip())
 

--- a/packages/plugin-electron-deliver-minidumps/send-minidump.js
+++ b/packages/plugin-electron-deliver-minidumps/send-minidump.js
@@ -4,18 +4,6 @@ const { basename } = require('path')
 const payload = require('@bugsnag/core/lib/json-payload')
 const FormData = require('form-data')
 
-const isValidApiKey = (apiKey, logger) => {
-  if (apiKey) {
-    if (!/^[0-9a-f]{32}$/i.test(apiKey)) {
-      logger.warn(`Ignoring invalid event-specific apiKey\n  - apiKey should be a string of 32 hexadecimal characters, got ${apiKey}`)
-    } else {
-      return true
-    }
-  }
-
-  return false
-}
-
 module.exports = (net, client) => {
   const send = (opts, formData) => {
     return new Promise((resolve, reject) => {
@@ -43,9 +31,7 @@ module.exports = (net, client) => {
   }
 
   const sendMinidump = async (minidumpPath, event) => {
-    const apiKey = event && isValidApiKey(event.apiKey, client._logger)
-      ? event.apiKey
-      : client._config.apiKey
+    const apiKey = (event && event.apiKey) || client._config.apiKey
     const url = new URL(client._config.endpoints.minidumps)
     url.pathname = `${url.pathname.replace(/\/$/, '')}/minidump`
     url.searchParams.set('api_key', apiKey)

--- a/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
@@ -11,9 +11,6 @@ const client = {
     endpoints: {
       minidumps: 'http://localhost/test-minidump-endpoint/'
     }
-  },
-  _logger: {
-    warn: jest.fn()
   }
 }
 
@@ -103,21 +100,6 @@ describe('electron-minidump-delivery: sendMinidump', () => {
       const parsedUrl = new URL(url)
       expect(parsedUrl.pathname).toBe('/test-minidump-endpoint/minidump')
       expect(parsedUrl.searchParams.get('api_key')).toBe('c0ffeec0ffeec0ffeec0ffeec0ffeec0')
-    })
-
-    it('is rejected when invalid', async () => {
-      const { sendMinidump } = sendMinidumpFactory(net, client)
-      await sendMinidump(minidumpFile, {
-        apiKey: 'not a valid key'
-      })
-
-      expect(net.request).toBeCalledTimes(1)
-
-      const { url } = net.request.mock.calls[0][0]
-      const parsedUrl = new URL(url)
-      expect(parsedUrl.pathname).toBe('/test-minidump-endpoint/minidump')
-      expect(parsedUrl.searchParams.get('api_key')).toBe('test-api-key')
-      expect(client._logger.warn).toBeCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## Goal
If `onSend` callbacks to change or set the `apiKey` of an event then this should be the `apiKey` used to send the event. This allows an application to direct events to different projects based on user-defined conditions.

## Testing
Added new unit test coverage.