### PR TITLE
Move Event API conversion to feature flag delegate

### DIFF
--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -1,7 +1,6 @@
 const ErrorStackParser = require('./lib/error-stack-parser')
 const StackGenerator = require('stack-generator')
 const hasStack = require('./lib/has-stack')
-const keys = require('./lib/es-utils/keys')
 const map = require('./lib/es-utils/map')
 const reduce = require('./lib/es-utils/reduce')
 const filter = require('./lib/es-utils/filter')
@@ -110,24 +109,9 @@ class Event {
       metaData: this._metadata,
       user: this._user,
       session: this._session,
-      featureFlags: formatFeatureFlags(this._features)
+      featureFlags: featureFlagDelegate.toEventApi(this._features)
     }
   }
-}
-
-const formatFeatureFlags = flags => {
-  return map(
-    keys(flags),
-    name => {
-      const flag = { featureFlag: name }
-
-      if (typeof flags[name] === 'string') {
-        flag.variant = flags[name]
-      }
-
-      return flag
-    }
-  )
 }
 
 // takes a stacktrace.js style stackframe (https://github.com/stacktracejs/stackframe)

--- a/packages/core/lib/feature-flag-delegate.js
+++ b/packages/core/lib/feature-flag-delegate.js
@@ -1,3 +1,5 @@
+const map = require('./es-utils/map')
+const keys = require('./es-utils/keys')
 const isArray = require('./es-utils/is-array')
 const jsonStringify = require('@bugsnag/safe-json-stringify')
 
@@ -32,4 +34,23 @@ function merge (existingFeatures, newFeatures) {
   }
 }
 
-module.exports = { add, merge }
+// convert feature flags from a map of 'name -> variant' into the format required
+// by the Bugsnag Event API:
+//   [{ featureFlag: 'name', variant: 'variant' }, { featureFlag: 'name 2' }]
+function toEventApi (featureFlags) {
+  return map(
+    keys(featureFlags),
+    name => {
+      const flag = { featureFlag: name }
+
+      // don't add a 'variant' property unless there's actually a value
+      if (typeof featureFlags[name] === 'string') {
+        flag.variant = featureFlags[name]
+      }
+
+      return flag
+    }
+  )
+}
+
+module.exports = { add, merge, toEventApi }

--- a/packages/core/lib/test/feature-flag-delegate.test.ts
+++ b/packages/core/lib/test/feature-flag-delegate.test.ts
@@ -192,4 +192,30 @@ describe('feature flag delegate', () => {
       expect(existingFeatures).toStrictEqual({ a: 'z', b: 'x', c: 'c', d: 'd', e: 'oooo' })
     })
   })
+
+  describe('#toEventApi', () => {
+    it('should convert a map into the event API format', () => {
+      const features = {}
+
+      delegate.add(features, 'a', 'b')
+      delegate.merge(features, [
+        { name: 'c', variant: 'd' },
+        { name: 'e' },
+        { name: 'f', variant: 'g' }
+      ])
+
+      expect(features).toStrictEqual({ a: 'b', c: 'd', e: null, f: 'g' })
+
+      expect(delegate.toEventApi(features)).toStrictEqual([
+        { featureFlag: 'a', variant: 'b' },
+        { featureFlag: 'c', variant: 'd' },
+        { featureFlag: 'e' },
+        { featureFlag: 'f', variant: 'g' }
+      ])
+    })
+
+    it('should handle an empty object', () => {
+      expect(delegate.toEventApi({})).toStrictEqual([])
+    })
+  })
 })


### PR DESCRIPTION
## Goal

This is a small refactor to move the function that converts feature flags into the Event API format to the feature flag delegate. Originally it seemed like we'd only need this in the Event class, however it's also necessary in Electron when sending flags to the native client so needs to be somewhere reusable

## Testing

A few new tests have been added, but this is also covered by existing unit tests for `Event#toJSON`