### PR TITLE
chore(plugin-express): send body in event.request

### DIFF
--- a/packages/plugin-express/src/express.js
+++ b/packages/plugin-express/src/express.js
@@ -75,10 +75,11 @@ module.exports = {
 }
 
 const getRequestAndMetadataFromReq = req => {
-  const requestInfo = extractRequestInfo(req)
+  const { body, ...requestInfo } = extractRequestInfo(req)
   return {
     metadata: requestInfo,
     request: {
+      body,
       clientIp: requestInfo.clientIp,
       headers: requestInfo.headers,
       httpMethod: requestInfo.httpMethod,

--- a/test/node/features/express.feature
+++ b/test/node/features/express.feature
@@ -116,5 +116,5 @@ Scenario: adding body to request metadata
   And the exception "message" equals "request body"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
-  And the event "metaData.request.body.data" equals "in_request_body"
+  And the event "request.body.data" equals "in_request_body"
   And the event "request.httpMethod" equals "POST"


### PR DESCRIPTION
## Goal

When using the express plugin send the body (if present) as `event.request.body` rather than `event.metadata.request.body` for better alignment with the notifier spec. This should not have any user-facing impact.

## Design

Better alignment with the spec

## Changeset

- send the body as `event.request.body` rather than `event.metadata.request.body`

## Testing

- Covered by an E2E test