### PR TITLE
Avoid jcenter where possible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,7 @@ services:
         - REGISTRY_URL
         - REG_BASIC_CREDENTIAL
         - REG_NPM_EMAIL
+        - MAVEN_REPO_URL
     environment:
       - DEBUG
       - BRANCH_NAME

--- a/dockerfiles/Dockerfile.react-native-android-builder
+++ b/dockerfiles/Dockerfile.react-native-android-builder
@@ -14,6 +14,11 @@ RUN echo "_auth=$REG_BASIC_CREDENTIAL" >> ~/.npmrc
 RUN echo "email=$REG_NPM_EMAIL" >> ~/.npmrc
 RUN echo "always-auth=true" >> ~/.npmrc
 
+# gradle / artifactory auth
+ARG MAVEN_REPO_URL
+ENV MAVEN_REPO_URL="$MAVEN_REPO_URL"
+ENV MAVEN_REPO_CREDS="$REG_BASIC_CREDENTIAL"
+
 # Now copy in all the files needed to build
 COPY .git .git
 COPY lerna.json .

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { // add this to use snapshots
             url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
@@ -70,8 +69,21 @@ allprojects {
     repositories {
         maven { url facebookRepo }
         maven { url bugsnagRepo }
-        jcenter()
+        mavenCentral()
         google()
+
+        if (System.getenv('MAVEN_REPO_URL') && System.getenv('MAVEN_REPO_CREDS')) {
+          def decodedCreds = new String(System.getenv('MAVEN_REPO_CREDS').decodeBase64(), 'UTF-8').split(':')
+          maven {
+            url(System.getenv('MAVEN_REPO_URL'))
+            credentials {
+              username decodedCreds[0]
+              password decodedCreds[1]
+            }
+          }
+        } else {
+          jcenter()
+        }
     }
 }
 

--- a/test/react-native/features/fixtures/rn0.60/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.60/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.1")
@@ -37,8 +37,22 @@ allprojects {
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 
+        mavenCentral()
         google()
-        jcenter()
+
+        if (System.getenv('MAVEN_REPO_URL') && System.getenv('MAVEN_REPO_CREDS')) {
+          def decodedCreds = new String(System.getenv('MAVEN_REPO_CREDS').decodeBase64(), 'UTF-8').split(':')
+          maven {
+            url(System.getenv('MAVEN_REPO_URL'))
+            credentials {
+              username decodedCreds[0]
+              password decodedCreds[1]
+            }
+          }
+        } else {
+          jcenter()
+        }
+
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/test/react-native/features/fixtures/rn0.63/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.63/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
@@ -33,8 +33,22 @@ allprojects {
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 
+        mavenCentral()
         google()
-        jcenter()
+
+        if (System.getenv('MAVEN_REPO_URL') && System.getenv('MAVEN_REPO_CREDS')) {
+          def decodedCreds = new String(System.getenv('MAVEN_REPO_CREDS').decodeBase64(), 'UTF-8').split(':')
+          maven {
+            url(System.getenv('MAVEN_REPO_URL'))
+            credentials {
+              username decodedCreds[0]
+              password decodedCreds[1]
+            }
+          }
+        } else {
+          jcenter()
+        }
+
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/test/react-native/features/fixtures/rn0.64-hermes/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.64-hermes/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.1.0")
@@ -36,8 +36,22 @@ allprojects {
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 
+        mavenCentral()
         google()
-        jcenter()
+
+        if (System.getenv('MAVEN_REPO_URL') && System.getenv('MAVEN_REPO_CREDS')) {
+          def decodedCreds = new String(System.getenv('MAVEN_REPO_CREDS').decodeBase64(), 'UTF-8').split(':')
+          maven {
+            url(System.getenv('MAVEN_REPO_URL'))
+            credentials {
+              username decodedCreds[0]
+              password decodedCreds[1]
+            }
+          }
+        } else {
+          jcenter()
+        }
+
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
## Goal
Remove `jcenter` as a dependency when building on CI by replacing it with the Bugsnag private Maven repository.

## Changes

- Replaced `jcenter` with `mavenCentral` for buildscript level repositories
- If available: use the new `MAVEN_REPO_URL` and `MAVEN_REPO_CREDS` environment variables to declare a Maven repository instead of `jcenter`
- Pass the `MAVEN_REPO_URL` and `MAVEN_REPO_CREDS` as environment variables to the BuildKite docker containers

## Testing
Relied on the existing tests