### PR TITLE
Add 'featureFlags' to Config type definition

### DIFF
--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -886,6 +886,7 @@ describe('@bugsnag/core/client', () => {
         featureFlags: [
           { name: 'a', variant: '1' },
           { name: 'b' },
+          // @ts-expect-error
           { name: 'c', variant: 3 }
         ]
       })
@@ -906,14 +907,15 @@ describe('@bugsnag/core/client', () => {
         logger,
         featureFlags: [
           { name: 'a', variant: '1' },
+          // @ts-expect-error
           { variant: 'b' },
-          { name: 'c', variant: 3 }
+          { name: 'c', variant: '3' }
         ]
       })
 
       const expectedMessage = [
         'Invalid configuration',
-        '  - featureFlags should be an array of objects that have a "name" property, got [{"name":"a","variant":"1"},{"variant":"b"},{"name":"c","variant":3}]'
+        '  - featureFlags should be an array of objects that have a "name" property, got [{"name":"a","variant":"1"},{"variant":"b"},{"name":"c","variant":"3"}]'
       ].join('\n')
 
       expect(client._features).toStrictEqual({})
@@ -943,6 +945,7 @@ describe('@bugsnag/core/client', () => {
         error: jest.fn()
       }
 
+      // @ts-expect-error
       const client = new Client({ apiKey: 'a123456789012345678901234567890b', logger, featureFlags })
 
       expect(client._features).toStrictEqual({})

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -24,6 +24,7 @@ export interface Config {
   logger?: Logger | null
   maxBreadcrumbs?: number
   metadata?: { [key: string]: any }
+  featureFlags?: FeatureFlag[]
   releaseStage?: string
   plugins?: Plugin[]
   user?: User | null


### PR DESCRIPTION
## Goal

The typescript definition for `Config` wasn't updated in https://github.com/bugsnag/bugsnag-js/pull/1551

This PR adds the missing `featureFlags` property to `Config` and ignores the deliberate errors in our tests (where we pass invalid types on purpose)