### PR TITLE
Miscellaneous test tidy-ups

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -19,7 +19,7 @@ steps:
 
   - label: ':chrome: v43 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -34,7 +34,7 @@ steps:
 
   - label: ':chrome: v61 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -49,7 +49,7 @@ steps:
 
   - label: ':chrome: latest Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -64,7 +64,7 @@ steps:
 
   - label: ':ie: v8 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -79,7 +79,7 @@ steps:
 
   - label: ':ie: v9 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -94,7 +94,7 @@ steps:
 
   - label: ':ie: v10 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -109,7 +109,7 @@ steps:
 
   - label: ':ie: v11 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -126,7 +126,7 @@ steps:
 
   - label: ':edge: v14 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -141,7 +141,7 @@ steps:
 
   - label: ':edge: v15 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -156,7 +156,7 @@ steps:
 
   - label: ':safari: v6 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -171,7 +171,7 @@ steps:
 
   - label: ':safari: v10 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -186,7 +186,7 @@ steps:
 
   - label: ':safari: v13 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -201,7 +201,7 @@ steps:
 
   - label: ':safari: v15 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -233,7 +233,7 @@ steps:
 
   - label: ':android: Samsung Galaxy S8 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -248,7 +248,7 @@ steps:
 
   - label: ':firefox: v30 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -263,7 +263,7 @@ steps:
 
   - label: ':firefox: v56 Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner
@@ -278,7 +278,7 @@ steps:
 
   - label: ':firefox: latest Browser tests'
     depends_on: "browser-maze-runner-image"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     plugins:
       docker-compose#v3.7.0:
         pull: browser-maze-runner

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -230,6 +230,7 @@ steps:
       queue: 'opensource-mac-rn'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_60.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_60
@@ -241,6 +242,7 @@ steps:
       queue: 'opensource-mac-rn'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_61.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_61
@@ -252,6 +254,7 @@ steps:
       queue: 'opensource-mac-rn'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_62.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_62
@@ -263,6 +266,7 @@ steps:
       queue: 'opensource-mac-rn'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_63.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_63
@@ -274,6 +278,7 @@ steps:
       queue: 'opensource-mac-cocoa-11'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_63_expo_ejected.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_63_expo_ejected
@@ -285,6 +290,7 @@ steps:
       queue: 'opensource-mac-cocoa-11'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_64.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_64
@@ -296,6 +302,7 @@ steps:
       queue: 'opensource-mac-cocoa-11'
     env:
       DEBUG: true
+      LANG: "en_US.UTF-8"
     artifact_paths: build/rn0_64_hermes.ipa
     commands:
       - test/react-native-cli/scripts/init-and-build-test.sh rn0_64_hermes

--- a/test/react-native/Gemfile
+++ b/test/react-native/Gemfile
@@ -2,11 +2,11 @@ source 'https://rubygems.org'
 
 gem 'cocoapods'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.1'
 
 # Use a branch of Maze Runner
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/use-maze-check'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
-#gem 'bugsnag-maze-runner', path: '../maze-runner'
+#gem 'bugsnag-maze-runner', path: '../../../maze-runner'
 

--- a/test/react-native/Gemfile.lock
+++ b/test/react-native/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: fe12189f83aad154f54221ee0fcd41b483d3c0d1
-  tag: v6.8.0
+  revision: 912006496701a0b70191470d8ec612367e5f4b4f
+  tag: v6.9.1
   specs:
-    bugsnag-maze-runner (6.8.0)
+    bugsnag-maze-runner (6.9.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -96,10 +96,10 @@ GEM
       mime-types (~> 3.3, >= 3.3.1)
       multi_test (~> 0.1, >= 0.1.2)
       sys-uname (~> 1.2, >= 1.2.2)
-    cucumber-core (10.1.0)
+    cucumber-core (10.1.1)
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
-      cucumber-tag-expressions (~> 4.0, >= 4.0.2)
+      cucumber-tag-expressions (~> 4.1, >= 4.1.0)
     cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
@@ -111,12 +111,11 @@ GEM
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
     cucumber-tag-expressions (4.1.0)
-    cucumber-wire (6.2.0)
+    cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-      cucumber-messages (~> 17.1, >= 17.1.1)
     curb (0.9.11)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     escape (0.0.4)
     ethon (0.12.0)
       ffi (>= 1.3.0)
@@ -134,16 +133,16 @@ GEM
     json (2.5.1)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
-    mini_portile2 (2.6.1)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.7.1)
     minitest (5.14.3)
     molinillo (0.6.6)
     multi_test (0.1.2)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -185,4 +184,4 @@ DEPENDENCIES
   cocoapods
 
 BUNDLED WITH
-   2.2.13
+   2.3.0

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/index.js
@@ -17,7 +17,6 @@ export default class AppScreen extends Component {
     super(props)
     this.state = {
       currentScenario: '',
-      scenarioMetaData: '',
       apiKey: '12312312312312312312312312312312',
       notifyEndpoint: 'http://bs-local.com:9339/notify',
       sessionsEndpoint: 'http://bs-local.com:9339/sessions',
@@ -40,18 +39,12 @@ export default class AppScreen extends Component {
     this.state.currentScenario = newScenario
   }
 
-  setScenarioMetaData = newScenarioMetaData => {
-    this.state.scenarioMetaData = newScenarioMetaData
-  }
-
   startScenario = () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
     const jsConfig = defaultJsConfig()
-    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    const scenario = new Scenarios[scenarioName](configuration, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
     Navigation.setRoot({
       root: {
@@ -72,12 +65,10 @@ export default class AppScreen extends Component {
 
   startBugsnag = () => {
     console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
     const jsConfig = defaultJsConfig()
-    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    const scenario = new Scenarios[scenarioName](configuration, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${jsConfig} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
       .then(() => {
@@ -95,10 +86,6 @@ export default class AppScreen extends Component {
             placeholder='Scenario Name'
             accessibilityLabel='scenario_name'
             onChangeText={this.setScenario} />
-          <TextInput style={styles.textInput}
-            placeholder='Scenario Metadata'
-            accessibilityLabel='scenario_metadata'
-            onChangeText={this.setScenarioMetaData} />
           <Button style={styles.clickyButton}
             accessibilityLabel='start_bugsnag'
             title='Start Bugsnag'

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/scenarios/ReactNavigationBreadcrumbsDisabledScenario.js
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/scenarios/ReactNavigationBreadcrumbsDisabledScenario.js
@@ -1,7 +1,7 @@
 import Scenario from './Scenario'
 
 export class ReactNavigationBreadcrumbsDisabledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.enabledBreadcrumbTypes = []
   }

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/App.js
@@ -21,7 +21,6 @@ export default class App extends Component {
     super(props)
     this.state = {
       currentScenario: '',
-      scenarioMetaData: '',
       apiKey: '12312312312312312312312312312312',
       notifyEndpoint: 'http://bs-local.com:9339/notify',
       sessionsEndpoint: 'http://bs-local.com:9339/sessions',
@@ -44,10 +43,6 @@ export default class App extends Component {
     this.setState(() => ({ currentScenario: newScenario }))
   }
 
-  setScenarioMetaData = newScenarioMetaData => {
-    this.setState(() => ({ scenarioMetaData: newScenarioMetaData }))
-  }
-
   setApiKey = newApiKey => {
     this.setState(() => ({ apiKey: newApiKey }))
   }
@@ -67,12 +62,10 @@ export default class App extends Component {
 
   startScenario = () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
     const jsConfig = defaultJsConfig()
-    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    const scenario = new Scenarios[scenarioName](configuration, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     this.setState({ scenario: scenario })
     scenario.run()
@@ -80,13 +73,11 @@ export default class App extends Component {
 
   startBugsnag = () => {
     console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
     const jsConfig = defaultJsConfig()
     // eslint-disable-next-line no-new
-    new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    new Scenarios[scenarioName](configuration, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     NativeModules.BugsnagTestInterface.startBugsnag(configuration)
       .then(() => {
@@ -103,10 +94,6 @@ export default class App extends Component {
             placeholder='Scenario Name'
             accessibilityLabel='scenario_name'
             onChangeText={this.setScenario}/>
-          <TextInput style={styles.textInput}
-            placeholder='Scenario Metadata'
-            accessibilityLabel='scenario_metadata'
-            onChangeText={this.setScenarioMetaData}/>
 
           <Button style={styles.clickyButton}
             accessibilityLabel='start_bugsnag'

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/scenarios/ReactNavigationBreadcrumbsDisabledScenario.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/scenarios/ReactNavigationBreadcrumbsDisabledScenario.js
@@ -5,7 +5,7 @@ import { View, Text, Button } from 'react-native'
 import { createStackNavigator } from '@react-navigation/stack'
 
 export class ReactNavigationBreadcrumbsDisabledScenario extends Scenario {
-  constructor (configuration, _extraData, _jsConfig) {
+  constructor (configuration, _jsConfig) {
     super()
     configuration.enabledBreadcrumbTypes = []
   }

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/scenarios/ReactNavigationBreadcrumbsEnabledScenario.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/scenarios/ReactNavigationBreadcrumbsEnabledScenario.js
@@ -5,7 +5,7 @@ import { View, Text, Button } from 'react-native'
 import { createStackNavigator } from '@react-navigation/stack'
 
 export class ReactNavigationBreadcrumbsEnabledScenario extends Scenario {
-  constructor (_configuration, _extraData, _jsConfig) {
+  constructor (_configuration, _jsConfig) {
     super()
   }
 

--- a/test/react-native/features/fixtures/app/scenario_js/app/App.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/App.js
@@ -15,7 +15,6 @@ export default class App extends Component {
     super(props)
     this.state = {
       currentScenario: '',
-      scenarioMetaData: '',
       apiKey: '12312312312312312312312312312312',
       notifyEndpoint: 'http://bs-local.com:9339/notify',
       sessionsEndpoint: 'http://bs-local.com:9339/sessions'
@@ -37,10 +36,6 @@ export default class App extends Component {
     this.setState(() => ({ currentScenario: newScenario }))
   }
 
-  setScenarioMetaData = newScenarioMetaData => {
-    this.setState(() => ({ scenarioMetaData: newScenarioMetaData }))
-  }
-
   setApiKey = newApiKey => {
     this.setState(() => ({ apiKey: newApiKey }))
   }
@@ -60,26 +55,22 @@ export default class App extends Component {
 
   runScenario = () => {
     console.log(`Running scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
     const jsConfig = {}
-    const scenario = new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    const scenario = new Scenarios[scenarioName](configuration, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
     scenario.run()
   }
 
   startBugsnag = () => {
     console.log(`Starting Bugsnag for scenario: ${this.state.currentScenario}`)
-    console.log(`  with MetaData: ${this.state.scenarioMetaData}`)
     const scenarioName = this.state.currentScenario
-    const scenarioMetaData = this.state.scenarioMetaData
     const configuration = this.getConfiguration()
 
     const jsConfig = {}
     // eslint-disable-next-line no-new
-    new Scenarios[scenarioName](configuration, scenarioMetaData, jsConfig)
+    new Scenarios[scenarioName](configuration, jsConfig)
     console.log(`  with config: ${JSON.stringify(configuration)} (native) and ${JSON.stringify(jsConfig)} (js)`)
 
     NativeModules.BugsnagTestInterface.startBugsnag(configuration).then(() => {
@@ -96,10 +87,6 @@ export default class App extends Component {
             placeholder='Scenario Name'
             accessibilityLabel='scenario_name'
             onChangeText={this.setScenario}/>
-          <TextInput style={styles.textInput}
-            placeholder='Scenario Metadata'
-            accessibilityLabel='scenario_metadata'
-            onChangeText={this.setScenarioMetaData}/>
 
           <Button style={styles.clickyButton}
             accessibilityLabel='start_bugsnag'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigAppTypeScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigAppTypeScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class AppConfigAppTypeScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.appType = 'mobileclient'
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigEnabledReleaseStagesNoSendScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigEnabledReleaseStagesNoSendScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class AppConfigEnabledReleaseStagesNoSendScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.releaseStage = 'testing'
     configuration.enabledReleaseStages = ['preprod', 'production']

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigEnabledReleaseStagesScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigEnabledReleaseStagesScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class AppConfigEnabledReleaseStagesScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.releaseStage = 'preprod'
     configuration.enabledReleaseStages = ['preprod', 'production']

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigReleaseStageScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppConfigReleaseStageScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class AppConfigReleaseStageScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.releaseStage = 'staging'
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppJsHandledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppJsHandledScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class AppJsHandledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.appVersion = '1.2.3'
     jsConfig.codeBundleId = '1.2.3-r00110011'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppJsUnhandledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppJsUnhandledScenario.js
@@ -1,7 +1,7 @@
 import Scenario from './Scenario'
 
 export class AppJsUnhandledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.appVersion = '1.2.3'
     jsConfig.codeBundleId = '1.2.3-r00110011'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppNativeHandledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppNativeHandledScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import { NativeModules } from 'react-native'
 
 export class AppNativeHandledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.appVersion = '1.2.3'
     jsConfig.codeBundleId = '1.2.3-r00110011'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppNativeUnhandledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/AppNativeUnhandledScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import { NativeModules } from 'react-native'
 
 export class AppNativeUnhandledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.appVersion = '1.2.3'
     jsConfig.codeBundleId = '1.2.3-r00110011'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/BreadcrumbsNullEnabledBreadcrumbTypesScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/BreadcrumbsNullEnabledBreadcrumbTypesScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class BreadcrumbsNullEnabledBreadcrumbTypesScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.enabledBreadcrumbTypes = null
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/ContextJsCustomScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/ContextJsCustomScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class ContextJsCustomScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     jsConfig.context = 'context-config'
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/MetadataJsScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/MetadataJsScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class MetadataJsScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.redactedKeys = ['redacted_data']
     jsConfig.metadata = {

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/MetadataNativeScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/MetadataNativeScenario.js
@@ -3,7 +3,7 @@ import Bugsnag from '@bugsnag/react-native'
 import { NativeModules } from 'react-native'
 
 export class MetadataNativeScenario extends Scenario {
-  constructor (configuration, _extraData, _jsConfig) {
+  constructor (configuration, _jsConfig) {
     super()
     configuration.configMetaData = {
       some_data: 'set via config',

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/MetadataNativeUnhandledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/MetadataNativeUnhandledScenario.js
@@ -3,7 +3,7 @@ import Bugsnag from '@bugsnag/react-native'
 import { NativeModules } from 'react-native'
 
 export class MetadataNativeUnhandledScenario extends Scenario {
-  constructor (configuration, _extraData, _jsConfig) {
+  constructor (configuration, _jsConfig) {
     super()
     configuration.configMetaData = {
       some_data: 'set via config',

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionAutoDisabledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionAutoDisabledScenario.js
@@ -1,7 +1,7 @@
 import Scenario from './Scenario'
 
 export class SessionAutoDisabledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.autoTrackSessions = false
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionAutoEnabledScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionAutoEnabledScenario.js
@@ -1,7 +1,7 @@
 import Scenario from './Scenario'
 
 export class SessionAutoEnabledScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.autoTrackSessions = true
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionJsControlledManualJsScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionJsControlledManualJsScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class SessionJsControlledManualJsScenario extends Scenario {
-  constructor (configuration, _extraData, _jsConfig) {
+  constructor (configuration, _jsConfig) {
     super()
     configuration.autoTrackSessions = false
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionJsControlledManualNativeScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionJsControlledManualNativeScenario.js
@@ -3,7 +3,7 @@ import Bugsnag from '@bugsnag/react-native'
 import { NativeModules } from 'react-native'
 
 export class SessionJsControlledManualNativeScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.autoTrackSessions = false
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionNativeControlledManualJsScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/SessionNativeControlledManualJsScenario.js
@@ -3,7 +3,7 @@ import Bugsnag from '@bugsnag/react-native'
 import { NativeModules } from 'react-native'
 
 export class SessionNativeControlledManualJsScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     configuration.autoTrackSessions = false
   }

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UnhandledJsErrorSeverityScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UnhandledJsErrorSeverityScenario.js
@@ -1,7 +1,7 @@
 import Scenario from './Scenario'
 
 export class UnhandledJsErrorSeverityScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     jsConfig.onError = (event) => {
       event.severity = 'info'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UnhandledOverrideJsErrorScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UnhandledOverrideJsErrorScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class UnhandledOverrideJsErrorScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     jsConfig.onError = (event) => {
       event.unhandled = false

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UserJsConfigScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UserJsConfigScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class UserJsConfigScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
     jsConfig.user = {
       id: '123',

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UserJsEventScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/UserJsEventScenario.js
@@ -2,7 +2,7 @@ import Scenario from './Scenario'
 import Bugsnag from '@bugsnag/react-native'
 
 export class UserJsEventScenario extends Scenario {
-  constructor (configuration, extraData, jsConfig) {
+  constructor (configuration, jsConfig) {
     super()
   }
 


### PR DESCRIPTION
## Goal

A few initial tidy-ups to the React Native e2e test setup, before embarking on a modest refactor.

## Changeset

- Set `LANG` on ipa build steps to shut CocoaPods up.
- Remove unused metadata field/arg from the test fixtures
- Update to the latest version of Maze Runner
- Increase the step timeout on Browser tests.  A few have timed out recently (although we will raise a support ticket if it persists).

## Testing

Covered by CI.