### PR TITLE
Sync feature flags from main -> renderers

### DIFF
--- a/packages/plugin-electron-ipc/bugsnag-ipc-main.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-main.js
@@ -102,6 +102,7 @@ module.exports = class BugsnagIpcMain {
       }
       event.context = event.context || this.client._context
       event._metadata = { ...event._metadata, ...this.client._metadata }
+      event._features = { ...event._features, ...this.client._features }
       event._user = { ...event._user, ...this.client._user }
       event.breadcrumbs = this.client._breadcrumbs.slice()
 
@@ -112,8 +113,8 @@ module.exports = class BugsnagIpcMain {
         if (!shouldSend) return resolve({ shouldSend: false })
 
         // extract just the properties we want from the event
-        const { app, breadcrumbs, context, device, _metadata, _user } = event
-        resolve({ app, breadcrumbs, context, device, metadata: _metadata, user: _user })
+        const { app, breadcrumbs, context, device, _metadata, _features, _user } = event
+        resolve({ app, breadcrumbs, context, device, metadata: _metadata, features: _features, user: _user })
       })
     })
   }

--- a/packages/plugin-electron-ipc/electron-ipc.js
+++ b/packages/plugin-electron-ipc/electron-ipc.js
@@ -11,7 +11,7 @@ module.exports = {
     // pre serialise config outside of the sync IPC call so we avoid unnecessary computation while the process is blocked
     let configStr
     const updateConfigStr = () => {
-      configStr = serializeConfigForRenderer(client._config, client._metadata, client.getUser(), client.getContext())
+      configStr = serializeConfigForRenderer(client._config, client._metadata, client._features, client.getUser(), client.getContext())
     }
     updateConfigStr()
 

--- a/packages/plugin-electron-ipc/lib/config-serializer.js
+++ b/packages/plugin-electron-ipc/lib/config-serializer.js
@@ -1,7 +1,7 @@
 const DO_NOT_SERIALIZE = ['logger', 'plugins']
 const jsonStringify = require('@bugsnag/safe-json-stringify')
 
-module.exports = (config, metadata, user, context) => {
+module.exports = (config, metadata, features, user, context) => {
   const onlySerializableConfig = Object.keys(config).reduce((accum, k) => {
     if (!DO_NOT_SERIALIZE.includes(k)) return { ...accum, [k]: config[k] }
     return accum
@@ -9,6 +9,7 @@ module.exports = (config, metadata, user, context) => {
   const configWithState = {
     ...onlySerializableConfig,
     metadata,
+    features,
     user,
     context
   }

--- a/packages/plugin-electron-ipc/lib/test/config-serializer.test.ts
+++ b/packages/plugin-electron-ipc/lib/test/config-serializer.test.ts
@@ -16,9 +16,10 @@ describe('serializeConfigForRenderer() method', () => {
       metadata: { foo: { bar: 'baz' } },
       user: { id: '123' },
       context: 'initial'
-    }, { foo: { bar: 'biz' } }, { id: '456' }, 'secondary'))).toEqual({
+    }, { foo: { bar: 'biz' } }, { flag: '123' }, { id: '456' }, 'secondary'))).toEqual({
       apiKey: '123',
       metadata: { foo: { bar: 'biz' } },
+      features: { flag: '123' },
       user: { id: '456' },
       context: 'secondary'
     })

--- a/packages/plugin-electron-renderer-event-data/renderer-event-data.js
+++ b/packages/plugin-electron-renderer-event-data/renderer-event-data.js
@@ -9,6 +9,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
         context,
         device,
         metadata,
+        features,
         user,
         shouldSend
       } = await BugsnagIpcRenderer.getPayloadInfo()
@@ -19,6 +20,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
       event.breadcrumbs = breadcrumbs
       event.app = { ...event.app, ...app, codeBundleId: client._config.codeBundleId }
       event.device = { ...event.device, ...device }
+      event._features = { ...event._features, ...features }
 
       if (!event._user || Object.keys(event._user).length === 0) {
         event._user = user

--- a/packages/plugin-electron-renderer-event-data/test/renderer-event-data.test.ts
+++ b/packages/plugin-electron-renderer-event-data/test/renderer-event-data.test.ts
@@ -13,15 +13,16 @@ describe('plugin: electron renderer event data', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  it('sets context, breadcrumbs, app, device, user and metadata from the main process', async () => {
+  it('sets context, breadcrumbs, app, device, user, feature flags and metadata from the main process', async () => {
     const context = 'abc context xyz'
     const breadcrumbs = [new Breadcrumb('message', { metadata: true }, 'manual')]
     const app = { abc: 123 }
     const device = { xyz: 456 }
     const user = { id: '10293847' }
+    const features = { flag1: 'variant1' }
     const metadata = { meta: { data: true } }
 
-    const { sendEvent } = makeClient({ context, breadcrumbs, app, device, user, metadata })
+    const { sendEvent } = makeClient({ context, breadcrumbs, app, device, user, features, metadata })
 
     const event = await sendEvent()
 
@@ -30,6 +31,7 @@ describe('plugin: electron renderer event data', () => {
     expect(event.app).toStrictEqual({ ...app, releaseStage: 'production', type: undefined, version: undefined, codeBundleId: undefined })
     expect(event.device).toStrictEqual(device)
     expect(event.getUser()).toStrictEqual(user)
+    expect(event._features).toStrictEqual(features)
     expect(event.getMetadata('meta')).toStrictEqual(metadata.meta)
   })
 


### PR DESCRIPTION
## Goal

Renderer processes will now contain all feature flags from the main process, both those added as config and with Bugsnag.addFeatureFlag(s)

## Testing

Unit tests for the individual changes and I've manually tested the whole thing. Integration tests will be added separately