### PR TITLE
Automatically retry the Electron performance test

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
     "local-npm:start": "verdaccio --config test/electron/local-npm-config.yml --listen 0.0.0.0:5539",
     "local-npm:publish-all": "lerna publish \"$VERSION_IDENTIFIER\" --yes --force-publish --exact --no-push --no-git-reset --no-git-tag-version --registry 'http://0.0.0.0:5539'",
     "local-npm:publish-all-win32": "lerna publish %VERSION_IDENTIFIER% --yes --force-publish --exact --no-push --no-git-reset --no-git-tag-version --registry 'http://0.0.0.0:5539'",
-    "test:electron": "xvfb-maybe --auto-servernum -- cucumber-js test/electron/features"
+    "test:electron": "xvfb-maybe --auto-servernum -- cucumber-js test/electron/features --retry 3 --retry-tag-filter @flaky"
   }
 }

--- a/test/electron/features/performance.feature
+++ b/test/electron/features/performance.feature
@@ -1,5 +1,5 @@
+@flaky
 Feature: Startup performance
-
     Scenario Outline: Notifier starts in a reasonable time frame
         Given I launch an app with configuration:
             | bugsnag | <config> |


### PR DESCRIPTION
## Goal

As this runs on GH Actions, it's inherently unreliable as we could be given a very over-provisioned VM so the performance is unpredictable

Until we can migrate to a more stable platform, we can only retry this test until it passes — there is some value in knowing it will pass when retried, rather than always failing

I'd like to avoid increasing the allowed time any further — 150ms is already a lot and is just a compromise to allow the test to pass on CI (locally this test runs _significantly_ quicker)