### PR TITLE
Add `featureFlags` to configuration

### DIFF
--- a/packages/core/client.d.ts
+++ b/packages/core/client.d.ts
@@ -50,6 +50,7 @@ export default class ClientWithInternals<T extends Config = Config> extends Clie
   _user: User
 
   _metadata: { [key: string]: any }
+  _features: { [key: string]: string | null }
 
   startSession(): ClientWithInternals
   resumeSession(): ClientWithInternals

--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -9,6 +9,7 @@ const reduce = require('./lib/es-utils/reduce')
 const keys = require('./lib/es-utils/keys')
 const assign = require('./lib/es-utils/assign')
 const runCallbacks = require('./lib/callback-runner')
+const featureFlagDelegate = require('./lib/feature-flag-delegate')
 const metadataDelegate = require('./lib/metadata-delegate')
 const runSyncCallbacks = require('./lib/sync-callback-runner')
 const BREADCRUMB_TYPES = require('./lib/breadcrumb-types')
@@ -35,6 +36,7 @@ class Client {
     this._breadcrumbs = []
     this._session = null
     this._metadata = {}
+    this._features = {}
     this._context = undefined
     this._user = {}
 
@@ -133,6 +135,7 @@ class Client {
 
     // update and elevate some options
     this._metadata = assign({}, config.metadata)
+    featureFlagDelegate.merge(this._features, config.featureFlags)
     this._user = assign({}, config.user)
     this._context = config.context
     if (config.logger) this._logger = config.logger

--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -153,5 +153,13 @@ module.exports.schema = {
       isArray(value) && value.length === filter(value, p =>
         (p && typeof p === 'object' && typeof p.load === 'function')
       ).length
+  },
+  featureFlags: {
+    defaultValue: () => [],
+    message: 'should be an array of objects that have a "name" property',
+    validate: value =>
+      isArray(value) && value.length === filter(value, feature =>
+        feature && typeof feature === 'object' && typeof feature.name === 'string'
+      ).length
   }
 }

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -56,4 +56,36 @@ describe('@bugsnag/core/config', () => {
       })).toBe(false)
     })
   })
+
+  describe('featureFlags', () => {
+    it.each([
+      undefined,
+      null,
+      1234,
+      'hello',
+      { name: 'example' },
+      { length: 1000 }
+    ])('fails when the supplied value is not an array (%p)', value => {
+      const validator = config.schema.featureFlags.validate
+
+      expect(validator(value)).toBe(false)
+    })
+
+    it('fails when a value does not have a "name"', () => {
+      const validator = config.schema.featureFlags.validate
+
+      expect(validator([{ name: 'hello' }, { notName: 'oops' }])).toBe(false)
+    })
+
+    it('passes when all values have a "name"', () => {
+      const validator = config.schema.featureFlags.validate
+      const featureFlags = [
+        { name: 'hello' },
+        { name: 'abc', variant: 'xyz' },
+        { name: 'hi' }
+      ]
+
+      expect(validator(featureFlags)).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Goal

Adds a new `featureFlags` configuration option, which populates the initial set of feature flags in a client

This takes an array of objects that have a `name` property and an optional `variant`, i.e.:

```js
Bugsnag.start({
  featureFlags: [
    { name: 'some flag', variant: 'a variant' },
    { name: 'another flag' },
  ]
})
```

Based on https://github.com/bugsnag/bugsnag-js/pull/1546 as the new delegate is used to load the flags