### PR TITLE
Fix RN CLI 'insert' command on RN 0.68+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - (plugin-react) Add 'children' prop to BugsnagErrorBoundary [#1723](https://github.com/bugsnag/bugsnag-js/pull/1723)
 - (react-native) Fix reporting of `RCTFatal()` crashes on iOS. [#1719](https://github.com/bugsnag/bugsnag-js/pull/1719)
+- (react-native-cli) Fix 'insert' command with RN 0.68+ [#1726](https://github.com/bugsnag/bugsnag-js/pull/1726)
 - (plugin-electron-app-breadcrumbs) Fix a TypeError caused by using a BrowserWindow object after it is destroyed [#1722](https://github.com/bugsnag/bugsnag-js/pull/1722)
 
 ## v7.16.3 (2022-04-05)

--- a/packages/react-native-cli/src/lib/__test__/Insert.test.ts
+++ b/packages/react-native-cli/src/lib/__test__/Insert.test.ts
@@ -73,7 +73,10 @@ test('insertJs(): already present', async () => {
 test('insertIos(): success', async () => {
   type readdir = (path: string) => Promise<string[]>
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
-  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  readdirMock
+    .mockResolvedValueOnce(['BugsnagReactNativeCliTest.xcodeproj'])
+    .mockResolvedValueOnce(['a', 'b', 'AppDelegate.m', 'c', 'd'])
 
   const appDelegate = await loadFixture(path.join(__dirname, 'fixtures', 'AppDelegate-before.m'))
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
@@ -94,7 +97,10 @@ test('insertIos(): success', async () => {
 test('insertIos(): already present', async () => {
   type readdir = (path: string) => Promise<string[]>
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
-  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  readdirMock
+    .mockResolvedValueOnce(['BugsnagReactNativeCliTest.xcodeproj'])
+    .mockResolvedValueOnce(['a', 'b', 'AppDelegate.mm', 'c', 'd'])
 
   const appDelegate = await loadFixture(path.join(__dirname, 'fixtures', 'AppDelegate-after.m'))
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
@@ -104,7 +110,7 @@ test('insertIos(): already present', async () => {
   writeFileMock.mockResolvedValue()
 
   await insertIos('/random/path', logger)
-  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.mm', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
 
   expect(logger.warn).toHaveBeenCalledWith('Bugsnag is already included, skipping')
@@ -113,7 +119,10 @@ test('insertIos(): already present', async () => {
 test('insertIos(): failure to locate file', async () => {
   type readdir = (path: string) => Promise<string[]>
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
-  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  readdirMock
+    .mockResolvedValueOnce(['BugsnagReactNativeCliTest.xcodeproj'])
+    .mockResolvedValueOnce(['a', 'b', 'not-an-AppDelegate.x', 'c', 'd'])
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockRejectedValue(await generateNotFoundError())
@@ -121,10 +130,10 @@ test('insertIos(): failure to locate file', async () => {
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
 
   await insertIos('/random/path', logger)
-  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(readFileMock).not.toHaveBeenCalled()
   expect(writeFileMock).not.toHaveBeenCalled()
 
-  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate" automatically.'))
 })
 
 test('insertIos(): failure to locate project directory', async () => {
@@ -139,7 +148,7 @@ test('insertIos(): failure to locate project directory', async () => {
   expect(readFileMock).not.toHaveBeenCalled()
   expect(writeFileMock).not.toHaveBeenCalled()
 
-  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate" automatically.'))
 })
 
 test('insertIos(): project directory error', async () => {
@@ -154,23 +163,26 @@ test('insertIos(): project directory error', async () => {
   expect(readFileMock).not.toHaveBeenCalled()
   expect(writeFileMock).not.toHaveBeenCalled()
 
-  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate" automatically.'))
 })
 
 test('insertIos(): no identifiable app launch method', async () => {
   type readdir = (path: string) => Promise<string[]>
   const readdirMock = fs.readdir as unknown as jest.MockedFunction<readdir>
-  readdirMock.mockResolvedValue(['BugsnagReactNativeCliTest.xcodeproj'])
+
+  readdirMock
+    .mockResolvedValueOnce(['BugsnagReactNativeCliTest.xcodeproj'])
+    .mockResolvedValueOnce(['a', 'b', 'AppDelegate.mm', 'c', 'd'])
 
   const readFileMock = fs.readFile as jest.MockedFunction<typeof fs.readFile>
   readFileMock.mockResolvedValue('not good objective c')
   const writeFileMock = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>
 
   await insertIos('/random/path', logger)
-  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.m', 'utf8')
+  expect(readFileMock).toHaveBeenCalledWith('/random/path/ios/BugsnagReactNativeCliTest/AppDelegate.mm', 'utf8')
   expect(writeFileMock).not.toHaveBeenCalled()
 
-  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.m" automatically.'))
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to update "AppDelegate.mm" automatically.'))
 })
 
 test('insertAndroid(): success', async () => {


### PR DESCRIPTION
## Goal

RN 0.68 changed 'AppDelegate.m' to 'AppDelegate.mm', which broke our previous logic for finding the file

This PR changes the logic to work for both extensions