### PR TITLE
Pass the cache-safe branch name to Expo pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,6 +79,8 @@ steps:
       env:
         BUGSNAG_JS_BRANCH: '${BUILDKITE_BRANCH}'
         BUGSNAG_JS_COMMIT: '${BUILDKITE_COMMIT}'
+        # a branch name that's safe to use as a docker cache identifier
+        BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME: '${BRANCH_NAME}'
 
   - label: 'Trigger React Native pipeline'
     depends_on:


### PR DESCRIPTION
## Goal

If a branch contains an illegal character, e.g. '/', docker would get very upset and fail the build. We have to pass over a safe version from this repo so that this doesn't happen, which can be used as the cache identifier instead