### PR TITLE
Fix network breadcrumbs being left for requests to the minidumps endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - (in-flight): Fix Typescript definition exporting a type instead of a value [skirsten](https://github.com/skirsten) [#1587](https://github.com/bugsnag/bugsnag-js/pull/1587)
+- (plugin-electron-net-breadcrumbs): Don't leave breadcrumbs for requests to the minidumps endpoint [#1597](https://github.com/bugsnag/bugsnag-js/pull/1597)
 
 ## 7.14.0 (2021-11-17)
 

--- a/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
+++ b/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
@@ -26,7 +26,9 @@ module.exports = net => ({
       const method = request._urlLoaderOptions.method
 
       // don't leave breadcrumbs for Bugsnag endpoints
-      if (ignoredUrls.includes(url)) {
+      // minidump requests will have an 'api_key' query string parameter, which
+      // we need to remove here
+      if (typeof url === 'string' && ignoredUrls.includes(url.replace(/\?.*$/, ''))) {
         return request
       }
 

--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -191,7 +191,7 @@ describe('plugin: electron net breadcrumbs', () => {
   })
 
   it.each([
-    'notify', 'sessions', 'minidump'
+    'notify', 'sessions'
   ])('does nothing when the request is to the %s endpoint', async (endpointName) => {
     currentServer = await startServer(200)
 
@@ -211,6 +211,38 @@ describe('plugin: electron net breadcrumbs', () => {
     })
 
     const request = net.request(url)
+
+    await new Promise(resolve => {
+      request.on('response', (response) => {
+        response.on('data', () => {})
+        response.on('end', resolve)
+      })
+
+      request.end()
+    })
+
+    expect(client._breadcrumbs).toHaveLength(0)
+  })
+
+  it.each('does nothing when the request is to the minidumps endpoint', async () => {
+    currentServer = await startServer(200)
+
+    const url = `http://localhost:${currentServer.port}`
+
+    const client = makeClient({
+      config: {
+        endpoints: {
+          notify: 'https://example.com/notify',
+          sessions: 'https://example.com/sessions',
+          minidumps: url
+        }
+      },
+      schema: {
+        endpoints: { defaultValue: () => ({}), message: '', validate: () => true }
+      }
+    })
+
+    const request = net.request(`${url}?api_key=1234567890`)
 
     await new Promise(resolve => {
       request.on('response', (response) => {


### PR DESCRIPTION
## Goal

We should ignore requests to Bugsnag URLs, but the logic for this didn't take into account the `api_key` query string parameter that the minidumps endpoint uses

We now remove the query string before checking if a URL should be ignored