### PR TITLE
[PLAT-7565] Rework network breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     [bugsnag-android#1696](https://github.com/bugsnag/bugsnag-android/pull/1696)
   - Improved `app.inForeground` reporting for NDK errors
     [bugsnag-android#1690](https://github.com/bugsnag/bugsnag-android/pull/1690)
+- (plugin-network-breadcrumbs) Improve robustness to losing XHR request data [#1751](https://github.com/bugsnag/bugsnag-js/pull/1751)
 
 ## v7.16.5 (2022-05-18)
 

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -1,10 +1,5 @@
 const BREADCRUMB_TYPE = 'request'
 
-// keys to safely store metadata on the request object
-const REQUEST_SETUP_KEY = 'BS~~S'
-const REQUEST_URL_KEY = 'BS~~U'
-const REQUEST_METHOD_KEY = 'BS~~M'
-
 const includes = require('@bugsnag/core/lib/es-utils/includes')
 
 /*
@@ -31,16 +26,14 @@ module.exports = (_ignoredUrls = [], win = window) => {
 
         // override native open()
         win.XMLHttpRequest.prototype.open = function open (method, url) {
-          // store url and HTTP method for later
-          this[REQUEST_URL_KEY] = url
-          this[REQUEST_METHOD_KEY] = method
+          let requestSetupKey = false
 
           const error = () => handleXHRError(method, url)
           const load = () => handleXHRLoad(method, url, this.status)
 
           // if we have already setup listeners, it means open() was called twice, we need to remove
           // the listeners and recreate them
-          if (this[REQUEST_SETUP_KEY]) {
+          if (requestSetupKey) {
             this.removeEventListener('load', load)
             this.removeEventListener('error', error)
           }
@@ -50,7 +43,7 @@ module.exports = (_ignoredUrls = [], win = window) => {
           // attach error event listener
           this.addEventListener('error', error)
 
-          this[REQUEST_SETUP_KEY] = true
+          requestSetupKey = true
 
           nativeOpen.apply(this, arguments)
         }

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -177,7 +177,7 @@ describe('plugin: network breadcrumbs', () => {
     expect(client._breadcrumbs.length).toBe(0)
   })
 
-  it('should not crash if the request data goes missing', () => {
+  it.skip('should not crash if the request data goes missing', () => {
     const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
 
     const logger = {
@@ -201,7 +201,7 @@ describe('plugin: network breadcrumbs', () => {
     )
   })
 
-  it('should not crash if the request data goes missing for a request that errors', () => {
+  it.skip('should not crash if the request data goes missing for a request that errors', () => {
     const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
 
     const logger = {

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -35,17 +35,6 @@ class XMLHttpRequest {
   }
 }
 
-class BrokenXMLHttpRequest extends XMLHttpRequest {
-  open (method: string, url: String) {
-    // @ts-ignore
-    delete this['BS~~S']
-    // @ts-ignore
-    delete this['BS~~U']
-    // @ts-ignore
-    delete this['BS~~M']
-  }
-}
-
 // mock fetch
 function fetch (urlOrRequest: string | Request | null | undefined, options: {} | null, fail: boolean, status: number | null = null) {
   return new Promise((resolve, reject) => {
@@ -175,56 +164,6 @@ describe('plugin: network breadcrumbs', () => {
     request.open('GET', client._config.endpoints!.sessions)
     request.send(false, 200)
     expect(client._breadcrumbs.length).toBe(0)
-  })
-
-  // skipped as it's now not possible to remove the request data as per test case
-  it.skip('should not crash if the request data goes missing', () => {
-    const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
-
-    const logger = {
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn()
-    }
-
-    p = plugin([], window)
-    const client = new Client({ apiKey: 'abcabcabcabcabcabcabc1234567890f', logger, plugins: [p] })
-
-    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
-    request.open('GET', '/')
-    request.send(false, 200)
-
-    expect(client._breadcrumbs.length).toBe(0)
-    expect(client._logger.warn).toHaveBeenCalledTimes(1)
-    expect(client._logger.warn).toHaveBeenCalledWith(
-      'The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.'
-    )
-  })
-
-  // skipped as it's now not possible to remove the request data as per test case
-  it.skip('should not crash if the request data goes missing for a request that errors', () => {
-    const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
-
-    const logger = {
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn()
-    }
-
-    p = plugin([], window)
-    const client = new Client({ apiKey: 'abcabcabcabcabcabcabc1234567890f', logger, plugins: [p] })
-
-    const request = new window.XMLHttpRequest() as unknown as XMLHttpRequest
-    request.open('GET', '/')
-    request.send(true)
-
-    expect(client._breadcrumbs.length).toBe(0)
-    expect(client._logger.warn).toHaveBeenCalledTimes(1)
-    expect(client._logger.warn).toHaveBeenCalledWith(
-      'The request URL is no longer present on this XMLHttpRequest. A breadcrumb cannot be left for this request.'
-    )
   })
 
   it('should leave a breadcrumb when the request URL is not a string', () => {

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -177,6 +177,7 @@ describe('plugin: network breadcrumbs', () => {
     expect(client._breadcrumbs.length).toBe(0)
   })
 
+  // skipped as it's now not possible to remove the request data as per test case
   it.skip('should not crash if the request data goes missing', () => {
     const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
 
@@ -201,6 +202,7 @@ describe('plugin: network breadcrumbs', () => {
     )
   })
 
+  // skipped as it's now not possible to remove the request data as per test case
   it.skip('should not crash if the request data goes missing for a request that errors', () => {
     const window = { XMLHttpRequest: BrokenXMLHttpRequest } as unknown as Window & typeof globalThis
 


### PR DESCRIPTION
## Goal

To reduce likelihood of xml http requests losing request data in network breadcrumbs

## Testing

Test for errors when losing request data must be skipped as the data can no longer be removed.