### PR TITLE
Deliver non-fatal minidumps

### DIFF
--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -1,6 +1,7 @@
 const { crashReporter } = require('electron')
 const MinidumpDeliveryLoop = require('./minidump-loop')
 const MinidumpQueue = require('./minidump-queue')
+const MinidumpWatcher = require('./minidump-watcher')
 const sendMinidumpFactory = require('./send-minidump')
 const NetworkStatus = require('@bugsnag/electron-network-status')
 
@@ -36,7 +37,9 @@ module.exports = (app, net, filestore, NativeClient) => ({
 
       const minidumpQueue = new MinidumpQueue(filestore)
       const minidumpLoop = new MinidumpDeliveryLoop(sendMinidump, client._config.onSend, minidumpQueue, client._logger)
+      const minidumpWatcher = new MinidumpWatcher(minidumpLoop, filestore.getPaths().minidumps)
       minidumpLoop.watchNetworkStatus(statusUpdater)
+      minidumpWatcher.watchNetworkStatus(statusUpdater)
     })
   }
 })

--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -36,8 +36,8 @@ module.exports = (app, net, filestore, NativeClient) => ({
       const { sendMinidump } = sendMinidumpFactory(net, client)
 
       const minidumpQueue = new MinidumpQueue(filestore)
-      const minidumpLoop = new MinidumpDeliveryLoop(sendMinidump, client._config.onSend, minidumpQueue, client._logger)
-      const minidumpWatcher = new MinidumpWatcher(minidumpLoop, filestore.getPaths().minidumps)
+      const minidumpLoop = new MinidumpDeliveryLoop(client, sendMinidump, client._config.onSend, minidumpQueue)
+      const minidumpWatcher = new MinidumpWatcher(minidumpLoop, filestore.getPaths().minidumps, client._logger)
       minidumpLoop.watchNetworkStatus(statusUpdater)
       minidumpWatcher.watchNetworkStatus(statusUpdater)
     })

--- a/packages/plugin-electron-deliver-minidumps/minidump-loop.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-loop.js
@@ -1,20 +1,41 @@
 const { readFile } = require('fs').promises
 
+const trackEvent = (client, event) => {
+  if (client._session) {
+    client._session._track(event || { _handledState: { unhandled: true } })
+  }
+}
+
 module.exports = class MinidumpDeliveryLoop {
-  constructor (sendMinidump, onSend = () => true, minidumpQueue, logger) {
+  constructor (client, sendMinidump, onSend = () => true, minidumpQueue) {
+    this._client = client
     this._sendMinidump = sendMinidump
     this._onSend = onSend
     this._minidumpQueue = minidumpQueue
-    this._logger = logger
     this._running = false
   }
 
   _onerror (err, minidump) {
-    this._logger.error('minidump failed to send…\n', (err && err.stack) ? err.stack : err)
+    this._client._logger.error('minidump failed to send…\n', (err && err.stack) ? err.stack : err)
 
     if (err.isRetryable === false) {
       this._minidumpQueue.remove(minidump)
     }
+  }
+
+  _updateEventSession (event) {
+    if (event) {
+      // take a copy of the session to avoid side-effects on the global session
+      const eventSession = event.session || { events: { handled: 0, unhandled: 0 } }
+
+      // if the event isn't marked "handled" - it's unhandled
+      const property = (event.unhandled === false) ? 'handled' : 'unhandled'
+      eventSession.events[property] = (eventSession.events[property] || 0) + 1
+
+      event.session = eventSession
+    }
+
+    return event
   }
 
   async _readEvent (eventPath) {
@@ -31,10 +52,12 @@ module.exports = class MinidumpDeliveryLoop {
   }
 
   async _deliverMinidump (minidump) {
-    const event = await this._readEvent(minidump.eventPath)
+    const event = this._updateEventSession(await this._readEvent(minidump.eventPath))
     const shouldSendMinidump = event && await this._onSend(event)
 
     if (shouldSendMinidump === false) {
+      // we track the events whether we deliver them or not
+      trackEvent(this._client, event)
       this._minidumpQueue.remove(minidump)
       this._scheduleSelf()
     } else {
@@ -43,6 +66,7 @@ module.exports = class MinidumpDeliveryLoop {
 
         // if we had a successful delivery - remove the minidump from the queue, and schedule the next
         this._minidumpQueue.remove(minidump)
+        trackEvent(this._client, event)
       } catch (e) {
         this._onerror(e, minidump)
       } finally {

--- a/packages/plugin-electron-deliver-minidumps/minidump-queue.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-queue.js
@@ -1,12 +1,13 @@
 module.exports = class MinidumpQueue {
   constructor (filestore) {
     this._filestore = filestore
+    this._removedMinidumpPaths = new Set()
   }
 
   async peek () {
     try {
       const minidumps = await this._filestore.listMinidumps()
-      return minidumps[0]
+      return minidumps.find(minidump => !this._removedMinidumpPaths.has(minidump.minidumpPath))
     } catch (e) {
     }
   }
@@ -15,6 +16,9 @@ module.exports = class MinidumpQueue {
     if (!minidump) {
       return
     }
+
+    // we mark the minidump file as "removed" to avoid problems if we cannot delete the file
+    this._removedMinidumpPaths.add(minidump.minidumpPath)
 
     // we ignore any file delete failures - the file has probably already been deleted
     this._filestore.deleteMinidump(minidump).catch(e => {})

--- a/packages/plugin-electron-deliver-minidumps/minidump-queue.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-queue.js
@@ -1,30 +1,20 @@
 module.exports = class MinidumpQueue {
   constructor (filestore) {
     this._filestore = filestore
-    this._minidumps = null
   }
 
   async peek () {
-    if (!this._minidumps) {
-      try {
-        this._minidumps = await this._filestore.listMinidumps()
-      } catch (e) {
-        this._minidumps = []
-      }
+    try {
+      const minidumps = await this._filestore.listMinidumps()
+      return minidumps[0]
+    } catch (e) {
     }
-
-    return this._minidumps[0]
   }
 
   remove (minidump) {
     if (!minidump) {
       return
     }
-
-    // remove the minidump from our in-memory queue, regardless of whether we can delete the file
-    // this prevents accidental re-delivery within the same session
-    this._minidumps = this._minidumps && this._minidumps.filter(
-      queued => queued.minidumpPath !== minidump.minidumpPath && queued.eventPath !== minidump.eventPath)
 
     // we ignore any file delete failures - the file has probably already been deleted
     this._filestore.deleteMinidump(minidump).catch(e => {})

--- a/packages/plugin-electron-deliver-minidumps/minidump-watcher.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-watcher.js
@@ -1,0 +1,47 @@
+const { watch, readdir } = require('fs')
+const { join } = require('path')
+
+module.exports = class MinidumpWatcher {
+  constructor (mindumpLoop, minidumpsPath) {
+    this._mindumpLoop = mindumpLoop
+    this._minidumpsPath = minidumpsPath
+    this._watchers = []
+  }
+
+  start () {
+    if (this._watchers.length) {
+      return
+    }
+
+    this._watch(this._minidumpsPath)
+    readdir(this._minidumpsPath, { withFileTypes: true }, (err, children) => {
+      if (err) return
+
+      children
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => join(this._minidumpsPath, dirent.name))
+        .forEach(path => this._watch(path))
+    })
+  }
+
+  _watch (dir) {
+    this._watchers.push(watch(dir, {}, eventType => {
+      if (eventType === 'rename') {
+        // there is a change in the directory - make sure the minidumpLoop is started and it will do the rest
+        this._mindumpLoop.start()
+      }
+    }))
+  }
+
+  stop () {
+    this._watchers.forEach(watcher => watcher.close())
+    this._watchers = []
+  }
+
+  watchNetworkStatus (statusUpdater) {
+    statusUpdater.watch(connected => {
+      if (connected) this.start()
+      else this.stop()
+    })
+  }
+}

--- a/packages/plugin-electron-deliver-minidumps/minidump-watcher.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-watcher.js
@@ -6,16 +6,19 @@ module.exports = class MinidumpWatcher {
     this._mindumpLoop = mindumpLoop
     this._minidumpsPath = minidumpsPath
     this._watchers = []
+    this._started = false
   }
 
   start () {
-    if (this._watchers.length) {
+    if (this._started) {
       return
     }
 
+    this._started = true
     this._watch(this._minidumpsPath)
     readdir(this._minidumpsPath, { withFileTypes: true }, (err, children) => {
-      if (err) return
+      // handle cases when stop() was called before this callback
+      if (err || !this._started) return
 
       children
         .filter(dirent => dirent.isDirectory())
@@ -36,6 +39,7 @@ module.exports = class MinidumpWatcher {
   stop () {
     this._watchers.forEach(watcher => watcher.close())
     this._watchers = []
+    this._started = false
   }
 
   watchNetworkStatus (statusUpdater) {

--- a/packages/plugin-electron-deliver-minidumps/package.json
+++ b/packages/plugin-electron-deliver-minidumps/package.json
@@ -15,6 +15,7 @@
     "deliver-minidumps.js",
     "minidump-loop.js",
     "minidump-queue.js",
+    "minidump-watcher.js",
     "send-minidump.js"
   ],
   "dependencies": {

--- a/packages/plugin-electron-deliver-minidumps/test/minidump-loop.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/minidump-loop.test.ts
@@ -28,8 +28,11 @@ const runDeliveryLoop = async (times: number = 1) => {
 
 describe('electron-minidump-delivery: minidump-loop', () => {
   const onSend = () => true
-  const logger = {
-    error: () => {}
+  const client = {
+    _logger: {
+      error: () => {
+      }
+    }
   }
 
   describe('delivers minidumps', () => {
@@ -40,7 +43,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
         { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
       )
 
-      const loop = new MinidumpDeliveryLoop(sendMinidump, onSend, minidumpQueue, logger)
+      const loop = new MinidumpDeliveryLoop(client, sendMinidump, onSend, minidumpQueue)
       loop.start()
 
       await runDeliveryLoop()
@@ -56,7 +59,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
         { minidumpPath: 'minidump-path2' }
       )
 
-      const loop = new MinidumpDeliveryLoop(sendMinidump, onSend, minidumpQueue, logger)
+      const loop = new MinidumpDeliveryLoop(client, sendMinidump, onSend, minidumpQueue)
       loop.start()
 
       await runDeliveryLoop()
@@ -73,7 +76,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
       { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
     )
 
-    const loop = new MinidumpDeliveryLoop(sendMinidump, () => false, minidumpQueue, logger)
+    const loop = new MinidumpDeliveryLoop(client, sendMinidump, () => false, minidumpQueue)
     loop.start()
 
     await runDeliveryLoop(2)
@@ -89,7 +92,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
       { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
     )
 
-    const loop = new MinidumpDeliveryLoop(sendMinidump, onSend, minidumpQueue, logger)
+    const loop = new MinidumpDeliveryLoop(client, sendMinidump, onSend, minidumpQueue)
     loop.start()
 
     await runDeliveryLoop(3)
@@ -112,7 +115,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
       { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
     )
 
-    const loop = new MinidumpDeliveryLoop(sendMinidump, onSend, minidumpQueue, logger)
+    const loop = new MinidumpDeliveryLoop(client, sendMinidump, onSend, minidumpQueue)
     loop.start()
 
     await runDeliveryLoop(2)
@@ -134,7 +137,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
         { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
       )
 
-      const loop = new MinidumpDeliveryLoop(sendMinidump, onSend, minidumpQueue, logger)
+      const loop = new MinidumpDeliveryLoop(client, sendMinidump, onSend, minidumpQueue)
       loop.watchNetworkStatus(statusWatcher)
 
       // ensure that nothing is delivered while disconnected
@@ -158,7 +161,7 @@ describe('electron-minidump-delivery: minidump-loop', () => {
         { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
       )
 
-      const loop = new MinidumpDeliveryLoop(sendMinidump, onSend, minidumpQueue, logger)
+      const loop = new MinidumpDeliveryLoop(client, sendMinidump, onSend, minidumpQueue)
       loop.watchNetworkStatus(statusWatcher)
 
       // ensure that the first minidump is delivered

--- a/packages/plugin-electron-deliver-minidumps/test/minidump-queue.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/minidump-queue.test.ts
@@ -24,6 +24,29 @@ describe('electron-minidump-delivery: queue', () => {
 
       expect(await queue.peek()).toStrictEqual(queueHead)
     })
+
+    it('does not return minidumps where remove() failed', async () => {
+      const minidump2 = { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
+      const mockFileStore = {
+        listMinidumps: jest.fn().mockResolvedValue([
+          { minidumpPath: 'minidump-path1', eventPath: 'event-path1' },
+          minidump2
+        ]),
+        deleteMinidump: jest.fn().mockRejectedValue(new Error())
+      }
+
+      const queue = new MinidumpQueue(mockFileStore)
+      const minidump1 = await queue.peek()
+      expect(minidump1).toStrictEqual({ minidumpPath: 'minidump-path1', eventPath: 'event-path1' })
+
+      try {
+        await queue.remove(minidump1)
+      } catch (e) {
+        // ignore error
+      }
+
+      expect(await queue.peek()).toStrictEqual(minidump2)
+    })
   })
 
   describe('remove()', () => {

--- a/packages/plugin-electron-deliver-minidumps/test/minidump-queue.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/minidump-queue.test.ts
@@ -24,29 +24,6 @@ describe('electron-minidump-delivery: queue', () => {
 
       expect(await queue.peek()).toStrictEqual(queueHead)
     })
-
-    it('does not return minidumps where remove() failed', async () => {
-      const minidump2 = { minidumpPath: 'minidump-path2', eventPath: 'event-path2' }
-      const mockFileStore = {
-        listMinidumps: jest.fn().mockResolvedValue([
-          { minidumpPath: 'minidump-path1', eventPath: 'event-path1' },
-          minidump2
-        ]),
-        deleteMinidump: jest.fn().mockRejectedValue(new Error())
-      }
-
-      const queue = new MinidumpQueue(mockFileStore)
-      const minidump1 = await queue.peek()
-      expect(minidump1).toStrictEqual({ minidumpPath: 'minidump-path1', eventPath: 'event-path1' })
-
-      try {
-        await queue.remove(minidump1)
-      } catch (e) {
-        // ignore error
-      }
-
-      expect(await queue.peek()).toStrictEqual(minidump2)
-    })
   })
 
   describe('remove()', () => {

--- a/packages/plugin-electron-deliver-minidumps/test/minidump-watcher.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/minidump-watcher.test.ts
@@ -1,0 +1,76 @@
+import { promises } from 'fs'
+import { join } from 'path'
+import MinidumpWatcher from '../minidump-watcher'
+
+const { mkdtemp, mkdir, writeFile, rmdir } = promises
+
+describe('electron-minidump-delivery: watcher', () => {
+  let watcher: MinidumpWatcher
+  let minidumpLoop, minidumpPath
+
+  beforeEach(async () => {
+    minidumpLoop = {
+      start: jest.fn()
+    }
+
+    minidumpPath = await mkdtemp('minidumps')
+
+    watcher = new MinidumpWatcher(minidumpLoop, minidumpPath)
+  })
+
+  afterEach(async () => {
+    watcher?.stop()
+    await rmdir(minidumpPath, { recursive: true })
+  })
+
+  const createStartPromise = () => new Promise(resolve => {
+    minidumpLoop.start.mockImplementation(resolve)
+  })
+
+  it('starts the MinidumpLoop for new files', async () => {
+    const startPromise = createStartPromise()
+    watcher.start()
+
+    expect(minidumpLoop.start).not.toHaveBeenCalled()
+    await writeFile(join(minidumpPath, 'new-minidump.dmp'), Buffer.of(0, 1, 2, 3, 4, 5, 6))
+    await startPromise
+  })
+
+  it('scans sub-directories', async () => {
+    const startPromise = createStartPromise()
+
+    // place the minidump in a sub-directory to ensure they are scanned as well
+    const newMinidumps = join(minidumpPath, 'new')
+    await mkdir(newMinidumps)
+
+    watcher.start()
+
+    expect(minidumpLoop.start).not.toHaveBeenCalled()
+    await writeFile(join(newMinidumps, 'new-minidump.dmp'), Buffer.of(0, 1, 2, 3, 4, 5, 6))
+    await startPromise
+  })
+
+  it('starts/stops based on network availability', async () => {
+    let networkListener
+    const statusUpdater = {
+      watch: listener => {
+        // capture the listener
+        networkListener = listener
+      }
+    }
+
+    watcher.watchNetworkStatus(statusUpdater)
+    expect(watcher._watchers.length).toBe(0)
+
+    // turn on the network
+    networkListener(true)
+
+    // check that some the minidump dir is being watched
+    expect(watcher._watchers.length).toBe(1)
+
+    // turn off the network
+    networkListener(false)
+    // we should have closed all of the file watchers
+    expect(watcher._watchers.length).toBe(0)
+  })
+})

--- a/test/electron/features/native-crash.feature
+++ b/test/electron/features/native-crash.feature
@@ -1,7 +1,7 @@
 Feature: Native Errors
 
   Scenario: A minidump is uploaded on native error
-    When I launch an app
+    Given I launch an app
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 0 |
@@ -13,8 +13,15 @@ Feature: Native Errors
       | events    | 0 |
       | minidumps | 1 |
       | sessions  | 2 |
-    And minidump request 0 contains a file form field named "upload_file_minidump"
-    And minidump request 0 contains a form field named "event" matching "minidump-event.json"
+    Then minidump request 0 contains a file form field named "upload_file_minidump"
+    Then minidump request 0 contains a form field named "event" matching "minidump-event.json"
+
+  Scenario: Non-fatal minidumps are detected and uploaded
+    Given I launch an app
+    And I click "renderer-process-crash"
+    Then the total requests received by the server matches:
+      | minidumps | 1 |
+    Then minidump request 0 contains a file form field named "upload_file_minidump"
 
   Scenario: Minidumps are retried when the network becomes available
     When I launch an app

--- a/test/electron/features/native-crash.feature
+++ b/test/electron/features/native-crash.feature
@@ -1,7 +1,7 @@
 Feature: Native Errors
 
   Scenario: A minidump is uploaded on native error
-    Given I launch an app
+    When I launch an app
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 0 |
@@ -17,7 +17,7 @@ Feature: Native Errors
     Then minidump request 0 contains a form field named "event" matching "minidump-event.json"
 
   Scenario: Non-fatal minidumps are detected and uploaded
-    Given I launch an app
+    When I launch an app
     And I click "renderer-process-crash"
     Then the total requests received by the server matches:
       | minidumps | 1 |
@@ -45,14 +45,14 @@ Feature: Native Errors
 
   Scenario: Minidumps are enqueued until next launch when the server is offline
     Given the server is unreachable
-    When I launch an app
+    When I launch an app with no network
     Then the total requests received by the server matches:
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 0 |
 
     When I click "main-process-crash"
-    And I launch an app
+    And I launch an app with no network
     Then the total requests received by the server matches:
       | minidumps | 0 |
       | events    | 0 |
@@ -84,6 +84,7 @@ Feature: Native Errors
 
     When I click "main-process-crash"
     And I launch an app
+    And I wait for 3 minidump uploads
     Then the total requests received by the server matches:
       | minidumps | 3 |
       | events    | 0 |

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -15,6 +15,7 @@
         <li><a href="#" id="main-notify" onclick="RunnerAPI.mainProcessNotify()">Handled error in main process</a></li>
     </ul>
     <ul>
+        <li><a href="#" id="renderer-process-crash">Crash in renderer process</a></li>
         <li><a href="#" id="renderer-uncaught-exception">Uncaught exception in renderer</a></li>
         <li><a href="#" id="renderer-unhandled-promise-rejection">Unhandled promise rejection in renderer</a></li>
         <li><a href="#" id="renderer-notify">Handled error in renderer</a></li>

--- a/test/electron/fixtures/app/preloads/default.js
+++ b/test/electron/fixtures/app/preloads/default.js
@@ -3,6 +3,9 @@ const { contextBridge, ipcRenderer } = require('electron')
 contextBridge.exposeInMainWorld('RunnerAPI', {
   rendererConfig: JSON.parse(process.env.BUGSNAG_RENDERER_CONFIG || '{}'),
   startOffline: process.env.BUGSNAG_RENDERER_OFFLINE,
+  renderProcessCrash: () => {
+    process.crash()
+  },
   mainProcessCrash: () => {
     ipcRenderer.send('main-process-crash')
   },

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -7,9 +7,15 @@ const Bugsnag = require('@bugsnag/electron')
 Bugsnag.start(window.RunnerAPI.rendererConfig)
 const startupTimestamp = Date.now()
 
-function emulateOnlineStatus (online) {
+function emulateOnlineStatus(online) {
   Object.defineProperty(window.navigator, 'onLine', { value: online, configurable: true })
   window.dispatchEvent(new window.Event(online ? 'online' : 'offline'))
+}
+
+document.getElementById('renderer-process-crash').onclick = () => {
+  setTimeout(() => {
+    window.RunnerAPI.renderProcessCrash()
+  }, 10)
 }
 
 document.getElementById('renderer-unhandled-promise-rejection').onclick = () => {

--- a/test/electron/fixtures/events/minidump-event.json
+++ b/test/electron/fixtures/events/minidump-event.json
@@ -53,6 +53,12 @@
             "height": "{TYPE:number}"
           }
         }
+      },
+      "session": {
+        "events": {
+          "unhandled": 1,
+          "handled": 0
+        }
       }
     }
   ]

--- a/test/electron/fixtures/events/on-error/complex-config.json
+++ b/test/electron/fixtures/events/on-error/complex-config.json
@@ -98,7 +98,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 37,
+              "lineNumber": 43,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/on-error/default.json
+++ b/test/electron/fixtures/events/on-error/default.json
@@ -85,7 +85,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 37,
+              "lineNumber": 43,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/config/appType.json
+++ b/test/electron/fixtures/events/renderer/config/appType.json
@@ -80,7 +80,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/config/codeBundleId.json
+++ b/test/electron/fixtures/events/renderer/config/codeBundleId.json
@@ -81,7 +81,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/context/page-title-clear-complex-config.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-clear-complex-config.json
@@ -96,7 +96,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/context/page-title-clear-default.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-clear-default.json
@@ -81,7 +81,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/context/page-title-update-complex-config.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-update-complex-config.json
@@ -96,7 +96,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/context/page-title-update-default.json
+++ b/test/electron/fixtures/events/renderer/context/page-title-update-default.json
@@ -81,7 +81,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/context/set-context-default.json
+++ b/test/electron/fixtures/events/renderer/context/set-context-default.json
@@ -81,7 +81,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js"
             }
           ],

--- a/test/electron/fixtures/events/renderer/handled-error/complex-config.json
+++ b/test/electron/fixtures/events/renderer/handled-error/complex-config.json
@@ -110,7 +110,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js",
               "code": {
                 "1": "{TYPE:string}"

--- a/test/electron/fixtures/events/renderer/handled-error/default.json
+++ b/test/electron/fixtures/events/renderer/handled-error/default.json
@@ -101,7 +101,7 @@
           "errorClass": "Error",
           "stacktrace": [
             {
-              "lineNumber": 24,
+              "lineNumber": 30,
               "file": "./renderer.js",
               "code": {
                 "1": "{TYPE:string}"

--- a/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/complex-config.json
@@ -104,7 +104,7 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 20,
+              "lineNumber": 26,
               "code": {
                 "1": "{TYPE:string}"
               }

--- a/test/electron/fixtures/events/renderer/uncaught-exception/default.json
+++ b/test/electron/fixtures/events/renderer/uncaught-exception/default.json
@@ -94,7 +94,7 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 20,
+              "lineNumber": 26,
               "code": {
                 "1": "{TYPE:string}"
               }

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/complex-config.json
@@ -104,7 +104,7 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 16,
+              "lineNumber": 22,
               "code": {
                 "1": "{TYPE:string}"
               }

--- a/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
+++ b/test/electron/fixtures/events/renderer/unhandled-rejection/default.json
@@ -94,7 +94,7 @@
           "stacktrace": [
             {
               "file": "./renderer.js",
-              "lineNumber": 16,
+              "lineNumber": 22,
               "code": {
                 "1": "{TYPE:string}"
               }


### PR DESCRIPTION
## Goal
Deliver non-fatal minidump files that are produced by crashing child processes (such as the `render` process). The new `MinidumpWatcher` uses file watchers on the minidump directory, and each of its direct child directories (to account for platform differences). The watcher is enabled and disabled based on network availability.

When any `'rename'` event is delivered the watcher ensures that the minidump-delivery-loop is running. The existing minidump loop will then pickup the file and ensure it is delivered to the configured endpoint.

## Testing
Added unit tests and a new end-to-end test to ensure that non-fatal minidumps are delivered without restarting the application.