### PR TITLE
Upload maze_output for RN and RN CLI e2e tests

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -7,13 +7,13 @@ steps:
       - artifacts#v1.3.0:
           download: min_packages.tar
           build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build:
             - browser-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push:
             - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
 
@@ -21,7 +21,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -36,7 +36,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -51,7 +51,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -66,7 +66,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -81,7 +81,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -96,7 +96,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -111,7 +111,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -128,7 +128,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -143,7 +143,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -158,7 +158,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -173,7 +173,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -188,7 +188,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -203,7 +203,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -218,7 +218,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -235,7 +235,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -250,7 +250,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -265,7 +265,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true
@@ -280,7 +280,7 @@ steps:
     depends_on: "browser-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: browser-maze-runner
         run: browser-maze-runner
         use-aliases: true

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -4,7 +4,7 @@ steps:
     key: "browser-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
-      - artifacts#v1.3.0:
+      - artifacts#v1.5.0:
           download: min_packages.tar
           build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
       - docker-compose#v3.9.0:

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -5,13 +5,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build: expo-publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push:
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
             - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
@@ -25,19 +25,19 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: expo-publisher
 
   - label: ':docker: Build expo maze runner image'
     key: "expo-maze-runner-image"
     timeout_in_minutes: 10
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build: expo-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push:
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
             - expo-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-latest
@@ -50,13 +50,13 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build: expo-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-${BRANCH_NAME}
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -75,7 +75,7 @@ steps:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: expo-android-builder
           cache-from:
             - expo-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-android-builder-latest
@@ -103,7 +103,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -127,7 +127,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -158,7 +158,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -189,7 +189,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -216,7 +216,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -243,7 +243,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -268,7 +268,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true
@@ -294,7 +294,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/output.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: expo-maze-runner
         run: expo-maze-runner
         use-aliases: true

--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -101,7 +101,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.apk"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -125,7 +125,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.ipa"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -156,7 +156,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.apk"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -187,7 +187,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.apk"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -214,7 +214,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.apk"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -241,7 +241,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.apk"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -266,7 +266,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.ipa"
       docker-compose#v3.9.0:
         pull: expo-maze-runner
@@ -292,7 +292,7 @@ steps:
       - "expo-maze-runner-image"
     timeout_in_minutes: 50
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/output.ipa"
       docker-compose#v3.9.0:
         pull: expo-maze-runner

--- a/.buildkite/node-pipeline.yml
+++ b/.buildkite/node-pipeline.yml
@@ -7,13 +7,13 @@ steps:
       - artifacts#v1.3.0:
           download: min_packages.tar
           build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build:
             - node-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push:
             - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
 
@@ -21,7 +21,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -32,7 +32,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -43,7 +43,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -54,7 +54,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -65,7 +65,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true
@@ -76,7 +76,7 @@ steps:
     depends_on: "node-maze-runner-image"
     timeout_in_minutes: 30
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: node-maze-runner
         use-aliases: true
         verbose: true

--- a/.buildkite/node-pipeline.yml
+++ b/.buildkite/node-pipeline.yml
@@ -4,7 +4,7 @@ steps:
     key: "node-maze-runner-image"
     timeout_in_minutes: 20
     plugins:
-      - artifacts#v1.3.0:
+      - artifacts#v1.5.0:
           download: min_packages.tar
           build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
       - docker-compose#v3.9.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,11 +16,11 @@ steps:
     key: 'android-builder-base'
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           build: android-builder-base
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:  android-builder-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:android-builder-base
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           push: android-builder-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:android-builder-base
 
   #
@@ -31,7 +31,7 @@ steps:
     key: 'package-js'
     timeout_in_minutes: 3
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: minimal-packager
     artifact_paths: min_packages.tar
 
@@ -39,7 +39,7 @@ steps:
     key: 'publish-js'
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           build: publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
     env:
@@ -126,14 +126,14 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: min_packages.tar
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build:
             - ci
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
@@ -143,7 +143,7 @@ steps:
     depends_on: 'ci-image'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: ci
     command: 'npm run test:lint'
 
@@ -152,7 +152,7 @@ steps:
     depends_on: 'ci-image'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: ci
     command: 'npm run test:unit'
 
@@ -161,6 +161,6 @@ steps:
     depends_on: 'ci-image'
     timeout_in_minutes: 10
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         run: ci
     command: 'npm run test:types'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,7 +124,7 @@ steps:
     depends_on: 'package-js'
     timeout_in_minutes: 20
     plugins:
-      - artifacts#v1.2.0:
+      - artifacts#v1.5.0:
           download: min_packages.tar
       - docker-compose#v3.9.0:
           build:

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -307,7 +307,7 @@ steps:
     depends_on: "rn-0-60-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_60.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -327,7 +327,7 @@ steps:
     depends_on: "rn-0-61-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_61.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -347,7 +347,7 @@ steps:
     depends_on: "rn-0-62-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_62.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -367,7 +367,7 @@ steps:
     depends_on: "rn-0-63-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_63.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -387,7 +387,7 @@ steps:
     depends_on: "rn-0-63-expo-ejected-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_63_expo_ejected.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -407,7 +407,7 @@ steps:
     depends_on: "rn-0-64-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_64.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -427,7 +427,7 @@ steps:
     depends_on: "rn-0-64-hermes-apk"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_64_hermes.apk"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -450,7 +450,7 @@ steps:
     depends_on: "rn-0-60-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_60.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -470,7 +470,7 @@ steps:
     depends_on: "rn-0-61-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_61.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -490,7 +490,7 @@ steps:
     depends_on: "rn-0-62-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_62.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -510,7 +510,7 @@ steps:
     depends_on: "rn-0-63-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_63.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -530,7 +530,7 @@ steps:
     depends_on: "rn-0-63-expo-ejected-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_63_expo_ejected.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -550,7 +550,7 @@ steps:
     depends_on: "rn-0-64-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_64.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
@@ -570,7 +570,7 @@ steps:
     depends_on: "rn-0-64-hermes-ipa"
     timeout_in_minutes: 10
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0_64_hermes.ipa"
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -21,6 +21,8 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
+      artifacts#v1.5.0:
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
@@ -35,6 +37,8 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
+      artifacts#v1.5.0:
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
@@ -49,6 +53,8 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
+      artifacts#v1.5.0:
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
@@ -63,6 +69,8 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
+      artifacts#v1.5.0:
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
@@ -77,6 +85,8 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
+      artifacts#v1.5.0:
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
@@ -91,6 +101,8 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
+      artifacts#v1.5.0:
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
@@ -309,6 +321,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_60.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -329,6 +342,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_61.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -349,6 +363,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_62.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -369,6 +384,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_63.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -389,6 +405,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_63_expo_ejected.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -409,6 +426,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_64.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -429,6 +447,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_64_hermes.apk"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -452,6 +471,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_60.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -472,6 +492,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_61.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -492,6 +513,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_62.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -512,6 +534,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_63.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -532,6 +555,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_63_expo_ejected.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -552,6 +576,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_64.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
@@ -572,6 +597,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0_64_hermes.ipa"
+        upload: ./test/react-native-cli/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -7,11 +7,11 @@ steps:
     key: 'cli-maze-image'
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build: react-native-cli-tool-maze-runner
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:  react-native-cli-tool-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:cli-maze-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push: react-native-cli-tool-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:cli-maze-${BRANCH_NAME}
 
   #
@@ -21,7 +21,7 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
         use-aliases: true
@@ -35,7 +35,7 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
         use-aliases: true
@@ -49,7 +49,7 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
         use-aliases: true
@@ -63,7 +63,7 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
         use-aliases: true
@@ -77,7 +77,7 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
         use-aliases: true
@@ -91,7 +91,7 @@ steps:
     depends_on: "cli-maze-image"
     timeout_in_minutes: 20
     plugins:
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-tool-maze-runner
         run: react-native-cli-tool-maze-runner
         use-aliases: true
@@ -108,11 +108,11 @@ steps:
     key: 'android-builder-image'
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           build: react-native-cli-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:  react-native-cli-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           push: react-native-cli-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
   - label: ':android: Init and build RN 0.60 apk'
@@ -124,7 +124,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_60
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -139,7 +139,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_61
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -154,7 +154,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_62
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -169,7 +169,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_63
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -184,7 +184,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_63_expo_ejected
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -199,7 +199,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_64
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -214,7 +214,7 @@ steps:
       DEBUG: true
       REACT_NATIVE_VERSION: rn0_64_hermes
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#v3.9.0:
           run: react-native-cli-android-builder
           command: ["features/build-app-tests/build-android-app.feature"]
     artifact_paths:
@@ -309,7 +309,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_60.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -329,7 +329,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_61.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -349,7 +349,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_62.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -369,7 +369,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_63.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -389,7 +389,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_63_expo_ejected.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -409,7 +409,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_64.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -429,7 +429,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_64_hermes.apk"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -452,7 +452,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_60.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -472,7 +472,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_61.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -492,7 +492,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_62.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -512,7 +512,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_63.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -532,7 +532,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_63_expo_ejected.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -552,7 +552,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_64.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true
@@ -572,7 +572,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0_64_hermes.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-cli-maze-runner
         run: react-native-cli-maze-runner
         use-aliases: true

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -224,7 +224,7 @@ steps:
     depends_on: "rn-0-60-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0.60.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -247,7 +247,7 @@ steps:
     depends_on: "rn-0-60-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0.60.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -271,7 +271,7 @@ steps:
     depends_on: "rn-0-63-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0.63.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -294,7 +294,7 @@ steps:
     depends_on: "rn-0-64-hermes-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0.64-hermes.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -317,7 +317,7 @@ steps:
     depends_on: "rn-0-63-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0.63.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -341,7 +341,7 @@ steps:
     depends_on: "rn-0-64-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/rn0.64-hermes.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -365,7 +365,7 @@ steps:
     depends_on: "react-navigation-0-60-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_navigation_0.60.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -389,7 +389,7 @@ steps:
     depends_on: "react-navigation-0-60-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_navigation_0.60.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -412,7 +412,7 @@ steps:
     depends_on: "react-navigation-0-63-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_navigation_0.63.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -436,7 +436,7 @@ steps:
     depends_on: "react-navigation-0-63-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_navigation_0.63.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -459,7 +459,7 @@ steps:
     depends_on: "react-native-navigation-0-60-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_native_navigation_0.60.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -483,7 +483,7 @@ steps:
     depends_on: "react-native-navigation-0-60-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_native_navigation_0.60.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -506,7 +506,7 @@ steps:
     depends_on: "react-native-navigation-0-63-apk"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_native_navigation_0.63.apk"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
@@ -530,7 +530,7 @@ steps:
     depends_on: "react-native-navigation-0-63-ipa"
     timeout_in_minutes: 60
     plugins:
-      artifacts#v1.2.0:
+      artifacts#v1.5.0:
         download: "build/r_native_navigation_0.63.ipa"
       docker-compose#v3.9.0:
         pull: react-native-maze-runner

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -226,6 +226,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0.60.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -249,6 +250,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0.60.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -273,6 +275,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0.63.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -296,6 +299,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0.64-hermes.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -319,6 +323,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0.63.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -343,6 +348,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/rn0.64-hermes.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -367,6 +373,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_navigation_0.60.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -391,6 +398,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_navigation_0.60.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -414,6 +422,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_navigation_0.63.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -438,6 +447,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_navigation_0.63.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -461,6 +471,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_native_navigation_0.60.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -485,6 +496,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_native_navigation_0.60.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -508,6 +520,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_native_navigation_0.63.apk"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
@@ -532,6 +545,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "build/r_native_navigation_0.63.ipa"
+        upload: ./test/react-native/maze_output/**/*
       docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -7,11 +7,11 @@ steps:
     key: "android-builder-image"
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           build: react-native-android-builder
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:  react-native-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           push: react-native-android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
 
   #
@@ -26,7 +26,7 @@ steps:
       REACT_NATIVE_VERSION: "rn0.60"
       LANG: "en_US.UTF-8"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/rn0.60.apk
@@ -51,7 +51,7 @@ steps:
     env:
       REACT_NATIVE_VERSION: "rn0.63"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/rn0.63.apk
@@ -76,7 +76,7 @@ steps:
     env:
       REACT_NATIVE_VERSION: "rn0.64-hermes"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/rn0.64-hermes.apk
@@ -103,7 +103,7 @@ steps:
       JS_SOURCE_DIR: "react_navigation_js"
       ARTEFACT_NAME: "r_navigation_0.60"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/r_navigation_0.60.apk
@@ -134,7 +134,7 @@ steps:
       JS_SOURCE_DIR: "react_navigation_js"
       ARTEFACT_NAME: "r_navigation_0.63"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/r_navigation_0.63.apk
@@ -165,7 +165,7 @@ steps:
       JS_SOURCE_DIR: "react_native_navigation_js"
       ARTEFACT_NAME: "r_native_navigation_0.60"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/r_native_navigation_0.60.apk
@@ -196,7 +196,7 @@ steps:
       JS_SOURCE_DIR: "react_native_navigation_js"
       ARTEFACT_NAME: "r_native_navigation_0.63"
     plugins:
-      - docker-compose#v3.3.0:
+      - docker-compose#v3.9.0:
           run: react-native-android-builder
     artifact_paths:
       - build/r_native_navigation_0.63.apk
@@ -226,7 +226,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.60.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -249,7 +249,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.60.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -273,7 +273,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.63.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -296,7 +296,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.64-hermes.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -319,7 +319,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.63.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -343,7 +343,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/rn0.64-hermes.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -367,7 +367,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_navigation_0.60.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -391,7 +391,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_navigation_0.60.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -414,7 +414,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_navigation_0.63.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -438,7 +438,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_navigation_0.63.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -461,7 +461,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_native_navigation_0.60.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -485,7 +485,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_native_navigation_0.60.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -508,7 +508,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_native_navigation_0.63.apk"
-      docker-compose#v3.3.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true
@@ -532,7 +532,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/r_native_navigation_0.63.ipa"
-      docker-compose#v3.7.0:
+      docker-compose#v3.9.0:
         pull: react-native-maze-runner
         run: react-native-maze-runner
         use-aliases: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,6 +249,7 @@ services:
     volumes:
       - ./build:/app/build
       - ./test/react-native/features/:/app/features
+      - ./test/react-native/maze_output:/app/maze_output
 
   react-native-cli-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v6-cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,7 @@ services:
           - maze-runner
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./test/react-native-cli/maze_output:/app/maze_output
 
   react-native-cli-android-builder:
     build:
@@ -272,6 +273,7 @@ services:
     volumes:
       - ./build:/app/build
       - ./test/react-native-cli/features/:/app/features/
+      - ./test/react-native-cli/maze_output:/app/maze_output
 
   release:
     build:


### PR DESCRIPTION
## Goal

Upload the contents of `maze_output` for RN and RN CLI e2e tests, which is often useful for debugging test failures.

## Changeset

Also bumped the artifact and docker-compose Buildkite plugins in all pipelines.

## Testing

Covered by CI and verifying that artifacts are included on build steps.