### PR TITLE
[PLAT-7717] Fix Xcode build error for ejected Expo apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBD
 
+### Fixed
+
+- (react-native-cli): Fix Xcode build error for ejected Expo apps [#1623](https://github.com/bugsnag/bugsnag-js/pull/1623)
+
 ### Changed
 
 - (react-native) Update bugsnag-android to v5.16.0

--- a/packages/react-native-cli/src/lib/Xcode.ts
+++ b/packages/react-native-cli/src/lib/Xcode.ts
@@ -51,7 +51,12 @@ async function updateBuildReactNativeTask (buildPhaseMap: Record<string, Record<
   let didAnythingUpdate = false
   for (const shellBuildPhaseKey in buildPhaseMap) {
     const phase = buildPhaseMap[shellBuildPhaseKey]
-    if (typeof phase.shellScript === 'string' && phase.shellScript.includes('react-native/scripts/react-native-xcode.sh')) {
+    // The shell script can vary slightly... Vanilla RN projects contain
+    //   ../node_modules/react-native/scripts/react-native-xcode.sh
+    // and ejected Expo projects contain
+    //   `node --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
+    // so we need a little leniency
+    if (typeof phase.shellScript === 'string' && phase.shellScript.includes('/react-native-xcode.sh')) {
       let didThisUpdate
       [phase.shellScript, didThisUpdate] = addExtraPackagerArgs(shellBuildPhaseKey, phase.shellScript, logger)
       if (didThisUpdate) {


### PR DESCRIPTION
## Goal

Fix `SOURCE_MAP ... could not be found` error after running `@bugsnag/react-native-cli init` on an ejected Expo app.

## Changeset

Xcode.ts is now lenient when matching the "Bundle React Native code and images" build phase.

For vanilla RN apps the build phase calls

```
../node_modules/react-native/scripts/react-native-xcode.sh
```

Whereas for ejected Expo apps the it contains

```
`node --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
```

This was causing the match for `react-native/scripts/react-native-xcode.sh` to fail. We now match on `/react-native-xcode.sh` to cater for further potential changes.

## Testing

Tested locally by creating a new expo project and running
* `(cd ~/Repos/bugsnag-js/packages/react-native-cli && npm run build)`
* `node ~/Repos/bugsnag-js/packages/react-native-cli/bin/cli init`