### PR TITLE
Use `app.whenReady` to start minidump delivery

### DIFF
--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -37,7 +37,7 @@ module.exports = (app, net, filestore, NativeClient) => ({
     const queue = new MinidumpQueue(filestore)
     const loop = new MinidumpDeliveryLoop(sendMinidump, client._config.onSend, queue, client._logger)
 
-    app.on('ready', () => {
+    app.whenReady().then(() => {
       const stateManagerPlugin = client.getPlugin('clientStateManager')
       const statusUpdater = new NetworkStatus(stateManagerPlugin, net, app)
       loop.watchNetworkStatus(statusUpdater)

--- a/packages/plugin-electron-deliver-minidumps/test/deliver-minidumps.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/deliver-minidumps.test.ts
@@ -7,7 +7,13 @@ jest.mock('electron', () => ({
 }))
 
 describe('electron-minidump-delivery: load', () => {
-  const app = { on: jest.fn() }
+  let whenReadyCallback
+
+  const app = {
+    whenReady: () => ({ then (callback) { whenReadyCallback = callback } }),
+    on: jest.fn()
+  }
+
   const net = {}
 
   const filestore = {
@@ -21,6 +27,8 @@ describe('electron-minidump-delivery: load', () => {
   }
 
   const plugin = createPlugin(app, net, filestore, nativeClient)
+
+  afterEach(() => { whenReadyCallback = undefined })
 
   it('should install when configured', () => {
     const client = {
@@ -36,6 +44,7 @@ describe('electron-minidump-delivery: load', () => {
     plugin.load(client)
 
     expect(nativeClient.install).toBeCalledTimes(1)
+    expect(whenReadyCallback).toBeInstanceOf(Function)
   })
 
   it('should not install when autoDetectErrors disabled', () => {
@@ -52,6 +61,7 @@ describe('electron-minidump-delivery: load', () => {
     plugin.load(client)
 
     expect(nativeClient.install).not.toBeCalled()
+    expect(whenReadyCallback).toBeUndefined()
   })
 
   it('should not install when nativeCrashes disabled', () => {
@@ -68,5 +78,6 @@ describe('electron-minidump-delivery: load', () => {
     plugin.load(client)
 
     expect(nativeClient.install).not.toBeCalled()
+    expect(whenReadyCallback).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Goal

Using app.on('ready') is problematic if Bugsnag is started in a user's app.on('ready') callback — Electron only fires this event once, so our event handler would never be called

This is not the intended way to start Bugsnag (because it means all errors that happen before the app is ready will not be reported) but we should still be able to handle this case

Using the promise-based API will work both when the app is ready and when it's not yet ready. This is the only instance where we use `app.on('ready')`[^1]; nowhere else is affected by this problem

## Testing

I spent a while trying to write unit tests for this, but I came to the conclusion that the only way to really test it would be to completely duplicate our existing Electron fixture and start Bugsnag inside `app.on('ready')`. That seems pretty excessive for a single line change, especially one that isn't easily reverted

[^1]: we do also use it in the app breadcrumbs plugin, but that's to leave a breadcrumb specifically when the app is ready — if the app was ready before Bugsnag started, it doesn't make sense to leave that breadcrumb at all