### PR TITLE
chore(plugin-restify): send body in event.request

### DIFF
--- a/packages/plugin-restify/src/restify.js
+++ b/packages/plugin-restify/src/restify.js
@@ -24,10 +24,10 @@ module.exports = {
       req.bugsnag = requestClient
 
       // extract request info and pass it to the relevant bugsnag properties
-      const { request, metadata } = getRequestAndMetadataFromReq(req)
-      requestClient.addMetadata('request', metadata)
       requestClient.addOnError((event) => {
+        const { request, metadata } = getRequestAndMetadataFromReq(req)
         event.request = { ...event.request, ...request }
+        requestClient.addMetadata('request', metadata)
       }, true)
 
       if (!client._config.autoDetectErrors) return next()
@@ -77,15 +77,16 @@ module.exports = {
 }
 
 const getRequestAndMetadataFromReq = req => {
-  const requestInfo = extractRequestInfo(req)
+  const { body, ...requestInfo } = extractRequestInfo(req)
   return {
     metadata: requestInfo,
     request: {
+      body,
       clientIp: requestInfo.clientIp,
       headers: requestInfo.headers,
       httpMethod: requestInfo.httpMethod,
       url: requestInfo.url,
-      referer: requestInfo.referer
+      referer: requestInfo.referer // Not part of the notifier spec for request but leaving for backwards compatibility
     }
   }
 }

--- a/test/node/features/fixtures/restify/scenarios/app.js
+++ b/test/node/features/fixtures/restify/scenarios/app.js
@@ -18,6 +18,8 @@ var server = restify.createServer()
 
 server.pre(middleware.requestHandler)
 
+server.use(restify.plugins.bodyParser());
+
 // If the server hasn't started sending something within 2 seconds
 // it probably won't. So end the request and hurry the failing test
 // along.
@@ -77,6 +79,10 @@ server.get('/internal', function (req, res, next) {
 server.get('/handled', function (req, res, next) {
   req.bugsnag.notify(new Error('handled'))
   res.end('OK')
+})
+
+server.post('/bodytest', function (req, res, next) {
+  throw new Error('request body')
 })
 
 server.on('restifyError', middleware.errorHandler)

--- a/test/node/features/restify.feature
+++ b/test/node/features/restify.feature
@@ -89,3 +89,16 @@ Scenario: a handled error passed to req.bugsnag.notify()
   And the event "request.url" equals "http://restify/handled"
   And the event "request.httpMethod" equals "GET"
   And the event "request.clientIp" is not null
+
+Scenario: adding body to request metadata
+  When I POST the data "data=in_request_body" to the URL "http://restify/bodytest"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "request body"
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.body.data" equals "in_request_body"
+  And the event "request.httpMethod" equals "POST"


### PR DESCRIPTION
## Goal

Send the body (if any) as `event.request.body`. This fixes a bug where the request body was not being included (not even as `event.metadata.request.body`. This was because those values were being determined when the requestHandler middleware was run, which would be before any body parsing middleware is added, as per our integration instructions, which suggest adding the Bugsnag middleware first.

The changes here are similar to https://github.com/bugsnag/bugsnag-js/pull/1292

## Design

Better agreement with the notifier spec.

## Changeset

- Collect event data at the right time (on the error handler)
- Send body as `event.request.body`

## Testing

- Covered with E2E test
- Tested using a modified version of the example project after deploying to a local verdaccio instance and depending on that. verified the request body is included in the request tab of the event