### PR TITLE
Pin Docker images to Node 14

### DIFF
--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -24,7 +24,9 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["features/cli-tests"]
+        command:
+          - "features/cli-tests"
+          - "--fail-fast"
     env:
       REACT_NATIVE_VERSION: "rn0_60"
 
@@ -35,7 +37,9 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["features/cli-tests"]
+        command:
+          - "features/cli-tests"
+          - "--fail-fast"
     env:
       REACT_NATIVE_VERSION: "rn0_61"
 
@@ -46,7 +50,9 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["features/cli-tests"]
+        command:
+          - "features/cli-tests"
+          - "--fail-fast"
     env:
       REACT_NATIVE_VERSION: "rn0_62"
 
@@ -57,7 +63,9 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["features/cli-tests"]
+        command:
+          - "features/cli-tests"
+          - "--fail-fast"
     env:
       REACT_NATIVE_VERSION: "rn0_63"
 
@@ -68,7 +76,9 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["features/cli-tests"]
+        command:
+          - "features/cli-tests"
+          - "--fail-fast"
     env:
       REACT_NATIVE_VERSION: "rn0_63_expo_ejected"
 
@@ -79,7 +89,9 @@ steps:
       docker-compose#v3.7.0:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
-        command: ["features/cli-tests"]
+        command:
+          - "features/cli-tests"
+          - "--fail-fast"
     env:
       REACT_NATIVE_VERSION: "rn0_64"
 

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:lts-alpine as browser-feature-builder
+FROM node:14-alpine as browser-feature-builder
 
 RUN apk add --update bash python3 make gcc g++ musl-dev xvfb-run
 

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:lts-alpine
+FROM node:14-alpine
 
 RUN apk add --update bash python3 make gcc g++ musl-dev xvfb-run
 

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:lts-alpine as node-feature-builder
+FROM node:14-alpine as node-feature-builder
 
 RUN apk add --update bash python3 make gcc g++ musl-dev xvfb-run
 

--- a/dockerfiles/Dockerfile.react-native-cli-tool
+++ b/dockerfiles/Dockerfile.react-native-cli-tool
@@ -1,5 +1,5 @@
 # CI test image for building the CLI
-FROM node:lts-alpine as react-native-cli-feature-builder
+FROM node:14-alpine as react-native-cli-feature-builder
 
 WORKDIR /app
 

--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:14-alpine
 RUN apk add --update git bash python3 make gcc g++ openssh-client curl
 
 RUN addgroup -S admins

--- a/test/react-native-cli/features/fixtures/Dockerfile
+++ b/test/react-native-cli/features/fixtures/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:14-alpine
 
 RUN apk add git
 


### PR DESCRIPTION
## Goal

Pin Docker images to Node 14, now that Node 16 is in Active LTS.  Further updates will be made for Node 16 separately.

## Changeset

Also added the `--fail-fast` option to the RN CLI tests as these currently have a tendency to flake.

## Testing

Covered by CI.