### PR TITLE
Fix filestore test and test deprecation warnings

### DIFF
--- a/packages/delivery-electron/test/delivery.test-main.ts
+++ b/packages/delivery-electron/test/delivery.test-main.ts
@@ -6,9 +6,8 @@ import { EventDeliveryPayload } from '@bugsnag/core/client'
 import { Client } from '@bugsnag/core'
 import PayloadQueue from '../queue'
 import PayloadDeliveryLoop from '../payload-loop'
-import { promises } from 'fs'
+import { mkdtemp, rm } from 'fs/promises'
 import EventEmitter from 'events'
-const { mkdtemp, rmdir } = promises
 
 const noopLogger = {
   debug: () => {},
@@ -77,8 +76,8 @@ describe('delivery: electron', () => {
 
   afterEach(async () => {
     const paths = filestore.getPaths()
-    await rmdir(paths.events, { recursive: true })
-    await rmdir(paths.sessions, { recursive: true })
+    await rm(paths.events, { recursive: true })
+    await rm(paths.sessions, { recursive: true })
   })
 
   it('sends events successfully', done => {

--- a/packages/delivery-electron/test/queue.test.ts
+++ b/packages/delivery-electron/test/queue.test.ts
@@ -1,7 +1,7 @@
-import { promises, constants } from 'fs'
+import { constants } from 'fs'
+import { access, mkdtemp, readdir, readFile, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import PayloadQueue from '../queue'
-const { access, mkdtemp, readdir, readFile, rmdir, writeFile } = promises
 const { F_OK } = constants
 
 const invalidDir = () => process.platform === 'win32' ? '6:\\non\\existent' : '/dev/null/non/existent'
@@ -14,7 +14,7 @@ describe('delivery: electron -> queue', () => {
   })
 
   afterEach(async () => {
-    await rmdir(tempdir, { recursive: true })
+    await rm(tempdir, { recursive: true })
   })
 
   describe('init()', () => {

--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -1,12 +1,13 @@
 import { FileStore } from '..'
 import { basename, dirname, join } from 'path'
 import { promises } from 'fs'
+import { tmpdir } from 'os'
 
-const { mkdir, readFile, rmdir, writeFile } = promises
+const { mkdir, readFile, rm, writeFile } = promises
 
 describe('FileStore', () => {
-  const fixtures = join(__dirname, 'fixtures', 'storage')
-  const crashes = join(__dirname, 'fixtures', 'crashes')
+  const fixtures = join(tmpdir(), 'fixtures', 'storage')
+  const crashes = join(tmpdir(), 'fixtures', 'crashes')
   let store: FileStore
 
   beforeEach(async () => {
@@ -16,8 +17,8 @@ describe('FileStore', () => {
   })
 
   afterEach(async () => {
-    await rmdir(fixtures, { recursive: true })
-    await rmdir(crashes, { recursive: true })
+    await rm(fixtures, { recursive: true, force: true })
+    await rm(crashes, { recursive: true, force: true })
   })
 
   describe('getPaths()', () => {

--- a/packages/electron-filestore/test/filestore.test.ts
+++ b/packages/electron-filestore/test/filestore.test.ts
@@ -1,9 +1,7 @@
 import { FileStore } from '..'
 import { basename, dirname, join } from 'path'
-import { promises } from 'fs'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
-
-const { mkdir, readFile, rm, writeFile } = promises
 
 describe('FileStore', () => {
   const fixtures = join(tmpdir(), 'fixtures', 'storage')

--- a/packages/plugin-electron-client-state-persistence/test/persistence.test.ts
+++ b/packages/plugin-electron-client-state-persistence/test/persistence.test.ts
@@ -1,8 +1,6 @@
-import { promises } from 'fs'
+import { mkdtemp, readFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { NativeClient } from '..'
-
-const { mkdtemp, readFile, rmdir } = promises
 
 describe('persisting changes to disk', () => {
   let tempdir: string = ''
@@ -22,7 +20,7 @@ describe('persisting changes to disk', () => {
 
   afterEach(async (done) => {
     NativeClient.uninstall()
-    await rmdir(tempdir, { recursive: true })
+    await rm(tempdir, { recursive: true })
     done()
   })
 

--- a/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
@@ -1,8 +1,6 @@
-import { promises } from 'fs'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import sendMinidumpFactory from '../send-minidump'
-
-const { mkdtemp, rmdir, writeFile } = promises
 
 const client = {
   _config: {
@@ -21,7 +19,7 @@ describe('electron-minidump-delivery: sendMinidump', () => {
     minidumpsPath = await mkdtemp('send-minidumps-')
   })
 
-  afterEach(() => rmdir(minidumpsPath, { recursive: true }))
+  afterEach(() => rm(minidumpsPath, { recursive: true }))
 
   it('sends minidump successfully', async () => {
     const net = {


### PR DESCRIPTION
## Filestore test

These tests try to cleanup by deleting directories after each test. However, if one of the directories doesn't exist then some of these tests will fail with an ENOENT error

The filestore itself should create these directories in its `init` method, however some of the tests don't need to call this and so never create the directories, leading to failures — this doesn't happen on CI because it's a change in Node v16 and we run the unit tests on v14 ([see "history" in the docs](https://nodejs.org/api/fs.html#fspromisesrmdirpath-options))

Using `rm` instead of `rmdir` gives us the `force` option, which works like `rm -f` and ignores the error if the directory doesn't exist

## Deprecations

`rmdir` with the `recursive` option is deprecated as of Node v16, so I've switched to the replacement `rm` to avoid warnings. We were only using this in the unit tests, so there's no issue with compatibility

## `fs/promises`

As we're running the unit tests on v14 we can also import functions from `fs/promises` directly, rather than doing the `fs.promises` dance:

```js
import { promises } from 'fs'
const { stuff } = promises

// becomes

import { stuff } from 'fs/promises'
```