### PR TITLE
Add feature flags support to the Electron native client

### DIFF
--- a/packages/plugin-electron-client-state-persistence/client-state-persistence.js
+++ b/packages/plugin-electron-client-state-persistence/client-state-persistence.js
@@ -1,3 +1,5 @@
+const featureFlagDelegate = require('@bugsnag/core/lib/feature-flag-delegate')
+
 module.exports = {
   NativeClient: require('bindings')('bugsnag_pecsp_bindings'),
   plugin: (NativeClient) => ({
@@ -39,6 +41,16 @@ module.exports = {
       clientStateManager.emitter.on('MetadataReplace', (metadata) => {
         try {
           NativeClient.updateMetadata(metadata)
+        } catch (e) {
+          client._logger.error(e)
+        }
+      })
+
+      clientStateManager.emitter.on('FeatureFlagUpdate', features => {
+        try {
+          // convert the feature flags to the Event API format, so they are
+          // ready to send immediately
+          NativeClient.updateFeatureFlags(featureFlagDelegate.toEventApi(features))
         } catch (e) {
           client._logger.error(e)
         }

--- a/packages/plugin-electron-client-state-persistence/src/api.c
+++ b/packages/plugin-electron-client-state-persistence/src/api.c
@@ -89,6 +89,9 @@ static bool throw_error_from_status(napi_env env, BECSP_STATUS status) {
   case BECSP_STATUS_EXPECTED_JSON_OBJECT:
     napi_throw_type_error(env, code, "Wrong argument type, expected object");
     break;
+  case BECSP_STATUS_EXPECTED_JSON_ARRAY:
+    napi_throw_type_error(env, code, "Wrong argument type, expected array");
+    break;
   case BECSP_STATUS_NULL_PARAM:
     napi_throw_type_error(env, code, "Expected argument to be non-null");
     break;
@@ -306,6 +309,41 @@ static napi_value UpdateMetadata(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value UpdateFeatureFlags(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_status status = napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+  assert(status == napi_ok);
+
+  if (argc < 1) {
+    napi_throw_type_error(
+      env,
+      NULL,
+      "Wrong number of arguments, expected 1"
+    );
+
+    return NULL;
+  }
+
+  bool is_array;
+  status = napi_is_array(env, args[0], &is_array);
+  assert(status == napi_ok);
+
+  if (is_array) {
+    char *feature_flags = read_string_value(env, json_stringify(env, args[0]), true);
+    throw_error_from_status(env, becsp_set_feature_flags(feature_flags));
+    free(feature_flags);
+  } else {
+    napi_throw_type_error(
+      env,
+      NULL,
+      "Wrong argument type, expected array"
+    );
+  }
+
+  return NULL;
+}
+
 static napi_value SetApp(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
@@ -388,6 +426,10 @@ napi_value Init(napi_env env, napi_value exports) {
   assert(status == napi_ok);
 
   desc = DECLARE_NAPI_METHOD("updateMetadata", UpdateMetadata);
+  status = napi_define_properties(env, exports, 1, &desc);
+  assert(status == napi_ok);
+
+  desc = DECLARE_NAPI_METHOD("updateFeatureFlags", UpdateFeatureFlags);
   status = napi_define_properties(env, exports, 1, &desc);
   assert(status == napi_ok);
 

--- a/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.h
+++ b/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.h
@@ -25,6 +25,10 @@ typedef enum {
    */
   BECSP_STATUS_EXPECTED_JSON_OBJECT,
   /**
+   * JSON value sent as a parameter used an unexpected type
+   */
+  BECSP_STATUS_EXPECTED_JSON_ARRAY,
+  /**
    * Required parameter was NULL
    */
   BECSP_STATUS_NULL_PARAM,
@@ -84,6 +88,14 @@ BECSP_STATUS becsp_update_metadata(const char *tab, const char *val);
  * clear
  */
 BECSP_STATUS becsp_set_metadata(const char *metadata);
+
+/**
+ * Set cached feature flags
+ *
+ * @param feature_flags An array of feature flag objects, serialized as JSON
+ *                      e.g. '[{ "featureFlag": "abc", variant: "xyz" }]'
+ */
+BECSP_STATUS becsp_set_feature_flags(const char *feature_flags);
 
 /**
  * Set cached top-level app value

--- a/packages/plugin-electron-client-state-persistence/test/error-handling.test.ts
+++ b/packages/plugin-electron-client-state-persistence/test/error-handling.test.ts
@@ -28,6 +28,11 @@ describe('handling poor inputs', () => {
     expect(update).toThrow('expected (object) or (string, object?)')
   })
 
+  it('rejects invalid data type for feature flags', () => {
+    const update = () => NativeClient.updateFeatureFlags('abcd')
+    expect(update).toThrow('expected array')
+  })
+
   it('rejects invalid data type for breadcrumb (int)', () => {
     const update = () => NativeClient.leaveBreadcrumb(80)
     expect(update).toThrow('expected object or string')
@@ -61,6 +66,11 @@ describe('handling poor inputs', () => {
   it('rejects missing parameters in updateMetadata()', () => {
     const update = () => NativeClient.updateMetadata()
     expect(update).toThrow('Wrong number of arguments, expected 1 or 2')
+  })
+
+  it('rejects missing parameters in updateFeatureFlags', () => {
+    const update = () => NativeClient.updateFeatureFlags()
+    expect(update).toThrow('Wrong number of arguments, expected 1')
   })
 
   it('rejects missing parameters in updateContext()', () => {

--- a/packages/plugin-electron-client-state-persistence/test/persistence.test.ts
+++ b/packages/plugin-electron-client-state-persistence/test/persistence.test.ts
@@ -128,6 +128,47 @@ describe('persisting changes to disk', () => {
     done()
   })
 
+  it('sets feature flags', async () => {
+    NativeClient.install(filepath, 5)
+
+    NativeClient.updateFeatureFlags([
+      { featureFlag: 'flag 1', variant: 'some variant' },
+      { featureFlag: 'flag 2' },
+      { featureFlag: 'flag 3', variant: 'variant xyz' },
+      { featureFlag: 'flag 4', variant: 'variont' }
+    ])
+
+    NativeClient.persistState()
+
+    const state = await readTempFile()
+
+    expect(state.featureFlags).toStrictEqual([
+      { featureFlag: 'flag 1', variant: 'some variant' },
+      { featureFlag: 'flag 2' },
+      { featureFlag: 'flag 3', variant: 'variant xyz' },
+      { featureFlag: 'flag 4', variant: 'variont' }
+    ])
+  })
+
+  it('clears feature flags', async () => {
+    NativeClient.install(filepath, 5)
+
+    NativeClient.updateFeatureFlags([
+      { featureFlag: 'flag 1', variant: 'some variant' },
+      { featureFlag: 'flag 2' },
+      { featureFlag: 'flag 3', variant: 'variant xyz' },
+      { featureFlag: 'flag 4', variant: 'variont' }
+    ])
+
+    NativeClient.updateFeatureFlags([])
+
+    NativeClient.persistState()
+
+    const state = await readTempFile()
+
+    expect(state.featureFlags).toStrictEqual([])
+  })
+
   it('sets session', async (done) => {
     NativeClient.install(filepath, 5)
     NativeClient.setSession({

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -19,7 +19,7 @@ SUPPRESSED_ERRORS=(\
     --suppress='ConfigurationNotChecked:*/deps/parson/parson.c:1425' \
     --suppress='knownConditionTrueFalse:*/deps/parson/parson.c:692' \
     --suppress='memleak:*/plugin-electron-client-state-persistence/src/deps/tinycthread/tinycthread.c:620' \
-    --suppress='unusedFunction:*/plugin-electron-client-state-persistence/src/api.c:429' \
+    --suppress='unusedFunction:*/plugin-electron-client-state-persistence/src/api.c:471' \
     --suppress='unusedFunction:*/plugin-electron-app/src/api.c:60')
 
 # Shared arguments:


### PR DESCRIPTION
## Goal

This PR adds wrapper methods to the feature flag API on the main process client to sync feature flags to the native client

We don't support partial updates; the feature flags are always replaced entirely when `NativeClient.updateFeatureFlags` is called

## Testing

Relies on unit tests as the rest of Electron doesn't support feature flags, so this can't be tested end to end yet