### PR TITLE
Expo: avoid using deprecated constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (expo): Avoid using deprecated constants [#1665](https://github.com/bugsnag/bugsnag-js/pull/1665)
+
 ## 7.15.1 (2022-01-18)
 
 ### Changed

--- a/packages/expo/CONTRIBUTING.md
+++ b/packages/expo/CONTRIBUTING.md
@@ -9,6 +9,7 @@ When a new version of the Expo SDK is released, the dependencies we use must be 
 The following modules are currently used:
 
 - `@react-native-community/netinfo` (`@bugsnag/delivery-expo`, `@bugsnsag/plugin-react-native-connectivity-breadcrumbs`)
+- `expo-application` (`@bugsnag/plugin-expo-app`)
 - `expo-constants` (`@bugsnag/expo`, `@bugsnag/plugin-expo-app`, `@bugsnag/plugin-expo-device`)
 - `expo-crypto` (`@bugsnag/expo`, `@bugsnag/delivery-expo`)
 - `expo-device` (`@bugsnag/plugin-expo-device`)

--- a/packages/expo/test/index.test.ts
+++ b/packages/expo/test/index.test.ts
@@ -16,6 +16,8 @@ jest.mock('../../plugin-expo-device/node_modules/expo-constants', () => ({
   }
 }))
 
+jest.mock('../../plugin-expo-app/node_modules/expo-application', () => ({}))
+
 jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
   default: {
     platform: {},

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -1,3 +1,4 @@
+const Application = require('expo-application')
 const Constants = require('expo-constants').default
 const { AppState } = require('react-native')
 
@@ -16,12 +17,14 @@ module.exports = {
     })
 
     let nativeBundleVersion, nativeVersionCode
+
     if (Constants.appOwnership === 'standalone') {
-      if (Constants.platform.ios && Constants.platform.ios.buildNumber) {
-        nativeBundleVersion = Constants.platform.ios.buildNumber
+      if (Constants.platform.ios) {
+        nativeBundleVersion = Application.nativeBuildVersion
       }
-      if (Constants.platform.android && Constants.platform.android.versionCode) {
-        nativeVersionCode = Constants.platform.android.versionCode
+
+      if (Constants.platform.android) {
+        nativeVersionCode = Application.nativeBuildVersion
       }
     }
 

--- a/packages/plugin-expo-app/package-lock.json
+++ b/packages/plugin-expo-app/package-lock.json
@@ -6,9 +6,10 @@
 	"packages": {
 		"": {
 			"name": "@bugsnag/plugin-expo-app",
-			"version": "7.14.0",
+			"version": "7.15.1",
 			"license": "MIT",
 			"dependencies": {
+				"expo-application": "~4.0.1",
 				"expo-constants": "~13.0.0"
 			},
 			"peerDependencies": {
@@ -351,6 +352,14 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/expo-application": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/expo-application/-/expo-application-4.0.1.tgz",
+			"integrity": "sha512-yZM/SrpWdi84m5+5F3VDfhrMZOz/uKwXcgBhOP1wzfXt0otGSRW1V5tM+a0sgaKZsDRCGojTU7Jm73BVwwVrwg==",
+			"peerDependencies": {
+				"expo": "*"
 			}
 		},
 		"node_modules/expo-constants": {
@@ -1129,6 +1138,11 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"expo-application": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/expo-application/-/expo-application-4.0.1.tgz",
+			"integrity": "sha512-yZM/SrpWdi84m5+5F3VDfhrMZOz/uKwXcgBhOP1wzfXt0otGSRW1V5tM+a0sgaKZsDRCGojTU7Jm73BVwwVrwg=="
 		},
 		"expo-constants": {
 			"version": "13.0.0",

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -20,6 +20,7 @@
     "@bugsnag/core": "^7.15.1"
   },
   "dependencies": {
+    "expo-application": "~4.0.1",
     "expo-constants": "~13.0.0"
   },
   "peerDependencies": {

--- a/packages/plugin-expo-app/test/app.test.ts
+++ b/packages/plugin-expo-app/test/app.test.ts
@@ -16,6 +16,8 @@ describe('plugin: expo app', () => {
   it('should should use revisionId if defined (all platforms)', done => {
     const VERSION = '1.0.0'
     const REVISION_ID = '1.0.0-r132432'
+
+    jest.doMock('expo-application', () => ({}))
     jest.doMock('expo-constants', () => ({
       default: {
         platform: {},
@@ -39,13 +41,14 @@ describe('plugin: expo app', () => {
     c.notify(new Error('flip'))
   })
 
-  it('should should use versionCode if defined (android)', done => {
+  it('should record nativeVersionCode on android', done => {
     const VERSION_CODE = '1.0'
 
+    jest.doMock('expo-application', () => ({ nativeBuildVersion: VERSION_CODE }))
     jest.doMock('expo-constants', () => ({
       default: {
         platform: {
-          android: { versionCode: VERSION_CODE }
+          android: {}
         },
         manifest: { version: '1.0.0' },
         appOwnership: 'standalone'
@@ -68,13 +71,14 @@ describe('plugin: expo app', () => {
     c.notify(new Error('flip'))
   })
 
-  it('should should use bundleVersion if defined (ios)', done => {
+  it('should record nativeBundleVersion on ios', done => {
     const BUNDLE_VERSION = '1.0'
 
+    jest.doMock('expo-application', () => ({ nativeBuildVersion: BUNDLE_VERSION }))
     jest.doMock('expo-constants', () => ({
       default: {
         platform: {
-          ios: { buildNumber: BUNDLE_VERSION }
+          ios: {}
         },
         manifest: { version: '1.0.0' },
         appOwnership: 'standalone'
@@ -103,6 +107,7 @@ describe('plugin: expo app', () => {
       currentState: 'active'
     }
 
+    jest.doMock('expo-application', () => ({}))
     jest.doMock('expo-constants', () => ({
       default: {
         platform: {},
@@ -152,6 +157,7 @@ describe('plugin: expo app', () => {
   it('includes duration in event.app', done => {
     const start = Date.now()
 
+    jest.doMock('expo-application', () => ({}))
     jest.doMock('expo-constants', () => ({
       default: {
         platform: {},

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -24,15 +24,10 @@ module.exports = {
     const device = {
       id: Constants.installationId,
       manufacturer: Device.manufacturer,
-      // On a real device these two seem equivalent, however on a simulator
-      // 'Constants' is a bit more useful as it returns 'Simulator' whereas
-      // 'Device' just returns 'iPhone'
-      model: Constants.platform.ios
-        ? Constants.platform.ios.model
-        : Device.modelName,
-      modelNumber: Constants.platform.ios ? Constants.platform.ios.platform : undefined,
+      model: Device.modelName,
+      modelNumber: Device.modelId || undefined,
       osName: Platform.OS,
-      osVersion: Constants.platform.ios ? Constants.platform.ios.systemVersion : Constants.systemVersion,
+      osVersion: Device.osVersion,
       runtimeVersions: {
         reactNative: rnVersion,
         expoApp: Constants.expoVersion,

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -51,7 +51,7 @@ module.exports = {
     client.addOnError(event => {
       event.device = { ...event.device, time: new Date(), orientation, ...device }
       event.addMetadata('device', {
-        isDevice: Constants.isDevice,
+        isDevice: Device.isDevice,
         appOwnership: Constants.appOwnership
       })
       addDefaultAppType(event)

--- a/packages/plugin-expo-device/test/device.test.ts
+++ b/packages/plugin-expo-device/test/device.test.ts
@@ -20,13 +20,13 @@ describe('plugin: expo device', () => {
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         systemVersion: ANDROID_VERSION,
-        isDevice: true,
         appOwnership: 'standalone'
       }
     }))
     jest.doMock('expo-device', () => ({
       manufacturer: 'Google',
-      modelName: 'Pixel 4'
+      modelName: 'Pixel 4',
+      isDevice: true
     }))
     jest.doMock('react-native', () => ({
       Dimensions: {
@@ -87,12 +87,12 @@ describe('plugin: expo device', () => {
         platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, systemVersion: IOS_VERSION } },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
-        isDevice: false,
         appOwnership: 'expo'
       }
     }))
     jest.doMock('expo-device', () => ({
-      manufacturer: 'Apple'
+      manufacturer: 'Apple',
+      isDevice: false
     }))
     jest.doMock('react-native', () => ({
       Dimensions: {
@@ -151,12 +151,12 @@ describe('plugin: expo device', () => {
         platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, systemVersion: IOS_VERSION } },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
-        isDevice: false,
         appOwnership: 'expo'
       }
     }))
     jest.doMock('expo-device', () => ({
-      manufacturer: 'Apple'
+      manufacturer: 'Apple',
+      isDevice: true
     }))
     jest.doMock('react-native', () => ({
       Dimensions: {
@@ -201,12 +201,12 @@ describe('plugin: expo device', () => {
         platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, systemVersion: IOS_VERSION } },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
-        isDevice: false,
         appOwnership: 'expo'
       }
     }))
     jest.doMock('expo-device', () => ({
-      manufacturer: 'Apple'
+      manufacturer: 'Apple',
+      isDevice: true
     }))
     jest.doMock('react-native', () => ({
       Dimensions: {
@@ -280,11 +280,10 @@ describe('plugin: expo device', () => {
         platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, system: IOS_VERSION } },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
-        isDevice: true,
         appOwnership: 'guest'
       }
     }))
-    jest.doMock('expo-device', () => ({}))
+    jest.doMock('expo-device', () => ({ isDevice: true }))
 
     jest.doMock('react-native', () => ({
       Dimensions: d,

--- a/packages/plugin-expo-device/test/device.test.ts
+++ b/packages/plugin-expo-device/test/device.test.ts
@@ -19,14 +19,14 @@ describe('plugin: expo device', () => {
         platform: { android: {} },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
-        systemVersion: ANDROID_VERSION,
         appOwnership: 'standalone'
       }
     }))
     jest.doMock('expo-device', () => ({
       manufacturer: 'Google',
       modelName: 'Pixel 4',
-      isDevice: true
+      isDevice: true,
+      osVersion: ANDROID_VERSION
     }))
     jest.doMock('react-native', () => ({
       Dimensions: {
@@ -84,7 +84,7 @@ describe('plugin: expo device', () => {
 
     jest.doMock('expo-constants', () => ({
       default: {
-        platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, systemVersion: IOS_VERSION } },
+        platform: { ios: {} },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'expo'
@@ -92,7 +92,10 @@ describe('plugin: expo device', () => {
     }))
     jest.doMock('expo-device', () => ({
       manufacturer: 'Apple',
-      isDevice: false
+      isDevice: false,
+      modelName: IOS_MODEL,
+      modelId: IOS_PLATFORM,
+      osVersion: IOS_VERSION
     }))
     jest.doMock('react-native', () => ({
       Dimensions: {
@@ -142,13 +145,10 @@ describe('plugin: expo device', () => {
     const REACT_NATIVE_VERSION = '0.57.1'
     const SDK_VERSION = '32.3.0'
     const EXPO_VERSION = '2.10.4'
-    const IOS_MODEL = 'iPhone 7 Plus'
-    const IOS_PLATFORM = 'iPhone1,1'
-    const IOS_VERSION = '11.2'
 
     jest.doMock('expo-constants', () => ({
       default: {
-        platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, systemVersion: IOS_VERSION } },
+        platform: { ios: {} },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'expo'
@@ -191,14 +191,11 @@ describe('plugin: expo device', () => {
     const REACT_NATIVE_VERSION = '0.57.1'
     const SDK_VERSION = '32.3.0'
     const EXPO_VERSION = '2.10.4'
-    const IOS_MODEL = 'iPhone 7 Plus'
-    const IOS_PLATFORM = 'iPhone1,1'
-    const IOS_VERSION = '11.2'
 
     jest.doMock('expo-constants', () => ({
       default: {
         installationId: '123',
-        platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, systemVersion: IOS_VERSION } },
+        platform: { ios: {} },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'expo'
@@ -242,9 +239,7 @@ describe('plugin: expo device', () => {
     const REACT_NATIVE_VERSION = '0.57.1'
     const SDK_VERSION = '32.3.0'
     const EXPO_VERSION = '2.10.4'
-    const IOS_MODEL = 'iPhone 7 Plus'
-    const IOS_PLATFORM = 'iPhone1,1'
-    const IOS_VERSION = '11.2'
+
     class Dimensions {
       _listeners: { change: Array<(payload: { screen: { width: number, height: number}, window: {} }) => void> } = { change: [] }
       _width!: number;
@@ -277,7 +272,7 @@ describe('plugin: expo device', () => {
 
     jest.doMock('expo-constants', () => ({
       default: {
-        platform: { ios: { model: IOS_MODEL, platform: IOS_PLATFORM, system: IOS_VERSION } },
+        platform: { ios: {} },
         manifest: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'guest'


### PR DESCRIPTION
## Goal

This PR migrates away from a number of deprecated constants, notably fixing a deprecation warning from `Constants.platform.ios.model` raised in the current version of `@bugsnag/expo`

| Previous constant | New constant |
| ----------------- | ------------ |
| `Constants.platform.ios.model` | `Device.modelName` |
| `Constants.platform.android.versionCode` | `Application.nativeBuildVersion` |
| `Constants.platform.ios.buildNumber`[^1] | `Application.nativeBuildVersion` |
| `Constants.platform.ios.platform` | `Device.modelId` |
| `Constants.platform.ios.systemVersion` | `Device.osVersion` |
| `Constants.isDevice` | `Device.isDevice` |

[^1]: This isn't actually deprecated, but `Application.nativeBuildVersion` is equivalent and it seemed sensible to use the same value for both iOS & Android