### PR TITLE
feat(deliver-minidumps): support adding minidumps, enforce uniqueness

### DIFF
--- a/packages/plugin-electron-deliver-minidumps/minidump-queue.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-queue.js
@@ -2,18 +2,33 @@ module.exports = class MinidumpQueue {
   constructor (filestore) {
     this._filestore = filestore
     this._minidumps = null
+    this._seen = new Set()
   }
 
   async peek () {
     if (!this._minidumps) {
       try {
         this._minidumps = await this._filestore.listMinidumps()
+        this._minidumps.forEach(m => this._seen.add(m.minidumpPath))
       } catch (e) {
         this._minidumps = []
       }
     }
 
     return this._minidumps[0]
+  }
+
+  push (minidump) {
+    // if _minidumps has not yet been lazy-loaded, this minidump will be picked
+    // up automatically when the list loads
+    if (this._minidumps && !this._seen.has(minidump.minidumpPath)) {
+      this._seen.add(minidump.minidumpPath)
+      this._minidumps.push(minidump)
+    }
+  }
+
+  hasSeen (minidumpPath) {
+    return this._seen.has(minidumpPath)
   }
 
   remove (minidump) {


### PR DESCRIPTION
## Goal

Support adding minidumps which appear while the app runs to a queue for later delivery, avoiding any duplication. 

## Design

This behavior has a lot of constraints given:

* The first disk access to generate the list of minidumps should be asynchronous
* We'll need to verify whether a minidump has been "seen" yet by its path, though the queue should keep whole minidump objects
* Delivery cannot start until "ready" (and that starts the lazy loading of existing minidumps) but a crash can happen at any time, even before that point

So it does something a bit unusual, but hopefully still makes sense

## Changeset

* Added `push()` and `hasSeen()` to `MinidumpQueue`, which if initialized, adds a new minidump to the existing ones. If not, the call is ignored (but the minidump should be picked up automatically by `filestore.listMinidumps()` afterwards)

## Testing

* Added new unit tests and integration tests in a subsequent changeset which uses the queue changes to send background minidumps