### PR TITLE
Remove unnecessary Cucumber steps

### DIFF
--- a/test/react-native/features/override_unhandled.feature
+++ b/test/react-native/features/override_unhandled.feature
@@ -3,9 +3,7 @@ Feature: Overriding unhandled state
 Scenario: Non-fatal error overridden to unhandled
     When I run "HandledOverrideJsErrorScenario"
     Then I wait to receive an error
-    And I wait to receive a session
-
-    Then the exception "message" equals "HandledOverrideJsErrorScenario"
+    And the exception "message" equals "HandledOverrideJsErrorScenario"
     And the event "unhandled" is true
     And the event "severity" equals "warning"
     And the event "severityReason.type" equals "handledException"
@@ -17,9 +15,7 @@ Scenario: Fatal error overridden to handled
     When I run "UnhandledOverrideJsErrorScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledOverrideJsErrorScenario"
     Then I wait to receive an error
-    And I wait to receive a session
-
-    Then the exception "message" equals "UnhandledOverrideJsErrorScenario"
+    And the exception "message" equals "UnhandledOverrideJsErrorScenario"
     And the event "unhandled" is false
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "unhandledPromiseRejection"

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -1,16 +1,3 @@
-def wait_for_true
-  # max_attempts = 300
-  max_attempts = 100
-  attempts = 0
-  assertion_passed = false
-  until (attempts >= max_attempts) || assertion_passed
-    attempts += 1
-    assertion_passed = yield
-    sleep 0.1
-  end
-  # raise 'Assertion not passed in 30s' unless assertion_passed
-end
-
 When('I run {string}') do |event_type|
   steps %Q{
     Given the element "scenario_name" is present within 60 seconds
@@ -29,15 +16,15 @@ When('I run {string} and relaunch the crashed app') do |event_type|
 end
 
 Then('the app is not running') do
-  wait_for_true do
+  Maze::Wait.new(interval: 1, timeout: 10).until do
     case Maze::Helper.get_current_platform
     when 'ios'
       state = Maze.driver.app_state('org.reactjs.native.example.reactnative')
-      $logger.info state
+      $logger.info "The app is #{state}"
       state == :not_running
     when 'android'
       state = Maze.driver.app_state('com.reactnative')
-      $logger.info state
+      $logger.info "The app is #{state}"
       # workaround for faulty app state detection in appium v1.23 and lower on
       # Android where an app that is not running is detected to be running in
       # the background


### PR DESCRIPTION
## Goal

Removes unnecessary test steps.

## Design

The removed steps expect a session request, without subsequently checking their contents - risking unnecessary flakes.  This will have been a hangover from when all requests were received on the same endpoint and the session needed to be received but immediately discarded.  We have test scenarios specifically designed for verifying session payloads.

## Changeset

Removed the unnecessary steps, as well as a `wait_for_true` function whose functionality is provided by Maze Runner.

## Testing

Covered by CI.