### PR TITLE
FeatureFlag Mazerunner tests for ReactNative

### DIFF
--- a/test/react-native/Gemfile
+++ b/test/react-native/Gemfile
@@ -4,7 +4,7 @@ gem 'cocoapods'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.2.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.6.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/test/react-native/features/feature_flags.feature
+++ b/test/react-native/features/feature_flags.feature
@@ -1,0 +1,48 @@
+Feature: Reporting with feature flags
+
+Scenario: Sends handled exception which includes feature flags
+  When I run "FeatureFlagsScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the event "unhandled" is false
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+# Android only pending PLAT-7766
+@android_only
+Scenario: Sends handled exception which includes feature flags added in the notify callback
+  When I configure the app to run in the "callback" state
+  And I run "FeatureFlagsScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the event "unhandled" is false
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+# Android only pending PLAT-7766
+@android_only
+Scenario: Sends unhandled exception which includes feature flags added in the notify callback
+  When I configure the app to run in the "unhandled callback" state
+  And I run "FeatureFlagsScenario" and relaunch the app
+  And I configure Bugsnag for "FeatureFlagsScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the event "unhandled" is true
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+Scenario: Sends no feature flags after clearFeatureFlags()
+  When I configure the app to run in the "cleared" state
+  And I run "FeatureFlagsScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the event "unhandled" is false
+  And event 0 has no feature flags

--- a/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
@@ -65,3 +65,6 @@ export { NativeStackUnhandledScenario } from './scenarios/NativeStackUnhandledSc
 // override_unhandled.feature
 export { HandledOverrideJsErrorScenario } from './scenarios/HandledOverrideJsErrorScenario'
 export { UnhandledOverrideJsErrorScenario } from './scenarios/UnhandledOverrideJsErrorScenario'
+
+// feature_flags.feature
+export { FeatureFlagsScenario } from './scenarios/FeatureFlagsScenario'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/FeatureFlagsScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/FeatureFlagsScenario.js
@@ -1,0 +1,39 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+
+export class FeatureFlagsScenario extends Scenario {
+  constructor (configuration, extraData, jsConfig) {
+    super()
+    this.extraData = extraData
+
+    if (extraData && extraData.includes('callback')) {
+      jsConfig.onError = (event) => {
+        event.addFeatureFlag('sample_group', 'a')
+      }
+    }
+  }
+
+  run () {
+    Bugsnag.addFeatureFlag('demo_mode')
+
+    Bugsnag.addFeatureFlags([
+      { name: 'should_not_be_reported_1' },
+      { name: 'should_not_be_reported_2' },
+      { name: 'should_not_be_reported_3' }
+    ])
+
+    Bugsnag.clearFeatureFlag('should_not_be_reported_3')
+    Bugsnag.clearFeatureFlag('should_not_be_reported_2')
+    Bugsnag.clearFeatureFlag('should_not_be_reported_1')
+
+    if (this.extraData && this.extraData.includes('cleared')) {
+      Bugsnag.clearFeatureFlags()
+    }
+
+    if (this.extraData && this.extraData.includes('unhandled')) {
+      throw new Error('FeatureFlagScenario unhandled')
+    } else {
+      Bugsnag.notify(new Error('FeatureFlagScenario handled'))
+    }
+  }
+}


### PR DESCRIPTION
## Goal
Introduce Mazerunner tests to exercise the FeatureFlags on ReactNative. This covers:

- Adding individual feature flags
- Adding batches of feature flags
- Adding feature flags in an OnErrorCallback
- Clearing individual feature flags
- Clearing all set feature flags

Depends on
- https://github.com/bugsnag/bugsnag-js/pull/1621
- https://github.com/bugsnag/bugsnag-js/pull/1618
to be merged before this will pass