### PR TITLE
Fix electron app breadcrumb exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - (react-native) Fix reporting of `RCTFatal()` crashes on iOS. [#1719](https://github.com/bugsnag/bugsnag-js/pull/1719)
+- (plugin-electron-app-breadcrumbs) Fix a TypeError caused by using a BrowserWindow object after it is destroyed [#1722](https://github.com/bugsnag/bugsnag-js/pull/1722)
 
 ## v7.16.3 (2022-04-05)
 

--- a/packages/electron-test-helpers/src/BrowserWindow.ts
+++ b/packages/electron-test-helpers/src/BrowserWindow.ts
@@ -41,6 +41,7 @@ export interface BrowserWindow {
   getSize: () => Size
   getPosition: () => Position
   isDestroyed: () => boolean
+  destroy: () => void
 
   _emit: (event: string, ...args: any[]) => void
   readonly callbacks: { [event in BrowserWindowEvent]: Function[] }
@@ -139,7 +140,7 @@ export function makeBrowserWindow ({ windows = [], focusedWindow = null } = {}):
       return this._isDestroyed
     }
 
-    _assertNotDestroyed (): void {
+    private _assertNotDestroyed (): void {
       if (this._isDestroyed) {
         throw new TypeError('Object has been destroyed')
       }

--- a/packages/plugin-electron-app-breadcrumbs/test/app-breadcrumbs.test.ts
+++ b/packages/plugin-electron-app-breadcrumbs/test/app-breadcrumbs.test.ts
@@ -254,6 +254,27 @@ describe('plugin: electron app breadcrumbs', () => {
         expect(client._breadcrumbs[0]).toMatchBreadcrumb(breadcrumb)
       })
 
+      it('moved with a destroyed window', () => {
+        const app = makeApp()
+        const BrowserWindow = makeBrowserWindow()
+        const window = new BrowserWindow(7575, 'bbb', { position: { top: 463, left: 817 } })
+
+        const client = makeClient({ app, BrowserWindow })
+
+        // destroy the window before emitting the 'moved' event; this can happen
+        // when closing the window just after moving it, as we debounce the
+        // 'moved' event callback
+        window.destroy()
+        window._emit('moved')
+
+        // the 'destroy' method will fire the 'closed' event, but the 'moved'
+        // event should be ignored as this window was destroyed before it settled
+        const breadcrumb = new Breadcrumb('Browser window 7575 closed', { id: 7575, title: 'bbb' }, 'state')
+
+        expect(client._breadcrumbs).toHaveLength(1)
+        expect(client._breadcrumbs[0]).toMatchBreadcrumb(breadcrumb)
+      })
+
       it('enter-full-screen', () => {
         const app = makeApp()
         const BrowserWindow = makeBrowserWindow()


### PR DESCRIPTION
## Goal

To avoid collecting too many breadcrumbs we debounce the `moved` event handler, but this can cause an exception when closing a window immediately after moving it (i.e. within the ~250ms debounce timer)

This PR protects against this in two ways:

1. check if the window is destroyed before using it in the `moved` callback
2. cancel a queued call to the `moved` callback when the `closed` event fires, as this is the point where the browser window is destroyed

The other event listeners should never be called with a destroyed browser window (other than `closed`) because they are not debounced and so run as soon as the event is emitted