### PR TITLE
Add tests for React Navigation 6

### DIFF
--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -143,9 +143,7 @@ steps:
     artifact_paths:
       - build/r_navigation_0.63.apk
 
-  # See: PLAT-5173
   - label: ':ios: Build react-navigation 0.63 ipa'
-    skip: "See PLAT-5173"
     key: "react-navigation-0-63-ipa"
     timeout_in_minutes: 60
     agents:
@@ -446,9 +444,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  # See: PLAT-5173
-  - label: ':ios: react-navigation 0.63 iOS 13 end-to-end tests'
-    skip: "See PLAT-5173"
+  - label: ':ios: react-navigation 0.63 iOS 14 end-to-end tests'
     depends_on: "react-navigation-0-63-ipa"
     timeout_in_minutes: 60
     plugins:
@@ -462,9 +458,9 @@ steps:
         command:
           - --app=build/r_navigation_0.63.ipa
           - --farm=bs
-          - --device=IOS_13
+          - --device=IOS_14
           - --a11y-locator
-          - --appium-version=1.18.0
+          - --appium-version=1.21.0
           - --fail-fast
           - --resilient
           - features/navigation.feature

--- a/test/react-native/features/fixtures/app/react_navigation_js/app/scenarios/ReactNavigationBreadcrumbsDisabledScenario.js
+++ b/test/react-native/features/fixtures/app/react_navigation_js/app/scenarios/ReactNavigationBreadcrumbsDisabledScenario.js
@@ -7,7 +7,7 @@ import { createStackNavigator } from '@react-navigation/stack'
 export class ReactNavigationBreadcrumbsDisabledScenario extends Scenario {
   constructor (configuration, _jsConfig) {
     super()
-    configuration.enabledBreadcrumbTypes = []
+    configuration.enabledBreadcrumbTypes = ['process', 'request', 'log']
   }
 
   view () {

--- a/test/react-native/features/fixtures/app/react_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_navigation_js/install.sh
@@ -1,9 +1,19 @@
-npm i @bugsnag/plugin-react-navigation@$BUGSNAG_VERSION --registry=$REGISTRY_URL
+npm install @bugsnag/plugin-react-navigation@$BUGSNAG_VERSION --registry=$REGISTRY_URL
 
-npm i @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
-npm i @react-navigation/native@^5.9 --registry=$REGISTRY_URL
-npm i @react-navigation/stack@^5.14 --registry=$REGISTRY_URL
-npm i react-native-gesture-handler@^1.10 --registry=$REGISTRY_URL
-npm i react-native-reanimated@^1.13 --registry=$REGISTRY_URL
-npm i react-native-safe-area-context@^3.1 --registry=$REGISTRY_URL
-npm i react-native-screens@^2.18 --registry=$REGISTRY_URL
+if [ "$REACT_NATIVE_VERSION" = "rn0.60" ]; then
+    npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
+    npm install @react-navigation/native@^5.9 --registry=$REGISTRY_URL
+    npm install @react-navigation/stack@^5.14 --registry=$REGISTRY_URL
+    npm install react-native-gesture-handler@^1.10 --registry=$REGISTRY_URL
+    npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
+    npm install react-native-safe-area-context@^3.1 --registry=$REGISTRY_URL
+    npm install react-native-screens@^2.18 --registry=$REGISTRY_URL
+else
+    npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
+    npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
+    npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
+    npm install react-native-gesture-handler@^2.2 --registry=$REGISTRY_URL
+    npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
+    npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
+    npm install react-native-screens@3.10 --registry=$REGISTRY_URL
+fi

--- a/test/react-native/features/fixtures/ios-module/BugsnagModule.m
+++ b/test/react-native/features/fixtures/ios-module/BugsnagModule.m
@@ -62,7 +62,29 @@ BugsnagConfiguration *createConfiguration(NSDictionary * options) {
     [config setEnabledReleaseStages:[NSSet setWithArray:options[@"enabledReleaseStages"]]];
   }
   if (options[@"enabledBreadcrumbTypes"] && ![options[@"enabledBreadcrumbTypes"] isEqual:[NSNull null]]) {
-    [config setEnabledBreadcrumbTypes:[NSSet setWithArray:options[@"enabledBreadcrumbTypes"]]];
+    BSGEnabledBreadcrumbType types = BSGEnabledBreadcrumbTypeNone;
+
+    for (NSString *const type in options[@"enabledBreadcrumbTypes"]) {
+      NSString *lcType = [type lowercaseString];
+      NSLog(@"Enabling breadcrumb type: %@", lcType);
+
+      if ([lcType isEqualToString:@"navigation"]) {
+        types |= BSGEnabledBreadcrumbTypeNavigation;
+      } else if ([lcType isEqualToString:@"request"]) {
+        types |= BSGEnabledBreadcrumbTypeRequest;
+      } else if ([lcType isEqualToString:@"process"]) {
+        types |= BSGEnabledBreadcrumbTypeProcess;
+      } else if ([lcType isEqualToString:@"log"]) {
+        types |= BSGEnabledBreadcrumbTypeLog;
+      } else if ([lcType isEqualToString:@"user"]) {
+        types |= BSGEnabledBreadcrumbTypeUser;
+      } else if ([lcType isEqualToString:@"state"]) {
+        types |= BSGEnabledBreadcrumbTypeState;
+      } else if ([lcType isEqualToString:@"error"]) {
+        types |= BSGEnabledBreadcrumbTypeError;
+      }
+    }
+    [config setEnabledBreadcrumbTypes:types];
   }
   if (options[@"configMetaData"] != nil) {
     NSDictionary *configMetaData = options[@"configMetaData"];

--- a/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
+++ b/test/react-native/features/fixtures/reactnative/module/BugsnagModule.java
@@ -138,7 +138,10 @@ public class BugsnagModule extends ReactContextBaseJavaModule {
         } else {
             Set<BreadcrumbType> enabledBreadcrumbTypes = new HashSet<BreadcrumbType>();
             ReadableArray ar = options.getArray("enabledBreadcrumbTypes");
-            for (int i = 0; i < ar.size(); i++) enabledBreadcrumbTypes.add(BreadcrumbType.valueOf(ar.getString(i)));
+            for (int i = 0; i < ar.size(); i++) {
+                BreadcrumbType type = BreadcrumbType.valueOf(ar.getString(i).toUpperCase());
+                enabledBreadcrumbTypes.add(type);
+            }
             config.setEnabledBreadcrumbTypes(enabledBreadcrumbTypes);
         }
       }


### PR DESCRIPTION
## Goal

Updates the React Navigation tests for RN 0.63 run with React Navigation v6.

## Design

A fix was needed to the test fixture code responsible for setting the enabledBreadcrumbTypes in Bugsnag configuration on iOS to achieve this.

## Changeset

- Enable React Navigation tests
- Bumpy to React Navigation v6
- Fix setting of `enabledBreadcrumbTypes` in iOS tests
- Update test scenario to demonstrate setting of `enabledBreadcrumbTypes` in action

## Testing

Covered by CI and I have also run the navigation tests on iOS locally 30 times without a failure.