### PR TITLE
Fix electron net breadcrumbs test

### DIFF
--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -5,6 +5,8 @@ import { createServer, STATUS_CODES, Server, IncomingMessage, ServerResponse } f
 import { makeClientForPlugin } from '@bugsnag/electron-test-helpers'
 import plugin from '..'
 
+jest.setTimeout(10 * 1000)
+
 interface ServerWithPort extends Server { port: number }
 
 let currentServer: ServerWithPort|null = null


### PR DESCRIPTION
## Goal

Something has caused the net breadcrumbs test to timeout on Linux (not Windows or MacOS)

I'm still not sure what this is, especially as it's only the first test that runs — after the first test is done, the rest finish in milliseconds. The obvious answers would be a new Electron or Node release, but neither seem to coincide with when it started failing

Increasing Jest's timeout to 10 seconds is enough to fix this for now, but we should revisit these tests to figure out the issue in future