### PR TITLE
Fix the react native 0.60 test fixture

### DIFF
--- a/test/react-native/features/fixtures/rn0.60/package.json
+++ b/test/react-native/features/fixtures/rn0.60/package.json
@@ -18,7 +18,7 @@
     "babel-jest": "^24.9.0",
     "eslint": "^6.3.0",
     "jest": "^24.9.0",
-    "metro-react-native-babel-preset": "^0.56.0",
+    "metro-react-native-babel-preset": "^0.66.2",
     "react-test-renderer": "16.8.6"
   },
   "jest": {


### PR DESCRIPTION
## Goal
Work around the build failure in the react-native 0.60 test fixture:
```
Error: Unexpected token punc «:», expected punc «,» in file node_modules/react-native/Libraries/Blob/URL.js at 106:30
    at /app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:415:17
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:75:24)
    at _next (/app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:95:9)
    at /app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:100:7
    at new Promise (<anonymous>)
    at /app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:92:12
    at JsTransformer._minifyCode (/app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:422:7)
    at /app/features/fixtures/rn0.60/node_modules/metro/src/JSTransformer/worker.js:356:33
```

## Changes:
Upgraded the `metro-react-native-babel-preset` version in the test fixture to 0.66.2 which bypasses the issue.

## Testing
Relied on existing tests passing