### PR TITLE
Search in all android/app/src/main/java subdirectories for MainApplication.java

### DIFF
--- a/packages/react-native-cli/src/lib/Insert.ts
+++ b/packages/react-native-cli/src/lib/Insert.ts
@@ -83,12 +83,12 @@ export async function insertAndroid (projectRoot: string, logger: Logger): Promi
 
   let mainApplicationPath
   try {
-    const comDir = path.join(projectRoot, 'android', 'app', 'src', 'main', 'java', 'com')
+    const javaDir = path.join(projectRoot, 'android', 'app', 'src', 'main', 'java')
     const relativeMainApplicationPath = (await asyncGlob('**/*/MainApplication.java', {
-      cwd: comDir
+      cwd: javaDir
     }))[0]
     if (!relativeMainApplicationPath) return logger.warn(FAIL_MSG('MainApplication.java'))
-    mainApplicationPath = path.join(comDir, relativeMainApplicationPath)
+    mainApplicationPath = path.join(javaDir, relativeMainApplicationPath)
   } catch (e) {
     logger.warn(FAIL_MSG('MainApplication.java'))
     return

--- a/packages/react-native-cli/src/lib/__test__/Insert.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Insert.test.ts
@@ -175,7 +175,7 @@ test('insertIos(): no identifiable app launch method', async () => {
 
 test('insertAndroid(): success', async () => {
   const globMock = glob as unknown as jest.MockedFunction<typeof glob>
-  globMock.mockImplementation((glob, opts, cb) => cb(null, ['bugsnagreactnativeclitest/MainApplication.java']))
+  globMock.mockImplementation((glob, opts, cb) => cb(null, ['com/bugsnagreactnativeclitest/MainApplication.java']))
 
   const mainApplication = await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-before.java'))
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
@@ -197,7 +197,7 @@ test('insertAndroid(): success', async () => {
 
 test('insertAndroid(): success, tolerates some differences in source', async () => {
   const globMock = glob as unknown as jest.MockedFunction<typeof glob>
-  globMock.mockImplementation((glob, opts, cb) => cb(null, ['bugsnagreactnativeclitest/MainApplication.java']))
+  globMock.mockImplementation((glob, opts, cb) => cb(null, ['com/bugsnagreactnativeclitest/MainApplication.java']))
 
   const mainApplication = await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-before-2.java'))
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
@@ -219,7 +219,7 @@ test('insertAndroid(): success, tolerates some differences in source', async () 
 
 test('insertAndroid(): already present', async () => {
   const globMock = glob as unknown as jest.MockedFunction<typeof glob>
-  globMock.mockImplementation((glob, opts, cb) => cb(null, ['bugsnagreactnativeclitest/MainApplication.java']))
+  globMock.mockImplementation((glob, opts, cb) => cb(null, ['com/bugsnagreactnativeclitest/MainApplication.java']))
 
   const mainApplication = await loadFixture(path.join(__dirname, 'fixtures', 'MainApplication-after.java'))
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
@@ -239,7 +239,7 @@ test('insertAndroid(): already present', async () => {
 
 test('insertAndroid(): failure to locate file', async () => {
   const globMock = glob as unknown as jest.MockedFunction<typeof glob>
-  globMock.mockImplementation((glob, opts, cb) => cb(null, ['bugsnagreactnativeclitest/MainApplication.java']))
+  globMock.mockImplementation((glob, opts, cb) => cb(null, ['com/bugsnagreactnativeclitest/MainApplication.java']))
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockRejectedValue(await generateNotFoundError())
@@ -286,7 +286,7 @@ test('insertAndroid(): project directory error', async () => {
 
 test('insertAndroid(): no identifiable onCreate method', async () => {
   const globMock = glob as unknown as jest.MockedFunction<typeof glob>
-  globMock.mockImplementation((glob, opts, cb) => cb(null, ['bugsnagreactnativeclitest/MainApplication.java']))
+  globMock.mockImplementation((glob, opts, cb) => cb(null, ['com/bugsnagreactnativeclitest/MainApplication.java']))
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockResolvedValue('not good java')


### PR DESCRIPTION
## Goal

Some of my react-native applications have another path to `MainApplication.java`.
That is the reason why i get a warning and have to modify the file myself.

Expected path: `android/app/src/main/java/com/**/MainApplication.java`.

Other paths:
- `android/app/src/main/java/de/**/MainApplication.java`
- `android/app/src/main/java/org/**/MainApplication.java`
- `android/app/src/main/java/net/**/MainApplication.java`.
- ...