### PR TITLE
Remove API key from CDN example

### DIFF
--- a/examples/js/browser-cdn/app.js
+++ b/examples/js/browser-cdn/app.js
@@ -17,7 +17,7 @@ document.getElementById('jsUnhandled').addEventListener('click', sendUnhandled)
 // here are some other helpful configuration details:
 Bugsnag.start({
   // get your own api key at bugsnag.com
-  apiKey: '6eccabc796ef28a154314498f79b724e',
+  apiKey: 'YOUR_API_KEY',
 
   // if you track deploys or use source maps, make sure to set the correct version.
   appVersion: '1.2.3',


### PR DESCRIPTION
## Goal

The CDN example was using an API key for a random test project. This isn't necessarily a problem, but it makes it easier for users to miss the fact that they have to change it. This could be confusing as everything will appear to work but they won't be able to see anything in the dashboard