### PR TITLE
Add .ts files to bugsnag/core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,8 @@
   "files": [
     "lib",
     "types",
-    "*.js"
+    "*.js",
+    "*.ts"
   ],
   "author": "Bugsnag",
   "license": "MIT",


### PR DESCRIPTION
## Goal

We use `@bugsnag/core` in our project, and use the `onBreadcrumb` option as per [the docs](https://docs.bugsnag.com/platforms/javascript/customizing-breadcrumbs/) to filter and modify breadcrumb metadata. In order to test this behaviour, we need to create `Breadcrumb` instances with specific metadata, however the type definitions in the repo don't include the constructor.

This PR adds the appropriate type definitions to `Breadcrumb`.