### PR TITLE
Sync feature flags from renderers -> main

### DIFF
--- a/packages/electron/src/config/renderer.js
+++ b/packages/electron/src/config/renderer.js
@@ -4,7 +4,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 const ALLOWED_IN_RENDERER = [
   // a list of config keys that are allowed to be supplied to the renderer client
   // this must be kept in sync with the typescript "AllowedRendererConfig" type
-  'onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins', 'appType'
+  'onError', 'onBreadcrumb', 'logger', 'metadata', 'featureFlags', 'user', 'context', 'codeBundleId', 'plugins', 'appType'
 ]
 
 module.exports.schema = {

--- a/packages/electron/types/notifier.d.ts
+++ b/packages/electron/types/notifier.d.ts
@@ -29,7 +29,7 @@ interface MainConfig extends Config {
 
 // a renderer is only allowed a subset of properties from Config
 // this must match the "ALLOWED_IN_RENDERER" list in the renderer config
-type AllowedRendererConfig = Pick<Config, 'onError'|'onBreadcrumb'|'logger'|'metadata'|'user'|'context'|'plugins'|'appType'>
+type AllowedRendererConfig = Pick<Config, 'onError'|'onBreadcrumb'|'logger'|'metadata'|'featureFlags'|'user'|'context'|'plugins'|'appType'>
 
 interface RendererConfig extends AllowedRendererConfig {
   codeBundleId?: string

--- a/packages/plugin-electron-ipc/bugsnag-ipc-main.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-main.js
@@ -24,8 +24,8 @@ module.exports = class BugsnagIpcMain {
     )
   }
 
-  update ({ context, user, metadata }) {
-    return this.clientStateManager.bulkUpdate({ context, user, metadata })
+  update ({ context, user, metadata, features }) {
+    return this.clientStateManager.bulkUpdate({ context, user, metadata, features })
   }
 
   dispatch (eventObject) {
@@ -160,6 +160,10 @@ module.exports = class BugsnagIpcMain {
       ['addMetadata', this.client.addMetadata.bind(this.client)],
       ['clearMetadata', this.client.clearMetadata.bind(this.client)],
       ['getMetadata', this.client.getMetadata.bind(this.client)],
+      ['addFeatureFlag', this.client.addFeatureFlag.bind(this.client)],
+      ['addFeatureFlags', this.client.addFeatureFlags.bind(this.client)],
+      ['clearFeatureFlag', this.client.clearFeatureFlag.bind(this.client)],
+      ['clearFeatureFlags', this.client.clearFeatureFlags.bind(this.client)],
       ['getUser', this.client.getUser.bind(this.client)],
       ['setUser', this.client.setUser.bind(this.client)],
       ['dispatch', this.dispatch.bind(this)],

--- a/packages/plugin-electron-ipc/bugsnag-ipc-renderer.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-renderer.js
@@ -13,8 +13,8 @@ const BugsnagIpcRenderer = {
   config: null,
   process: null,
 
-  update ({ context, user, metadata }) {
-    return safeInvoke(false, 'update', { context, user, metadata })
+  update ({ context, user, metadata, features }) {
+    return safeInvoke(false, 'update', { context, user, metadata, features })
   },
 
   getContext () {
@@ -35,6 +35,22 @@ const BugsnagIpcRenderer = {
 
   getMetadata (...args) {
     return safeInvoke(true, 'getMetadata', ...args)
+  },
+
+  addFeatureFlag (...args) {
+    return safeInvoke(false, 'addFeatureFlag', ...args)
+  },
+
+  addFeatureFlags (...args) {
+    return safeInvoke(false, 'addFeatureFlags', ...args)
+  },
+
+  clearFeatureFlag (...args) {
+    return safeInvoke(false, 'clearFeatureFlag', ...args)
+  },
+
+  clearFeatureFlags () {
+    return safeInvoke(false, 'clearFeatureFlags')
   },
 
   getUser () {

--- a/packages/plugin-electron-ipc/test/bugsnag-ipc-renderer.test.ts
+++ b/packages/plugin-electron-ipc/test/bugsnag-ipc-renderer.test.ts
@@ -96,6 +96,46 @@ describe('BugsnagIpcRenderer', () => {
     )
   })
 
+  it('should call ipcRenderer correctly for addFeatureFlag', async () => {
+    await BugsnagIpcRenderer.addFeatureFlag('name', 'variant')
+
+    expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+      CHANNEL_RENDERER_TO_MAIN,
+      'addFeatureFlag',
+      JSON.stringify('name'),
+      JSON.stringify('variant')
+    )
+  })
+
+  it('should call ipcRenderer correctly for addFeatureFlags', async () => {
+    await BugsnagIpcRenderer.addFeatureFlags([{ name: 'name', variant: 'variant' }])
+
+    expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+      CHANNEL_RENDERER_TO_MAIN,
+      'addFeatureFlags',
+      JSON.stringify([{ name: 'name', variant: 'variant' }])
+    )
+  })
+
+  it('should call ipcRenderer correctly for clearFeatureFlag', async () => {
+    await BugsnagIpcRenderer.clearFeatureFlag('name')
+
+    expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+      CHANNEL_RENDERER_TO_MAIN,
+      'clearFeatureFlag',
+      JSON.stringify('name')
+    )
+  })
+
+  it('should call ipcRenderer correctly for clearFeatureFlags', async () => {
+    await BugsnagIpcRenderer.clearFeatureFlags()
+
+    expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(
+      CHANNEL_RENDERER_TO_MAIN,
+      'clearFeatureFlags'
+    )
+  })
+
   it('should call ipcRenderer correctly for payload info', async () => {
     await BugsnagIpcRenderer.getPayloadInfo()
     expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(CHANNEL_RENDERER_TO_MAIN, 'getPayloadInfo')

--- a/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
+++ b/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
@@ -20,6 +20,11 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
     client.setContext = safeExec(client, BugsnagIpcRenderer, 'setContext')
     client.addMetadata = safeExec(client, BugsnagIpcRenderer, 'addMetadata')
     client.clearMetadata = safeExec(client, BugsnagIpcRenderer, 'clearMetadata')
+    client.addFeatureFlag = safeExec(client, BugsnagIpcRenderer, 'addFeatureFlag')
+    client.addFeatureFlags = safeExec(client, BugsnagIpcRenderer, 'addFeatureFlags')
+    client.clearFeatureFlag = safeExec(client, BugsnagIpcRenderer, 'clearFeatureFlag')
+    client.clearFeatureFlags = safeExec(client, BugsnagIpcRenderer, 'clearFeatureFlags')
+
     client.startSession = () => {
       safeExec(client, BugsnagIpcRenderer, 'startSession')()
       return client

--- a/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
+++ b/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
@@ -38,7 +38,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
     // sync any client state that was set in the renderer config
 
     try {
-      const updates = { metadata: client._metadata }
+      const updates = { metadata: client._metadata, features: client._features }
       const user = client.getUser()
       const context = client.getContext()
       if (context && context.length > 0) {

--- a/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
+++ b/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
@@ -75,6 +75,29 @@ describe('clientStateUpdatesPlugin', () => {
       client.getMetadata('layers', 'strawberry')
     })
 
+    it('propagates feature flag changes', () => {
+      const mockBugsnagIpcRenderer = {
+        addFeatureFlag: jest.fn(),
+        addFeatureFlags: jest.fn(),
+        clearFeatureFlag: jest.fn(),
+        clearFeatureFlags: jest.fn()
+      }
+
+      const client = new Client({ apiKey: '123' }, {}, [clientStateUpdatesPlugin(mockBugsnagIpcRenderer)], Notifier)
+
+      client.addFeatureFlag('name', 'variant')
+      expect(mockBugsnagIpcRenderer.addFeatureFlag).toHaveBeenCalledWith('name', 'variant')
+
+      client.addFeatureFlags([{ name: 'abc' }])
+      expect(mockBugsnagIpcRenderer.addFeatureFlags).toHaveBeenCalledWith([{ name: 'abc' }])
+
+      client.clearFeatureFlag('name')
+      expect(mockBugsnagIpcRenderer.clearFeatureFlag).toHaveBeenCalledWith('name')
+
+      client.clearFeatureFlags()
+      expect(mockBugsnagIpcRenderer.clearFeatureFlags).toHaveBeenCalledWith()
+    })
+
     it('propagates breadcrumb changes', () => {
       const mockBugsnagIpcRenderer = {
         leaveBreadcrumb: jest.fn()

--- a/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
+++ b/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
@@ -171,12 +171,14 @@ describe('clientStateUpdatesPlugin', () => {
       const client = new Client({
         apiKey: '123',
         metadata: { section: { key: 'value' } },
+        featureFlags: [{ name: 'abc' }, { name: 'xyz', variant: '123' }],
         context: 'renderer config',
         user: { id: 'ab23' }
       }, undefined, [clientStateUpdatesPlugin(mockBugsnagIpcRenderer)])
 
       expect(mockBugsnagIpcRenderer.update).toHaveBeenCalledWith({
         metadata: { section: { key: 'value' } },
+        features: { abc: null, xyz: '123' },
         user: { id: 'ab23' },
         context: 'renderer config'
       })
@@ -195,7 +197,8 @@ describe('clientStateUpdatesPlugin', () => {
       }, undefined, [clientStateUpdatesPlugin(mockBugsnagIpcRenderer)])
 
       expect(mockBugsnagIpcRenderer.update).toHaveBeenCalledWith({
-        metadata: { section: { key: 'value' } }
+        metadata: { section: { key: 'value' } },
+        features: {}
       })
     })
 


### PR DESCRIPTION
## Goal

Feature flags are now allowed to be set in renderer process config and will be synced to the main process

Calling `Bugsnag.addFeatureFlag(s)` or `Bugsnag.clearFeatureFlag(s)` will now forward the call on to the main process, in the same way that `addMetadata` and friends do

## Testing

Unit tests have been added for each individual change and I've tested this locally end-to-end. Integration tests will be added separately