### PR TITLE
Add feature flag delegate

### DIFF
--- a/packages/core/lib/feature-flag-delegate.js
+++ b/packages/core/lib/feature-flag-delegate.js
@@ -1,0 +1,35 @@
+const isArray = require('./es-utils/is-array')
+const jsonStringify = require('@bugsnag/safe-json-stringify')
+
+function add (existingFeatures, name, variant) {
+  if (typeof name !== 'string') {
+    return
+  }
+
+  if (variant === undefined) {
+    variant = null
+  } else if (variant !== null && typeof variant !== 'string') {
+    variant = jsonStringify(variant)
+  }
+
+  existingFeatures[name] = variant
+}
+
+function merge (existingFeatures, newFeatures) {
+  if (!isArray(newFeatures)) {
+    return
+  }
+
+  for (let i = 0; i < newFeatures.length; ++i) {
+    const feature = newFeatures[i]
+
+    if (feature === null || typeof feature !== 'object') {
+      continue
+    }
+
+    // 'add' will handle if 'name' doesn't exist & 'variant' is optional
+    add(existingFeatures, feature.name, feature.variant)
+  }
+}
+
+module.exports = { add, merge }

--- a/packages/core/lib/test/feature-flag-delegate.test.ts
+++ b/packages/core/lib/test/feature-flag-delegate.test.ts
@@ -1,0 +1,195 @@
+import delegate from '../feature-flag-delegate'
+
+describe('feature flag delegate', () => {
+  describe('#add', () => {
+    it('should do nothing if name is not passed', () => {
+      const existingFeatures = { abc: 'xyz' }
+
+      delegate.add(existingFeatures)
+
+      expect(existingFeatures).toStrictEqual({ abc: 'xyz' })
+    })
+
+    it('should do nothing if name is undefined but variant is passed', () => {
+      const existingFeatures = { abc: 'xyz' }
+
+      delegate.add(existingFeatures, undefined, '???')
+
+      expect(existingFeatures).toStrictEqual({ abc: 'xyz' })
+    })
+
+    it('should do nothing if name is null but variant is passed', () => {
+      const existingFeatures = { abc: 'xyz' }
+
+      delegate.add(existingFeatures, null, '???')
+
+      expect(existingFeatures).toStrictEqual({ abc: 'xyz' })
+    })
+
+    it('should add a feature flag with only a name if variant is undefined', () => {
+      const existingFeatures = {}
+
+      delegate.add(existingFeatures, 'good_feature')
+
+      expect(existingFeatures).toStrictEqual({ good_feature: null })
+    })
+
+    it('should add a feature flag with only a name if variant is null', () => {
+      const existingFeatures = {}
+
+      delegate.add(existingFeatures, 'ok_feature', null)
+
+      expect(existingFeatures).toStrictEqual({ ok_feature: null })
+    })
+
+    it('should add a feature flag with a variant', () => {
+      const existingFeatures = {}
+
+      delegate.add(existingFeatures, 'cool_feature', 'very ant')
+
+      expect(existingFeatures).toStrictEqual({ cool_feature: 'very ant' })
+    })
+
+    it.each([
+      [12345, '12345'],
+      [0, '0'],
+      [true, 'true'],
+      [false, 'false'],
+      [[1, 2, 3], '[1,2,3]'],
+      [[], '[]'],
+      [{ a: 1, b: 2, c: { d: 3 } }, '{"a":1,"b":2,"c":{"d":3}}'],
+      [{ abc: 123, toString () { throw new Error('nope') } }, '{"abc":123}']
+    ])('should handle non-string variant: %p', (variant, expected) => {
+      const existingFeatures = {}
+
+      delegate.add(existingFeatures, 'some_feature', variant)
+
+      expect(existingFeatures).toStrictEqual({ some_feature: expected })
+    })
+
+    it('should overwrite an existing flag if the name already exists', () => {
+      const existingFeatures = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }
+
+      delegate.add(existingFeatures, 'b', 'x')
+      delegate.add(existingFeatures, 'e', 'y')
+      delegate.add(existingFeatures, 'a', 'z')
+
+      expect(existingFeatures).toStrictEqual({ a: 'z', b: 'x', c: 'c', d: 'd', e: 'y' })
+    })
+  })
+
+  describe('#merge', () => {
+    it('should set feature flags when there are no existing flags', () => {
+      const existingFeatures = {}
+
+      delegate.merge(existingFeatures, [
+        { name: 'a', variant: 'b' },
+        { name: 'c', variant: 'd' }
+      ])
+
+      expect(existingFeatures).toStrictEqual({ a: 'b', c: 'd' })
+    })
+
+    it('should merge feature flags with existing flags', () => {
+      const existingFeatures = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }
+
+      delegate.merge(existingFeatures, [
+        { name: 'b', variant: 'x' },
+        { name: 'e', variant: 'y' },
+        { name: 'a', variant: 'z' }
+      ])
+
+      expect(existingFeatures).toStrictEqual({ a: 'z', b: 'x', c: 'c', d: 'd', e: 'y' })
+    })
+
+    it('should handle non-string variants', () => {
+      const existingFeatures = {
+        a: 'a',
+        b: 'b',
+        c: 'c',
+        d: 'd',
+        e: 'e',
+        f: 'f',
+        g: 'g',
+        h: 'h',
+        i: 'i',
+        j: 'j',
+        k: 'k',
+        l: 'l',
+        m: 'm',
+        n: 'n',
+        o: 'o',
+        p: 'p'
+      }
+
+      delegate.merge(existingFeatures, [
+        { name: 'a', variant: 12345 },
+        { name: 'c', variant: 0 },
+        { name: 'e', variant: true },
+        { name: 'g', variant: false },
+        { name: 'i', variant: [1, 2, 3] },
+        { name: 'k', variant: [] },
+        { name: 'm', variant: { a: 1, b: 2, c: { d: 3 } } },
+        { name: 'o', variant: { abc: 123, toString () { throw new Error('nope') } } }
+      ])
+
+      expect(existingFeatures).toStrictEqual({
+        a: '12345',
+        b: 'b',
+        c: '0',
+        d: 'd',
+        e: 'true',
+        f: 'f',
+        g: 'false',
+        h: 'h',
+        i: '[1,2,3]',
+        j: 'j',
+        k: '[]',
+        l: 'l',
+        m: '{"a":1,"b":2,"c":{"d":3}}',
+        n: 'n',
+        o: '{"abc":123}',
+        p: 'p'
+      })
+    })
+
+    it('should ignore feature flags with invalid/missing names', () => {
+      const existingFeatures = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }
+
+      delegate.merge(existingFeatures, [
+        { name: 'b', variant: 'x' },
+        { variant: 'y' },
+        { name: 'a', variant: 'z' },
+        { name: [1, 2, 3], variant: 'zzz' },
+        { name: 1234, variant: 'oooo' },
+        { name: { a: 1 }, variant: 'oooo' }
+      ])
+
+      expect(existingFeatures).toStrictEqual({ a: 'z', b: 'x', c: 'c', d: 'd', e: 'e' })
+    })
+
+    it('should do nothing if not given an array of features', () => {
+      const existingFeatures = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }
+
+      delegate.merge(existingFeatures, { a: 'a', b: 'b', c: 'c' })
+
+      expect(existingFeatures).toStrictEqual({ a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' })
+    })
+
+    it('should skip feature flags that are not objects', () => {
+      const existingFeatures = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e' }
+
+      delegate.merge(existingFeatures, [
+        { name: 'b', variant: 'x' },
+        'name: yes',
+        undefined,
+        { name: 'a', variant: 'z' },
+        null,
+        1234,
+        { name: 'e', variant: 'oooo' }
+      ])
+
+      expect(existingFeatures).toStrictEqual({ a: 'z', b: 'x', c: 'c', d: 'd', e: 'oooo' })
+    })
+  })
+})


### PR DESCRIPTION
## Goal

This is like [the metadata delegate](https://github.com/bugsnag/bugsnag-js/blob/2723b7ea90b33d785198f5104216fbcf533af936/packages/core/lib/metadata-delegate.js), but for feature flags. It holds a common API for both Client & Event to use in future, though is unused as of this PR

## Design

This implements two functions: `add` & `merge`. `add` is used to add a single flag at a time and is given a `name` and optionally a `variant`. `merge` will add new flags and overwrite existing flags from an array of objects with a `name` and optionally a `variant` (e.g. `{ name: 'flag' }` or `{ name: 'flag', variant: 'example' }`)

Removing feature flags should be straight-forward enough that it's actually less duplication to implement in both Client & Event directly, rather than going through a delegate