### PR TITLE
Send feature flags in event payloads

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -295,6 +295,7 @@ class Client {
     })
     event.context = event.context || this._context
     event._metadata = assign({}, event._metadata, this._metadata)
+    event._features = assign({}, event._features, this._features)
     event._user = assign({}, event._user, this._user)
     event.breadcrumbs = this._breadcrumbs.slice()
 

--- a/packages/core/event.d.ts
+++ b/packages/core/event.d.ts
@@ -7,6 +7,11 @@ interface HandledState {
   severityReason: { type: string }
 }
 
+interface FeatureFlagPayload {
+  featureFlag: string
+  variant?: string
+}
+
 /**
  * Extend the public type definitions with internal declarations.
  *
@@ -38,5 +43,6 @@ export default class EventWithInternals extends Event {
     metaData: { [key: string]: any }
     user: User
     session: Session
+    featureFlags: FeatureFlagPayload[]
   };
 }

--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -1,6 +1,7 @@
 const ErrorStackParser = require('./lib/error-stack-parser')
 const StackGenerator = require('stack-generator')
 const hasStack = require('./lib/has-stack')
+const keys = require('./lib/es-utils/keys')
 const map = require('./lib/es-utils/map')
 const reduce = require('./lib/es-utils/reduce')
 const filter = require('./lib/es-utils/filter')
@@ -108,9 +109,25 @@ class Event {
       groupingHash: this.groupingHash,
       metaData: this._metadata,
       user: this._user,
-      session: this._session
+      session: this._session,
+      featureFlags: formatFeatureFlags(this._features)
     }
   }
+}
+
+const formatFeatureFlags = flags => {
+  return map(
+    keys(flags),
+    name => {
+      const flag = { featureFlag: name }
+
+      if (typeof flags[name] === 'string') {
+        flag.variant = flags[name]
+      }
+
+      return flag
+    }
+  )
 }
 
 // takes a stacktrace.js style stackframe (https://github.com/stacktracejs/stackframe)

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -315,5 +315,24 @@ describe('@bugsnag/core/event', () => {
         expect(event._features).toStrictEqual({})
       })
     })
+
+    it('includes feature flags in JSON payload', () => {
+      const event = new Event('Err', 'bad', [])
+      event.addFeatureFlag('abc', '123')
+      event.addFeatureFlags([
+        { name: 'x', variant: '9' },
+        { name: 'y' },
+        { name: 'z', variant: '8' }
+      ])
+
+      const payload = event.toJSON()
+
+      expect(payload.featureFlags).toStrictEqual([
+        { featureFlag: 'abc', variant: '123' },
+        { featureFlag: 'x', variant: '9' },
+        { featureFlag: 'y' },
+        { featureFlag: 'z', variant: '8' }
+      ])
+    })
   })
 })


### PR DESCRIPTION
## Goal

This PR adds `featureFlags` as a new top-level field in event payloads. This is an array of objects with one of these shapes:

```ts
{ featureFlag: string }
// or
{ featureFlag: string, variant: string }
```