### PR TITLE
Trigger expo pipeline on push

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,12 +74,11 @@ steps:
   - label: 'Trigger Expo pipeline'
     if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"
     depends_on: 'publish-js'
-    trigger: 'bugsnag-js-expo'
+    trigger: 'bugsnag-expo'
     build:
-      branch: '${BUILDKITE_BRANCH}'
-      commit: '${BUILDKITE_COMMIT}'
-      message: '${BUILDKITE_MESSAGE}'
-    async: true
+      env:
+        BUGSNAG_JS_BRANCH: '${BUILDKITE_BRANCH}'
+        BUGSNAG_JS_COMMIT: '${BUILDKITE_COMMIT}'
 
   - label: 'Trigger React Native pipeline'
     depends_on:


### PR DESCRIPTION
## Goal

Adds a trigger step for bugsnag-expo to the pipeline. This passes over the branch & commit so that the bugsnag-expo tests can be run against any bugsnag-js changes