### PR TITLE
Fix a crash when XMLHttpRequest URL isn't a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- (plugin-network-breadcrumbs): Fix a crash when request URL is not a string [#1598](https://github.com/bugsnag/bugsnag-js/pull/1598)
 - (in-flight): Fix Typescript definition exporting a type instead of a value [skirsten](https://github.com/skirsten) [#1587](https://github.com/bugsnag/bugsnag-js/pull/1587)
 
 ## 7.14.0 (2021-11-17)

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -60,12 +60,16 @@ module.exports = (_ignoredUrls = [], win = window) => {
       }
 
       function handleXHRLoad () {
-        if (this[REQUEST_URL_KEY] === undefined) {
+        const url = this[REQUEST_URL_KEY]
+
+        if (url === undefined) {
           client._logger.warn('The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.')
           return
         }
 
-        if (includes(ignoredUrls, this[REQUEST_URL_KEY].replace(/\?.*$/, ''))) {
+        // an XMLHttpRequest's URL can be an object as long as its 'toString'
+        // returns a URL, e.g. a HTMLAnchorElement
+        if (typeof url === 'string' && includes(ignoredUrls, url.replace(/\?.*$/, ''))) {
           // don't leave a network breadcrumb from bugsnag notify calls
           return
         }
@@ -82,12 +86,14 @@ module.exports = (_ignoredUrls = [], win = window) => {
       }
 
       function handleXHRError () {
-        if (this[REQUEST_URL_KEY] === undefined) {
+        const url = this[REQUEST_URL_KEY]
+
+        if (url === undefined) {
           client._logger.warn('The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.')
           return
         }
 
-        if (includes(ignoredUrls, this[REQUEST_URL_KEY].replace(/\?.*$/, ''))) {
+        if (typeof url === 'string' && includes(ignoredUrls, url.replace(/\?.*$/, ''))) {
           // don't leave a network breadcrumb from bugsnag notify calls
           return
         }


### PR DESCRIPTION
## Goal

An `XMLHttpRequest` can be passed any object that returns a URL from its `toString` method. For example, [a `HTMLAnchorElement` returns its `href`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/toString) and so can be passed to `XMLHttpRequest.open` (obviously other values can also be passed, but they wouldn't lead to a valid URL so the request wouldn't work)

This PR allows us to handle this case as previously we assumed the URL was a string. As Bugsnag endpoints must be strings we don't try to convert an object into a string, because we would never send a request with any other value in the first place