### PR TITLE
Fix feature flags being missing from renderer crashes

### DIFF
--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -5,6 +5,7 @@ const MinidumpDeliveryLoop = require('./minidump-loop')
 const MinidumpQueue = require('./minidump-queue')
 const sendMinidumpFactory = require('./send-minidump')
 const NetworkStatus = require('@bugsnag/electron-network-status')
+const featureFlagDelegate = require('@bugsnag/core/lib/feature-flag-delegate')
 
 const isEnabledFor = client => client._config.autoDetectErrors && client._config.enabledErrorTypes.nativeCrashes
 
@@ -95,6 +96,7 @@ const takeEventSnapshot = (client) => ({
   context: client._context,
   device: { ...client._device },
   metadata: { ...client._metadata },
+  featureFlags: featureFlagDelegate.toEventApi(client._features),
   severity: 'error',
   severityReason: { type: 'unhandledException' },
   unhandled: true,

--- a/test/electron/features/feature-flags.feature
+++ b/test/electron/features/feature-flags.feature
@@ -197,6 +197,29 @@ Scenario: feature flags are attached to native crashes from the main process
     And minidump request 0 contains a file form field named "upload_file_minidump"
     And minidump request 0 contains a form field named "event" matching "minidump-event.json"
 
+Scenario: feature flags can be cleared entirely in the main process with a native crash
+    Given I launch an app with configuration:
+        | bugsnag         | feature-flags                                            |
+        | renderer_config | { "featureFlags": [{ "name": "from renderer config" }] } |
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 0 |
+        | sessions  | 1 |
+    When I click "main-process-clear-feature-flags-now"
+    And I click "main-process-crash"
+    And I launch an app
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 1 |
+        | sessions  | 2 |
+    And the headers of every event request contains:
+        | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+        | Content-Type      | application/json                 |
+        | Bugsnag-Integrity | {BODY_SHA1}                      |
+    And minidump request 0 has no feature flags
+    And minidump request 0 contains a file form field named "upload_file_minidump"
+    And minidump request 0 contains a form field named "event" matching "minidump-event.json"
+
 Scenario: feature flags are attached to native crashes from a renderer process
     Given I launch an app with configuration:
         | bugsnag         | feature-flags                                            |
@@ -218,5 +241,28 @@ Scenario: feature flags are attached to native crashes from a renderer process
         | from renderer config       |           |
         | from renderer at runtime 1 | runtime   |
         | from renderer at runtime 2 |           |
+    And minidump request 0 contains a file form field named "upload_file_minidump"
+    And minidump request 0 contains a form field named "event" matching "minidump-event.json"
+
+Scenario: feature flags can be cleared entirely in a renderer process with a native crash
+    Given I launch an app with configuration:
+        | bugsnag         | feature-flags                                            |
+        | renderer_config | { "featureFlags": [{ "name": "from renderer config" }] } |
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 0 |
+        | sessions  | 1 |
+    When I click "renderer-clear-feature-flags-now"
+    And I click "renderer-process-crash"
+    And I launch an app
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 1 |
+        | sessions  | 2 |
+    And the headers of every event request contains:
+        | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+        | Content-Type      | application/json                 |
+        | Bugsnag-Integrity | {BODY_SHA1}                      |
+    And minidump request 0 has no feature flags
     And minidump request 0 contains a file form field named "upload_file_minidump"
     And minidump request 0 contains a form field named "event" matching "minidump-event.json"

--- a/test/electron/features/feature-flags.feature
+++ b/test/electron/features/feature-flags.feature
@@ -13,7 +13,7 @@ Scenario: feature flags are attached to unhandled errors in the main process
         | Content-Type      | application/json                 |
         | Bugsnag-Integrity | {BODY_SHA1}                      |
     And the event contains the following feature flags:
-        | featureFlag              | variant    |
+        | featureFlag                | variant    |
         | from main config 1         | 1234       |
         | from main config 2         |            |
         | from main at runtime       | runtime 1  |
@@ -171,3 +171,52 @@ Scenario: feature flags can be cleared entirely in a renderer process with a han
         | featureFlag        | variant    |
         | from main on error | on error 1 |
     And the contents of an event request matches "renderer/handled-error/default.json"
+
+Scenario: feature flags are attached to native crashes from the main process
+    Given I launch an app with configuration:
+        | bugsnag         | feature-flags                                            |
+        | renderer_config | { "featureFlags": [{ "name": "from renderer config" }] } |
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 0 |
+        | sessions  | 1 |
+    When I click "main-process-crash"
+    And I launch an app
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 1 |
+        | sessions  | 2 |
+    And minidump request 0 contains the following feature flags:
+        | featureFlag                | variant   |
+        | from main config 1         | 1234      |
+        | from main config 2         |           |
+        | from main at runtime       | runtime 1 |
+        | from renderer config       |           |
+        | from renderer at runtime 1 | runtime   |
+        | from renderer at runtime 2 |           |
+    And minidump request 0 contains a file form field named "upload_file_minidump"
+    And minidump request 0 contains a form field named "event" matching "minidump-event.json"
+
+Scenario: feature flags are attached to native crashes from a renderer process
+    Given I launch an app with configuration:
+        | bugsnag         | feature-flags                                            |
+        | renderer_config | { "featureFlags": [{ "name": "from renderer config" }] } |
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 0 |
+        | sessions  | 1 |
+    When I click "renderer-process-crash"
+    Then the total requests received by the server matches:
+        | events    | 0 |
+        | minidumps | 1 |
+        | sessions  | 1 |
+    And minidump request 0 contains the following feature flags:
+        | featureFlag                | variant   |
+        | from main config 1         | 1234      |
+        | from main config 2         |           |
+        | from main at runtime       | runtime 1 |
+        | from renderer config       |           |
+        | from renderer at runtime 1 | runtime   |
+        | from renderer at runtime 2 |           |
+    And minidump request 0 contains a file form field named "upload_file_minidump"
+    And minidump request 0 contains a form field named "event" matching "minidump-event.json"

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -14,6 +14,18 @@ const readPayloads = (requests) => {
   return requests.map(req => JSON.parse(req.body.trim()))
 }
 
+const featureFlagsTableToExpected = table => {
+  return table.hashes().map((featureFlag) => {
+    // an empty cell in the .feature is parsed as an empty string but really
+    // means that the variant should be missing entirely
+    if (featureFlag.variant === '') {
+      delete featureFlag.variant
+    }
+
+    return featureFlag
+  })
+}
+
 Given('I launch an app', launchConfig, async () => {
   return global.automator.start()
 })
@@ -85,6 +97,26 @@ Then('minidump request {int} contains a form field named {string} matching {stri
   } catch (e) {
     throw new Error(`Could not parse ${field} as JSON: ${e} -- ${req.fields[field]}`)
   }
+})
+
+Then('minidump request {int} contains the following feature flags:', async (index, table) => {
+  const request = global.server.minidumpUploads[index]
+
+  expect(request.fields).toHaveProperty('event')
+
+  let actual
+
+  try {
+    actual = JSON.parse(request.fields.event)
+  } catch (e) {
+    throw new Error(`Could not parse event as JSON: ${e} -- ${request.fields.event}`)
+  }
+
+  const expected = featureFlagsTableToExpected(table)
+
+  expect(actual).toHaveProperty('events')
+  expect(actual.events).toHaveLength(1)
+  expect(actual.events[0]).toHaveProperty('featureFlags', expected)
 })
 
 Then('the total requests received by the server matches:', async (data) => {
@@ -183,16 +215,7 @@ Then('I wait {int} seconds', delay => {
 
 Then('the event contains the following feature flags:', async (table) => {
   const payloads = readPayloads(global.server.uploadsForType('event'))
-
-  const expected = table.hashes().map((featureFlag) => {
-    // an empty cell in the .feature is parsed as an empty string but really
-    // means that the variant should be missing entirely
-    if (featureFlag.variant === '') {
-      delete featureFlag.variant
-    }
-
-    return featureFlag
-  })
+  const expected = featureFlagsTableToExpected(table)
 
   expect(payloads).toHaveLength(1)
   expect(payloads[0].events).toHaveLength(1)

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -119,6 +119,24 @@ Then('minidump request {int} contains the following feature flags:', async (inde
   expect(actual.events[0]).toHaveProperty('featureFlags', expected)
 })
 
+Then('minidump request {int} has no feature flags', async (index) => {
+  const request = global.server.minidumpUploads[index]
+
+  expect(request.fields).toHaveProperty('event')
+
+  let actual
+
+  try {
+    actual = JSON.parse(request.fields.event)
+  } catch (e) {
+    throw new Error(`Could not parse event as JSON: ${e} -- ${request.fields.event}`)
+  }
+
+  expect(actual).toHaveProperty('events')
+  expect(actual.events).toHaveLength(1)
+  expect(actual.events[0]).toHaveProperty('featureFlags', [])
+})
+
 Then('the total requests received by the server matches:', async (data) => {
   return requestDelay((done) => {
     const expected = {}

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -53,8 +53,11 @@
         <li><a href="#" id="set-context">Manually call setContext() in renderer</a></li>
     </ul>
     <ul>
-        <li><a href="#" id="main-process-clear-feature-flags" onclick="RunnerAPI.mainProcessClearFeatureFlags()">clear feature flags in main process</a></li>
-        <li><a href="#" id="renderer-clear-feature-flags">clear feature flags in renderer</a></li>
+        <li><a href="#" id="main-process-clear-feature-flags" onclick="RunnerAPI.mainProcessClearFeatureFlags()">clear feature flags in an on error in main process</a></li>
+        <li><a href="#" id="renderer-clear-feature-flags">clear feature flags in an on error in renderer</a></li>
+
+        <li><a href="#" id="main-process-clear-feature-flags-now" onclick="RunnerAPI.mainProcessClearFeatureFlagsNow()">immediately clear feature flags in main process</a></li>
+        <li><a href="#" id="renderer-clear-feature-flags-now">immediately clear feature flags in renderer</a></li>
     </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/main.js
+++ b/test/electron/fixtures/app/main.js
@@ -89,3 +89,7 @@ ipcMain.on('main-process-clear-feature-flags', () => {
     event.clearFeatureFlags()
   })
 })
+
+ipcMain.on('main-process-clear-feature-flags-now', () => {
+  Bugsnag.clearFeatureFlags()
+})

--- a/test/electron/fixtures/app/preloads/default.js
+++ b/test/electron/fixtures/app/preloads/default.js
@@ -36,5 +36,8 @@ contextBridge.exposeInMainWorld('RunnerAPI', {
   mainProcessClearFeatureFlags: () => {
     ipcRenderer.send('main-process-clear-feature-flags')
   },
+  mainProcessClearFeatureFlagsNow: () => {
+    ipcRenderer.send('main-process-clear-feature-flags-now')
+  },
   preloadStart: Date.now()
 })

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -78,4 +78,8 @@ document.getElementById('renderer-clear-feature-flags').onclick = () => {
   })
 }
 
+document.getElementById('renderer-clear-feature-flags-now').onclick = () => {
+  Bugsnag.clearFeatureFlags()
+}
+
 Bugsnag.addFeatureFlag('from renderer at runtime 2')


### PR DESCRIPTION
## Goal

When a renderer crashes we take a snapshot of event information and attach it to the minidump. This wasn't updated to account for feature flags and so they were missing from events in minidumps created from renderer crashes

This PR fixes this and adds integration tests for feature flags in native crashes