### PR TITLE
[PLAT-8330] Fix reporting of RCTFatal crashes on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBC
+
+### Fixed
+
+- (react-native) Fix reporting of `RCTFatal()` crashes on iOS. [#1719](https://github.com/bugsnag/bugsnag-js/pull/1719)
+
 ## v7.16.3 (2022-04-05)
 
 ### Changed

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
@@ -1,24 +1,34 @@
 #import "BugsnagReactNativePlugin.h"
 
 #import "BugsnagClient+Private.h"
-#import "BugsnagError.h"
 
-@interface BugsnagReactNativePlugin () <BugsnagPlugin>
-@end
-
+//
+// BugsnagReactNativePlugin is instantiated by bugsnag-cocoa during its startup:
+// https://github.com/bugsnag/bugsnag-cocoa/blob/v6.16.6/Bugsnag/Client/BugsnagClient.m#L355-L365
+//
+// This makes it the ideal place for configuring the native layer before it sends any events.
+//
 @implementation BugsnagReactNativePlugin
 
-- (void)load:(BugsnagClient *_Nonnull)client {
-    [client.configuration addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
-        BugsnagError *error;
-
-        if ([event.errors count] > 0) {
-            error = event.errors[0];
-        }
-        return error != nil
-                && ![error.errorClass hasPrefix:@"RCTFatalException"]
-                && ![error.errorMessage hasPrefix:@"Unhandled JS Exception"];
-    }];
+- (void)load:(BugsnagClient *)client {
+    //
+    // React Native catches JS exceptions and calls RCTFatal() to raise an Objective-C exception in response.
+    // These need to be ignored because Bugsnag's JS layer also catches JS exceptions, via a different mechanism.
+    //
+    // RCTFatal() sets the exception name to "RCTFatalException: ${error.localizedDescription}"
+    // https://github.com/facebook/react-native/blob/v0.68.0/React/Base/RCTAssert.m#L132
+    //
+    // For JS errors the localizedDescription is @"Unhandled JS Exception: ${message}"
+    // https://github.com/facebook/react-native/blob/v0.68.0/React/CoreModules/RCTExceptionsManager.mm#L66
+    // https://github.com/facebook/react-native/blob/v0.68.0/React/CxxModule/RCTCxxUtils.mm#L51
+    //
+    // The exception name gets recorded as the error's `errorClass`.
+    //
+    NSString *discardPattern = @"^RCTFatalException: Unhandled JS Exception: ";
+    
+    NSMutableSet *discardClasses = [client.configuration.discardClasses mutableCopy] ?: [NSMutableSet set];
+    [discardClasses addObject:[NSRegularExpression regularExpressionWithPattern:discardPattern options:0 error:nil]];
+    client.configuration.discardClasses = discardClasses;
 }
 
 - (void)unload {

--- a/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/Scenarios.js
@@ -7,6 +7,7 @@ export { UnhandledNativeErrorScenario } from './scenarios/UnhandledNativeErrorSc
 export { UnhandledJsErrorScenario } from './scenarios/UnhandledJsErrorScenario'
 export { UnhandledJsErrorSeverityScenario } from './scenarios/UnhandledJsErrorSeverityScenario'
 export { UnhandledJsPromiseRejectionScenario } from './scenarios/UnhandledJsPromiseRejectionScenario'
+export { RCTFatalScenario } from './scenarios/RCTFatalScenario'
 
 // api-key-ios.feature
 export { EventApiKeyOverrideScenario } from './scenarios/EventApiKeyOverrideScenario'

--- a/test/react-native/features/fixtures/app/scenario_js/app/scenarios/RCTFatalScenario.js
+++ b/test/react-native/features/fixtures/app/scenario_js/app/scenarios/RCTFatalScenario.js
@@ -1,0 +1,8 @@
+import Scenario from './Scenario'
+import { NativeModules } from 'react-native'
+
+export class RCTFatalScenario extends Scenario {
+  run () {
+    NativeModules.BugsnagTestInterface.runScenario('RCTFatalScenario')
+  }
+}

--- a/test/react-native/features/fixtures/ios-module/Scenarios/RCTFatalScenario.m
+++ b/test/react-native/features/fixtures/ios-module/Scenarios/RCTFatalScenario.m
@@ -1,0 +1,16 @@
+#import "Scenario.h"
+
+#import <React/RCTAssert.h>
+
+@interface RCTFatalScenario : Scenario
+
+@end
+
+@implementation RCTFatalScenario
+
+- (void)run:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+  RCTFatal([NSError errorWithDomain:@"MyErrorDomain" code:1 userInfo:@{
+    NSLocalizedDescriptionKey: @"Should not be discarded by BugsnagReactNativePlugin's OnSendErrorBlock"}]);
+}
+
+@end

--- a/test/react-native/features/fixtures/rn0.60/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.60/ios/reactnative.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* reactnativeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* reactnativeTests.m */; };
+		0154E1FE2806DFEE009044E4 /* RCTFatalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E1FD2806DFEE009044E4 /* RCTFatalScenario.m */; };
+		0154E1FF2806DFEE009044E4 /* RCTFatalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E1FD2806DFEE009044E4 /* RCTFatalScenario.m */; };
 		0186104D257900FF00FCB626 /* NativeStackHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186104C257900FF00FCB626 /* NativeStackHandledScenario.swift */; };
 		0186104E257900FF00FCB626 /* NativeStackHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186104C257900FF00FCB626 /* NativeStackHandledScenario.swift */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
@@ -65,6 +67,7 @@
 		00E356EE1AD99517003FC87E /* reactnativeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = reactnativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* reactnativeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = reactnativeTests.m; sourceTree = "<group>"; };
+		0154E1FD2806DFEE009044E4 /* RCTFatalScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTFatalScenario.m; sourceTree = "<group>"; };
 		0186104C257900FF00FCB626 /* NativeStackHandledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeStackHandledScenario.swift; sourceTree = "<group>"; };
 		05F6C73355E0C5E95435B68E /* Pods-reactnative-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnative-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-reactnative-tvOS/Pods-reactnative-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* reactnative.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnative.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -263,10 +266,6 @@
 		A145176724A7A1F500C6FC6E /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
-				96A7D7502799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.h */,
-				96A7D7512799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m */,
-				96A7D7532799DF700043AAB6 /* NativeFeatureFlagsScenario.h */,
-				96A7D7522799DF700043AAB6 /* NativeFeatureFlagsScenario.m */,
 				A1BFB36624BCEE0200394C5D /* AppNativeHandledScenario.h */,
 				A1BFB36724BCEE0200394C5D /* AppNativeHandledScenario.m */,
 				A1BFB36424BCEE0200394C5D /* AppNativeUnhandledScenario.h */,
@@ -279,17 +278,22 @@
 				A181223D24C59F4D0073596F /* DeviceNativeHandledScenario.m */,
 				A181224024C59F4D0073596F /* DeviceNativeUnhandledScenario.h */,
 				A181223F24C59F4D0073596F /* DeviceNativeUnhandledScenario.m */,
+				96A7D7502799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.h */,
+				96A7D7512799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m */,
 				A1CC9DE324B3D76A002A4760 /* HandledNativeErrorScenario.h */,
 				A1CC9DE224B3D76A002A4760 /* HandledNativeErrorScenario.m */,
 				A1F389CA24C6192500C30B50 /* MetadataNativeScenario.h */,
 				A1F389CB24C6192500C30B50 /* MetadataNativeScenario.m */,
 				A1F389CD24C73B6000C30B50 /* MetadataNativeUnhandledScenario.h */,
 				A1F389CE24C73B6000C30B50 /* MetadataNativeUnhandledScenario.m */,
+				96A7D7532799DF700043AAB6 /* NativeFeatureFlagsScenario.h */,
+				96A7D7522799DF700043AAB6 /* NativeFeatureFlagsScenario.m */,
 				0186104C257900FF00FCB626 /* NativeStackHandledScenario.swift */,
 				6591A4D32511602C0040A5FA /* NativeStackUnhandledScenario.h */,
 				6591A4D22511602C0040A5FA /* NativeStackUnhandledScenario.m */,
 				A1F63D1C24CE53EE00C31ABC /* PauseSessionScenario.h */,
 				A1F63D1D24CE53EE00C31ABC /* PauseSessionScenario.m */,
+				0154E1FD2806DFEE009044E4 /* RCTFatalScenario.m */,
 				A1F63D1F24CE53EE00C31ABC /* ResumeSessionScenario.h */,
 				A1F63D1E24CE53EE00C31ABC /* ResumeSessionScenario.m */,
 				A145176924A7A20300C6FC6E /* Scenario.h */,
@@ -667,6 +671,7 @@
 				6555A23024C7329600CC41ED /* UserNativeClientScenario.m in Sources */,
 				A145176A24A7A20300C6FC6E /* Scenario.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				0154E1FE2806DFEE009044E4 /* RCTFatalScenario.m in Sources */,
 				A145176624A7A1F000C6FC6E /* BugsnagModule.m in Sources */,
 				A1F63D2024CE53EE00C31ABC /* StartSessionScenario.m in Sources */,
 				96A7D7542799DF700043AAB6 /* FeatureFlagsNativeCrashScenario.m in Sources */,
@@ -692,6 +697,7 @@
 			files = (
 				0186104E257900FF00FCB626 /* NativeStackHandledScenario.swift in Sources */,
 				2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */,
+				0154E1FF2806DFEE009044E4 /* RCTFatalScenario.m in Sources */,
 				2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/test/react-native/features/fixtures/rn0.66/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.66/ios/reactnative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* reactnativeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* reactnativeTests.m */; };
+		0154E1FC2806DFE5009044E4 /* RCTFatalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E1FB2806DFE5009044E4 /* RCTFatalScenario.m */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
@@ -50,6 +51,7 @@
 		00E356EE1AD99517003FC87E /* reactnativeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = reactnativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* reactnativeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = reactnativeTests.m; sourceTree = "<group>"; };
+		0154E1FB2806DFE5009044E4 /* RCTFatalScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFatalScenario.m; path = "../../ios-module/Scenarios/RCTFatalScenario.m"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* reactnative.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnative.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = reactnative/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = reactnative/AppDelegate.m; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 				A1EC7FC527E263EA00F3A43D /* NativeStackUnhandledScenario.m */,
 				A1EC7FD827E263EB00F3A43D /* PauseSessionScenario.h */,
 				A1EC7FC027E263EA00F3A43D /* PauseSessionScenario.m */,
+				0154E1FB2806DFE5009044E4 /* RCTFatalScenario.m */,
 				A1EC7FD227E263EB00F3A43D /* ResumeSessionScenario.h */,
 				A1EC7FB627E263EA00F3A43D /* ResumeSessionScenario.m */,
 				A1EC7FC127E263EA00F3A43D /* Scenario.h */,
@@ -522,6 +525,7 @@
 				A1EC7FEA27E263EB00F3A43D /* StartSessionScenario.m in Sources */,
 				A1EC7FDD27E263EB00F3A43D /* Scenario.m in Sources */,
 				A1A3C2EF27EB3B4900C3970C /* BugsnagModule.m in Sources */,
+				0154E1FC2806DFE5009044E4 /* RCTFatalScenario.m in Sources */,
 				A1EC7FE627E263EB00F3A43D /* DeviceNativeHandledScenario.m in Sources */,
 				A1EC7FD927E263EB00F3A43D /* DeviceNativeUnhandledScenario.m in Sources */,
 				A1EC7FE027E263EB00F3A43D /* PauseSessionScenario.m in Sources */,

--- a/test/react-native/features/fixtures/rn0.67/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.67/ios/reactnative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* reactnativeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* reactnativeTests.m */; };
+		0154E1FA2806DFDC009044E4 /* RCTFatalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E1F92806DFDC009044E4 /* RCTFatalScenario.m */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
@@ -50,6 +51,7 @@
 		00E356EE1AD99517003FC87E /* reactnativeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = reactnativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* reactnativeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = reactnativeTests.m; sourceTree = "<group>"; };
+		0154E1F92806DFDC009044E4 /* RCTFatalScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFatalScenario.m; path = "../../ios-module/Scenarios/RCTFatalScenario.m"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* reactnative.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnative.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = reactnative/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = reactnative/AppDelegate.m; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				A1CDD9A027E1039900946B0D /* NativeStackUnhandledScenario.m */,
 				A1CDD9AE27E1039A00946B0D /* PauseSessionScenario.h */,
 				A1CDD99327E1039900946B0D /* PauseSessionScenario.m */,
+				0154E1F92806DFDC009044E4 /* RCTFatalScenario.m */,
 				A1CDD9B027E1039A00946B0D /* ResumeSessionScenario.h */,
 				A1CDD9AA27E1039900946B0D /* ResumeSessionScenario.m */,
 				A1CDD9AC27E1039A00946B0D /* Scenario.h */,
@@ -522,6 +525,7 @@
 				A1CDD9BF27E1039A00946B0D /* MetadataNativeScenario.m in Sources */,
 				A1CDD9BE27E1039A00946B0D /* ContextNativeCustomScenario.m in Sources */,
 				A1A3C2EC27EB3B2D00C3970C /* BugsnagModule.m in Sources */,
+				0154E1FA2806DFDC009044E4 /* RCTFatalScenario.m in Sources */,
 				A1CDD9BB27E1039A00946B0D /* StartSessionScenario.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				A1CDD9BC27E1039A00946B0D /* NativeStackUnhandledScenario.m in Sources */,

--- a/test/react-native/features/fixtures/rn0.68-hermes/ios/reactnative.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/rn0.68-hermes/ios/reactnative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* reactnativeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* reactnativeTests.m */; };
+		0154E1F82806DFD4009044E4 /* RCTFatalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E1F72806DFD4009044E4 /* RCTFatalScenario.m */; };
 		0C80B921A6F3F58F76C31292 /* libPods-reactnative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-reactnative.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
@@ -50,6 +51,7 @@
 		00E356EE1AD99517003FC87E /* reactnativeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = reactnativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* reactnativeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = reactnativeTests.m; sourceTree = "<group>"; };
+		0154E1F72806DFD4009044E4 /* RCTFatalScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTFatalScenario.m; path = "../../ios-module/Scenarios/RCTFatalScenario.m"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* reactnative.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnative.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = reactnative/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = reactnative/AppDelegate.mm; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				A1EAB10027F5C1A6005EFEE6 /* NativeStackUnhandledScenario.m */,
 				A1EAB10A27F5C1A6005EFEE6 /* PauseSessionScenario.h */,
 				A1EAB10C27F5C1A6005EFEE6 /* PauseSessionScenario.m */,
+				0154E1F72806DFD4009044E4 /* RCTFatalScenario.m */,
 				A1EAB10227F5C1A6005EFEE6 /* ResumeSessionScenario.h */,
 				A1EAB11527F5C1A6005EFEE6 /* ResumeSessionScenario.m */,
 				A1EAB10527F5C1A6005EFEE6 /* Scenario.h */,
@@ -522,6 +525,7 @@
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				A1EAB12D27F5C1A7005EFEE6 /* ResumeSessionScenario.m in Sources */,
 				A1EAB12E27F5C1A7005EFEE6 /* MetadataNativeUnhandledScenario.m in Sources */,
+				0154E1F82806DFD4009044E4 /* RCTFatalScenario.m in Sources */,
 				A1EAB13027F5C1A7005EFEE6 /* UserNativeClientScenario.m in Sources */,
 				A1EAB12427F5C1A7005EFEE6 /* NativeStackHandledScenario.swift in Sources */,
 				A1EAB0F727F5C17F005EFEE6 /* BugsnagModule.m in Sources */,

--- a/test/react-native/features/unhandled.feature
+++ b/test/react-native/features/unhandled.feature
@@ -40,3 +40,12 @@ Scenario: Updating severity on an unhandled JS error
   And the exception "message" equals "UnhandledJsErrorSeverityScenario"
   And the event "unhandled" is true
   And the event "severity" equals "info"
+
+@ios_only
+Scenario: Reporting an unhandled Objective-C exception raise by RCTFatal
+  When I run "RCTFatalScenario" and relaunch the crashed app
+  And I configure Bugsnag for "RCTFatalScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" matches "RCTFatalException: .*"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"


### PR DESCRIPTION
## Goal

Send crash reports when `RCTFatal()` is called, fixing:
* #1712 

## Changeset

Configures Bugsnag to ignore errors whose `errorClass` starts with `RCTFatalException: Unhandled JS Exception: `.

## Testing

Adds an E2E scenario to verify that an error is sent after app crashes with `RCTFatal()`.