### PR TITLE
Reduce browser testing concurrency to 2

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -29,7 +29,7 @@ steps:
         command:
           - --farm=bs
           - --browser=chrome_43
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':chrome: v61 Browser tests'
@@ -44,7 +44,7 @@ steps:
         command:
           - --farm=bs
           - --browser=chrome_61
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':chrome: latest Browser tests'
@@ -59,7 +59,7 @@ steps:
         command:
           - --farm=bs
           - --browser=chrome_latest
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':ie: v8 Browser tests'
@@ -74,7 +74,7 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_8
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':ie: v9 Browser tests'
@@ -89,7 +89,7 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_9
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':ie: v10 Browser tests'
@@ -104,7 +104,7 @@ steps:
         command:
           - --farm=bs
           - --browser=ie_10
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':ie: v11 Browser tests'
@@ -121,7 +121,7 @@ steps:
           - --browser=ie_11
     env:
       HOST: 'localhost' # IE11 needs the host set to localhost for some reason!ß
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':edge: v14 Browser tests'
@@ -136,7 +136,7 @@ steps:
         command:
           - --farm=bs
           - --browser=edge_14
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':edge: v15 Browser tests'
@@ -151,7 +151,7 @@ steps:
         command:
           - --farm=bs
           - --browser=edge_15
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':safari: v6 Browser tests'
@@ -166,7 +166,7 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_6
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':safari: v10 Browser tests'
@@ -181,7 +181,7 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_10
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':safari: v13 Browser tests'
@@ -196,7 +196,7 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_13
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':safari: v15 Browser tests'
@@ -211,7 +211,7 @@ steps:
         command:
           - --farm=bs
           - --browser=safari_15
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':iphone: iOS 10.3 Browser tests'
@@ -228,7 +228,7 @@ steps:
           - --browser=iphone_7
     env:
       HOST: "bs-local.com"
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':android: Samsung Galaxy S8 Browser tests'
@@ -243,7 +243,7 @@ steps:
         command:
           - --farm=bs
           - --browser=android_s8
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v30 Browser tests'
@@ -258,7 +258,7 @@ steps:
         command:
           - --farm=bs
           - --browser=firefox_30
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':firefox: v56 Browser tests'
@@ -273,7 +273,7 @@ steps:
         command:
           - --farm=bs
           - --browser=firefox_56
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'
 
   - label: ':firefox: latest Browser tests'
@@ -288,5 +288,5 @@ steps:
         command:
           - --farm=bs
           - --browser=firefox_latest
-    concurrency: 5
+    concurrency: 2
     concurrency_group: 'browserstack'


### PR DESCRIPTION
## Goal

Reduce browser testing concurrency to 2, reflecting the number of licenses we now have.

## Testing

Covered by CI.