### PR TITLE
Fixes for build failures

### DIFF
--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -24,6 +24,7 @@ steps:
     timeout_in_minutes: 60
     env:
       REACT_NATIVE_VERSION: "rn0.60"
+      LANG: "en_US.UTF-8"
     plugins:
       - docker-compose#v3.3.0:
           run: react-native-android-builder
@@ -37,6 +38,7 @@ steps:
       queue: "opensource-mac-rn"
     env:
       REACT_NATIVE_VERSION: rn0.60
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0.60.ipa
     commands:
       - npm run test:build-react-native-ios
@@ -61,6 +63,7 @@ steps:
       queue: "opensource-mac-cocoa-11"
     env:
       REACT_NATIVE_VERSION: rn0.63
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0.63.ipa
     commands:
       - npm run test:build-react-native-ios
@@ -85,6 +88,7 @@ steps:
       queue: "opensource-mac-cocoa-11"
     env:
       REACT_NATIVE_VERSION: rn0.64-hermes
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0.64-hermes.ipa
     commands:
       - npm run test:build-react-native-ios
@@ -115,6 +119,7 @@ steps:
       REACT_NATIVE_VERSION: rn0.60
       JS_SOURCE_DIR: "react_navigation_js"
       ARTEFACT_NAME: "r_navigation_0.60"
+      LANG: "en_US.UTF-8"
     artifact_paths: build/r_navigation_0.60.ipa
     commands:
       - npm run test:build-react-native-ios
@@ -145,6 +150,7 @@ steps:
       REACT_NATIVE_VERSION: rn0.63
       JS_SOURCE_DIR: "react_navigation_js"
       ARTEFACT_NAME: "r_navigation_0.63"
+      LANG: "en_US.UTF-8"
     artifact_paths: build/r_navigation_0.63.ipa
     commands:
       - npm run test:build-react-native-ios
@@ -175,6 +181,7 @@ steps:
       REACT_NATIVE_VERSION: rn0.60
       JS_SOURCE_DIR: "react_native_navigation_js"
       ARTEFACT_NAME: "r_native_navigation_0.60"
+      LANG: "en_US.UTF-8"
     artifact_paths: build/r_native_navigation_0.60.ipa
     commands:
       - npm run test:build-react-native-ios
@@ -205,6 +212,7 @@ steps:
       REACT_NATIVE_VERSION: rn0.63
       JS_SOURCE_DIR: "react_native_navigation_js"
       ARTEFACT_NAME: "r_native_navigation_0.63"
+      LANG: "en_US.UTF-8"
     artifact_paths: build/r_native_navigation_0.63.ipa
     commands:
       - npm run test:build-react-native-ios

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -1,13 +1,10 @@
-FROM openjdk:8-jdk-stretch
-
-RUN apt-get update
+FROM openjdk:8-jdk-buster
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update
-RUN apt-get install -y nodejs make g++ yarn rsync jq
+RUN apt-get update && apt-get install -y nodejs make g++ yarn rsync jq
 
 WORKDIR /app/test/expo/features/fixtures/test-app
 


### PR DESCRIPTION
## Goal

Fixes some build failures that have crept in due to external changes:
- Fix React Native IPA build failures by setting the LANG environment variable as suggested.
- Update base Debian version used for Expo Android builder image