### PR TITLE
Remove incorrect type definition

### DIFF
--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -1,6 +1,5 @@
 import Breadcrumb from './breadcrumb'
 import {
-  NotifiableError,
   BreadcrumbType,
   OnErrorCallback,
   OnSessionCallback,
@@ -16,7 +15,7 @@ declare class Client {
 
   // reporting errors
   public notify(
-    error: NotifiableError,
+    error: Error,
     onError?: OnErrorCallback,
     cb?: (err: any, event: Event) => void
   ): void;

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -73,11 +73,6 @@ export interface SessionPayload {
   sessions: Session[]
 }
 
-export type NotifiableError = Error
-| { errorClass: string, errorMessage: string }
-| { name: string, message: string }
-| string
-
 export type BreadcrumbType = 'error' | 'log' | 'manual' | 'navigation' | 'process' | 'request' | 'state' | 'user';
 
 interface Device {


### PR DESCRIPTION
## Goal

The type definition for `client.notify` method implies that several types are acceptable. Which isn't exactly true. When using an `Error` type `client.notify` works as expected. When using a `string` type, the error reported is `notify() received a non-error. See "notify()" tab for more detail.` while the error details are on the `notify` tab. This is confusing and does not work as expected.

## Design

I removed the `NotifiableError` type in favor of `Error`. This is purely a type definition change with **no** change in functionality.

## Changeset

The `NotifiableError` type was removed in favor of `Error`.

## Testing

I'm having issues building/testing the repo as is. I was able to run the typescript check command with 400+ errors. After my changes, the typescript check did not register any new errors.