### PR TITLE
Eager concurrency

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -110,6 +110,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: expo iOS 12'
     depends_on:
@@ -133,6 +134,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - block: "Trigger full test suite"
     key: "trigger-full-suite"
@@ -161,6 +163,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
     soft_fail:
       - exit_status: "*"
 
@@ -186,6 +189,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: expo Android 6'
     depends_on:
@@ -209,6 +213,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: expo Android 5'
     depends_on:
@@ -232,6 +237,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: expo iOS 11'
     depends_on:
@@ -256,6 +262,7 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: expo iOS 10'
     depends_on:
@@ -279,3 +286,4 @@ steps:
           - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -315,6 +315,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.61 Android end-to-end tests'
     depends_on: "rn-0-61-apk"
@@ -334,6 +335,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.62 Android end-to-end tests'
     depends_on: "rn-0-62-apk"
@@ -353,6 +355,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.63 Android end-to-end tests'
     depends_on: "rn-0-63-apk"
@@ -372,6 +375,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.63 Expo (ejected) Android end-to-end tests'
     depends_on: "rn-0-63-expo-ejected-apk"
@@ -391,6 +395,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.64 Android end-to-end tests (non-Hermes)'
     depends_on: "rn-0-64-apk"
@@ -410,6 +415,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.64 Android end-to-end tests (Hermes)'
     depends_on: "rn-0-64-hermes-apk"
@@ -429,6 +435,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   #
   # Init, build and notify end-to-end tests - iOS
@@ -451,6 +458,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.61 iOS end-to-end tests'
     depends_on: "rn-0-61-ipa"
@@ -470,6 +478,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.62 iOS end-to-end tests'
     depends_on: "rn-0-62-ipa"
@@ -489,6 +498,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.63 iOS end-to-end tests'
     depends_on: "rn-0-63-ipa"
@@ -508,6 +518,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.63 Expo (ejected) iOS end-to-end tests'
     depends_on: "rn-0-63-expo-ejected-ipa"
@@ -527,6 +538,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.64 iOS end-to-end tests (non-Hermes)'
     depends_on: "rn-0-64-ipa"
@@ -546,6 +558,7 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':runner: RN 0.64 iOS end-to-end tests (Hermes)'
     depends_on: "rn-0-64-hermes-ipa"
@@ -565,3 +578,4 @@ steps:
           - features/run-app-tests
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -241,6 +241,7 @@ steps:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':ios: RN 0.60 iOS 12 end-to-end tests'
     depends_on: "rn-0-60-ipa"
@@ -264,6 +265,7 @@ steps:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: RN 0.63 Android 9 end-to-end tests'
     depends_on: "rn-0-63-apk"
@@ -286,6 +288,7 @@ steps:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: RN 0.64 (Hermes) Android 11 end-to-end tests'
     depends_on: "rn-0-64-hermes-apk"
@@ -308,6 +311,7 @@ steps:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':ios: RN 0.63 iOS 12 end-to-end tests'
     depends_on: "rn-0-63-ipa"
@@ -331,6 +335,7 @@ steps:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':ios: RN 0.64 iOS 14 end-to-end tests'
     depends_on: "rn-0-64-ipa"
@@ -354,6 +359,7 @@ steps:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: react-navigation 0.60 Android 9 end-to-end tests'
     depends_on: "react-navigation-0-60-apk"
@@ -375,6 +381,7 @@ steps:
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # See: PLAT-5173
   - label: ':ios: react-navigation 0.60 iOS 13 end-to-end tests'
@@ -399,6 +406,7 @@ steps:
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: react-navigation 0.63 Android 9 end-to-end tests'
     depends_on: "react-navigation-0-63-apk"
@@ -420,6 +428,7 @@ steps:
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # See: PLAT-5173
   - label: ':ios: react-navigation 0.63 iOS 13 end-to-end tests'
@@ -444,6 +453,7 @@ steps:
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: react-native-navigation 0.60 Android 9 end-to-end tests'
     depends_on: "react-native-navigation-0-60-apk"
@@ -465,6 +475,7 @@ steps:
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # See: PLAT-5173
   - label: ':ios: react-native-navigation 0.60 iOS 13 end-to-end tests'
@@ -489,6 +500,7 @@ steps:
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: react-native-navigation 0.63 Android 9 end-to-end tests'
     depends_on: "react-native-navigation-0-63-apk"
@@ -510,6 +522,7 @@ steps:
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # See: PLAT-5173
   - label: ':ios: react-native-navigation 0.63 iOS 13 end-to-end tests'
@@ -534,3 +547,4 @@ steps:
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager


### PR DESCRIPTION
## Goal

Implement eager concurrency for the CI browserstack-app concurrency group.

## Design

By default, Buildkite processes jobs in the order in which they were created, which is often very inefficient for our needs.  Jobs that are ready to be processed can be held behind those that are still waiting for other steps to complete.  

## Changeset

Setting `concurrency_method` to `eager` is Buildkite's mechanism to avoid this situation and is perfect for our needs.

## Testing

Covered by CI.