### PR TITLE
Fix iOS version in BugsnagReactNative.podspec

### DIFF
--- a/packages/react-native/BugsnagReactNative.podspec
+++ b/packages/react-native/BugsnagReactNative.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/bugsnag/"
   s.license      = "MIT"
   s.author       = { "Bugsnag" => "platforms@bugsnag.com" }
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/bugsnag/bugsnag-js.git", :tag => "v#{s.version}" }
   s.source_files = "ios/BugsnagReactNative/**/*.{h,m}",
                    "ios/vendor/bugsnag-cocoa/**/*.{h,mm,m,cpp,c}",


### PR DESCRIPTION
## Goal

Fix build warnings and prevent crashes.

`packages/react-native/BugsnagReactNative.podspec` declares support for iOS 7.0 but includes code from `bugsnag-cocoa` which requires iOS 9 and makes unchecked use of APIs introduced after that.

This results in build warnings and would lead to crashes if run on iOS 7 or 8.

## Changeset

Changes `platform` to `"ios", 9.0`

## Testing

Verified build warnings locally.