### PR TITLE
feat(electron): include session info in minidump events

### DIFF
--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -43,7 +43,7 @@ module.exports = (opts) => {
     require('@bugsnag/plugin-electron-app')(NativeClient, process, electron.app, electron.BrowserWindow, filestore),
     require('@bugsnag/plugin-electron-app-breadcrumbs')(electron.app, electron.BrowserWindow),
     require('@bugsnag/plugin-electron-device')(electron.app, electron.screen, process, filestore, NativeClient, electron.powerMonitor),
-    require('@bugsnag/plugin-electron-session')(electron.app, electron.BrowserWindow, filestore),
+    require('@bugsnag/plugin-electron-session')(electron.app, electron.BrowserWindow, NativeClient),
     require('@bugsnag/plugin-console-breadcrumbs'),
     require('@bugsnag/plugin-strip-project-root'),
     require('@bugsnag/plugin-electron-process-info')(),

--- a/test/electron/features/native-crash.feature
+++ b/test/electron/features/native-crash.feature
@@ -16,6 +16,25 @@ Feature: Native Errors
     And minidump request 0 contains a file form field named "upload_file_minidump"
     And minidump request 0 contains a form field named "event" matching "minidump-event.json"
 
+  Scenario: A native error occurs after a handled event
+    When I launch an app
+    And I click "custom-breadcrumb"
+    And I click "main-notify"
+    Then the total requests received by the server matches:
+      | events    | 1 |
+      | minidumps | 0 |
+      | sessions  | 1 |
+
+    When I click "main-process-crash"
+    And I launch an app
+    Then the total requests received by the server matches:
+      | events    | 1 |
+      | minidumps | 1 |
+      | sessions  | 2 |
+    And the contents of an event request matches "main/handled-error/default.json"
+    And minidump request 0 contains a file form field named "upload_file_minidump"
+    And minidump request 0 contains a form field named "event" matching "minidump-plus-handled-event.json"
+
   Scenario: Minidumps are retried when the network becomes available
     When I launch an app
     Then the total requests received by the server matches:

--- a/test/electron/fixtures/events/minidump-plus-handled-event.json
+++ b/test/electron/fixtures/events/minidump-plus-handled-event.json
@@ -58,7 +58,7 @@
         "id": "{TYPE:string}",
         "startedAt": "{TIMESTAMP}",
         "events": {
-          "handled": 0,
+          "handled": 1,
           "unhandled": 1
         }
       }


### PR DESCRIPTION
## Design

Amended `plugin-electron-session` to set native session info in crash events, which was previously not set. The session info is set with an incremented `unhandled` even count, which should be correct in the event of a main process crash.

## Changeset

* In `plugin-electron-session` created a new session delegate which sends the event JSON representation of a session to the crash info cache upon change. This info is sent with a subsequent crash. (The native plumbing was already there, so this just hooks it all together)
* Hooked `Session._track()` to update session info in the native cache when new events are detected

## Testing

* Added additional unit-y tests around pausing/resuming sessions, and asserted the contents of the session in start session events
* Updated the native crash event to assert session event counts