### PR TITLE
electron: persist and retry events on network error

### DIFF
--- a/packages/delivery-electron/delivery.js
+++ b/packages/delivery-electron/delivery.js
@@ -6,7 +6,13 @@ const NetworkStatus = require('@bugsnag/electron-network-status')
 
 const delivery = (client, filestore, net, app) => {
   const send = (opts, body, cb) => {
+    const errorHandler = err => {
+      err.isRetryable = true
+      cb(err)
+    }
+
     const req = net.request(opts, response => {
+      req.removeListener('error', errorHandler)
       if (isOk(response)) {
         cb(null)
       } else {
@@ -16,10 +22,7 @@ const delivery = (client, filestore, net, app) => {
       }
     })
 
-    req.on('error', err => {
-      err.isRetryable = true
-      cb(err)
-    })
+    req.on('error', errorHandler)
 
     try {
       req.write(body)

--- a/packages/delivery-electron/delivery.js
+++ b/packages/delivery-electron/delivery.js
@@ -16,7 +16,10 @@ const delivery = (client, filestore, net, app) => {
       }
     })
 
-    req.on('error', cb)
+    req.on('error', err => {
+      err.isRetryable = true
+      cb(err)
+    })
 
     try {
       req.write(body)

--- a/test/electron/features/native-crash.feature
+++ b/test/electron/features/native-crash.feature
@@ -2,39 +2,82 @@ Feature: Native Errors
 
   Scenario: A minidump is uploaded on native error
     When I launch an app
-    And I wait for 1 session upload
-    And I click "main-process-crash"
+    Then the total requests received by the server matches:
+      | events    | 0 |
+      | minidumps | 0 |
+      | sessions  | 1 |
+
+    When I click "main-process-crash"
     And I launch an app
     Then the total requests received by the server matches:
+      | events    | 0 |
       | minidumps | 1 |
       | sessions  | 2 |
-    Then minidump request 0 contains a file form field named "upload_file_minidump"
-    Then minidump request 0 contains a form field named "event" matching "minidump-event.json"
+    And minidump request 0 contains a file form field named "upload_file_minidump"
+    And minidump request 0 contains a form field named "event" matching "minidump-event.json"
 
   Scenario: Minidumps are retried when the network becomes available
-    Given I launch an app
-    And I wait for 1 session upload
-    And I click "main-process-crash"
-    And the server is unreachable
+    When I launch an app
+    Then the total requests received by the server matches:
+      | minidumps | 0 |
+      | events    | 0 |
+      | sessions  | 1 |
+
+    When I click "main-process-crash"
     And I launch an app with no network
-    And the server becomes reachable
-    And the app gains network connectivity
+    Then the total requests received by the server matches:
+      | minidumps | 0 |
+      | events    | 0 |
+      | sessions  | 1 |
+
+    When the app gains network connectivity
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 1 |
       | sessions  | 2 |
 
-  Scenario: Minidumps are queued for delivery until the network is available
+  Scenario: Minidumps are enqueued until next launch when the server is offline
     Given the server is unreachable
     When I launch an app
-    And I click "main-process-crash"
+    Then the total requests received by the server matches:
+      | minidumps | 0 |
+      | events    | 0 |
+      | sessions  | 0 |
+
+    When I click "main-process-crash"
     And I launch an app
-    And I click "main-process-crash"
-    And I launch an app
-    And I click "main-process-crash"
-    And I launch an app
+    Then the total requests received by the server matches:
+      | minidumps | 0 |
+      | events    | 0 |
+      | sessions  | 0 |
+
+    When I click "main-process-crash"
     And the server becomes reachable
-    And the app gains network connectivity
+    And I launch an app
+    Then the total requests received by the server matches:
+      | minidumps | 2 |
+      | events    | 0 |
+      | sessions  | 3 |
+
+  Scenario: Minidumps are queued for delivery until the network is available
+    When I launch an app with no network
+    And I click "main-process-crash"
+    And I launch an app with no network
+    Then the total requests received by the server matches:
+      | minidumps | 0 |
+      | events    | 0 |
+      | sessions  | 0 |
+
+    When I click "main-process-crash"
+    And I launch an app with no network
+    Then the total requests received by the server matches:
+      | minidumps | 0 |
+      | events    | 0 |
+      | sessions  | 0 |
+
+    When I click "main-process-crash"
+    And I launch an app
     Then the total requests received by the server matches:
       | minidumps | 3 |
       | events    | 0 |
+      | sessions  | 4 |

--- a/test/electron/features/support/steps/connectivity-steps.js
+++ b/test/electron/features/support/steps/connectivity-steps.js
@@ -15,3 +15,9 @@ Given('the app lacks network connectivity', async () => {
 When('the app gains network connectivity', async () => {
   await global.automator.click('emulate-online')
 })
+
+When('I launch an app with no network', () => {
+  return global.automator.start({
+    BUGSNAG_RENDERER_OFFLINE: 'true'
+  })
+})

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -32,12 +32,6 @@ Given('I launch an app with configuration:', launchConfig, (data) => {
   })
 })
 
-Given('I launch an app with no network', () => {
-  return global.automator.start({
-    BUGSNAG_RENDERER_OFFLINE: 'true'
-  })
-})
-
 When('I click {string}', async (link) => {
   return global.automator.click(link)
 })


### PR DESCRIPTION
## Goal

Ensure events/sessions aren't lost in the event of a connectivity issue

## Design

* Marked network errors as retryable prior to invoking the completion callback. No other changes were needed to ensure other enqueued errors are sent, as payloads are then sent to the back of the queue (ordered by date).

## Tests

Refactored the tests to separate the server reachability cases from the network connectivity cases, so now there are one of each scenario:

* server and app connected from the start, single crash
* no network connection, single crash, connection restored during app lifetime
* no network connection, multiple crashes enqueued, send next connected launch
* no server available, multiple crashes enqueued, send next connected launch

## Discussion

Its somewhat subjective, but I opted to print all types of request counts at each junction to ensure requests were not attempted to be sent when offline. The upside is that its consistent (because I confused myself a few times), the downside is that its very verbose.