### PR TITLE
Don't send minidumps if the endpoint isn't configured

### DIFF
--- a/packages/electron/src/config/common.js
+++ b/packages/electron/src/config/common.js
@@ -33,6 +33,8 @@ module.exports.schema = {
       (val && typeof val === 'object') &&
       (
         // notify and sessions must always be set
+        // minidumps isn't required because it was added after the initial launch
+        // so would be a breaking change
         stringWithLength(val.notify) && stringWithLength(val.sessions)
       ) &&
       // ensure no keys other than notify/session/minidumps are set on endpoints object

--- a/packages/electron/src/config/test/main.test.ts
+++ b/packages/electron/src/config/test/main.test.ts
@@ -34,6 +34,12 @@ describe('main process client config schema', () => {
         notify: 'http://fakeurl.xyz/n',
         sessions: 'http://fakeurl.xyz/s'
       })).toBe(true)
+
+      expect(schema.endpoints.validate({
+        notify: 'http://fakeurl.xyz/n',
+        sessions: 'http://fakeurl.xyz/s',
+        minidumps: 'http://fakeurl.xyz/m'
+      })).toBe(true)
     })
 
     it('rejects invalid values', () => {

--- a/packages/electron/types/notifier.d.ts
+++ b/packages/electron/types/notifier.d.ts
@@ -18,6 +18,7 @@ interface MainConfig extends Config {
   endpoints?: {
     notify: string
     sessions: string
+    minidumps?: string
   }
   onSendError?: OnSendErrorCallback | OnSendErrorCallback[]
   onUncaughtException?: AfterErrorCallback

--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -18,6 +18,16 @@ module.exports = (app, net, filestore, NativeClient) => ({
       return
     }
 
+    // the minidumps endpoint can only be missing for on-premise users who
+    // haven't configured it as it's not required by the config validation
+    if (typeof client._config.endpoints.minidumps !== 'string') {
+      client._logger.warn(
+        `Invalid configuration. endpoint.minidumps should be a valid URL, got ${typeof client._config.endpoints.minidumps}. Bugsnag will not send minidumps.`
+      )
+
+      return
+    }
+
     const appRunMetadata = filestore.getAppRunMetadata()
 
     // make sure that the Electron CrashReporter is configured

--- a/packages/plugin-electron-deliver-minidumps/test/deliver-minidumps.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/deliver-minidumps.test.ts
@@ -37,7 +37,18 @@ describe('electron-minidump-delivery: load', () => {
         enabledErrorTypes: {
           nativeCrashes: true
         },
+        endpoints: {
+          notify: 'notify.bugsnag.com',
+          sessions: 'sessions.bugsnag.com',
+          minidumps: 'notify.bugsnag.com'
+        },
         maxBreadcrumbs: 16
+      },
+      _logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
       }
     }
 
@@ -45,6 +56,7 @@ describe('electron-minidump-delivery: load', () => {
 
     expect(nativeClient.install).toBeCalledTimes(1)
     expect(whenReadyCallback).toBeInstanceOf(Function)
+    expect(client._logger.warn).not.toBeCalled()
   })
 
   it('should not install when autoDetectErrors disabled', () => {
@@ -54,7 +66,18 @@ describe('electron-minidump-delivery: load', () => {
         enabledErrorTypes: {
           nativeCrashes: true
         },
+        endpoints: {
+          notify: 'notify.bugsnag.com',
+          sessions: 'sessions.bugsnag.com',
+          minidumps: 'notify.bugsnag.com'
+        },
         maxBreadcrumbs: 16
+      },
+      _logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
       }
     }
 
@@ -62,6 +85,7 @@ describe('electron-minidump-delivery: load', () => {
 
     expect(nativeClient.install).not.toBeCalled()
     expect(whenReadyCallback).toBeUndefined()
+    expect(client._logger.warn).not.toBeCalled()
   })
 
   it('should not install when nativeCrashes disabled', () => {
@@ -71,7 +95,45 @@ describe('electron-minidump-delivery: load', () => {
         enabledErrorTypes: {
           nativeCrashes: false
         },
+        endpoints: {
+          notify: 'notify.bugsnag.com',
+          sessions: 'sessions.bugsnag.com',
+          minidumps: 'notify.bugsnag.com'
+        },
         maxBreadcrumbs: 16
+      },
+      _logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
+      }
+    }
+
+    plugin.load(client)
+
+    expect(nativeClient.install).not.toBeCalled()
+    expect(client._logger.warn).not.toBeCalled()
+  })
+
+  it('should not install when the minidumps endpoint is not configured', () => {
+    const client = {
+      _config: {
+        autoDetectErrors: true,
+        enabledErrorTypes: {
+          nativeCrashes: true
+        },
+        endpoints: {
+          notify: 'notify.bugsnag.com',
+          sessions: 'sessions.bugsnag.com'
+        },
+        maxBreadcrumbs: 16
+      },
+      _logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn()
       }
     }
 
@@ -79,5 +141,9 @@ describe('electron-minidump-delivery: load', () => {
 
     expect(nativeClient.install).not.toBeCalled()
     expect(whenReadyCallback).toBeUndefined()
+    expect(client._logger.warn).toHaveBeenCalledTimes(1)
+    expect(client._logger.warn).toHaveBeenCalledWith(
+      'Invalid configuration. endpoint.minidumps should be a valid URL, got undefined. Bugsnag will not send minidumps.'
+    )
   })
 })


### PR DESCRIPTION
## Goal

The `minidumps` endpoint has to be optional because we've already shipped endpoint validation that only requires `notify` & `sessions`. This means we have to handle the case where the `minidumps` endpoint is not present as we can't rely on it always being set

This PR adds a check to ensure the minidumps endpoint is set before starting the minidump delivery process and adds `minidumps` as an allowed value in the `endpoints` type definition