### PR TITLE
plugin-react-navigation: Allow React Navigation v6 as a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### TBD
+
+### Changed
+
+- (plugin-react-navigation): Allow React Navigation v6 as a peer dependency [#1691](https://github.com/bugsnag/bugsnag-js/pull/1691)
+
 ### 7.16.1 (2022-02-02)
 
 ### Fixed

--- a/packages/plugin-react-navigation/package-lock.json
+++ b/packages/plugin-react-navigation/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@bugsnag/plugin-react-navigation",
-			"version": "7.14.1",
+			"version": "7.16.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@react-navigation/native": "^5.7.3",
@@ -18,59 +18,34 @@
 			},
 			"peerDependencies": {
 				"@bugsnag/core": "^7.0.0",
-				"@react-navigation/native": "^5.0"
+				"@react-navigation/native": "^5.0 || ^6.0"
 			}
-		},
-		"node_modules/@bugsnag/core": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.14.0.tgz",
-			"integrity": "sha512-DKN7hNEA6zEOgnucihgNEiMmx4GVaFHD9dJUYQFiouAIL19R/TLgG6B+pGC+QAqHVYsCUt5XDnG8jD+J+3fKOA==",
-			"peer": true,
-			"dependencies": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "^6.0.0",
-				"error-stack-parser": "^2.0.3",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"node_modules/@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==",
-			"peer": true
-		},
-		"node_modules/@bugsnag/safe-json-stringify": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
-			"integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
-			"peer": true
 		},
 		"node_modules/@react-navigation/core": {
-			"version": "5.12.3",
-			"resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.3.tgz",
-			"integrity": "sha512-aEOTAw4FRRNsNu6F9ibLk3SVSs4Res8BI832NEZN6qUto5ZgtuYnQHWeWV2cZ43Nc9KvUyQC/vXvO2RScwgFwA==",
+			"version": "5.16.1",
+			"resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.16.1.tgz",
+			"integrity": "sha512-3AToC7vPNeSNcHFLd1h71L6u34hfXoRAS1CxF9Fc4uC8uOrVqcNvphpeFbE0O9Bw6Zpl0BnMFl7E5gaL3KGzNA==",
 			"dev": true,
 			"dependencies": {
-				"@react-navigation/routers": "^5.4.11",
+				"@react-navigation/routers": "^5.7.4",
 				"escape-string-regexp": "^4.0.0",
-				"nanoid": "^3.1.12",
-				"query-string": "^6.13.1",
-				"react-is": "^16.13.0",
-				"use-subscription": "^1.4.0"
+				"nanoid": "^3.1.15",
+				"query-string": "^6.13.6",
+				"react-is": "^16.13.0"
 			},
 			"peerDependencies": {
 				"react": "*"
 			}
 		},
 		"node_modules/@react-navigation/native": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.7.3.tgz",
-			"integrity": "sha512-bXb1g/cLpGF2DW1Vxk90Ch5vbaZTk5b/4Fn5xjQlueQODgc9ca+GPEssKZ84hCrNmS+Xg+iK1m/ArawLF5gMlw==",
+			"version": "5.9.8",
+			"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.9.8.tgz",
+			"integrity": "sha512-DNbcDHXQPSFDLn51kkVVJjT3V7jJy2GztNYZe/2bEg29mi5QEcHHcpifjMCtyFKntAOWzKlG88UicIQ17UEghg==",
 			"dev": true,
 			"dependencies": {
-				"@react-navigation/core": "^5.12.3",
-				"nanoid": "^3.1.12"
+				"@react-navigation/core": "^5.16.1",
+				"escape-string-regexp": "^4.0.0",
+				"nanoid": "^3.1.15"
 			},
 			"peerDependencies": {
 				"react": "*",
@@ -78,52 +53,59 @@
 			}
 		},
 		"node_modules/@react-navigation/routers": {
-			"version": "5.4.11",
-			"resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.4.11.tgz",
-			"integrity": "sha512-J/CsHdIjYBRe81UUiLOoz9NSrQ91uP23Oe21QPCALInRHx+rfwo2oPl6Fn8xAa7n8Dtt2oQUGyF+g5d05cB74w==",
+			"version": "5.7.4",
+			"resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.7.4.tgz",
+			"integrity": "sha512-0N202XAqsU/FlE53Nmh6GHyMtGm7g6TeC93mrFAFJOqGRKznT0/ail+cYlU6tNcPA9AHzZu1Modw1eoDINSliQ==",
 			"dev": true,
 			"dependencies": {
-				"nanoid": "^3.1.12"
+				"nanoid": "^3.1.15"
 			}
 		},
 		"node_modules/@types/prop-types": {
-			"version": "15.7.3",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+			"version": "15.7.4",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "16.9.49",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-			"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+			"version": "16.14.23",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.23.tgz",
+			"integrity": "sha512-WngBZLuSkP4IAgPi0HOsGCHo6dn3CcuLQnCfC17VbA7YBgipZiZoTOhObwl/93DsFW0Y2a/ZXeonpW4DxirEJg==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
+				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@types/react-native": {
-			"version": "0.63.20",
-			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.20.tgz",
-			"integrity": "sha512-APnxRTDxbWw/IYjvwvXkhYJiz1gahyVA579pJqAVsEfZ+ZUwUHZpWKnexobyH5NmRJHuA/8LrThyps/BW3SYXA==",
+			"version": "0.63.60",
+			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.60.tgz",
+			"integrity": "sha512-AHWCfwXZr3ESbD1G6hAKF+6w986RchYycj+4dm1psAYTEnKCpZAtPM01qrJwb8CI3OCmJ1bl8kAPNzmcnRdfYg==",
 			"dev": true,
 			"dependencies": {
 				"@types/react": "*"
 			}
 		},
 		"node_modules/@types/react-test-renderer": {
-			"version": "16.9.3",
-			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
-			"integrity": "sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==",
+			"version": "16.9.5",
+			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz",
+			"integrity": "sha512-C4cN7C2uSSGOYelp2XfdtJb5TsCP+QiZ+0Bm4U3ZfUswN8oN9O/l86XO/OvBSFCmWY7w75fzsQvZ50eGkFN34A==",
 			"dev": true,
 			"dependencies": {
-				"@types/react": "*"
+				"@types/react": "^16"
 			}
 		},
+		"node_modules/@types/scheduler": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+			"dev": true
+		},
 		"node_modules/csstype": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-			"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
 			"dev": true
 		},
 		"node_modules/decode-uri-component": {
@@ -133,15 +115,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
-			}
-		},
-		"node_modules/error-stack-parser": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-			"peer": true,
-			"dependencies": {
-				"stackframe": "^1.1.1"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -156,11 +129,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=",
-			"peer": true
+		"node_modules/filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -181,15 +157,15 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-			"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
 			"engines": {
-				"node": "^10 || ^12 || >=13.7"
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
 		"node_modules/object-assign": {
@@ -202,23 +178,24 @@
 			}
 		},
 		"node_modules/prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
+				"react-is": "^16.13.1"
 			}
 		},
 		"node_modules/query-string": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
-			"integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+			"integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
 			"dev": true,
 			"dependencies": {
 				"decode-uri-component": "^0.2.0",
+				"filter-obj": "^1.1.0",
 				"split-on-first": "^1.0.0",
 				"strict-uri-encode": "^2.0.0"
 			},
@@ -230,9 +207,9 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
 			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
@@ -250,9 +227,9 @@
 			"dev": true
 		},
 		"node_modules/react-test-renderer": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
-			"integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+			"integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
 			"dev": true,
 			"dependencies": {
 				"object-assign": "^4.1.1",
@@ -261,7 +238,7 @@
 				"scheduler": "^0.19.1"
 			},
 			"peerDependencies": {
-				"react": "^16.13.1"
+				"react": "^16.14.0"
 			}
 		},
 		"node_modules/scheduler": {
@@ -283,21 +260,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/stack-generator": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-			"integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
-			"peer": true,
-			"dependencies": {
-				"stackframe": "^1.1.1"
-			}
-		},
-		"node_modules/stackframe": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-			"peer": true
-		},
 		"node_modules/strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -306,117 +268,87 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/use-subscription": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.4.1.tgz",
-			"integrity": "sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4.1.1"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0"
-			}
 		}
 	},
 	"dependencies": {
-		"@bugsnag/core": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.14.0.tgz",
-			"integrity": "sha512-DKN7hNEA6zEOgnucihgNEiMmx4GVaFHD9dJUYQFiouAIL19R/TLgG6B+pGC+QAqHVYsCUt5XDnG8jD+J+3fKOA==",
-			"peer": true,
-			"requires": {
-				"@bugsnag/cuid": "^3.0.0",
-				"@bugsnag/safe-json-stringify": "^6.0.0",
-				"error-stack-parser": "^2.0.3",
-				"iserror": "0.0.2",
-				"stack-generator": "^2.0.3"
-			}
-		},
-		"@bugsnag/cuid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-			"integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==",
-			"peer": true
-		},
-		"@bugsnag/safe-json-stringify": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
-			"integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
-			"peer": true
-		},
 		"@react-navigation/core": {
-			"version": "5.12.3",
-			"resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.3.tgz",
-			"integrity": "sha512-aEOTAw4FRRNsNu6F9ibLk3SVSs4Res8BI832NEZN6qUto5ZgtuYnQHWeWV2cZ43Nc9KvUyQC/vXvO2RScwgFwA==",
+			"version": "5.16.1",
+			"resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.16.1.tgz",
+			"integrity": "sha512-3AToC7vPNeSNcHFLd1h71L6u34hfXoRAS1CxF9Fc4uC8uOrVqcNvphpeFbE0O9Bw6Zpl0BnMFl7E5gaL3KGzNA==",
 			"dev": true,
 			"requires": {
-				"@react-navigation/routers": "^5.4.11",
+				"@react-navigation/routers": "^5.7.4",
 				"escape-string-regexp": "^4.0.0",
-				"nanoid": "^3.1.12",
-				"query-string": "^6.13.1",
-				"react-is": "^16.13.0",
-				"use-subscription": "^1.4.0"
+				"nanoid": "^3.1.15",
+				"query-string": "^6.13.6",
+				"react-is": "^16.13.0"
 			}
 		},
 		"@react-navigation/native": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.7.3.tgz",
-			"integrity": "sha512-bXb1g/cLpGF2DW1Vxk90Ch5vbaZTk5b/4Fn5xjQlueQODgc9ca+GPEssKZ84hCrNmS+Xg+iK1m/ArawLF5gMlw==",
+			"version": "5.9.8",
+			"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.9.8.tgz",
+			"integrity": "sha512-DNbcDHXQPSFDLn51kkVVJjT3V7jJy2GztNYZe/2bEg29mi5QEcHHcpifjMCtyFKntAOWzKlG88UicIQ17UEghg==",
 			"dev": true,
 			"requires": {
-				"@react-navigation/core": "^5.12.3",
-				"nanoid": "^3.1.12"
+				"@react-navigation/core": "^5.16.1",
+				"escape-string-regexp": "^4.0.0",
+				"nanoid": "^3.1.15"
 			}
 		},
 		"@react-navigation/routers": {
-			"version": "5.4.11",
-			"resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.4.11.tgz",
-			"integrity": "sha512-J/CsHdIjYBRe81UUiLOoz9NSrQ91uP23Oe21QPCALInRHx+rfwo2oPl6Fn8xAa7n8Dtt2oQUGyF+g5d05cB74w==",
+			"version": "5.7.4",
+			"resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.7.4.tgz",
+			"integrity": "sha512-0N202XAqsU/FlE53Nmh6GHyMtGm7g6TeC93mrFAFJOqGRKznT0/ail+cYlU6tNcPA9AHzZu1Modw1eoDINSliQ==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.1.12"
+				"nanoid": "^3.1.15"
 			}
 		},
 		"@types/prop-types": {
-			"version": "15.7.3",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+			"version": "15.7.4",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.9.49",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-			"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+			"version": "16.14.23",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.23.tgz",
+			"integrity": "sha512-WngBZLuSkP4IAgPi0HOsGCHo6dn3CcuLQnCfC17VbA7YBgipZiZoTOhObwl/93DsFW0Y2a/ZXeonpW4DxirEJg==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
+				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"@types/react-native": {
-			"version": "0.63.20",
-			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.20.tgz",
-			"integrity": "sha512-APnxRTDxbWw/IYjvwvXkhYJiz1gahyVA579pJqAVsEfZ+ZUwUHZpWKnexobyH5NmRJHuA/8LrThyps/BW3SYXA==",
+			"version": "0.63.60",
+			"resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.60.tgz",
+			"integrity": "sha512-AHWCfwXZr3ESbD1G6hAKF+6w986RchYycj+4dm1psAYTEnKCpZAtPM01qrJwb8CI3OCmJ1bl8kAPNzmcnRdfYg==",
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
 			}
 		},
 		"@types/react-test-renderer": {
-			"version": "16.9.3",
-			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
-			"integrity": "sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==",
+			"version": "16.9.5",
+			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz",
+			"integrity": "sha512-C4cN7C2uSSGOYelp2XfdtJb5TsCP+QiZ+0Bm4U3ZfUswN8oN9O/l86XO/OvBSFCmWY7w75fzsQvZ50eGkFN34A==",
 			"dev": true,
 			"requires": {
-				"@types/react": "*"
+				"@types/react": "^16"
 			}
 		},
+		"@types/scheduler": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+			"dev": true
+		},
 		"csstype": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-			"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
 			"dev": true
 		},
 		"decode-uri-component": {
@@ -425,26 +357,17 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"error-stack-parser": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-			"peer": true,
-			"requires": {
-				"stackframe": "^1.1.1"
-			}
-		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true
 		},
-		"iserror": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-			"integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=",
-			"peer": true
+		"filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -462,9 +385,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "3.1.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-			"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
 			"dev": true
 		},
 		"object-assign": {
@@ -474,31 +397,32 @@
 			"dev": true
 		},
 		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
+				"react-is": "^16.13.1"
 			}
 		},
 		"query-string": {
-			"version": "6.13.2",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
-			"integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+			"integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
 			"dev": true,
 			"requires": {
 				"decode-uri-component": "^0.2.0",
+				"filter-obj": "^1.1.0",
 				"split-on-first": "^1.0.0",
 				"strict-uri-encode": "^2.0.0"
 			}
 		},
 		"react": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
@@ -513,9 +437,9 @@
 			"dev": true
 		},
 		"react-test-renderer": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
-			"integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+			"integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
@@ -540,35 +464,11 @@
 			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
 			"dev": true
 		},
-		"stack-generator": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-			"integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
-			"peer": true,
-			"requires": {
-				"stackframe": "^1.1.1"
-			}
-		},
-		"stackframe": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-			"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
-			"peer": true
-		},
 		"strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
 			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
 			"dev": true
-		},
-		"use-subscription": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.4.1.tgz",
-			"integrity": "sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.1.1"
-			}
 		}
 	}
 }

--- a/packages/plugin-react-navigation/package.json
+++ b/packages/plugin-react-navigation/package.json
@@ -32,6 +32,6 @@
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-navigation/native": "^5.0"
+    "@react-navigation/native": "^5.0 || ^6.0"
   }
 }


### PR DESCRIPTION
## Goal

Allows React Navigation v6 as a peer dependency of `@bugsnag/plugin-react-navigation` to fix a peer dependency warning. No changes to the plugin are required

## Testing

This is tested in the Maze Runner tests:

https://github.com/bugsnag/bugsnag-js/blob/fdb9e562c4d295134cbc819d5b74a00b5212be05/test/react-native/features/fixtures/app/react_navigation_js/install.sh#L12-L18

I've not updated the unit tests to run against v6 because it requires a Typescript update, which causes a host of dependency issues