### PR TITLE
Mazerunner tests for React Native feature flags in native code

### DIFF
--- a/test/react-native/features/feature_flags.feature
+++ b/test/react-native/features/feature_flags.feature
@@ -42,3 +42,32 @@ Scenario: Sends no feature flags after clearFeatureFlags()
   And the exception "errorClass" equals "Error"
   And the event "unhandled" is false
   And event 0 has no feature flags
+
+Scenario: Sends JS feature flags in a native crash
+  When I run "FeatureFlagsNativeCrashScenario" and relaunch the app
+  And I configure Bugsnag for "FeatureFlagsNativeCrashScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals the platform-dependent string:
+    | android | java.lang.RuntimeException |
+    | ios     | NSException                |
+  And the event "exceptions.0.type" equals the platform-dependent string:
+    | android | android |
+    | ios     | cocoa   |
+  And the event "unhandled" is true
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+Scenario: Sends native feature flags in JS errors
+  When I run "NativeFeatureFlagsScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the event "unhandled" is false
+  And event 0 contains the feature flag "native_flag" with no variant
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"

--- a/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
@@ -68,3 +68,5 @@ export { UnhandledOverrideJsErrorScenario } from './scenarios/UnhandledOverrideJ
 
 // feature_flags.feature
 export { FeatureFlagsScenario } from './scenarios/FeatureFlagsScenario'
+export { FeatureFlagsNativeCrashScenario } from './scenarios/FeatureFlagsNativeCrashScenario'
+export { NativeFeatureFlagsScenario } from './scenarios/NativeFeatureFlagsScenario'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/FeatureFlagsNativeCrashScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/FeatureFlagsNativeCrashScenario.js
@@ -1,0 +1,19 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+import { NativeModules } from 'react-native'
+
+export class FeatureFlagsNativeCrashScenario extends Scenario {
+  run () {
+    Bugsnag.addFeatureFlag('demo_mode')
+    Bugsnag.addFeatureFlag('sample_group', 'a')
+    Bugsnag.addFeatureFlags([
+      { name: 'should_not_be_reported_1' },
+      { name: 'should_not_be_reported_2' },
+      { name: 'should_not_be_reported_3', variant: 'with variant' }
+    ])
+
+    setTimeout(() => {
+      NativeModules.BugsnagTestInterface.runScenario('FeatureFlagsNativeCrashScenario')
+    }, 100)
+  }
+}

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/NativeFeatureFlagsScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/NativeFeatureFlagsScenario.js
@@ -1,0 +1,22 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+import { NativeModules } from 'react-native'
+
+export class NativeFeatureFlagsScenario extends Scenario {
+  run () {
+    Bugsnag.addFeatureFlag('demo_mode')
+    Bugsnag.addFeatureFlag('sample_group', 'a')
+    Bugsnag.addFeatureFlags([
+      { name: 'should_not_be_reported_1' },
+      { name: 'should_not_be_reported_2' },
+      { name: 'should_not_be_reported_3', variant: 'with variant' }
+    ])
+
+    setTimeout(() => {
+      NativeModules.BugsnagTestInterface.runScenario('NativeFeatureFlagsScenario')
+      setTimeout(() => {
+        Bugsnag.notify(new Error())
+      }, 100)
+    }, 100)
+  }
+}

--- a/test/react-native/features/fixtures/ios-module/Scenarios/FeatureFlagsNativeCrashScenario.h
+++ b/test/react-native/features/fixtures/ios-module/Scenarios/FeatureFlagsNativeCrashScenario.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+@interface FeatureFlagsNativeCrashScenario : Scenario
+
+@end

--- a/test/react-native/features/fixtures/ios-module/Scenarios/FeatureFlagsNativeCrashScenario.m
+++ b/test/react-native/features/fixtures/ios-module/Scenarios/FeatureFlagsNativeCrashScenario.m
@@ -1,0 +1,15 @@
+#import "FeatureFlagsNativeCrashScenario.h"
+
+@implementation FeatureFlagsNativeCrashScenario
+
+- (void)run: (RCTPromiseResolveBlock)resolve
+     reject:(RCTPromiseRejectBlock)reject {
+
+  [Bugsnag clearFeatureFlagWithName:@"should_not_be_reported_1"];
+  [Bugsnag clearFeatureFlagWithName:@"should_not_be_reported_2"];
+  [Bugsnag clearFeatureFlagWithName:@"should_not_be_reported_3"];
+
+  @throw [[NSException alloc] initWithName:@"NSException" reason:@"FeatureFlagsNativeCrashScenario" userInfo:nil];
+}
+
+@end

--- a/test/react-native/features/fixtures/ios-module/Scenarios/NativeFeatureFlagsScenario.h
+++ b/test/react-native/features/fixtures/ios-module/Scenarios/NativeFeatureFlagsScenario.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+@interface NativeFeatureFlagsScenario : Scenario
+
+@end

--- a/test/react-native/features/fixtures/ios-module/Scenarios/NativeFeatureFlagsScenario.m
+++ b/test/react-native/features/fixtures/ios-module/Scenarios/NativeFeatureFlagsScenario.m
@@ -1,0 +1,15 @@
+#import "NativeFeatureFlagsScenario.h"
+
+@implementation NativeFeatureFlagsScenario
+
+- (void)run: (RCTPromiseResolveBlock)resolve
+     reject:(RCTPromiseRejectBlock)reject {
+
+  [Bugsnag clearFeatureFlagWithName:@"should_not_be_reported_1"];
+  [Bugsnag clearFeatureFlagWithName:@"should_not_be_reported_2"];
+  [Bugsnag clearFeatureFlagWithName:@"should_not_be_reported_3"];
+
+  [Bugsnag addFeatureFlagWithName:@"native_flag"];
+}
+
+@end

--- a/test/react-native/features/fixtures/reactnative/scenarios/FeatureFlagsNativeCrashScenario.kt
+++ b/test/react-native/features/fixtures/reactnative/scenarios/FeatureFlagsNativeCrashScenario.kt
@@ -1,0 +1,16 @@
+package com.reactnative.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.facebook.react.bridge.Promise
+
+class FeatureFlagsNativeCrashScenario(context: Context): Scenario(context) {
+
+    override fun run(promise: Promise) {
+        Bugsnag.clearFeatureFlag("should_not_be_reported_1")
+        Bugsnag.clearFeatureFlag("should_not_be_reported_2")
+        Bugsnag.clearFeatureFlag("should_not_be_reported_3")
+
+        throw generateException()
+    }
+}

--- a/test/react-native/features/fixtures/reactnative/scenarios/NativeFeatureFlagsScenario.kt
+++ b/test/react-native/features/fixtures/reactnative/scenarios/NativeFeatureFlagsScenario.kt
@@ -1,0 +1,16 @@
+package com.reactnative.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.facebook.react.bridge.Promise
+
+class NativeFeatureFlagsScenario(context: Context): Scenario(context) {
+
+  override fun run(promise: Promise) {
+    Bugsnag.clearFeatureFlag("should_not_be_reported_1")
+    Bugsnag.clearFeatureFlag("should_not_be_reported_2")
+    Bugsnag.clearFeatureFlag("should_not_be_reported_3")
+
+    Bugsnag.addFeatureFlag("native_flag")
+  }
+}

--- a/test/react-native/features/fixtures/rn0.60/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.60/ios/reactnative.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		6591A4D62511602C0040A5FA /* NativeStackUnhandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 6591A4D22511602C0040A5FA /* NativeStackUnhandledScenario.m */; };
 		7B1C2C97F3E1FBCE4DEFF803 /* libPods-reactnative-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F67EF5665D8FDE0BCD26897 /* libPods-reactnative-tvOS.a */; };
 		819AA33DD9E4324894666F7B /* libPods-reactnativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 34A013DC763918594BCEAE99 /* libPods-reactnativeTests.a */; };
+		96A7D7542799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A7D7512799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m */; };
+		96A7D7552799DF700043AAB6 /* NativeFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A7D7522799DF700043AAB6 /* NativeFeatureFlagsScenario.m */; };
 		A145176624A7A1F000C6FC6E /* BugsnagModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A145176524A7A1F000C6FC6E /* BugsnagModule.m */; };
 		A145176A24A7A20300C6FC6E /* Scenario.m in Sources */ = {isa = PBXBuildFile; fileRef = A145176824A7A20300C6FC6E /* Scenario.m */; };
 		A181223C24C0BF5B0073596F /* BreadcrumbsNativeManualScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = A181223B24C0BF5B0073596F /* BreadcrumbsNativeManualScenario.m */; };
@@ -87,6 +89,10 @@
 		68A8F5F58BB4A2F366AFCA57 /* Pods-reactnativeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeTests.release.xcconfig"; path = "Target Support Files/Pods-reactnativeTests/Pods-reactnativeTests.release.xcconfig"; sourceTree = "<group>"; };
 		6B42C8C4E3A41C003188F72C /* Pods-reactnative-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative-tvOS.release.xcconfig"; path = "Target Support Files/Pods-reactnative-tvOS/Pods-reactnative-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		8FF14CF0FC033078A6F6C5E3 /* Pods-reactnative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative.release.xcconfig"; path = "Target Support Files/Pods-reactnative/Pods-reactnative.release.xcconfig"; sourceTree = "<group>"; };
+		96A7D7502799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FeatureFlagsNativeCrashScenario.h; sourceTree = "<group>"; };
+		96A7D7512799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FeatureFlagsNativeCrashScenario.m; sourceTree = "<group>"; };
+		96A7D7522799DF700043AAB6 /* NativeFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeFeatureFlagsScenario.m; sourceTree = "<group>"; };
+		96A7D7532799DF700043AAB6 /* NativeFeatureFlagsScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeFeatureFlagsScenario.h; sourceTree = "<group>"; };
 		A145176424A7A1F000C6FC6E /* BugsnagModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagModule.h; path = "../../ios-module/BugsnagModule.h"; sourceTree = "<group>"; };
 		A145176524A7A1F000C6FC6E /* BugsnagModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagModule.m; path = "../../ios-module/BugsnagModule.m"; sourceTree = "<group>"; };
 		A145176824A7A20300C6FC6E /* Scenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Scenario.m; sourceTree = "<group>"; };
@@ -257,6 +263,10 @@
 		A145176724A7A1F500C6FC6E /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				96A7D7502799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.h */,
+				96A7D7512799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m */,
+				96A7D7532799DF700043AAB6 /* NativeFeatureFlagsScenario.h */,
+				96A7D7522799DF700043AAB6 /* NativeFeatureFlagsScenario.m */,
 				A1BFB36624BCEE0200394C5D /* AppNativeHandledScenario.h */,
 				A1BFB36724BCEE0200394C5D /* AppNativeHandledScenario.m */,
 				A1BFB36424BCEE0200394C5D /* AppNativeUnhandledScenario.h */,
@@ -659,6 +669,7 @@
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				A145176624A7A1F000C6FC6E /* BugsnagModule.m in Sources */,
 				A1F63D2024CE53EE00C31ABC /* StartSessionScenario.m in Sources */,
+				96A7D7542799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */,
 				A181224124C59F4D0073596F /* DeviceNativeHandledScenario.m in Sources */,
 				A1F389CF24C73B6000C30B50 /* MetadataNativeUnhandledScenario.m in Sources */,
 				A1CC9DE424B3D76A002A4760 /* HandledNativeErrorScenario.m in Sources */,
@@ -671,6 +682,7 @@
 				6591A4D62511602C0040A5FA /* NativeStackUnhandledScenario.m in Sources */,
 				A181223C24C0BF5B0073596F /* BreadcrumbsNativeManualScenario.m in Sources */,
 				A1F63D2124CE53EE00C31ABC /* PauseSessionScenario.m in Sources */,
+				96A7D7552799DF700043AAB6 /* NativeFeatureFlagsScenario.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test/react-native/features/fixtures/rn0.63/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.63/ios/reactnative.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		6591A4CD251156330040A5FA /* NativeStackUnhandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 6591A4CB251156330040A5FA /* NativeStackUnhandledScenario.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		846B588ABB4674ABAB757586 /* libPods-reactnative-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 371411D2A466FE231036920D /* libPods-reactnative-tvOS.a */; };
+		96A7D74E2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A7D74A2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.m */; };
+		96A7D74F2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A7D74D2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.m */; };
 		9DE3655056EB996BD94DFAB3 /* libPods-reactnative-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7734725AC8FF4FE1ECBDC08A /* libPods-reactnative-tvOSTests.a */; };
 		A1F389D224C875E000C30B50 /* BugsnagModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A1F389D124C875E000C30B50 /* BugsnagModule.m */; };
 		A1F389E824C875FF00C30B50 /* AppNativeHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = A1F389D424C875FF00C30B50 /* AppNativeHandledScenario.m */; };
@@ -85,6 +87,10 @@
 		7ACFF03E09F562E6DC4E6F8D /* Pods-reactnative-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-reactnative-tvOSTests/Pods-reactnative-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = reactnative/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8FE91473D7AC052F10151CD4 /* Pods-reactnative-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-reactnative-tvOS/Pods-reactnative-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		96A7D74A2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NativeFeatureFlagsScenario.m; sourceTree = "<group>"; };
+		96A7D74B2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeFeatureFlagsScenario.h; sourceTree = "<group>"; };
+		96A7D74C2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FeatureFlagsNativeCrashScenario.h; sourceTree = "<group>"; };
+		96A7D74D2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FeatureFlagsNativeCrashScenario.m; sourceTree = "<group>"; };
 		A1F389D024C875E000C30B50 /* BugsnagModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagModule.h; path = "../../ios-module/BugsnagModule.h"; sourceTree = "<group>"; };
 		A1F389D124C875E000C30B50 /* BugsnagModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagModule.m; path = "../../ios-module/BugsnagModule.m"; sourceTree = "<group>"; };
 		A1F389D424C875FF00C30B50 /* AppNativeHandledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppNativeHandledScenario.m; sourceTree = "<group>"; };
@@ -256,6 +262,10 @@
 		A1F389D324C875E900C30B50 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				96A7D74C2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.h */,
+				96A7D74D2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.m */,
+				96A7D74B2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.h */,
+				96A7D74A2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.m */,
 				A1F389D924C875FF00C30B50 /* AppNativeHandledScenario.h */,
 				A1F389D424C875FF00C30B50 /* AppNativeHandledScenario.m */,
 				A1F389D824C875FF00C30B50 /* AppNativeUnhandledScenario.h */,
@@ -673,6 +683,7 @@
 				A1F389E924C875FF00C30B50 /* UserNativeClientScenario.m in Sources */,
 				01815B632578F91900541817 /* NativeStackHandledScenario.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				96A7D74E2799DD1A0043AAB6 /* NativeFeatureFlagsScenario.m in Sources */,
 				A1F389ED24C875FF00C30B50 /* BreadcrumbsNativeManualScenario.m in Sources */,
 				A1F63D2924CE541100C31ABC /* StartSessionScenario.m in Sources */,
 				A1F389F624C87F5000C30B50 /* MetadataNativeUnhandledScenario.m in Sources */,
@@ -685,6 +696,7 @@
 				A1F389F024C875FF00C30B50 /* DeviceNativeHandledScenario.m in Sources */,
 				A1F389F124C875FF00C30B50 /* ContextNativeCustomScenario.m in Sources */,
 				A1F389F724C87F5000C30B50 /* MetadataNativeScenario.m in Sources */,
+				96A7D74F2799DD1A0043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test/react-native/features/fixtures/rn0.64-hermes/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.64-hermes/ios/reactnative.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		96A7D75A2799DFB50043AAB6 /* NativeFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A7D7572799DFB50043AAB6 /* NativeFeatureFlagsScenario.m */; };
+		96A7D75B2799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A7D7592799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.m */; };
 		AA60280326703021000EBABD /* BugsnagModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA60280026703020000EBABD /* BugsnagModule.m */; };
 		AA6028B32670A077000EBABD /* NativeStackHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6028942670A076000EBABD /* NativeStackHandledScenario.swift */; };
 		AA6028B42670A077000EBABD /* PauseSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6028952670A076000EBABD /* PauseSessionScenario.m */; };
@@ -60,6 +62,10 @@
 		85DF2F09E06A9A3FDE77CED0 /* Pods-reactnative-reactnativeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative-reactnativeTests.release.xcconfig"; path = "Target Support Files/Pods-reactnative-reactnativeTests/Pods-reactnative-reactnativeTests.release.xcconfig"; sourceTree = "<group>"; };
 		94943FCB6092C2DC566FDFCD /* Pods-reactnative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative.release.xcconfig"; path = "Target Support Files/Pods-reactnative/Pods-reactnative.release.xcconfig"; sourceTree = "<group>"; };
 		958EFF09A7ED6639DAA9815F /* Pods-reactnative.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative.debug.xcconfig"; path = "Target Support Files/Pods-reactnative/Pods-reactnative.debug.xcconfig"; sourceTree = "<group>"; };
+		96A7D7562799DFB50043AAB6 /* NativeFeatureFlagsScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NativeFeatureFlagsScenario.h; path = "../../ios-module/Scenarios/NativeFeatureFlagsScenario.h"; sourceTree = "<group>"; };
+		96A7D7572799DFB50043AAB6 /* NativeFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NativeFeatureFlagsScenario.m; path = "../../ios-module/Scenarios/NativeFeatureFlagsScenario.m"; sourceTree = "<group>"; };
+		96A7D7582799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeatureFlagsNativeCrashScenario.h; path = "../../ios-module/Scenarios/FeatureFlagsNativeCrashScenario.h"; sourceTree = "<group>"; };
+		96A7D7592799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FeatureFlagsNativeCrashScenario.m; path = "../../ios-module/Scenarios/FeatureFlagsNativeCrashScenario.m"; sourceTree = "<group>"; };
 		AA60280026703020000EBABD /* BugsnagModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagModule.m; path = "../../ios-module/BugsnagModule.m"; sourceTree = "<group>"; };
 		AA60280126703020000EBABD /* BugsnagModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagModule.h; path = "../../ios-module/BugsnagModule.h"; sourceTree = "<group>"; };
 		AA6028912670A076000EBABD /* reactnative-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "reactnative-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -208,6 +214,10 @@
 		AA6028902670A054000EBABD /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				96A7D7582799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.h */,
+				96A7D7592799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.m */,
+				96A7D7562799DFB50043AAB6 /* NativeFeatureFlagsScenario.h */,
+				96A7D7572799DFB50043AAB6 /* NativeFeatureFlagsScenario.m */,
 				AA6028AD2670A077000EBABD /* AppNativeHandledScenario.h */,
 				AA60289C2670A077000EBABD /* AppNativeHandledScenario.m */,
 				AA6028922670A076000EBABD /* AppNativeUnhandledScenario.h */,
@@ -481,6 +491,7 @@
 				AA6028C32670A077000EBABD /* MetadataNativeUnhandledScenario.m in Sources */,
 				AA6028BD2670A077000EBABD /* ResumeSessionScenario.m in Sources */,
 				AA6028B72670A077000EBABD /* DeviceNativeHandledScenario.m in Sources */,
+				96A7D75A2799DFB50043AAB6 /* NativeFeatureFlagsScenario.m in Sources */,
 				AA6028C22670A077000EBABD /* Scenario.m in Sources */,
 				AA6028B42670A077000EBABD /* PauseSessionScenario.m in Sources */,
 				AA6028BF2670A077000EBABD /* DeviceNativeUnhandledScenario.m in Sources */,
@@ -493,6 +504,7 @@
 				AA6028C12670A077000EBABD /* ContextNativeCustomScenario.m in Sources */,
 				AA6028B62670A077000EBABD /* AppNativeHandledScenario.m in Sources */,
 				AA6028BE2670A077000EBABD /* MetadataNativeScenario.m in Sources */,
+				96A7D75B2799DFB50043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Goal
Ensure that React Native feature flags are included in reports generated when native code (JVM / Cocoa) crashes are reported. Any changes made to feature flags in JavaScript should be visible in native reports, and changes made to feature flags from native code should be visible in JavaScript reports.

## Testing
Added new Mazerunner scenarios