### PR TITLE
Plat 8665 react native install error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v7.17.2 (2022-06-30)
+
+### Fixed
+
+- (react-native) Fixed missing files when installing react-native [#1780](https://github.com/bugsnag/bugsnag-js/pull/1780)
+
 ## v7.17.1 (2022-06-29)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Most updates to this repo will be made by Bugsnag employees. We are unable to ac
 
 ```sh
 # Clone the repository
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js
 
 # Install top-level dependencies

--- a/TESTING.md
+++ b/TESTING.md
@@ -5,7 +5,7 @@
 Clone and navigate to this repo:
 
 ```sh
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js
 ```
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -15,7 +15,7 @@ if [[ -z ${VERSION:-} ]]; then error_missing_field "VERSION"; fi
 if [[ -z ${AWS_ACCESS_KEY_ID:-} ]]; then error_missing_field "AWS_ACCESS_KEY_ID"; fi
 if [[ -z ${AWS_SECRET_ACCESS_KEY:-} ]]; then error_missing_field "AWS_SECRET_ACCESS_KEY"; fi
 
-git clone --single-branch \
+git clone --single-branch --recursive \
   --branch "$RELEASE_BRANCH" \
   https://"$GITHUB_USER":"$GITHUB_ACCESS_TOKEN"@github.com/bugsnag/bugsnag-js.git
 

--- a/examples/electron/electron-basic/README.md
+++ b/examples/electron/electron-basic/README.md
@@ -9,7 +9,7 @@ This example app was created with Electron forge.
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/electron/electron-basic
 ```
 

--- a/examples/electron/electron-bundled/README.md
+++ b/examples/electron/electron-bundled/README.md
@@ -9,7 +9,7 @@ This example app was created with Electron forge.
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/electron/electron-bundled
 ```
 

--- a/examples/js/browser-cdn/README.md
+++ b/examples/js/browser-cdn/README.md
@@ -7,7 +7,7 @@ This is an example project showing how to use the CDN delivered version of `@bug
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/browser-cdn
 ```
 

--- a/examples/js/express/README.md
+++ b/examples/js/express/README.md
@@ -7,7 +7,7 @@ This is an example project showing how to use `@bugsnag/js` with an Express appl
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/express
 ```
 

--- a/examples/js/koa/README.md
+++ b/examples/js/koa/README.md
@@ -7,7 +7,7 @@ This is an example project showing how to use `@bugsnag/js` with a Koa applicati
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/koa
 ```
 

--- a/examples/js/nuxtjs/README.md
+++ b/examples/js/nuxtjs/README.md
@@ -9,7 +9,7 @@ We recommend creating two projects in your dashboard, one for the server errors 
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/nuxtjs
 ```
 

--- a/examples/js/plain-node/README.md
+++ b/examples/js/plain-node/README.md
@@ -7,7 +7,7 @@ This is an example project showing how to use `@bugsnag/js` with a basic Node.js
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/plain-node
 ```
 

--- a/examples/js/react/README.md
+++ b/examples/js/react/README.md
@@ -9,7 +9,7 @@ This project was bootstrapped with [`create-react-app`](https://github.com/faceb
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/react
 ```
 Take a look at…

--- a/examples/js/restify/README.md
+++ b/examples/js/restify/README.md
@@ -7,7 +7,7 @@ This is an example project showing how to use `@bugsnag/js` with a Restify appli
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/restify
 ```
 

--- a/examples/js/vue/README.md
+++ b/examples/js/vue/README.md
@@ -9,7 +9,7 @@ This project was bootstrapped with [`Vue CLI`](https://cli.vuejs.org/).
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/js/vue
 ```
 Take a look at…

--- a/examples/reactnative/rn063example/README.md
+++ b/examples/reactnative/rn063example/README.md
@@ -12,7 +12,7 @@ For instructions on how to install and configure Bugsnag in your own application
 
 1. Clone the repo and `cd` into the directory of this example:
     ```
-    git clone git@github.com:bugsnag/bugsnag-js.git
+    git clone git@github.com:bugsnag/bugsnag-js.git --recursive
     cd bugsnag-js/examples/reactnative/rn063example
     npm install
     ```

--- a/examples/ts/angular/README.md
+++ b/examples/ts/angular/README.md
@@ -9,7 +9,7 @@ This project was bootstrapped with [`Angular CLI`](https://github.com/angular/an
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/ts/angular
 ```
 

--- a/examples/ts/plain-node/README.md
+++ b/examples/ts/plain-node/README.md
@@ -7,7 +7,7 @@ This is an example project showing how to use `@bugsnag/js` with a basic TypeScr
 Clone the repo and `cd` into the directory of this example:
 
 ```
-git clone git@github.com:bugsnag/bugsnag-js.git
+git clone git@github.com:bugsnag/bugsnag-js.git --recursive
 cd bugsnag-js/examples/ts/plain-node
 ```
 


### PR DESCRIPTION
## Goal

To fix missing files issue when installing @bugsag/react-native

## Design

cocoapods within the `react-native` package have now been changed to use a submodule, which was not included in the release script, the script and all references to cloning to repo have been updated to recursively clone submodules