### PR TITLE
Fix Electron notifier URL

### DIFF
--- a/packages/electron/src/id.js
+++ b/packages/electron/src/id.js
@@ -1,5 +1,5 @@
 module.exports = {
   name: 'Bugsnag Electron',
   version: require('../package.json').version,
-  url: 'https://github.com/bugsnag/bugsnag-electron'
+  url: 'https://github.com/bugsnag/bugsnag-js'
 }


### PR DESCRIPTION
## Goal

This was pointing at https://github.com/bugsnag/bugsnag-electron which doesn't exist — the correct URL is this monorepo, which matches the other JS notifiers