### PR TITLE
Fix Lerna URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Learn more about [JavaScript error reporting](https://www.bugsnag.com/platforms/
 
 ---
 
-This is a monorepo (managed with [Lerna](https://lernajs.io/)) containing our universal error reporting client [`@bugsnag/js`](/packages/js), our Expo client [`@bugsnag/expo`](/packages/expo) and our React Native client [`@bugsnag/react-native`](/packages/react-native), along with:
+This is a monorepo (managed with [Lerna](https://lerna.js.org/) containing our universal error reporting client [`@bugsnag/js`](/packages/js), our Expo client [`@bugsnag/expo`](/packages/expo) and our React Native client [`@bugsnag/react-native`](/packages/react-native), along with:
 
 - the core Bugsnag libraries for reporting errors ([`@bugsnag/core`](/packages/core))
 - plugins for supporting various frameworks (e.g. [`@bugsnag/plugin-react`](/packages/plugin-react))


### PR DESCRIPTION
"https://lernajs.io/" is incorrect and goes to a click capturing page:

![Screenshot 2022-01-18 at 06 45 41](https://user-images.githubusercontent.com/180819/149931948-1b37f88a-ebe4-4eee-aac4-094febb31dca.png)


"https://lerna.js.org/" is the correct URL.

This likely changed at some point in the past and the old URL was scooped up by a domain sitter.