### PR TITLE
Run the EventApiKeyOverrideScenario on all react-native platforms

### DIFF
--- a/test/react-native/features/api-key-override.feature
+++ b/test/react-native/features/api-key-override.feature
@@ -1,5 +1,4 @@
-@ios_only
-Feature: iOS API key override
+Feature: API key override
 
 Scenario: Handled JS error overrides API key
   When I run "EventApiKeyOverrideScenario"


### PR DESCRIPTION
## Goal
Test that the `Event.apiKey` can be overridden in callbacks on both Android and iOS
