### PR TITLE
Fix python installation in expo publisher dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --update bash git python
+RUN apk add --update bash git python3
 
 WORKDIR /app
 


### PR DESCRIPTION
## Goal

There is no "python" package in Alpine linux; it has "python2" and "python3" instead

I'm not sure how this worked previously, but it has started complaining that the "python" package doesn't exist: https://buildkite.com/bugsnag/bugsnag-js-expo/builds/3511#f003482c-cf37-4312-8218-3ce0bad1ab66/191-222

All of our other dockerfiles that install Python use "python3"