### PR TITLE
Prevent a crash when XMLHttpRequest data goes missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBC
 
+### Fixed
+
+- (plugin-network-breadcrumbs): Fix a crash when request data goes missing [#1564](https://github.com/bugsnag/bugsnag-js/pull/1564)
+
 ### Changed
 
 - (react-native): Update bugsnag-cocoa to v6.14.2

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -60,6 +60,11 @@ module.exports = (_ignoredUrls = [], win = window) => {
       }
 
       function handleXHRLoad () {
+        if (this[REQUEST_URL_KEY] === undefined) {
+          client._logger.warn('The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.')
+          return
+        }
+
         if (includes(ignoredUrls, this[REQUEST_URL_KEY].replace(/\?.*$/, ''))) {
           // don't leave a network breadcrumb from bugsnag notify calls
           return
@@ -77,10 +82,16 @@ module.exports = (_ignoredUrls = [], win = window) => {
       }
 
       function handleXHRError () {
+        if (this[REQUEST_URL_KEY] === undefined) {
+          client._logger.warn('The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.')
+          return
+        }
+
         if (includes(ignoredUrls, this[REQUEST_URL_KEY].replace(/\?.*$/, ''))) {
           // don't leave a network breadcrumb from bugsnag notify calls
           return
         }
+
         // failed to contact server
         client.leaveBreadcrumb('XMLHttpRequest error', {
           request: `${this[REQUEST_METHOD_KEY]} ${this[REQUEST_URL_KEY]}`

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -35,6 +35,17 @@ class XMLHttpRequest {
   }
 }
 
+class BrokenXMLHttpRequest extends XMLHttpRequest {
+  open (method: string, url: String) {
+    // @ts-ignore
+    delete this['BS~~S']
+    // @ts-ignore
+    delete this['BS~~U']
+    // @ts-ignore
+    delete this['BS~~M']
+  }
+}
+
 // mock fetch
 function fetch (urlOrRequest: string | Request | null | undefined, options: {} | null, fail: boolean, status: number | null = null) {
   return new Promise((resolve, reject) => {
@@ -164,6 +175,54 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', client._config.endpoints!.sessions)
     request.send(false, 200)
     expect(client._breadcrumbs.length).toBe(0)
+  })
+
+  it('should not crash if the request data goes missing', () => {
+    const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
+
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }
+
+    p = plugin([], window)
+    const client = new Client({ apiKey: 'abcabcabcabcabcabcabc1234567890f', logger, plugins: [p] })
+
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
+    request.open('GET', '/')
+    request.send(false, 200)
+
+    expect(client._breadcrumbs.length).toBe(0)
+    expect(client._logger.warn).toHaveBeenCalledTimes(1)
+    expect(client._logger.warn).toHaveBeenCalledWith(
+      'The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.'
+    )
+  })
+
+  it('should not crash if the request data goes missing for a request that errors', () => {
+    const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
+
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }
+
+    p = plugin([], window)
+    const client = new Client({ apiKey: 'abcabcabcabcabcabcabc1234567890f', logger, plugins: [p] })
+
+    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
+    request.open('GET', '/')
+    request.send(true)
+
+    expect(client._breadcrumbs.length).toBe(0)
+    expect(client._logger.warn).toHaveBeenCalledTimes(1)
+    expect(client._logger.warn).toHaveBeenCalledWith(
+      'The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.'
+    )
   })
 
   it('should leave a breadcrumb when a fetch() resolves', (done) => {


### PR DESCRIPTION
## Goal

This fixes the crash reported in https://github.com/bugsnag/bugsnag-js/issues/1561, though this means the network breadcrumb plugin is in a broken state — the data attached to the `XMLHttpRequest` has been removed and therefore we can't leave network breadcrumbs if this happens