### PR TITLE
Miscellaneous CI improvements

### DIFF
--- a/.buildkite/expo-pipeline.yml
+++ b/.buildkite/expo-pipeline.yml
@@ -114,7 +114,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -139,7 +138,6 @@ steps:
           - --appium-version=1.16.0
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -171,7 +169,6 @@ steps:
           - --retry=2
           - --appium-version=1.18.0
           - --capabilities={"appWaitForLaunch":"false"}
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -200,7 +197,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -227,7 +223,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -254,7 +249,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -280,7 +274,6 @@ steps:
           - --appium-version=1.16.0
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -305,7 +298,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --resilient
     concurrency: 9
     concurrency_group: 'browserstack-app'
     concurrency_method: eager

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -28,9 +28,9 @@ steps:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
         command:
-          - "features/cli-tests"
-          - "--fail-fast"
-          - "--retry=2"
+          - --fail-fast
+          - --retry=2
+          - features/cli-tests
     env:
       REACT_NATIVE_VERSION: "rn0_60"
 
@@ -45,9 +45,9 @@ steps:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
         command:
-          - "features/cli-tests"
-          - "--fail-fast"
-          - "--retry=2"
+          - --fail-fast
+          - --retry=2
+          - features/cli-tests
     env:
       REACT_NATIVE_VERSION: "rn0_61"
 
@@ -62,9 +62,9 @@ steps:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
         command:
-          - "features/cli-tests"
-          - "--fail-fast"
-          - "--retry=2"
+          - --fail-fast
+          - --retry=2
+          - features/cli-tests
     env:
       REACT_NATIVE_VERSION: "rn0_62"
 
@@ -79,9 +79,9 @@ steps:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
         command:
-          - "features/cli-tests"
-          - "--fail-fast"
-          - "--retry=2"
+          - --fail-fast
+          - --retry=2
+          - features/cli-tests
     env:
       REACT_NATIVE_VERSION: "rn0_63"
 
@@ -96,9 +96,9 @@ steps:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
         command:
-          - "features/cli-tests"
-          - "--fail-fast"
-          - "--retry=2"
+          - --fail-fast
+          - --retry=2
+          - features/cli-tests
     env:
       REACT_NATIVE_VERSION: "rn0_63_expo_ejected"
 
@@ -113,9 +113,9 @@ steps:
         run: react-native-cli-tool-maze-runner
         use-aliases: true
         command:
-          - "features/cli-tests"
-          - "--fail-fast"
-          - "--retry=2"
+          - --fail-fast
+          - --retry=2
+          - features/cli-tests
     env:
       REACT_NATIVE_VERSION: "rn0_64"
 

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -30,6 +30,7 @@ steps:
         command:
           - "features/cli-tests"
           - "--fail-fast"
+          - "--retry=2"
     env:
       REACT_NATIVE_VERSION: "rn0_60"
 
@@ -46,6 +47,7 @@ steps:
         command:
           - "features/cli-tests"
           - "--fail-fast"
+          - "--retry=2"
     env:
       REACT_NATIVE_VERSION: "rn0_61"
 
@@ -62,6 +64,7 @@ steps:
         command:
           - "features/cli-tests"
           - "--fail-fast"
+          - "--retry=2"
     env:
       REACT_NATIVE_VERSION: "rn0_62"
 
@@ -78,6 +81,7 @@ steps:
         command:
           - "features/cli-tests"
           - "--fail-fast"
+          - "--retry=2"
     env:
       REACT_NATIVE_VERSION: "rn0_63"
 
@@ -94,6 +98,7 @@ steps:
         command:
           - "features/cli-tests"
           - "--fail-fast"
+          - "--retry=2"
     env:
       REACT_NATIVE_VERSION: "rn0_63_expo_ejected"
 
@@ -110,6 +115,7 @@ steps:
         command:
           - "features/cli-tests"
           - "--fail-fast"
+          - "--retry=2"
     env:
       REACT_NATIVE_VERSION: "rn0_64"
 

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -242,7 +242,6 @@ steps:
         - --device=ANDROID_9_0
         - --a11y-locator
         - --fail-fast
-        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -267,7 +266,6 @@ steps:
         - --a11y-locator
         - --appium-version=1.18.0
         - --fail-fast
-        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -291,7 +289,6 @@ steps:
         - --device=ANDROID_9_0
         - --a11y-locator
         - --fail-fast
-        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -315,7 +312,6 @@ steps:
           - --device=ANDROID_11_0
           - --a11y-locator
           - --fail-fast
-          - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -340,7 +336,6 @@ steps:
         - --a11y-locator
         - --appium-version=1.18.0
         - --fail-fast
-        - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -365,7 +360,6 @@ steps:
           - --a11y-locator
           - --appium-version=1.18.0
           - --fail-fast
-          - --resilient
     env:
       SKIP_NAVIGATION_SCENARIOS: "true"
     concurrency: 9
@@ -389,7 +383,6 @@ steps:
         - --device=ANDROID_9_0
         - --a11y-locator
         - --fail-fast
-        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -415,7 +408,6 @@ steps:
           - --a11y-locator
           - --appium-version=1.18.0
           - --fail-fast
-          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -438,7 +430,6 @@ steps:
         - --device=ANDROID_9_0
         - --a11y-locator
         - --fail-fast
-        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -462,7 +453,6 @@ steps:
           - --a11y-locator
           - --appium-version=1.21.0
           - --fail-fast
-          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -485,7 +475,6 @@ steps:
         - --device=ANDROID_9_0
         - --a11y-locator
         - --fail-fast
-        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -511,7 +500,6 @@ steps:
           - --appium-version=1.18.0
           - --a11y-locator
           - --fail-fast
-          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -534,7 +522,6 @@ steps:
         - --device=ANDROID_9_0
         - --a11y-locator
         - --fail-fast
-        - --resilient
         - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -560,7 +547,6 @@ steps:
           - --a11y-locator
           - --appium-version=1.18.0
           - --fail-fast
-          - --resilient
           - features/navigation.feature
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -225,7 +225,7 @@ steps:
   #
   # End-to-end tests
   #
-  - label: ':android: RN 0.60 Android 9 end-to-end tests'
+  - label: ':android: RN 0.60 Android 11 end-to-end tests'
     depends_on: "rn-0-60-apk"
     timeout_in_minutes: 60
     plugins:
@@ -239,7 +239,7 @@ steps:
         command:
         - --app=build/rn0.60.apk
         - --farm=bs
-        - --device=ANDROID_9_0
+        - --device=ANDROID_11_0
         - --a11y-locator
         - --fail-fast
     env:
@@ -272,7 +272,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: RN 0.63 Android 9 end-to-end tests'
+  - label: ':android: RN 0.63 Android 11 end-to-end tests'
     depends_on: "rn-0-63-apk"
     timeout_in_minutes: 60
     plugins:
@@ -286,7 +286,7 @@ steps:
         command:
         - --app=build/rn0.63.apk
         - --farm=bs
-        - --device=ANDROID_9_0
+        - --device=ANDROID_11_0
         - --a11y-locator
         - --fail-fast
     env:
@@ -366,7 +366,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: react-navigation 0.60 Android 9 end-to-end tests'
+  - label: ':android: react-navigation 0.60 Android 11 end-to-end tests'
     depends_on: "react-navigation-0-60-apk"
     timeout_in_minutes: 60
     plugins:
@@ -380,7 +380,7 @@ steps:
         command:
         - --app=build/r_navigation_0.60.apk
         - --farm=bs
-        - --device=ANDROID_9_0
+        - --device=ANDROID_11_0
         - --a11y-locator
         - --fail-fast
         - features/navigation.feature
@@ -413,7 +413,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: react-navigation 0.63 Android 9 end-to-end tests'
+  - label: ':android: react-navigation 0.63 Android 11 end-to-end tests'
     depends_on: "react-navigation-0-63-apk"
     timeout_in_minutes: 60
     plugins:
@@ -427,7 +427,7 @@ steps:
         command:
         - --app=build/r_navigation_0.63.apk
         - --farm=bs
-        - --device=ANDROID_9_0
+        - --device=ANDROID_11_0
         - --a11y-locator
         - --fail-fast
         - features/navigation.feature
@@ -458,7 +458,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: react-native-navigation 0.60 Android 9 end-to-end tests'
+  - label: ':android: react-native-navigation 0.60 Android 11 end-to-end tests'
     depends_on: "react-native-navigation-0-60-apk"
     timeout_in_minutes: 60
     plugins:
@@ -472,7 +472,7 @@ steps:
         command:
         - --app=build/r_native_navigation_0.60.apk
         - --farm=bs
-        - --device=ANDROID_9_0
+        - --device=ANDROID_11_0
         - --a11y-locator
         - --fail-fast
         - features/navigation.feature
@@ -505,7 +505,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: react-native-navigation 0.63 Android 9 end-to-end tests'
+  - label: ':android: react-native-navigation 0.63 Android 11 end-to-end tests'
     depends_on: "react-native-navigation-0-63-apk"
     timeout_in_minutes: 60
     plugins:
@@ -519,7 +519,7 @@ steps:
         command:
         - --app=build/r_native_navigation_0.63.apk
         - --farm=bs
-        - --device=ANDROID_9_0
+        - --device=ANDROID_11_0
         - --a11y-locator
         - --fail-fast
         - features/navigation.feature

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -1,6 +1,6 @@
 BeforeAll do
-  Maze.config.receive_no_requests_wait = 15
-  Maze.config.receive_requests_wait = 60 # Theoretical maximum on Android
+  Maze.config.receive_no_requests_wait = 30
+  Maze.config.receive_requests_wait = 30
 end
 
 Before('@android_only') do |scenario|

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -1,5 +1,6 @@
 BeforeAll do
-  Maze.config.receive_no_requests_wait = 15 if Maze.config.respond_to? :receive_no_requests_wait=
+  Maze.config.receive_no_requests_wait = 15
+  Maze.config.receive_requests_wait = 60 # Theoretical maximum on Android
 end
 
 Before('@android_only') do |scenario|


### PR DESCRIPTION
## Goal

A few miscellaneous CI pipeline improvements:
- Allow retries on known-flaky RN CLI tests, to reduce frustration for developers while a fix is being worked on.
- Bump Android to 11 for RN tests in the hope of quicker/more stable runs.
- Increase maximum wait to receive errors to 60 seconds - the theoretical maximum for the Android notifier.
- Remove use of the resilient Appium driver.  It didn't work as intended and only confused things in the case of a genuine problem.

The retry mechanism in Maze Runner is currently broken, but will be fixed shortly.

## Testing

Covered by CI.