### PR TITLE
Add feature flag API to Client & Event

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -89,6 +89,22 @@ class Client {
     return metadataDelegate.clear(this._metadata, section, key)
   }
 
+  addFeatureFlag (name, variant = null) {
+    featureFlagDelegate.add(this._features, name, variant)
+  }
+
+  addFeatureFlags (featureFlags) {
+    featureFlagDelegate.merge(this._features, featureFlags)
+  }
+
+  clearFeatureFlag (name) {
+    delete this._features[name]
+  }
+
+  clearFeatureFlags () {
+    this._features = {}
+  }
+
   getContext () {
     return this._context
   }

--- a/packages/core/event.d.ts
+++ b/packages/core/event.d.ts
@@ -16,6 +16,7 @@ interface HandledState {
 export default class EventWithInternals extends Event {
   constructor (errorClass: string, errorMessage: string, stacktrace: any[], handledState?: HandledState, originalError?: Error)
   _metadata: { [key: string]: any }
+  _features: { [key: string]: string | null }
   _user: User
   _handledState: HandledState
   _session?: Session

--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -6,6 +6,7 @@ const reduce = require('./lib/es-utils/reduce')
 const filter = require('./lib/es-utils/filter')
 const assign = require('./lib/es-utils/assign')
 const metadataDelegate = require('./lib/metadata-delegate')
+const featureFlagDelegate = require('./lib/feature-flag-delegate')
 const isError = require('./lib/iserror')
 
 class Event {
@@ -27,6 +28,7 @@ class Event {
     this.threads = []
 
     this._metadata = {}
+    this._features = {}
     this._user = {}
     this._session = undefined
 
@@ -65,6 +67,22 @@ class Event {
 
   clearMetadata (section, key) {
     return metadataDelegate.clear(this._metadata, section, key)
+  }
+
+  addFeatureFlag (name, variant = null) {
+    featureFlagDelegate.add(this._features, name, variant)
+  }
+
+  addFeatureFlags (featureFlags) {
+    featureFlagDelegate.merge(this._features, featureFlags)
+  }
+
+  clearFeatureFlag (name) {
+    delete this._features[name]
+  }
+
+  clearFeatureFlags () {
+    this._features = {}
   }
 
   getUser () {

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -947,5 +947,142 @@ describe('@bugsnag/core/client', () => {
 
       expect(client._features).toStrictEqual({})
     })
+
+    describe('#addFeatureFlag', () => {
+      it('adds the given flag/variant combination', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.addFeatureFlag('a name', 'variant number 1234')
+
+        expect(client._features).toStrictEqual({ a: '1', 'a name': 'variant number 1234' })
+      })
+
+      it('overwrites an existing flag by name', () => {
+        const client = new Client({ apiKey: 'API_KEY' })
+
+        client.addFeatureFlag('a name', 'variant number 1234')
+        client.addFeatureFlag('a name', 'variant number 5678')
+
+        expect(client._features).toStrictEqual({ 'a name': 'variant number 5678' })
+      })
+
+      it('adds the given flag when no variant is passed', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.addFeatureFlag('a name')
+
+        expect(client._features).toStrictEqual({ a: '1', 'a name': null })
+      })
+
+      it('adds the given flag when the variant is null', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.addFeatureFlag('a name', null)
+
+        expect(client._features).toStrictEqual({ a: '1', 'a name': null })
+      })
+
+      it('does not add the flag if no name is passed', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        // @ts-expect-error
+        client.addFeatureFlag()
+
+        expect(client._features).toStrictEqual({ a: '1' })
+      })
+    })
+
+    describe('#addFeatureFlags', () => {
+      it('adds the given feature flags', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.addFeatureFlags([
+          { name: 'abc' },
+          { name: 'xyz', variant: 'yes' },
+          { name: 'aaa', variant: 'no' },
+          { name: 'zzz', variant: 'maybe' },
+          { name: 'idk' }
+        ])
+
+        expect(client._features).toStrictEqual({
+          a: '1',
+          abc: null,
+          xyz: 'yes',
+          aaa: 'no',
+          zzz: 'maybe',
+          idk: null
+        })
+      })
+
+      it('does not add the flags if none are passed', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.addFeatureFlags([])
+
+        expect(client._features).toStrictEqual({ a: '1' })
+      })
+
+      it('does not add flags if nothing is passed', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        // @ts-expect-error
+        client.addFeatureFlags()
+
+        expect(client._features).toStrictEqual({ a: '1' })
+      })
+    })
+
+    describe('#clearFeatureFlag', () => {
+      it('removes the given flag', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.clearFeatureFlag('a')
+
+        expect(client._features).toStrictEqual({})
+      })
+
+      it('does nothing if there are no flags', () => {
+        const client = new Client({ apiKey: 'API_KEY' })
+
+        client.clearFeatureFlag('a')
+
+        expect(client._features).toStrictEqual({})
+      })
+
+      it('does nothing if the given flag does not exist', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.clearFeatureFlag('b')
+
+        expect(client._features).toStrictEqual({ a: '1' })
+      })
+
+      it('does nothing if not given a flag', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        // @ts-expect-error
+        client.clearFeatureFlag()
+
+        expect(client._features).toStrictEqual({ a: '1' })
+      })
+    })
+
+    describe('#clearFeatureFlags', () => {
+      it('removes all flags', () => {
+        const client = new Client({ apiKey: 'API_KEY', featureFlags: [{ name: 'a', variant: '1' }] })
+
+        client.clearFeatureFlags()
+
+        expect(client._features).toStrictEqual({})
+      })
+
+      it('does nothing if there are no flags', () => {
+        const client = new Client({ apiKey: 'API_KEY' })
+
+        client.clearFeatureFlags()
+
+        expect(client._features).toStrictEqual({})
+      })
+    })
   })
 })

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -178,4 +178,142 @@ describe('@bugsnag/core/event', () => {
       expect(reserialized.exceptions.length).toBe(1)
     })
   })
+
+  describe('feature flags', () => {
+    describe('#addFeatureFlag', () => {
+      it('adds the given flag/variant combination', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.addFeatureFlag('a name', 'variant number 1234')
+
+        expect(event._features).toStrictEqual({ 'a name': 'variant number 1234' })
+      })
+
+      it('overwrites an existing flag by name', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.addFeatureFlag('a name', 'variant number 1234')
+        event.addFeatureFlag('a name', 'variant number 5678')
+
+        expect(event._features).toStrictEqual({ 'a name': 'variant number 5678' })
+      })
+
+      it('adds the given flag when no variant is passed', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.addFeatureFlag('a name')
+
+        expect(event._features).toStrictEqual({ 'a name': null })
+      })
+
+      it('adds the given flag when the variant is null', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.addFeatureFlag('a name', null)
+
+        expect(event._features).toStrictEqual({ 'a name': null })
+      })
+
+      it('does not add the flag if no name is passed', () => {
+        const event = new Event('Err', 'bad', [])
+
+        // @ts-expect-error
+        event.addFeatureFlag()
+
+        expect(event._features).toStrictEqual({})
+      })
+    })
+
+    describe('#addFeatureFlags', () => {
+      it('adds the given feature flags', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.addFeatureFlags([
+          { name: 'abc' },
+          { name: 'xyz', variant: 'yes' },
+          { name: 'aaa', variant: 'no' },
+          { name: 'zzz', variant: 'maybe' },
+          { name: 'idk' }
+        ])
+
+        expect(event._features).toStrictEqual({
+          abc: null,
+          xyz: 'yes',
+          aaa: 'no',
+          zzz: 'maybe',
+          idk: null
+        })
+      })
+
+      it('does not add the flags if none are passed', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.addFeatureFlags([])
+
+        expect(event._features).toStrictEqual({})
+      })
+
+      it('does not add flags if nothing is passed', () => {
+        const event = new Event('Err', 'bad', [])
+
+        // @ts-expect-error
+        event.addFeatureFlags()
+
+        expect(event._features).toStrictEqual({})
+      })
+    })
+
+    describe('#clearFeatureFlag', () => {
+      it('removes the given flag', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.clearFeatureFlag('a')
+
+        expect(event._features).toStrictEqual({})
+      })
+
+      it('does nothing if there are no flags', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.clearFeatureFlag('a')
+
+        expect(event._features).toStrictEqual({})
+      })
+
+      it('does nothing if the given flag does not exist', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.clearFeatureFlag('b')
+
+        expect(event._features).toStrictEqual({})
+      })
+
+      it('does nothing if not given a flag', () => {
+        const event = new Event('Err', 'bad', [])
+
+        // @ts-expect-error
+        event.clearFeatureFlag()
+
+        expect(event._features).toStrictEqual({})
+      })
+    })
+
+    describe('#clearFeatureFlags', () => {
+      it('removes all flags', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.clearFeatureFlags()
+
+        expect(event._features).toStrictEqual({})
+      })
+
+      it('does nothing if there are no flags', () => {
+        const event = new Event('Err', 'bad', [])
+
+        event.clearFeatureFlags()
+
+        expect(event._features).toStrictEqual({})
+      })
+    })
+  })
 })

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -5,7 +5,8 @@ import {
   OnErrorCallback,
   OnSessionCallback,
   OnBreadcrumbCallback,
-  User
+  User,
+  FeatureFlag
 } from './common'
 import Event from './event'
 import Session from './session'
@@ -38,6 +39,12 @@ declare class Client {
   public addMetadata(section: string, key: string, value: any): void;
   public getMetadata(section: string, key?: string): any;
   public clearMetadata(section: string, key?: string): void;
+
+  // feature flags
+  public addFeatureFlag(name: string, variant?: string | null): void
+  public addFeatureFlags(featureFlags: FeatureFlag[]): void
+  public clearFeatureFlag(name: string): void
+  public clearFeatureFlags(): void
 
   // context
   public getContext(): string | undefined;

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -141,3 +141,8 @@ export interface Stackframe {
   code?: Record<string, string>
   inProject?: boolean
 }
+
+export interface FeatureFlag {
+  name: string
+  variant?: string | null
+}

--- a/packages/core/types/event.d.ts
+++ b/packages/core/types/event.d.ts
@@ -6,7 +6,8 @@ import {
   Logger,
   User,
   Thread,
-  Stackframe
+  Stackframe,
+  FeatureFlag
 } from './common'
 
 declare class Event {
@@ -45,6 +46,12 @@ declare class Event {
   public addMetadata(section: string, key: string, value: any): void
   public getMetadata(section: string, key?: string): any
   public clearMetadata(section: string, key?: string): void
+
+  // feature flags
+  public addFeatureFlag(name: string, variant?: string | null): void
+  public addFeatureFlags(featureFlags: FeatureFlag[]): void
+  public clearFeatureFlag(name: string): void
+  public clearFeatureFlags(): void
 }
 
 interface HandledState {


### PR DESCRIPTION
## Goal

Adds the following API to both Client and Event:

```typescript
interface FeatureFlagApi {
  public addFeatureFlag(name: string, variant?: string | null): void
  public addFeatureFlags(featureFlags: FeatureFlag[]): void
  public clearFeatureFlag(name: string): void
  public clearFeatureFlags(): void
}

interface FeatureFlag {
  name: string
  variant?: string | null
}
```

This is similar to the metadata API, but a bit simpler as nested data isn't required

Events aren't passed feature flags from the client yet, nor do they send feature flags to the Bugsnag API — this will be done in a separate PR