### PR TITLE
Fixed minidump generation for electron applications on Linux

### DIFF
--- a/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.c
+++ b/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.c
@@ -50,7 +50,7 @@ static const char *const keypath_user_id = "user.id";
 static const char *const keypath_user_name = "user.name";
 static const char *const keypath_user_email = "user.email";
 
-static void handle_crash(int context) {
+static void handle_crash(void *context) {
   becsp_persist_to_disk();
   bescp_persist_last_run_info_if_required();
   // Uninstall handlers

--- a/packages/plugin-electron-client-state-persistence/src/crash_handler-posix.c
+++ b/packages/plugin-electron-client-state-persistence/src/crash_handler-posix.c
@@ -3,44 +3,82 @@
 #include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 static const int bsg_native_signals[] = {SIGILL, SIGTRAP, SIGABRT,
                                          SIGBUS, SIGFPE,  SIGSEGV};
 #define SIGNAL_COUNT sizeof(bsg_native_signals) / sizeof(const int)
 
-static void (*prev_handlers[SIGNAL_COUNT])(int);
-static void (*registered_handler)(int);
+struct bsg_signal_continue_data {
+  int signal;
+   siginfo_t *info;
+   void *user_context;
+};
 
-static void crash_handler(int signal) {
+static struct sigaction prev_handlers[SIGNAL_COUNT];
+static void (*registered_handler)(void*);
+
+static void crash_handler(int signal, siginfo_t *info, void *user_context) {
+  struct bsg_signal_continue_data scd;
+  scd.signal = signal;
+  scd.info = info;
+  scd.user_context = user_context;
   if (registered_handler) {
-    registered_handler(signal);
+    registered_handler(&scd);
   }
 }
 
-void becsp_crash_handler_install(void (*func)(int context)) {
+void becsp_crash_handler_install(void (*func)(void *context)) {
   registered_handler = func;
+
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+
   for (size_t index = 0; index < SIGNAL_COUNT; index++) {
     const int sig = bsg_native_signals[index];
-    prev_handlers[index] = signal(sig, crash_handler);
+    // remember the previous signal handlers
+    sigaction(sig, NULL, &prev_handlers[index]);
+    // add every signal to the sigaction mask
+    sigaddset(&sa.sa_mask, sig);
+  }
+
+  sa.sa_sigaction = crash_handler;
+  sa.sa_flags = SA_SIGINFO;
+
+  // set the new signal handler
+  for (size_t index = 0; index < SIGNAL_COUNT; index++) {
+      const int sig = bsg_native_signals[index];
+      sigaction(sig, &sa, NULL);
   }
 }
 
 void becsp_crash_handler_uninstall(void) {
   for (size_t index = 0; index < SIGNAL_COUNT; index++) {
     const int sig = bsg_native_signals[index];
-    signal(sig, prev_handlers[index]);
+    sigaction(sig, &prev_handlers[index], NULL);
   }
 }
 
-void becsp_crash_handler_continue(int _sig) {
+void becsp_crash_handler_continue(void *context) {
+  struct bsg_signal_continue_data *scd = context;
+
   for (size_t index = 0; index < SIGNAL_COUNT; index++) {
     const int sig = bsg_native_signals[index];
-    if (sig == _sig) {
-      void (*prev)(int) = prev_handlers[index];
-      if (prev == SIG_DFL) {
-        raise(_sig);
-      } else if (prev != NULL && prev != SIG_IGN) {
-        prev(_sig);
+    if (sig == scd->signal) {
+      if((prev_handlers[index].sa_flags & SA_SIGINFO) != 0) {
+        void (*prev_action)(int, siginfo_t *, void *) = prev_handlers[index].sa_sigaction;
+
+        if(prev_action != NULL) {
+          prev_action(sig, scd->info, scd->user_context);
+        }
+      } else {
+        void (*prev)(int) = prev_handlers[index].sa_handler;
+        if (prev == SIG_DFL) {
+          raise(sig);
+        } else if (prev != NULL && prev != SIG_IGN) {
+          prev(sig);
+        }
       }
     }
   }

--- a/packages/plugin-electron-client-state-persistence/src/crash_handler-win.c
+++ b/packages/plugin-electron-client-state-persistence/src/crash_handler-win.c
@@ -2,7 +2,7 @@
 
 #include "crash_handler.h"
 
-static void (*registered_handler)(int);
+static void (*registered_handler)(void*);
 static PVOID vectored_handler_token;
 
 // AddVectoredExceptionHandler's initial parameter is a number indicating
@@ -14,13 +14,13 @@ static LONG WINAPI crash_handler(struct _EXCEPTION_POINTERS *info) {
   // vectored handlers can be called for non-crash reasons, so the exception
   // code should be checked to ensure this is a termination.
   if (FAILED(info->ExceptionRecord->ExceptionCode) && registered_handler) {
-    registered_handler(0); // the parameter value is unused, sending a sentinel
+    registered_handler(NULL); // the parameter value is unused, sending a sentinel
   }
 
   return EXCEPTION_CONTINUE_SEARCH;
 }
 
-void becsp_crash_handler_install(void (*func)(int)) {
+void becsp_crash_handler_install(void (*func)(void*)) {
   registered_handler = func;
   vectored_handler_token = AddVectoredExceptionHandler(CALL_FIRST, crash_handler);
 }
@@ -32,6 +32,6 @@ void becsp_crash_handler_uninstall(void) {
   }
 }
 
-void becsp_crash_handler_continue(int context) {
+void becsp_crash_handler_continue(void *context) {
   // not needed on windows as continue handlers are called automatically
 }

--- a/packages/plugin-electron-client-state-persistence/src/crash_handler.h
+++ b/packages/plugin-electron-client-state-persistence/src/crash_handler.h
@@ -7,7 +7,7 @@
  *             called from here. The context parameter value is necessary to
  *             invoke bescp_crash_handler_continue().
  */
-void becsp_crash_handler_install(void (*func)(int context));
+void becsp_crash_handler_install(void (*func)(void *context));
 
 /**
  * Remove any registered crash handlers, restoring the system to its previous
@@ -21,4 +21,4 @@ void becsp_crash_handler_uninstall(void);
  *
  * @param context The value passed to the registered crash function
  */
-void becsp_crash_handler_continue(int context);
+void becsp_crash_handler_continue(void *context);


### PR DESCRIPTION
## Goal
Electron applications running on Linux should generate minidump files for all of the signals that we handle as crashes, as it was only producing minidump files for `SIGSEGV` related errors.

## Design
Due to a limitation in [Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) and the implementation of [signal](https://man7.org/linux/man-pages/man2/signal.2.html), we could not forward the required information to the [Breakpad signal handler](https://github.com/google/breakpad/blob/78f7ae495bc147e97a58e8158072fd35fdd99419/src/client/linux/handler/exception_handler.cc#L344). This stopped Breadpad from generating minidump files for anything except `SIGSEGV` errors.

The new implementation replaces the `int context` in our internal handler implementation with an opaque pointer. This allows us to use `sigaction` with the `SA_SIGINFO` flag to capture all of the signal information, and then pass it to any signal handlers registered before Bugsnag.

## Changeset
Changed the posix signal install / uninstall in the `plugin-electron-client-state-persistence` module to use `sigaction` instead of `signal` - allowing us to forward errors to signal handlers with the `SA_SIGINFO` flag.

## Testing
Manual testing in a Linux VM using the internal `electron-minidump-example` application. Further automated testing will require updates to the Electron test fixture.