### PR TITLE
[PLAT-7801] Add early check for undefined apiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Small performance improvements to `Bugnag.start`
     [bugsnag-android#1680](https://github.com/bugsnag/bugsnag-android/pull/1680)
 - (plugin-react|plugin-vue|plugin-react-navigation|plugin-react-native-navigation) Set `@bugsnag/core` to be an optional peer dependency to avoid unmet peer dependency warnings [#1735](https://github.com/bugsnag/bugsnag-js/pull/1735)
+- (electron) Improved error message when no apiKey is provided to Bugsnag.start() [#1738](https://github.com/bugsnag/bugsnag-js/pull/1738)
 
 ## v7.16.4 (2022-05-03)
 

--- a/packages/electron/src/client/main.js
+++ b/packages/electron/src/client/main.js
@@ -16,6 +16,11 @@ const { schema } = require('../config/main')
 Event.__type = 'electronnodejs'
 
 module.exports = (opts) => {
+  // Sanity check api key has been provided
+  if (typeof opts.apiKey !== 'string') {
+    throw new Error('No Bugsnag API Key set')
+  }
+
   const filestore = new FileStore(
     opts.apiKey,
     electron.app.getPath('userCache'),

--- a/packages/electron/src/client/test/client.test-main.ts
+++ b/packages/electron/src/client/test/client.test-main.ts
@@ -1,0 +1,13 @@
+import createClient from '../main'
+
+describe('@bugsnag/electron client', () => {
+  describe('createClient', () => {
+    it('throws an error when an apiKey is not provided', () => {
+      expect(
+        () => {
+          createClient({})
+        }
+      ).toThrowError('No Bugsnag API Key set')
+    })
+  })
+})


### PR DESCRIPTION
## Goal

To improve error message shown to end user when the apiKey is undefined/null

## Design

We were trying to use the apiKey to create a file store before validating it

## Changeset

Added early check to `electron/src/client/main.js`

## Testing

Added unit test for specific test case