### PR TITLE
Fix failing filestore test

### DIFF
--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -12,6 +12,7 @@ describe('FileStore', () => {
   beforeEach(async () => {
     await mkdir(join(crashes, 'reports'), { recursive: true })
     await mkdir(join(crashes, 'pending'), { recursive: true })
+    await mkdir(fixtures, { recursive: true })
     store = new FileStore('mykey', fixtures, crashes)
   })
 


### PR DESCRIPTION
Several test failed because storage fixtures directory is not created.
 FAIL  packages/electron-filestore/test/filestore.test.ts
    ENOENT: no such file or directory, stat '/Users/grop/dev/bugsnag-js/packages/electron-filestore/test/fixtures/storage'

## Goal

to get test green.

## Design

create correct test context before running the tests by creating fixtures/storage dir.

## Changeset

filestore.test.ts with test fix

## Testing

test itself is fixed and was returning errors and now succeeds