### PR TITLE
Add default exports to directly imported plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (plugin-network-breadcrumbs): Fix a crash when request URL is not a string [#1598](https://github.com/bugsnag/bugsnag-js/pull/1598)
 - (in-flight): Fix Typescript definition exporting a type instead of a value [skirsten](https://github.com/skirsten) [#1587](https://github.com/bugsnag/bugsnag-js/pull/1587)
 - (plugin-electron-net-breadcrumbs): Don't leave breadcrumbs for requests to the minidumps endpoint [#1597](https://github.com/bugsnag/bugsnag-js/pull/1597)
+- Add a `default` export to plugins that were missing one [#1599](https://github.com/bugsnag/bugsnag-js/pull/1599)
 
 ## 7.14.0 (2021-11-17)
 

--- a/packages/plugin-aws-lambda/src/index.js
+++ b/packages/plugin-aws-lambda/src/index.js
@@ -153,3 +153,6 @@ function isPromise (value) {
 }
 
 module.exports = BugsnagPluginAwsLambda
+
+// add a default export for ESM modules without interop
+module.exports.default = module.exports

--- a/packages/plugin-contextualize/contextualize.js
+++ b/packages/plugin-contextualize/contextualize.js
@@ -29,3 +29,6 @@ module.exports = {
     return contextualize
   }
 }
+
+// add a default export for ESM modules without interop
+module.exports.default = module.exports

--- a/packages/plugin-intercept/intercept.js
+++ b/packages/plugin-intercept/intercept.js
@@ -31,3 +31,6 @@ module.exports = {
     return intercept
   }
 }
+
+// add a default export for ESM modules without interop
+module.exports.default = module.exports

--- a/packages/plugin-react-native-navigation/react-native-navigation.js
+++ b/packages/plugin-react-native-navigation/react-native-navigation.js
@@ -27,3 +27,6 @@ module.exports = class BugsnagPluginReactNativeNavigation {
     })
   }
 }
+
+// add a default export for ESM modules without interop
+module.exports.default = module.exports

--- a/packages/plugin-react-navigation/react-navigation.js
+++ b/packages/plugin-react-navigation/react-navigation.js
@@ -61,3 +61,6 @@ class BugsnagPluginReactNavigation {
 }
 
 module.exports = BugsnagPluginReactNavigation
+
+// add a default export for ESM modules without interop
+module.exports.default = module.exports

--- a/packages/plugin-vue/src/index.js
+++ b/packages/plugin-vue/src/index.js
@@ -34,3 +34,6 @@ module.exports = class BugsnagPluginVue {
     }
   }
 }
+
+// add a default export for ESM modules without interop
+module.exports.default = module.exports


### PR DESCRIPTION
## Goal

This PR adds a default export to plugins that users need to import directly in their apps, e.g. `@bugsnag/plugin-vue` (see https://github.com/bugsnag/bugsnag-js/issues/1584)

We don't want to add a default export to every single plugin because it bloats the browser bundle size quite a lot (a few hundred bytes) and offers no benefit to the vast majority of users, as they will never import those plugins anyway

If users do want to import plugins that don't have a default export, this can be achieved anyway, e.g. Typescript's `esModuleInterop` option

However, for a good user experience, things that are directly imported should "just work"