### PR TITLE
Move to new macOS 10.15 queue

### DIFF
--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -245,7 +245,7 @@ steps:
     key: 'rn-0-60-ipa'
     timeout_in_minutes: 30
     agents:
-      queue: "opensource-mac-cocoa-10-15"
+      queue: "opensource-mac-cocoa-10.15"
     env:
       DEBUG: true
       LANG: "en_US.UTF-8"
@@ -258,7 +258,7 @@ steps:
     key: 'rn-0-61-ipa'
     timeout_in_minutes: 30
     agents:
-      queue: "opensource-mac-cocoa-10-15"
+      queue: "opensource-mac-cocoa-10.15"
     env:
       DEBUG: true
       LANG: "en_US.UTF-8"
@@ -271,7 +271,7 @@ steps:
     key: 'rn-0-62-ipa'
     timeout_in_minutes: 30
     agents:
-      queue: "opensource-mac-cocoa-10-15"
+      queue: "opensource-mac-cocoa-10.15"
     env:
       DEBUG: true
       LANG: "en_US.UTF-8"

--- a/.buildkite/react-native-pipeline.yml
+++ b/.buildkite/react-native-pipeline.yml
@@ -35,7 +35,7 @@ steps:
     key: "rn-0-60-ipa"
     timeout_in_minutes: 60
     agents:
-      queue: "opensource-mac-cocoa-10-15"
+      queue: "opensource-mac-cocoa-10.15"
     env:
       REACT_NATIVE_VERSION: rn0.60
       LANG: "en_US.UTF-8"
@@ -117,7 +117,7 @@ steps:
     key: "react-navigation-0-60-ipa"
     timeout_in_minutes: 60
     agents:
-      queue: "opensource-mac-cocoa-10-15"
+      queue: "opensource-mac-cocoa-10.15"
     env:
       REACT_NATIVE_VERSION: rn0.60
       JS_SOURCE_DIR: "react_navigation_js"
@@ -179,7 +179,7 @@ steps:
     key: "react-native-navigation-0-60-ipa"
     timeout_in_minutes: 60
     agents:
-      queue: "opensource-mac-cocoa-10-15"
+      queue: "opensource-mac-cocoa-10.15"
     env:
       REACT_NATIVE_VERSION: rn0.60
       JS_SOURCE_DIR: "react_native_navigation_js"


### PR DESCRIPTION
## Goal

Corrects the Buildkite queue name following a recent set of server updates.

## Testing 

Covered by CI.