### PR TITLE
Allow `featureFlags` in ReactNative config

### DIFF
--- a/packages/plugin-react-native-client-sync/client-sync.js
+++ b/packages/plugin-react-native-client-sync/client-sync.js
@@ -42,6 +42,34 @@ module.exports = (NativeClient) => ({
       return ret
     }
 
+    const origAddFeatureFlags = client.addFeatureFlags
+    client.addFeatureFlags = function (featureFlags) {
+      const ret = origAddFeatureFlags.apply(this, arguments)
+      NativeClient.addFeatureFlags(featureFlags)
+      return ret
+    }
+
+    const origAddFeatureFlag = client.addFeatureFlag
+    client.addFeatureFlag = function (name, variant) {
+      const ret = origAddFeatureFlag.apply(this, arguments)
+      NativeClient.addFeatureFlag(name, variant)
+      return ret
+    }
+
+    const origClearFeatureFlag = client.clearFeatureFlag
+    client.clearFeatureFlag = function (name) {
+      const ret = origClearFeatureFlag.apply(this, arguments)
+      NativeClient.clearFeatureFlag(name)
+      return ret
+    }
+
+    const origClearFeatureFlags = client.clearFeatureFlags
+    client.clearFeatureFlags = function () {
+      const ret = origClearFeatureFlags.apply(this, arguments)
+      NativeClient.clearFeatureFlags()
+      return ret
+    }
+
     const getEmitter = () => {
       switch (Platform.OS) {
         case 'android':

--- a/packages/plugin-react-native-client-sync/test/client-sync.test.ts
+++ b/packages/plugin-react-native-client-sync/test/client-sync.test.ts
@@ -107,6 +107,74 @@ describe('plugin: react native client sync', () => {
       })
       c.leaveBreadcrumb('Spin', { direction: 'ccw', deg: '90' })
     })
+
+    describe('feature flags', () => {
+      it('adds individual feature flags', done => {
+        const c = new Client({
+          apiKey: 'api_key',
+          plugins: [
+            plugin({
+              addFeatureFlag: (name: string, variant?: string) => {
+                expect(name).toBe('feature flag')
+                expect(variant).toBe('flag variant')
+                done()
+              }
+            })
+          ]
+        })
+
+        c.addFeatureFlag('feature flag', 'flag variant')
+      })
+
+      it('adds arrays of feature flags', done => {
+        const c = new Client({
+          apiKey: 'api_key',
+          plugins: [
+            plugin({
+              addFeatureFlags: (flags: { name: string, variant?: string }) => {
+                expect(flags).toStrictEqual([
+                  { name: 'feature flag', variant: 'flag variant' },
+                  { name: 'name only flag' }
+                ])
+                done()
+              }
+            })
+          ]
+        })
+
+        c.addFeatureFlags([
+          { name: 'feature flag', variant: 'flag variant' },
+          { name: 'name only flag' }
+        ])
+      })
+
+      it('clears specific feature flags', done => {
+        const c = new Client({
+          apiKey: 'api_key',
+          plugins: [
+            plugin({
+              clearFeatureFlag: (name: string) => {
+                expect(name).toStrictEqual('feature flag')
+                done()
+              }
+            })
+          ]
+        })
+
+        c.clearFeatureFlag('feature flag')
+      })
+
+      it('clears all feature flags', () => {
+        const clearFeatureFlags = jest.fn()
+        const c = new Client({
+          apiKey: 'api_key',
+          plugins: [plugin({ clearFeatureFlags })]
+        })
+
+        c.clearFeatureFlags()
+        expect(clearFeatureFlags).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 
   describe('native -> JS', () => {

--- a/packages/react-native/src/config.js
+++ b/packages/react-native/src/config.js
@@ -3,7 +3,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 const rnPackage = require('react-native/package.json')
 const iserror = require('iserror')
 
-const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins']
+const ALLOWED_IN_JS = ['onError', 'onBreadcrumb', 'logger', 'metadata', 'user', 'context', 'codeBundleId', 'plugins', 'featureFlags']
 const allowedErrorTypes = () => ({
   unhandledExceptions: true,
   unhandledRejections: true,

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -80,6 +80,10 @@ const _createClient = (opts, jsOpts) => {
     bugsnag.setContext(opts.context)
   }
 
+  if (opts.featureFlags && opts.featureFlags !== opts._originalValues.featureFlags) {
+    bugsnag.addFeatureFlags(opts.featureFlags)
+  }
+
   if (opts.metadata && opts.metadata !== opts._originalValues.metadata) {
     Object.keys(opts.metadata).forEach(k => bugsnag.addMetadata(k, opts.metadata[k]))
   }

--- a/packages/react-native/src/test/notifier.test.ts
+++ b/packages/react-native/src/test/notifier.test.ts
@@ -1,0 +1,39 @@
+// @ts-ignore
+import { NativeModules } from 'react-native'
+
+import Bugsnag from '../..'
+
+jest.mock('react-native', () => {
+  return {
+    NativeModules: {
+      BugsnagReactNative: {
+        configure: () => ({
+          apiKey: 'abab1212abab1212abab1212abab1212'
+        }),
+        resumeSession: () => {},
+        addFeatureFlags: jest.fn()
+      }
+    },
+    Platform: {
+      OS: 'android'
+    }
+  }
+})
+
+beforeEach(() => {
+  window.fetch = jest.fn()
+  window.XMLHttpRequest = jest.fn() as any
+})
+
+describe('react-native notifier: start()', () => {
+  it('supports featureFlags', () => {
+    Bugsnag.start({
+      featureFlags: [
+        { name: 'demo_mode' },
+        { name: 'sample_group', variant: 'abc123' }
+      ]
+    })
+
+    expect(NativeModules.BugsnagReactNative.addFeatureFlags).toHaveBeenCalled()
+  })
+})

--- a/packages/react-native/types/bugsnag.d.ts
+++ b/packages/react-native/types/bugsnag.d.ts
@@ -5,7 +5,7 @@ interface ReactNativeSchema extends Config {
 }
 
 // these properties are allowed to be configured in the JS layer
-type Configurable = 'onError' | 'onBreadcrumb' | 'logger' | 'metadata' | 'user' | 'context' | 'plugins' | 'codeBundleId'
+type Configurable = 'onError' | 'onBreadcrumb' | 'logger' | 'metadata' | 'user' | 'context' | 'plugins' | 'codeBundleId' | 'featureFlags'
 
 type ReactNativeConfig = Pick<ReactNativeSchema, Configurable>
 


### PR DESCRIPTION
## Goal
Send `featureFlags` configured as part of `Bugsnag.start` to the `NativeClient` so that they can be included in all future events.

## Testing
Additional unit tests, and some manual testing using additional code to ensure the feature flags can be sent to a native client and will be included in delivered events.