### PR TITLE
explicitly build prior to version/publish

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -26,8 +26,16 @@ npm ci
 npm run bootstrap -- --ci
 
 npx lerna run build \
-    --ignore @bugsnag/plugin-electron-app \
-    --ignore @bugsnag/plugin-electron-client-state-persistence
+  --scope @bugsnag/node \
+  --scope @bugsnag/browser \
+  --scope @bugsnag/expo
+  
+npx lerna run build \
+  --ignore @bugsnag/node\
+  --ignore @bugsnag/browser \
+  --ignore @bugsnag/expo \
+  --ignore @bugsnag/plugin-electron-app \
+  --ignore @bugsnag/plugin-electron-client-state-persistence
 
 # check if the browser package changed – if it didn't we don't need to upload to the CDN
 BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/js$ || test $? = 1;)

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -25,6 +25,10 @@ cd /app/bugsnag-js
 npm ci
 npm run bootstrap -- --ci
 
+npx lerna run build \
+    --ignore @bugsnag/plugin-electron-app \
+    --ignore @bugsnag/plugin-electron-client-state-persistence
+
 # check if the browser package changed – if it didn't we don't need to upload to the CDN
 BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/js$ || test $? = 1;)
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -25,8 +25,7 @@
     "build": "npm run clean && npm run build:dist && npm run build:dist:min",
     "build:dist": "cross-env NODE_ENV=production bash -c '../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/extract-source-map dist/bugsnag.js'",
     "build:dist:min": "cross-env NODE_ENV=production bash -c '../../bin/bundle src/notifier.js --standalone=Bugsnag | ../../bin/minify dist/bugsnag.min.js'",
-    "cdn-upload": "./bin/cdn-upload",
-    "postversion": "npm run build"
+    "cdn-upload": "./bin/cdn-upload"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "build": "npm run clean && npm run build:dist",
-    "build:dist": "../../bin/bundle src/notifier.js --node --exclude=iserror,stack-generator,error-stack-parser,pump,byline --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js",
-    "postversion": "npm run build"
+    "build:dist": "../../bin/bundle src/notifier.js --node --exclude=iserror,stack-generator,error-stack-parser,pump,byline --standalone=bugsnag | ../../bin/extract-source-map dist/bugsnag.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -25,8 +25,7 @@
     "build": "npm run clean && npm run build:esm2015 && npm run build:esm5",
     "build:esm2015": "ngc -p tsconfig.json",
     "build:esm5": "ngc -p tsconfig.esm5.json",
-    "test:types": "npm run build",
-    "postversion": "npm run build"
+    "test:types": "npm run build"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -18,8 +18,7 @@
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "build": "npm run clean && ../../bin/bundle src/index.js --node --standalone=BugsnagPluginAwsLambda | ../../bin/extract-source-map dist/bugsnag-aws-lambda.js",
-    "postversion": "npm run build"
+    "build": "npm run clean && ../../bin/bundle src/index.js --node --standalone=BugsnagPluginAwsLambda | ../../bin/extract-source-map dist/bugsnag-aws-lambda.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-electron-ipc/package.json
+++ b/packages/plugin-electron-ipc/package.json
@@ -8,8 +8,7 @@
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
   "scripts": {
-    "build": "browserify preload.js --exclude electron --bare -o dist/preload.bundle.js",
-    "postversion": "npm run build"
+    "build": "browserify preload.js --exclude electron --bare -o dist/preload.bundle.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "build": "npm run clean && npm run build:dist",
-    "build:dist": "../../bin/bundle src/express.js --node --exclude=iserror --standalone=bugsnag-express | ../../bin/extract-source-map dist/bugsnag-express.js",
-    "postversion": "npm run build"
+    "build:dist": "../../bin/bundle src/express.js --node --exclude=iserror --standalone=bugsnag-express | ../../bin/extract-source-map dist/bugsnag-express.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "build": "npm run clean && npm run build:dist",
-    "build:dist": "../../bin/bundle src/koa.js --node --exclude=iserror --standalone=bugsnag-koa | ../../bin/extract-source-map dist/bugsnag-koa.js",
-    "postversion": "npm run build"
+    "build:dist": "../../bin/bundle src/koa.js --node --exclude=iserror --standalone=bugsnag-koa | ../../bin/extract-source-map dist/bugsnag-koa.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -19,8 +19,7 @@
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "build": "npm run clean && ../../bin/bundle src/index.js --standalone=BugsnagPluginReact | ../../bin/extract-source-map dist/bugsnag-react.js",
-    "postversion": "npm run build"
+    "build": "npm run clean && ../../bin/bundle src/index.js --standalone=BugsnagPluginReact | ../../bin/extract-source-map dist/bugsnag-react.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
     "build": "npm run clean && npm run build:dist",
-    "build:dist": "../../bin/bundle src/restify.js --node --exclude=iserror --standalone=bugsnag-restify | ../../bin/extract-source-map dist/bugsnag-restify.js",
-    "postversion": "npm run build"
+    "build:dist": "../../bin/bundle src/restify.js --node --exclude=iserror --standalone=bugsnag-restify | ../../bin/extract-source-map dist/bugsnag-restify.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -19,8 +19,7 @@
   ],
   "scripts": {
     "clean": "rm -fr dist && mkdir dist",
-    "build": "npm run clean && ../../bin/bundle src/index.js --standalone=BugsnagPluginVue | ../../bin/extract-source-map dist/bugsnag-vue.js",
-    "postversion": "npm run build"
+    "build": "npm run clean && ../../bin/bundle src/index.js --standalone=BugsnagPluginVue | ../../bin/extract-source-map dist/bugsnag-vue.js"
   },
   "author": "Bugsnag",
   "license": "MIT",

--- a/packages/react-native-cli/package.json
+++ b/packages/react-native-cli/package.json
@@ -10,8 +10,7 @@
   },
   "scripts": {
     "clean": "rm -fr dist",
-    "build": "npm run clean && tsc -p tsconfig.build.json",
-    "preversion": "npm run build"
+    "build": "npm run clean && tsc -p tsconfig.build.json"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Goal

Ensures that the packages are explicitly built prior to attempting to publish. the change is designed to alleviate the scenario where publishing fails and need to be re-attempted, by altering the release script to publish without versioning

## Design

Explicitly running the build reduces the likelihood of publishing packages that are not correctly built in the case of retrying following a failed publish (e.g. due to authentication problems with npm).

## Changeset

- Update release.sh to explicitly run the build step, excluding packages using node-gyp that do not need building for a release as they get built on the client machine
- Remove postversion and preversion hooks

## Testing

The change was a little tricky to test. Not sure if there is a better way.

Tested locally against a verdaccio instance using a modified version of the release script.

1. Set up a new repo to clone from on the host machine: `git clone --bare git@github.com:bugsnag/bugsnag-js.git bugsnag-js-bare`
2. Mount the bare repo to the docker container by modifying docker-compose release service by adding `../bugsnag-js-bare:/home/bugsnag-js-bare` to the volumes definition
3. Change `release.sh` to clone from the bare repo (this is so that tags aren't sent to the real repo when testing):
```
git clone --single-branch \
  --branch "$RELEASE_BRANCH" \
  /home/bugsnag-js-bare bugsnag-js
```

4. Make lerna publish to verdaccio by adding `--registry "http://host.docker.internal:4873"` to the publish command in `release.sh`
5. Disable CDN upload by commenting out `npm run cdn-upload`
6. Build the release container with `docker-compose build release`
7. Run the release with `RELEASE_BRANCH=improve-release VERSION=minor docker-compose run release`
8. Using an example project with a `.npmrc` containing `registry=http://localhost:4873/`, depend on the version of @bugsnag/js just published to verdaccio and test by ensuring an event is sent.