### PR TITLE
Add 'children' prop to React ErrorBoundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- (plugin-react) Add 'children' prop to BugsnagErrorBoundary [#1723](https://github.com/bugsnag/bugsnag-js/pull/1723)
 - (react-native) Fix reporting of `RCTFatal()` crashes on iOS. [#1719](https://github.com/bugsnag/bugsnag-js/pull/1719)
 
 ## v7.16.3 (2022-04-05)

--- a/packages/plugin-react/types/bugsnag-plugin-react.d.ts
+++ b/packages/plugin-react/types/bugsnag-plugin-react.d.ts
@@ -9,6 +9,7 @@ declare class BugsnagPluginReact {
 }
 
 export type BugsnagErrorBoundary = React.ComponentType<{
+  children?: React.ReactNode | undefined
   onError?: OnErrorCallback
   FallbackComponent?: React.ComponentType<{
     error: Error


### PR DESCRIPTION
## Goal

This was removed from the ComponentType definition in @types/react v18, so now has to be explicitly listed as an allowed prop