### PR TITLE
Fix in-flight plugin type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (in-flight): Fix Typescript definition exporting a type instead of a value [skirsten](https://github.com/skirsten) [#1587](https://github.com/bugsnag/bugsnag-js/pull/1587)
+
 ## 7.14.0 (2021-11-17)
 
 This release adds support for reporting native crashes to `@bugsnag/electron`.

--- a/packages/in-flight/test/in-flight.test.ts
+++ b/packages/in-flight/test/in-flight.test.ts
@@ -5,7 +5,7 @@ import Client, { EventDeliveryPayload, SessionDeliveryPayload } from '@bugsnag/c
 // 'bugsnagInFlight' variable for this test to compile
 import BugsnagInFlightJustForTypescript from '../types/bugsnag-in-flight'
 
-let bugsnagInFlight: BugsnagInFlightJustForTypescript
+let bugsnagInFlight: typeof BugsnagInFlightJustForTypescript
 jest.isolateModules(() => { bugsnagInFlight = require('../src/in-flight') })
 const noop = () => {}
 const id = <T>(a: T) => a

--- a/packages/in-flight/types/bugsnag-in-flight.d.ts
+++ b/packages/in-flight/types/bugsnag-in-flight.d.ts
@@ -5,4 +5,6 @@ interface BugsnagInFlight {
   flush (timeoutMs: number): Promise<void>
 }
 
-export default BugsnagInFlight
+declare const BugsnagInFlightPlugin: BugsnagInFlight
+
+export default BugsnagInFlightPlugin


### PR DESCRIPTION
Fixed the type of the in-flight plugin.

Before it was exporting the actual type instead of a declaration.