### PR TITLE
[PLAT-8277] Add maxEvents error message and update tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Small performance improvements to `Bugnag.start`
     [bugsnag-android#1680](https://github.com/bugsnag/bugsnag-android/pull/1680)
 - (plugin-react|plugin-vue|plugin-react-navigation|plugin-react-native-navigation) Set `@bugsnag/core` to be an optional peer dependency to avoid unmet peer dependency warnings [#1735](https://github.com/bugsnag/bugsnag-js/pull/1735)
+- (plugin-simple-throttle) Warning message added when error handler has exceeded `maxEvents` [#1739](https://github.com/bugsnag/bugsnag-js/pull/1739)
 
 ## v7.16.4 (2022-05-03)
 

--- a/packages/plugin-simple-throttle/test/throttle.test.ts
+++ b/packages/plugin-simple-throttle/test/throttle.test.ts
@@ -3,11 +3,21 @@ import plugin from '../'
 import Client from '@bugsnag/core/client'
 
 describe('plugin: throttle', () => {
-  it('prevents more than maxEvents being sent', () => {
+  describe('addOnError', () => {
     const payloads = []
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' }, undefined, [plugin])
+    const mockWarn = jest.fn(message => message)
+    c._logger.warn = mockWarn
     c._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload), sendSession: () => {} }))
-    for (let i = 0; i < 100; i++) c.notify(new Error('This is fail'))
-    expect(payloads.length).toBe(10)
+
+    it('prevents more than maxEvents being sent', () => {
+      for (let i = 0; i < 100; i++) c.notify(new Error('This is fail'))
+      expect(payloads.length).toBe(10)
+      expect(mockWarn).toHaveBeenCalledTimes(90)
+    })
+
+    it('throws an appropriate error message', () => {
+      expect(mockWarn.mock.results[11].value).toBe('Cancelling event send due to maxEvents per session limit of 10 being reached')
+    })
   })
 })

--- a/packages/plugin-simple-throttle/test/throttle.test.ts
+++ b/packages/plugin-simple-throttle/test/throttle.test.ts
@@ -3,21 +3,19 @@ import plugin from '../'
 import Client from '@bugsnag/core/client'
 
 describe('plugin: throttle', () => {
-  describe('addOnError', () => {
-    const payloads = []
-    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' }, undefined, [plugin])
-    const mockWarn = jest.fn(message => message)
-    c._logger.warn = mockWarn
-    c._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload), sendSession: () => {} }))
+  const payloads = []
+  const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa' }, undefined, [plugin])
+  const mockWarn = jest.fn()
+  c._logger.warn = mockWarn
+  c._setDelivery(client => ({ sendEvent: (payload) => payloads.push(payload), sendSession: () => {} }))
 
-    it('prevents more than maxEvents being sent', () => {
-      for (let i = 0; i < 100; i++) c.notify(new Error('This is fail'))
-      expect(payloads.length).toBe(10)
-      expect(mockWarn).toHaveBeenCalledTimes(90)
-    })
+  it('prevents more than maxEvents being sent', () => {
+    for (let i = 0; i < 100; i++) c.notify(new Error('This is fail'))
+    expect(payloads.length).toBe(10)
+    expect(mockWarn).toHaveBeenCalledTimes(90)
+  })
 
-    it('throws an appropriate error message', () => {
-      expect(mockWarn.mock.results[11].value).toBe('Cancelling event send due to maxEvents per session limit of 10 being reached')
-    })
+  it('logs an appropriate error message', () => {
+    expect(mockWarn).toHaveBeenCalledWith('Cancelling event send due to maxEvents per session limit of 10 being reached')
   })
 })

--- a/packages/plugin-simple-throttle/throttle.js
+++ b/packages/plugin-simple-throttle/throttle.js
@@ -12,7 +12,10 @@ module.exports = {
     // add onError hook
     client.addOnError((event) => {
       // have max events been sent already?
-      if (n >= client._config.maxEvents) return false
+      if (n >= client._config.maxEvents) {
+        client._logger.warn(`Cancelling event send due to maxEvents per session limit of ${client._config.maxEvents} being reached`)
+        return false
+      }
       n++
     })
 


### PR DESCRIPTION
## Goal

To better clarify the reason for cancelled events when using `plugin-simple-throttle`

## Changeset

Added a logger message in `throttle.load` when calling `client.addOnError` 

## Testing

Updated unit tests to check number of throttled calls and message wording