### PR TITLE
Fix web server staying alive if Cucumber crashes

### DIFF
--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -41,7 +41,7 @@ BeforeAll do
   Process.detach(pid)
 end
 
-AfterAll do
+at_exit do
   # Stop the web page server
   begin
     Process.kill('KILL', pid)


### PR DESCRIPTION
`AfterAll` only runs if Cucumber doesn't crash, so this has to be an `at_exit`