### PR TITLE
Ensure unhandled JS errors crash the app in e2e test scenarios

### DIFF
--- a/test/react-native/features/app.feature
+++ b/test/react-native/features/app.feature
@@ -24,7 +24,7 @@ Scenario: Handled JS error
   | ios     | iOS     |
 
 Scenario: Unhandled JS error
-  When I run "AppJsUnhandledScenario" and relaunch the app
+  When I run "AppJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "AppJsUnhandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -73,7 +73,7 @@ Scenario: Handled native error
   | ios     | iOS     |
 
 Scenario: Unhandled native error
-  When I run "AppNativeUnhandledScenario" and relaunch the app
+  When I run "AppNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "AppNativeUnhandledScenario"
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/react-native/features/device-android.feature
+++ b/test/react-native/features/device-android.feature
@@ -25,7 +25,7 @@ Scenario: Handled JS error
   And the event "device.time" is a timestamp
 
 Scenario: Unhandled JS error
-  When I run "DeviceJsUnhandledScenario" and relaunch the app
+  When I run "DeviceJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceJsUnhandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -73,7 +73,7 @@ Scenario: Handled native error
   And the event "device.time" is a timestamp
 
 Scenario: Unhandled native error
-  When I run "DeviceNativeUnhandledScenario" and relaunch the app
+  When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceNativeUnhandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "java.lang.RuntimeException"

--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -27,7 +27,7 @@ Scenario: Handled JS error
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
 Scenario: Unhandled JS error
-  When I run "DeviceJsUnhandledScenario" and relaunch the app
+  When I run "DeviceJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceJsUnhandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -78,7 +78,7 @@ Scenario: Handled native error
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
 Scenario: Unhandled native error
-  When I run "DeviceNativeUnhandledScenario" and relaunch the app
+  When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceNativeUnhandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "NSException"

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
@@ -53,6 +53,19 @@ export default class AppScreen extends Component {
     const jsConfig = defaultJsConfig()
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
+    this.state.scenario = scenario
+    scenario.run()
+  }
+
+  startBugsnag = () => {
+    console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
+    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
+    const scenarioName = this.state.currentScenario
+    const scenarioMetaData = this.state.scenarioMetaData
+    const configuration = this.getConfiguration()
+    const jsConfig = defaultJsConfig()
+    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
       .then(() => {
         Navigation.setRoot({
@@ -68,23 +81,6 @@ export default class AppScreen extends Component {
             }
           }
         })
-        Bugsnag.start(jsConfig)
-        this.state.scenario = scenario
-        scenario.run()
-      })
-  }
-
-  startBugsnag = () => {
-    console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
-    const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
-    const configuration = this.getConfiguration()
-    const jsConfig = defaultJsConfig()
-    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
-    console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
-    NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-      .then(() => {
         Bugsnag.start(jsConfig)
         this.state.scenario = scenario
       })
@@ -105,11 +101,11 @@ export default class AppScreen extends Component {
             onChangeText={this.setScenarioMetaData} />
           <Button style={styles.clickyButton}
             accessibilityLabel='start_bugsnag'
-            title='Start Bugsnag only'
+            title='Start Bugsnag'
             onPress={this.startBugsnag}/>
           <Button style={styles.clickyButton}
             accessibilityLabel='run_scenario'
-            title='Start Bugsnag and run scenario'
+            title='Run scenario'
             onPress={this.startScenario}/>
 
           <Text>Configuration</Text>

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
@@ -53,6 +53,19 @@ export default class AppScreen extends Component {
     const jsConfig = defaultJsConfig()
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
+    Navigation.setRoot({
+      root: {
+        stack: {
+          children: [
+            {
+              component: {
+                name: 'Home'
+              }
+            }
+          ]
+        }
+      }
+    })
     this.state.scenario = scenario
     scenario.run()
   }
@@ -68,19 +81,6 @@ export default class AppScreen extends Component {
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
       .then(() => {
-        Navigation.setRoot({
-          root: {
-            stack: {
-              children: [
-                {
-                  component: {
-                    name: 'Home'
-                  }
-                }
-              ]
-            }
-          }
-        })
         Bugsnag.start(jsConfig)
         this.state.scenario = scenario
       })

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -85,12 +85,13 @@ export default class App extends Component {
     const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
     const jsConfig = defaultJsConfig()
-    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    // eslint-disable-next-line no-new
+    new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    NativeModules.BugsnagTestInterface.startBugsnag(configuration).then(() => {
-      this.setState({ scenario: scenario })
-      Bugsnag.start(jsConfig)
-    })
+    NativeModules.BugsnagTestInterface.startBugsnag(configuration)
+      .then(() => {
+        Bugsnag.start(jsConfig)
+      })
   }
 
   waiting () {
@@ -113,7 +114,7 @@ export default class App extends Component {
             onPress={this.startBugsnag}/>
           <Button style={styles.clickyButton}
             accessibilityLabel='run_scenario'
-            title='Start Bugsnag and run scenario'
+            title='Run scenario'
             onPress={this.startScenario}/>
 
           <Text>Configuration</Text>

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -74,12 +74,8 @@ export default class App extends Component {
     const jsConfig = defaultJsConfig()
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-      .then(() => {
-        Bugsnag.start(jsConfig)
-        this.setState({ scenario: scenario })
-        scenario.run()
-      })
+    this.setState({ scenario : scenario })
+    scenario.run()
   }
 
   startBugsnag = () => {
@@ -91,11 +87,10 @@ export default class App extends Component {
     const jsConfig = defaultJsConfig()
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-      .then(() => {
-        Bugsnag.start(jsConfig)
-        this.setState({ scenario: scenario })
-      })
+    NativeModules.BugsnagTestInterface.startBugsnag(configuration).then(() => {
+      this.setState({ scenario : scenario })
+      Bugsnag.start(jsConfig)
+    })
   }
 
   waiting () {

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -74,7 +74,7 @@ export default class App extends Component {
     const jsConfig = defaultJsConfig()
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    this.setState({ scenario : scenario })
+    this.setState({ scenario: scenario })
     scenario.run()
   }
 
@@ -88,7 +88,7 @@ export default class App extends Component {
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration).then(() => {
-      this.setState({ scenario : scenario })
+      this.setState({ scenario: scenario })
       Bugsnag.start(jsConfig)
     })
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -58,11 +58,7 @@ export default class App extends Component {
     this.setState({ sessionsEndpoint: 'https://sessions.bugsnag.com' })
   }
 
-  timeout (ms) {
-    return new Promise(resolve => setTimeout(resolve, ms))
-  }
-
-  startScenario = async () => {
+  runScenario = () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
@@ -71,16 +67,10 @@ export default class App extends Component {
     const jsConfig = {}
     const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    await NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-    Bugsnag.start(jsConfig)
-    // The notifier needs a little time to synch to the native layer, otherwise flakes occur - however it's also
-    // important that the scenario waits longer than this period before relaunching the app (see the Cucumber step
-    // 'I relaunch the app').
-    await this.timeout(2000)
     scenario.run()
   }
 
-  startBugsnag = async () => {
+  startBugsnag = () => {
     console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
     console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
@@ -91,8 +81,10 @@ export default class App extends Component {
     // eslint-disable-next-line no-new
     new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-    await NativeModules.BugsnagTestInterface.startBugsnag(configuration)
-    Bugsnag.start(jsConfig)
+
+    NativeModules.BugsnagTestInterface.startBugsnag(configuration).then(() => {
+      Bugsnag.start(jsConfig)
+    })
   }
 
   render () {
@@ -111,12 +103,12 @@ export default class App extends Component {
 
           <Button style={styles.clickyButton}
             accessibilityLabel='start_bugsnag'
-            title='Start Bugsnag only'
+            title='Start Bugsnag'
             onPress={this.startBugsnag}/>
           <Button style={styles.clickyButton}
             accessibilityLabel='run_scenario'
-            title='Start Bugsnag and run scenario'
-            onPress={this.startScenario}/>
+            title='Run scenario'
+            onPress={this.runScenario}/>
 
           <Text>Configuration</Text>
           <TextInput placeholder='Notify endpoint'

--- a/test/react-native/features/metadata.feature
+++ b/test/react-native/features/metadata.feature
@@ -27,7 +27,7 @@ Scenario: Setting metadata (native unhandled)
   When I run "MetadataNativeUnhandledScenario"
   And I wait for 2 seconds
   And I clear any error dialogue
-  And I relaunch the app
+  And I relaunch the app after a crash
   And I configure Bugsnag for "MetadataNativeUnhandledScenario"
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:

--- a/test/react-native/features/navigation.feature
+++ b/test/react-native/features/navigation.feature
@@ -21,7 +21,7 @@ Scenario: Navigating screens causes breadcrumbs and context to be updated
 
   When I trigger an unhandled error
   And I wait for 5 seconds
-  And I relaunch the app
+  And I relaunch the app after a crash
   And I configure Bugsnag for "ReactNavigationBreadcrumbsEnabledScenario"
   And I wait to receive an error
   Then the exception "message" equals "DetailsNavigationUnhandledError"
@@ -48,7 +48,7 @@ Scenario: Navigating when navigation breadcrumbs are disabled only updates conte
   And I discard the oldest error
 
   When I trigger an unhandled error
-  And I relaunch the app
+  And I relaunch the app after a crash
   And I configure Bugsnag for "ReactNavigationBreadcrumbsDisabledScenario"
   And I wait to receive an error
   Then the exception "message" equals "DetailsNavigationUnhandledError"

--- a/test/react-native/features/override_unhandled.feature
+++ b/test/react-native/features/override_unhandled.feature
@@ -14,7 +14,7 @@ Scenario: Non-fatal error overridden to unhandled
     And the event "session.events.unhandled" equals 1
 
 Scenario: Fatal error overridden to handled
-    When I run "UnhandledOverrideJsErrorScenario" and relaunch the app
+    When I run "UnhandledOverrideJsErrorScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledOverrideJsErrorScenario"
     Then I wait to receive an error
     And I wait to receive a session

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -11,10 +11,11 @@ def wait_for_true
   # raise 'Assertion not passed in 30s' unless assertion_passed
 end
 
-When("I run {string}") do |event_type|
+When('I run {string}') do |event_type|
   steps %Q{
     Given the element "scenario_name" is present within 60 seconds
     When I clear and send the keys "#{event_type}" to the element "scenario_name"
+    And I click the element "start_bugsnag"
     And I click the element "run_scenario"
   }
 end
@@ -29,12 +30,14 @@ end
 
 Then('the app is not running') do
   wait_for_true do
-    state = Maze.driver.app_state('org.reactjs.native.example.reactnative')
-    $logger.info state
     case Maze::Helper.get_current_platform
     when 'ios'
+      state = Maze.driver.app_state('org.reactjs.native.example.reactnative')
+      $logger.info state
       state == :not_running
     when 'android'
+      state = Maze.driver.app_state('com.reactnative')
+      $logger.info state
       # workaround for faulty app state detection in appium v1.23 and lower on
       # Android where an app that is not running is detected to be running in
       # the background
@@ -49,17 +52,17 @@ When('I relaunch the app after a crash') do
   Maze.driver.launch_app
 end
 
-When("I clear any error dialogue") do
+When('I clear any error dialogue') do
   # Error dialogue is auto-cleared on IOS
-  next unless Maze.driver.capabilities["os"] == 'android'
+  next unless Maze.driver.capabilities['os'] == 'android'
 
   driver = Maze.driver
-  driver.click_element("android:id/button1") if driver.wait_for_element("android:id/button1", 3)
-  driver.click_element("android:id/aerr_close") if driver.wait_for_element("android:id/aerr_close", 3)
-  driver.click_element("android:id/aerr_restart") if driver.wait_for_element("android:id/aerr_restart", 3)
+  driver.click_element('android:id/button1') if driver.wait_for_element('android:id/button1', 3)
+  driver.click_element('android:id/aerr_close') if driver.wait_for_element('android:id/aerr_close', 3)
+  driver.click_element('android:id/aerr_restart') if driver.wait_for_element('android:id/aerr_restart', 3)
 end
 
-When("I configure Bugsnag for {string}") do |event_type|
+When('I configure Bugsnag for {string}') do |event_type|
   steps %Q{
     Given the element "scenario_name" is present within 60 seconds
     When I clear and send the keys "#{event_type}" to the element "scenario_name"
@@ -67,14 +70,14 @@ When("I configure Bugsnag for {string}") do |event_type|
   }
 end
 
-When("I configure the app to run in the {string} state") do |event_metadata|
+When('I configure the app to run in the {string} state') do |event_metadata|
   steps %Q{
     Given the element "scenario_metadata" is present
     And I clear and send the keys "#{event_metadata}" to the element "scenario_metadata"
   }
 end
 
-Then("the event {string} equals one of:") do |field_path, table|
+Then('the event {string} equals one of:') do |field_path, table|
   payload = Maze::Server.errors.current[:body]
   actual_value = Maze::Helper.read_key_path(payload, "events.0.#{field_path}")
   valid_values = table.raw.flatten
@@ -82,7 +85,7 @@ Then("the event {string} equals one of:") do |field_path, table|
                   "#{field_path} value: #{actual_value} did not match the given list: #{valid_values}")
 end
 
-Then("the {word} payload field {string} equals one of:") do |request_type, field_path, table|
+Then('the {word} payload field {string} equals one of:') do |request_type, field_path, table|
   payload = Maze::Server.list_for(request_type).current[:body]
   actual_value = Maze::Helper.read_key_path(payload, field_path)
   valid_values = table.raw.flatten
@@ -90,7 +93,7 @@ Then("the {word} payload field {string} equals one of:") do |request_type, field
                   "#{field_path} value: #{actual_value} did not match the given list: #{valid_values}")
 end
 
-Then("the following sets are present in the current {word} payloads:") do |request_type, data_table|
+Then('the following sets are present in the current {word} payloads:') do |request_type, data_table|
   expected_values = data_table.hashes
   requests = Maze::Server.list_for(request_type)
   Maze.check.equal(expected_values.length, requests.size_all)

--- a/test/react-native/features/unhandled.feature
+++ b/test/react-native/features/unhandled.feature
@@ -1,7 +1,7 @@
 Feature: Reporting unhandled errors
 
 Scenario: Catching an Unhandled error
-  When I run "UnhandledJsErrorScenario" and relaunch the app
+  When I run "UnhandledJsErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsErrorScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -10,7 +10,7 @@ Scenario: Catching an Unhandled error
   And the exception "message" equals "UnhandledJsErrorScenario"
 
 Scenario: Catching an Unhandled promise rejection
-  When I run "UnhandledJsPromiseRejectionScenario" and relaunch the app
+  When I run "UnhandledJsPromiseRejectionScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsPromiseRejectionScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -19,7 +19,7 @@ Scenario: Catching an Unhandled promise rejection
   And the exception "message" equals "UnhandledJsPromiseRejectionScenario"
 
 Scenario: Catching an Unhandled Native error
-  When I run "UnhandledNativeErrorScenario" and relaunch the app
+  When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledNativeErrorScenario"
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
@@ -32,7 +32,7 @@ Scenario: Catching an Unhandled Native error
   And the exception "message" equals "UnhandledNativeErrorScenario"
 
 Scenario: Updating severity on an unhandled JS error
-  When I run "UnhandledJsErrorSeverityScenario" and relaunch the app
+  When I run "UnhandledJsErrorSeverityScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsErrorSeverityScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"

--- a/test/react-native/features/unhandled.feature
+++ b/test/react-native/features/unhandled.feature
@@ -10,8 +10,7 @@ Scenario: Catching an Unhandled error
   And the exception "message" equals "UnhandledJsErrorScenario"
 
 Scenario: Catching an Unhandled promise rejection
-  When I run "UnhandledJsPromiseRejectionScenario" and relaunch the crashed app
-  And I configure Bugsnag for "UnhandledJsPromiseRejectionScenario"
+  When I run "UnhandledJsPromiseRejectionScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "type" equals "reactnativejs"

--- a/test/react-native/features/user.feature
+++ b/test/react-native/features/user.feature
@@ -28,7 +28,7 @@ Scenario: Setting user in JS via event
   And the event "user.id" equals "123"
 
 Scenario: Setting user in native via client
-  When I run "UserNativeClientScenario" and relaunch the app
+  When I run "UserNativeClientScenario" and relaunch the crashed app
   And I configure Bugsnag for "UserNativeClientScenario"
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
@@ -40,7 +40,7 @@ Scenario: Setting user in native via client
   And the event "user.id" equals "123"
 
 Scenario: Setting user in JS via client and sending Native error
-  When I run "UserJsNativeScenario" and relaunch the app
+  When I run "UserJsNativeScenario" and relaunch the crashed app
   And I configure Bugsnag for "UserJsNativeScenario"
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:


### PR DESCRIPTION
## Goal

Ensure that unhandled JS errors crash the app in the React Native end-to-end test scenarios.

## Design

The click handler for the `run_scenario` button was `async`, leading to unhandled JS errors behaving the same as unhandled Promise rejections and the app not crashing.  The Cucumber steps that follow assume the app crashed and tell it to relaunch, which is likely to have caused a number of flakes.

## Changeset

- Refactors the test fixtures to ensure that scenarios are not run `async`.  This led to separating the Start Bugsnag and Run Scenario steps.
- Renamed the Cucumber step to make it clear that the app (should have) crashed, matching what bugsnag-cocoa now does.
- Updated the Unhandled Promise rejection scenario to cater for the app not crashing (it is not expected to).
- Added a mechanism to wait for Appium to report the app is not running after a crash before relaunching.  This isn't perfect as sometimes it seems not to report as not_running.  Further investigation is needed, but it seems to relate to running scenarios together, as it doesn't happen if running the scenario by itself.

## Testing

Covered by CI.