### PR TITLE
Electron integration tests for feature flags in the main process

### DIFF
--- a/test/electron/features/feature-flags.feature
+++ b/test/electron/features/feature-flags.feature
@@ -1,0 +1,71 @@
+Feature: Feature flags
+
+Scenario: feature flags are attached to unhandled errors in the main process
+    Given I launch an app with configuration:
+        | bugsnag | feature-flags |
+    When I click "main-process-uncaught-exception"
+    Then the total requests received by the server matches:
+        | events   | 1        |
+        | sessions | 1        |
+    And the headers of every event request contains:
+        | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+        | Content-Type      | application/json                 |
+        | Bugsnag-Integrity | {BODY_SHA1}                      |
+    And the event contains the following feature flags:
+        | featureFlag          | variant    |
+        | from main config 1   | 1234       |
+        | from main config 2   |            |
+        | from main at runtime | runtime 1  |
+        | from main on error   | on error 1 |
+    And the contents of an event request matches "main/uncaught-exception/default.json"
+
+Scenario: feature flags are attached to handled errors in the main process
+    Given I launch an app with configuration:
+        | bugsnag | feature-flags |
+    When I click "custom-breadcrumb"
+    And I click "main-notify"
+    Then the total requests received by the server matches:
+        | events   | 1        |
+        | sessions | 1        |
+    And the headers of every event request contains:
+        | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+        | Content-Type      | application/json                 |
+        | Bugsnag-Integrity | {BODY_SHA1}                      |
+    And the event contains the following feature flags:
+        | featureFlag          | variant    |
+        | from main config 1   | 1234       |
+        | from main config 2   |            |
+        | from main at runtime | runtime 1  |
+        | from main on error   | on error 1 |
+    And the contents of an event request matches "main/handled-error/default.json"
+
+Scenario: feature flags can be cleared entirely in the main process with an unhandled error
+    Given I launch an app with configuration:
+        | bugsnag | feature-flags |
+    When I click "main-process-clear-feature-flags"
+    And I click "main-process-uncaught-exception"
+    Then the total requests received by the server matches:
+        | events   | 1        |
+        | sessions | 1        |
+    And the headers of every event request contains:
+        | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+        | Content-Type      | application/json                 |
+        | Bugsnag-Integrity | {BODY_SHA1}                      |
+    And the event has no feature flags
+    And the contents of an event request matches "main/uncaught-exception/default.json"
+
+Scenario: feature flags can be cleared entirely in the main process with a handled error
+    Given I launch an app with configuration:
+        | bugsnag | feature-flags |
+    When I click "main-process-clear-feature-flags"
+    And I click "custom-breadcrumb"
+    And I click "main-notify"
+    Then the total requests received by the server matches:
+        | events   | 1        |
+        | sessions | 1        |
+    And the headers of every event request contains:
+        | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+        | Content-Type      | application/json                 |
+        | Bugsnag-Integrity | {BODY_SHA1}                      |
+    And the event has no feature flags
+    And the contents of an event request matches "main/handled-error/default.json"

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -180,3 +180,29 @@ Then('the event metadata {string} is less than {int}', async (field, max) => {
 Then('I wait {int} seconds', delay => {
   return new Promise(resolve => setTimeout(resolve, delay * 1000))
 })
+
+Then('the event contains the following feature flags:', async (table) => {
+  const payloads = readPayloads(global.server.uploadsForType('event'))
+
+  const expected = table.hashes().map((featureFlag) => {
+    // an empty cell in the .feature is parsed as an empty string but really
+    // means that the variant should be missing entirely
+    if (featureFlag.variant === '') {
+      delete featureFlag.variant
+    }
+
+    return featureFlag
+  })
+
+  expect(payloads).toHaveLength(1)
+  expect(payloads[0].events).toHaveLength(1)
+  expect(payloads[0].events[0]).toHaveProperty('featureFlags', expected)
+})
+
+Then('the event has no feature flags', async () => {
+  const payloads = readPayloads(global.server.uploadsForType('event'))
+
+  expect(payloads).toHaveLength(1)
+  expect(payloads[0].events).toHaveLength(1)
+  expect(payloads[0].events[0]).toHaveProperty('featureFlags', [])
+})

--- a/test/electron/fixtures/app/configs/feature-flags.js
+++ b/test/electron/fixtures/app/configs/feature-flags.js
@@ -1,0 +1,8 @@
+module.exports = () => {
+  return {
+    featureFlags: [
+      { name: 'from main config 1', variant: '1234' },
+      { name: 'from main config 2' }
+    ]
+  }
+}

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -52,5 +52,8 @@
         <li><a href="#" id="page-title-clear" onclick="document.title = ''">Clear the page title</a></li>
         <li><a href="#" id="set-context">Manually call setContext() in renderer</a></li>
     </ul>
+    <ul>
+        <li><a href="#" id="main-process-clear-feature-flags" onclick="RunnerAPI.mainProcessClearFeatureFlags()">clear feature flags in main process</a></li>
+    </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/main.js
+++ b/test/electron/fixtures/app/main.js
@@ -18,6 +18,13 @@ Bugsnag.start(config)
 
 const { app, BrowserWindow, ipcMain } = require('electron')
 
+Bugsnag.addFeatureFlag('from main at runtime', 'runtime 1')
+Bugsnag.addOnError(event => {
+  event.addFeatureFlags([
+    { name: 'from main on error', variant: 'on error 1' }
+  ])
+})
+
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
@@ -74,4 +81,11 @@ ipcMain.on('mark-launch-complete', () => {
 
 ipcMain.on('last-run-info-breadcrumb', () => {
   Bugsnag.leaveBreadcrumb('last-run-info', Bugsnag.lastRunInfo)
+})
+
+ipcMain.on('main-process-clear-feature-flags', () => {
+  // clear feature flags in a new on error callback to also clear flags from other callbacks
+  Bugsnag.addOnError(event => {
+    event.clearFeatureFlags()
+  })
 })

--- a/test/electron/fixtures/app/preloads/default.js
+++ b/test/electron/fixtures/app/preloads/default.js
@@ -33,5 +33,8 @@ contextBridge.exposeInMainWorld('RunnerAPI', {
   renderProcessCrash: () => {
     process.crash()
   },
+  mainProcessClearFeatureFlags: () => {
+    ipcRenderer.send('main-process-clear-feature-flags')
+  },
   preloadStart: Date.now()
 })

--- a/test/electron/fixtures/events/app-launch/complex-config.json
+++ b/test/electron/fixtures/events/app-launch/complex-config.json
@@ -90,8 +90,11 @@
           "errorClass": "ReferenceError",
           "stacktrace": [
             {
-              "lineNumber": 315,
-              "file": "events.js"
+              "file": "./src/errors.js",
+              "lineNumber": 6,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronnodejs"

--- a/test/electron/fixtures/events/app-launch/default.json
+++ b/test/electron/fixtures/events/app-launch/default.json
@@ -77,8 +77,11 @@
           "errorClass": "ReferenceError",
           "stacktrace": [
             {
-              "lineNumber": 315,
-              "file": "events.js"
+              "file": "./src/errors.js",
+              "lineNumber": 6,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronnodejs"

--- a/test/electron/fixtures/events/app-launch/launch-complete.json
+++ b/test/electron/fixtures/events/app-launch/launch-complete.json
@@ -77,8 +77,11 @@
           "errorClass": "ReferenceError",
           "stacktrace": [
             {
-              "lineNumber": 315,
-              "file": "events.js"
+              "file": "./src/errors.js",
+              "lineNumber": 6,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronnodejs"

--- a/test/electron/fixtures/events/app-launch/launch-incomplete.json
+++ b/test/electron/fixtures/events/app-launch/launch-incomplete.json
@@ -77,8 +77,11 @@
           "errorClass": "ReferenceError",
           "stacktrace": [
             {
-              "lineNumber": 315,
-              "file": "events.js"
+              "file": "./src/errors.js",
+              "lineNumber": 6,
+              "code": {
+                "1": "{TYPE:string}"
+              }
             }
           ],
           "type": "electronnodejs"


### PR DESCRIPTION
## Goal

Adds some integration tests to ensure feature flags are reported for errors in the main process

This uses a new step rather than the existing "the contents of an event request matches "<fixture>" step because the new step is much stricter — the feature flags must match exactly, i.e. there can't be more flags than we assert against and flags can't have additional properties

I was also getting flakes from the app-launch fixture as it was asserting against a file we don't control in the stacktrace. I think this was just a mistake when it was made, so I swapped it to check against a file we do control, which also matches the other fixtures