### PR TITLE
feat(electron-filestore): support extracting crash paths for bg processes

### DIFF
--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -70,6 +70,14 @@ describe('FileStore', () => {
     })
   })
 
+  describe('getBackgroundEventInfoPath()', () => {
+    it('joins runinfo with a filename and an extension', () => {
+      const minidumpPath = process.platform === 'win32' ? 'E:\\some\\path\\myfile.dmp' : '/some/path/myfile.dmp'
+      const path = store.getBackgroundEventInfoPath(minidumpPath)
+      expect(path).toEqual(join(store.getPaths().runinfo, 'myfile.dmp.info'))
+    })
+  })
+
   describe('getDeviceInfo()', () => {
     it('returns an empty object if something goes wrong', async () => {
       const dir = process.platform === 'win32' ? '6:\\non\\existent' : '/dev/null/non/existent'


### PR DESCRIPTION
## Goal

Adds a new way to find event info for a given minidump, using the filename as a base. This is a prerequisite for uploading background crash reports.

## Testing

* Added a new unit for the function, and additional integration tests in a subsequent pull