### PR TITLE
[WIP] Replace the current Expo device ID implementation

### DIFF
--- a/packages/expo/CONTRIBUTING.md
+++ b/packages/expo/CONTRIBUTING.md
@@ -8,7 +8,9 @@ When a new version of the Expo SDK is released, the dependencies we use must be 
 
 The following modules are currently used:
 
+- `@react-native-async-storage/async-storage` (`@bugsnag/plugin-expo-device`)
 - `@react-native-community/netinfo` (`@bugsnag/delivery-expo`, `@bugsnsag/plugin-react-native-connectivity-breadcrumbs`)
+- `expo-application` (`@bugsnag/plugin-expo-device`)
 - `expo-constants` (`@bugsnag/expo`, `@bugsnag/plugin-expo-app`, `@bugsnag/plugin-expo-device`)
 - `expo-crypto` (`@bugsnag/expo`, `@bugsnag/delivery-expo`)
 - `expo-device` (`@bugsnag/plugin-expo-device`)

--- a/packages/plugin-expo-device/device-id.js
+++ b/packages/plugin-expo-device/device-id.js
@@ -1,0 +1,109 @@
+const uuid = require('uuid')
+
+// an arbitrary name to use for generated UUIDs, this is augmented with data
+// unique to the application and device so we can generate the same UUID on
+// different runs
+const UUID_NAME = 'bugsnag-device-id'
+
+// an arbitrary UUID to use as the UUID v5 namespace
+// generated with `uuid.v5('bugsnag-device-id', uuid.NIL)`
+const UUID_NAMESPACE = '87fbaa2d-5030-50b0-800f-45f0c2a04b6d'
+
+// the key to store device IDs under
+const DEVICE_ID_STORAGE_KEY = UUID_NAME
+
+module.exports = class DeviceId {
+  static _cache = null
+
+  constructor (os, constants, application, storage) {
+    this._isAndroid = os == 'android'
+    this._constants = constants
+    this._application = application
+    this._storage = storage
+  }
+
+  get (callback) {
+    // attempt to get an ID synchronously, if possible
+    const maybeId = this._getSync()
+
+    if (maybeId) {
+      callback(null, maybeId)
+    } else {
+      this._getAsync()
+        .then(id => { callback(null, id) })
+        .catch(error => { callback(error, null) })
+    }
+  }
+
+  _getSync () {
+    if (DeviceId._cache) {
+      return DeviceId._cache
+    }
+
+    if (this._constants.installationId) {
+      return this._cacheAndStoreId(this._constants.installationId)
+    }
+
+    return null
+  }
+
+  async _getAsync () {
+    // TODO if this fails should we retry? does failing to get something from
+    //      storage mean it will always fail? it _should_ be safe to generate the
+    //      UUID again as it is deterministic, but that doesn't apply if we had
+    //      a stored installation ID
+    const storedId = await this._storage.getItem(DEVICE_ID_STORAGE_KEY)
+
+    if (storedId) {
+      DeviceId._cache = storedId
+
+      return storedId
+    }
+
+    let vendorId
+
+    if (this._isAndroid) {
+      vendorId = this._constants.androidId
+    } else {
+      vendorId = await this._getIosVendorId()
+    }
+
+    const newId = this._generateDeviceId(vendorId)
+
+    return this._cacheAndStoreId(newId)
+  }
+
+  _generateDeviceId (vendorId) {
+    // create an ID using the application ID and a vendor-specific device ID
+    // this ensures our device ID is different across apps & devices
+    // this also ensures the same app & device will always generate the same UUID
+    return uuid.v5(
+      `${UUID_NAME}-${this._application.applicationId}-${vendorId}`,
+      UUID_NAMESPACE
+    )
+  }
+
+  _cacheAndStoreId (id) {
+    DeviceId._cache = id
+
+    // save the ID but don't wait for it to be stored before returning
+    // ignore errors as the UUIDs we generate are deterministic - if we fail
+    // to store it this time, we will generate the same ID and try again next time
+    this._storage.setItem(DEVICE_ID_STORAGE_KEY, DeviceId._cache)
+      .catch(() => {})
+
+    return DeviceId._cache
+  }
+
+  async _getIosVendorId () {
+    const vendorId = await this._application.getIosIdForVendorAsync()
+
+    // iOS will sometimes return null as the ID for vendor; usually this means
+    // that the device has restarted and not yet been unlocked
+    if (vendorId) {
+      return vendorId
+    }
+
+    throw new Error('Unable to fetch the ID For Vendor')
+  }
+}

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -1,7 +1,10 @@
+const Application = require('expo-application').default
+const AsyncStorage = require('@react-native-async-storage/async-storage')
 const Device = require('expo-device')
 const Constants = require('expo-constants').default
 const { Dimensions, Platform } = require('react-native')
 const rnVersion = require('react-native/package.json').version
+const DeviceId = require('./device-id')
 
 module.exports = {
   load: client => {
@@ -22,7 +25,6 @@ module.exports = {
     updateOrientation()
 
     const device = {
-      id: Constants.installationId,
       manufacturer: Device.manufacturer,
       // On a real device these two seem equivalent, however on a simulator
       // 'Constants' is a bit more useful as it returns 'Simulator' whereas
@@ -41,6 +43,15 @@ module.exports = {
       },
       totalMemory: Device.totalMemory
     }
+
+    const deviceId = new DeviceId(Platform.OS, Constants, Application, AsyncStorage)
+    deviceId.get((error, id) => {
+      if (error) {
+        client._logger.error('Failed to get a Bugsnag device ID:', error)
+      } else {
+        device.id = id
+      }
+    })
 
     client.addOnSession(session => {
       session.device = { ...session.device, ...device }

--- a/packages/plugin-expo-device/package-lock.json
+++ b/packages/plugin-expo-device/package-lock.json
@@ -9,8 +9,11 @@
 			"version": "7.11.0",
 			"license": "MIT",
 			"dependencies": {
-				"expo-constants": "~11.0.0",
-				"expo-device": "~3.3.0"
+				"@react-native-async-storage/async-storage": "~1.15.0",
+				"expo-application": "^3.2.0",
+				"expo-constants": "~11.0.1",
+				"expo-device": "~3.3.0",
+				"uuid": "^8.3.2"
 			},
 			"peerDependencies": {
 				"@bugsnag/core": "^7.0.0"
@@ -1401,31 +1404,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@bugsnag/core": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.11.0.tgz",
-			"integrity": "sha512-xCaaONqQEAewifrvHC8v+yqN+Is4WNUcmK+sdeLcSb+ghLQ52y3BQ9nEDYzQxGuJRpv1zW3edCVIB4RN5eunSQ==",
-			"peer": true,
-			"dependencies": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "^6.0.0",
-				"error-stack-parser": "^2.0.3",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"node_modules/@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==",
-			"peer": true
-		},
-		"node_modules/@bugsnag/safe-json-stringify": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
-			"integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
-			"peer": true
-		},
 		"node_modules/@expo/config": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@expo/config/-/config-4.0.4.tgz",
@@ -1509,6 +1487,17 @@
 				"base64-js": "^1.2.3",
 				"xmlbuilder": "^14.0.0",
 				"xmldom": "~0.5.0"
+			}
+		},
+		"node_modules/@react-native-async-storage/async-storage": {
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.5.tgz",
+			"integrity": "sha512-4AYehLH39B9a8UXCMf3ieOK+G61wGMP72ikx6/XSMA0DUnvx0PgaeaT2Wyt06kTrDTy8edewKnbrbeqwaM50TQ==",
+			"dependencies": {
+				"deep-assign": "^3.0.0"
+			},
+			"peerDependencies": {
+				"react-native": "^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || 1000.0.0"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -1722,6 +1711,18 @@
 				}
 			}
 		},
+		"node_modules/deep-assign": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+			"integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+			"deprecated": "Check out `lodash.merge` or `merge-options` instead.",
+			"dependencies": {
+				"is-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1737,15 +1738,6 @@
 			"version": "1.3.790",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.790.tgz",
 			"integrity": "sha512-epMH/S2MkhBv+Y0+nHK8dC7bzmOaPwcmiYqt+VwxSUJLgPzkqZnGUEQ8eVhy5zGmgWm9tDDdXkHDzOEsVU979A=="
-		},
-		"node_modules/error-stack-parser": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-			"peer": true,
-			"dependencies": {
-				"stackframe": "^1.1.1"
-			}
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
@@ -1771,6 +1763,11 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/expo-application": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/expo-application/-/expo-application-3.2.0.tgz",
+			"integrity": "sha512-NDPQAtB05Jeiw771bDYsecbLrLA39X33Jk8uP1VUVdHMy6cCfJrL8PSDssgMLElAzR94K8toeqdGsGx9mVv8zw=="
+		},
 		"node_modules/expo-constants": {
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-11.0.1.tgz",
@@ -1779,6 +1776,15 @@
 				"@expo/config": "^4.0.0",
 				"expo-modules-core": "~0.2.0",
 				"uuid": "^3.3.2"
+			}
+		},
+		"node_modules/expo-constants/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
 			}
 		},
 		"node_modules/expo-device": {
@@ -1957,11 +1963,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=",
-			"peer": true
+		"node_modules/is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -2317,21 +2325,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/stack-generator": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-			"integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
-			"peer": true,
-			"dependencies": {
-				"stackframe": "^1.1.1"
-			}
-		},
-		"node_modules/stackframe": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-			"peer": true
-		},
 		"node_modules/stream-buffers": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
@@ -2422,12 +2415,11 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/wrappy": {
@@ -3454,31 +3446,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@bugsnag/core": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.11.0.tgz",
-			"integrity": "sha512-xCaaONqQEAewifrvHC8v+yqN+Is4WNUcmK+sdeLcSb+ghLQ52y3BQ9nEDYzQxGuJRpv1zW3edCVIB4RN5eunSQ==",
-			"peer": true,
-			"requires": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "^6.0.0",
-				"error-stack-parser": "^2.0.3",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==",
-			"peer": true
-		},
-		"@bugsnag/safe-json-stringify": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
-			"integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
-			"peer": true
-		},
 		"@expo/config": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@expo/config/-/config-4.0.4.tgz",
@@ -3561,6 +3528,14 @@
 				"base64-js": "^1.2.3",
 				"xmlbuilder": "^14.0.0",
 				"xmldom": "~0.5.0"
+			}
+		},
+		"@react-native-async-storage/async-storage": {
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.5.tgz",
+			"integrity": "sha512-4AYehLH39B9a8UXCMf3ieOK+G61wGMP72ikx6/XSMA0DUnvx0PgaeaT2Wyt06kTrDTy8edewKnbrbeqwaM50TQ==",
+			"requires": {
+				"deep-assign": "^3.0.0"
 			}
 		},
 		"ansi-styles": {
@@ -3715,6 +3690,14 @@
 				"ms": "2.1.2"
 			}
 		},
+		"deep-assign": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+			"integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+			"requires": {
+				"is-obj": "^1.0.0"
+			}
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3727,15 +3710,6 @@
 			"version": "1.3.790",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.790.tgz",
 			"integrity": "sha512-epMH/S2MkhBv+Y0+nHK8dC7bzmOaPwcmiYqt+VwxSUJLgPzkqZnGUEQ8eVhy5zGmgWm9tDDdXkHDzOEsVU979A=="
-		},
-		"error-stack-parser": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-			"peer": true,
-			"requires": {
-				"stackframe": "^1.1.1"
-			}
 		},
 		"escalade": {
 			"version": "3.1.1",
@@ -3752,6 +3726,11 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
+		"expo-application": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/expo-application/-/expo-application-3.2.0.tgz",
+			"integrity": "sha512-NDPQAtB05Jeiw771bDYsecbLrLA39X33Jk8uP1VUVdHMy6cCfJrL8PSDssgMLElAzR94K8toeqdGsGx9mVv8zw=="
+		},
 		"expo-constants": {
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-11.0.1.tgz",
@@ -3760,6 +3739,13 @@
 				"@expo/config": "^4.0.0",
 				"expo-modules-core": "~0.2.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
 			}
 		},
 		"expo-device": {
@@ -3893,11 +3879,10 @@
 				"has": "^1.0.3"
 			}
 		},
-		"iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=",
-			"peer": true
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -4164,21 +4149,6 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
-		"stack-generator": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-			"integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
-			"peer": true,
-			"requires": {
-				"stackframe": "^1.1.1"
-			}
-		},
-		"stackframe": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-			"peer": true
-		},
 		"stream-buffers": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
@@ -4232,9 +4202,9 @@
 			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
 		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -20,8 +20,11 @@
     "@bugsnag/core": "^7.11.0"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "~1.15.0",
+    "expo-application": "^3.2.0",
     "expo-constants": "~11.0.1",
-    "expo-device": "~3.3.0"
+    "expo-device": "~3.3.0",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0"

--- a/packages/plugin-expo-device/test/device-id.test.ts
+++ b/packages/plugin-expo-device/test/device-id.test.ts
@@ -1,0 +1,210 @@
+const DeviceId = require('../device-id')
+
+describe('plugin: expo device - device ID', () => {
+  const platforms = ['android', 'ios']
+  const storage = {
+    setItem: jest.fn(),
+    getItem: jest.fn()
+  }
+
+  beforeEach(() => {
+    Object.values(storage).forEach(mock => mock.mockReset())
+
+    // ensure setItem returns a promise so we can call 'catch' on its return value
+    storage.setItem.mockResolvedValue()
+
+    // reset the cached device ID otherwise tests will interfere with eachother
+    DeviceId._cache = null
+  })
+
+  describe('synchronous', () => {
+    it.each(platforms)('[%s] should return and store the installationId when available', os => {
+      const constants = { installationId: 'the installation ID' }
+      const application = {}
+      const callback = jest.fn()
+
+      const deviceId = new DeviceId(os, constants, application, storage)
+      deviceId.get(callback)
+
+      // ensure the callback is called synchronously
+      expect(callback).toHaveBeenCalledWith(null, 'the installation ID')
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      expect(storage.setItem).toHaveBeenCalledWith('bugsnag-device-id', 'the installation ID')
+      expect(storage.setItem).toHaveBeenCalledTimes(1)
+    })
+
+    // TODO is this actually necessary? will we ever call this more than once?
+    //      given the (low) possibility for changing the device ID if called
+    //      multiple times, it feels like this is useful but maybe it's not...
+    it.each(platforms)('[%s] should return the cached ID when available', os => {
+      const constants = {}
+      const application = {}
+      const callback = jest.fn()
+
+      const deviceId = new DeviceId(os, constants, application, storage)
+      DeviceId._cache = 'a cached value'
+
+      deviceId.get(callback)
+
+      // ensure the callback is called synchronously
+      expect(callback).toHaveBeenCalledWith(null, 'a cached value')
+      expect(callback).toHaveBeenCalledTimes(1)
+
+      // if the ID is cached then we expect that it has already been stored, so
+      // we shouldn't try to store it again
+      expect(storage.setItem).not.toHaveBeenCalled()
+    })
+  })
+
+  const getDeviceId = function (deviceId) {
+    return new Promise(function (resolve, reject) {
+      deviceId.get(function (error, id) {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(id)
+        }
+      })
+    })
+  }
+
+  describe('asynchronous', () => {
+    it.each(platforms)('[%s] should resolve to the stored ID when available', async os => {
+      const constants = {}
+      const application = {}
+
+      storage.getItem.mockImplementation(key => {
+        if (key === 'bugsnag-device-id') {
+          return 'a stored ID'
+        }
+      })
+
+      const deviceId = new DeviceId(os, constants, application, storage)
+
+      const id = await getDeviceId(deviceId)
+
+      expect(id).toBe('a stored ID')
+      expect(storage.setItem).not.toHaveBeenCalled()
+    })
+
+    it('[android] should store and resolve to a newly generated ID', async () => {
+      const constants = { androidId: 'andrew droid' }
+      const application = { applicationId: 'gansgub' }
+
+      const deviceId = new DeviceId('android', constants, application, storage)
+
+      const id = await getDeviceId(deviceId)
+
+      // the generated UUID should be based off of the given android ID
+      const expectedUuid = deviceId._generateDeviceId(constants.androidId)
+
+      expect(id).toBe(expectedUuid)
+      expect(storage.setItem).toHaveBeenCalledWith('bugsnag-device-id', expectedUuid)
+      expect(storage.setItem).toHaveBeenCalledTimes(1)
+      expect(storage.getItem).toHaveBeenCalledTimes(1)
+    })
+
+    it('[ios] should store and resolve to a newly generated ID using the iOS vendor ID', async () => {
+      const constants = {}
+      const application = {
+        async getIosIdForVendorAsync () {
+          return 'iGansgub'
+        }
+      }
+
+      const deviceId = new DeviceId('ios', constants, application, storage)
+
+      const id = await getDeviceId(deviceId)
+
+      // on iOS the generated UUID should be based off of the 'ID for vendor'
+      const expectedUuid = deviceId._generateDeviceId(await application.getIosIdForVendorAsync())
+
+      expect(id).toBe(expectedUuid)
+      expect(storage.setItem).toHaveBeenCalledWith('bugsnag-device-id', expectedUuid)
+      expect(storage.setItem).toHaveBeenCalledTimes(1)
+      expect(storage.getItem).toHaveBeenCalledTimes(1)
+    })
+
+    it('[ios] should error when vendor ID returns null', async () => {
+      const constants = {}
+      const application = {
+        async getIosIdForVendorAsync () {
+          return null
+        }
+      }
+
+      const deviceId = new DeviceId('ios', constants, application, storage)
+
+      await expect(getDeviceId(deviceId)).rejects.toThrow(new Error('Unable to fetch the ID For Vendor'))
+
+      expect(storage.setItem).not.toHaveBeenCalled()
+      expect(storage.getItem).toHaveBeenCalledTimes(1)
+    })
+
+    it.each(platforms)('[%s] succeeds if AsyncStorage.setItem throws an error', async os => {
+      const constants = {}
+      const application = {
+        androidId: 'gansgub',
+
+        async getIosIdForVendorAsync () {
+          return 'iGansgub'
+        }
+      }
+
+      storage.setItem.mockRejectedValueOnce(new Error('Failed to get from storage'))
+
+      const deviceId = new DeviceId(os, constants, application, storage)
+
+      expect(await getDeviceId(deviceId)).toBeTruthy()
+
+      expect(storage.setItem).toHaveBeenCalledWith('bugsnag-device-id', expect.any(String))
+      expect(storage.setItem).toHaveBeenCalledTimes(1)
+      expect(storage.getItem).toHaveBeenCalledTimes(1)
+    })
+
+    it.each(platforms)('[%s] fails if AsyncStorage.getItem throws an error', async os => {
+      const constants = {}
+      const application = {
+        androidId: 'gansgub',
+
+        async getIosIdForVendorAsync () {
+          return 'iGansgub'
+        }
+      }
+
+      storage.getItem.mockRejectedValue(new Error('Failed to get from storage'))
+
+      const deviceId = new DeviceId(os, constants, application, storage)
+
+      await expect(getDeviceId(deviceId)).rejects.toThrow(new Error('Failed to get from storage'))
+
+      expect(storage.setItem).not.toHaveBeenCalled()
+      expect(storage.getItem).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // TODO should this use the public API?
+  it.each(platforms)('[%s] should generate deterministic IDs', os => {
+    const constants = {}
+    const application = {}
+    const storage = {}
+
+    const deviceId = new DeviceId(os, constants, application, storage)
+
+    // two IDs generated with the same key should be the same
+    const id1 = deviceId._generateDeviceId('a key')
+    const id2 = deviceId._generateDeviceId('a key')
+
+    expect(id1).toBe(id2)
+
+    // two IDs generated with the same key different to the above should also be the same
+    const id3 = deviceId._generateDeviceId('a different key')
+    const id4 = deviceId._generateDeviceId('a different key')
+
+    expect(id3).toBe(id4)
+
+    // the IDs generated with different keys should _not_ be the same
+    expect(id3).not.toBe(id1)
+  })
+})

--- a/packages/plugin-expo-device/test/device.test.ts
+++ b/packages/plugin-expo-device/test/device.test.ts
@@ -38,6 +38,10 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'android', Version: ANDROID_API_LEVEL }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-application', () => ({ default: {} }))
+
+    const AsyncStorage = { setItem: jest.fn().mockResolvedValue(null), getItem: jest.fn() }
+    jest.doMock('@react-native-async-storage/async-storage', () => AsyncStorage)
 
     const plugin = require('..')
 
@@ -67,6 +71,10 @@ describe('plugin: expo device', () => {
         expect(r.events[0].metaData.device.appOwnership).toBe('standalone')
         expect(r.events[0].device.id).toBe('123')
         expect(r.events[0].user.id).toBe('123')
+
+        expect(AsyncStorage.setItem).toHaveBeenCalledWith('bugsnag-device-id', '123')
+        expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+
         done()
       },
       sendSession: () => {}
@@ -104,6 +112,11 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'ios' }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-application', () => ({ default: {} }))
+    jest.doMock('@react-native-async-storage/async-storage', () => ({
+      setItem: () => Promise.resolve(),
+      getItem: () => {}
+    }))
 
     const plugin = require('..')
 
@@ -168,6 +181,11 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'ios' }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-application', () => ({ default: {} }))
+    jest.doMock('@react-native-async-storage/async-storage', () => ({
+      setItem: () => Promise.resolve(),
+      getItem: () => {}
+    }))
 
     const plugin = require('..')
 
@@ -218,6 +236,11 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'ios' }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-application', () => ({ default: {} }))
+    jest.doMock('@react-native-async-storage/async-storage', () => ({
+      setItem: () => Promise.resolve(),
+      getItem: () => {}
+    }))
 
     const plugin = require('..')
 
@@ -292,6 +315,11 @@ describe('plugin: expo device', () => {
     }))
 
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-application', () => ({ default: {} }))
+    jest.doMock('@react-native-async-storage/async-storage', () => ({
+      setItem: () => Promise.resolve(),
+      getItem: () => {}
+    }))
 
     const plugin = require('..')
 


### PR DESCRIPTION
## Goal

Currently we use Expo's installation ID, but this is deprecated and will be removed in SDK 44 (2 SDKs time)

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->