### PR TITLE
Add maze runner tests for feature flags in node

### DIFF
--- a/test/node/Gemfile
+++ b/test/node/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.2.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.4.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../../../maze-runner'

--- a/test/node/Gemfile.lock
+++ b/test/node/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: e27004e424b165651f729a574ab21a277c75a355
-  tag: v6.2.1
+  revision: e557877be1d2f3881d93a420aa5582b55923069c
+  tag: v6.4.0
   specs:
-    bugsnag-maze-runner (6.2.1)
+    bugsnag-maze-runner (6.4.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -46,7 +46,7 @@ GEM
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
       cucumber-tag-expressions (~> 4.0, >= 4.0.2)
-    cucumber-create-meta (6.0.2)
+    cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
     cucumber-cucumber-expressions (14.0.0)
@@ -68,9 +68,9 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.15.4)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
+    mime-types-data (3.2021.1115)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     multi_test (0.1.2)
@@ -103,4 +103,4 @@ DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.2.20
+   2.2.28

--- a/test/node/features/feature_flags.feature
+++ b/test/node/features/feature_flags.feature
@@ -1,0 +1,97 @@
+Feature: feature flags
+
+Background:
+  Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+  And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
+  And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+
+Scenario: adding feature flags for an unhandled error
+  Given I start the service "express"
+  And I wait for the host "express" to open port "80"
+  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://express/features/unhandled"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "oh no"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.httpMethod" equals "POST"
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | from config 1 | 1234    |
+     | from config 2 |         |
+     | a             | 1       |
+     | b             | 2       |
+     | c             | 3       |
+     | d             | 4       |
+  # ensure each request can have its own set of feature flags
+  When I discard the oldest error
+  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/unhandled"
+  And I wait to receive an error
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | from config 1 | 1234    |
+     | from config 2 |         |
+     | x             | 9       |
+     | y             | 8       |
+     | z             | 7       |
+
+Scenario: adding feature flags for a handled error
+  Given I start the service "express"
+  And I wait for the host "express" to open port "80"
+  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://express/features/handled"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "oh no"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.httpMethod" equals "POST"
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | from config 1 | 1234    |
+     | from config 2 |         |
+     | a             | 1       |
+     | b             | 2       |
+     | c             | 3       |
+     | d             | 4       |
+  # ensure each request can have its own set of feature flags
+  When I discard the oldest error
+  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/handled"
+  And I wait to receive an error
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | from config 1 | 1234    |
+     | from config 2 |         |
+     | x             | 9       |
+     | y             | 8       |
+     | z             | 7       |
+
+Scenario: clearing all feature flags doesn't affect subsequent requests
+  Given I start the service "express"
+  And I wait for the host "express" to open port "80"
+  When I POST the data "a=1&b=2&c=3&d=4&clearAllFeatureFlags" to the URL "http://express/features/unhandled"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "oh no"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.httpMethod" equals "POST"
+  And the event has no feature flags
+  When I discard the oldest error
+  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/unhandled"
+  And I wait to receive an error
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | from config 1 | 1234    |
+     | from config 2 |         |
+     | x             | 9       |
+     | y             | 8       |
+     | z             | 7       |


### PR DESCRIPTION
## Goal

Adds some maze runner tests for feature flags to the Node test suite. These focus on the request-scoped client having separate lists of feature flags (so each request can have their own set of flags), while also ensuring global flags are supported