### PR TITLE
Temporarily skip Expo testing on Android

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -43,6 +43,8 @@ steps:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
 
   - label:  ':docker: Build expo APK builder'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     key: "expo-android-builder"
     timeout_in_minutes: 40
     env:
@@ -60,6 +62,8 @@ steps:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
 
   - label:  ':docker: Build expo APK'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     key: "build-expo-apk"
     depends_on:
       - "publish-expo-app"
@@ -90,6 +94,8 @@ steps:
       - test/expo/scripts/build-ios.sh
 
   - label: ':runner: expo Android 9'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     depends_on:
       - "build-expo-apk"
       - "expo-maze-runner-image"
@@ -140,6 +146,8 @@ steps:
     key: "trigger-full-suite"
 
   - label: ':runner: expo Android 8'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     depends_on:
       - "trigger-full-suite"
       - "build-expo-apk"
@@ -168,6 +176,8 @@ steps:
       - exit_status: "*"
 
   - label: ':runner: expo Android 7'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     depends_on:
       - "trigger-full-suite"
       - "build-expo-apk"
@@ -192,6 +202,8 @@ steps:
     concurrency_method: eager
 
   - label: ':runner: expo Android 6'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     depends_on:
       - "trigger-full-suite"
       - "build-expo-apk"
@@ -216,6 +228,8 @@ steps:
     concurrency_method: eager
 
   - label: ':runner: expo Android 5'
+    # TODO: Pending PLAT-7743
+    skip: Pending PLAT-7743
     depends_on:
       - "trigger-full-suite"
       - "build-expo-apk"


### PR DESCRIPTION
## Goal

Skip Expo testing on Android pending PLAT-7743, as building of the test fixture APK got broken by external change - leading to conflicting dependencies.