### PR TITLE
deps(react-native): Update bugsnag-cocoa to v6.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- (react-native) Update bugsnag-cocoa from v6.20.0 to [v6.22.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6222-2022-08-17)
+- (react-native) Update bugsnag-cocoa from v6.20.0 to [v6.22.3](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6223-2022-09-01)
 - (react-native) Update bugsnag-android from v5.24.0 to [v5.26.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5260-2022-08-18)
 
 ## v7.17.3 (2022-07-18)

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -74,8 +74,6 @@ Scenario: Handled JS error with native stacktrace
 
   # the native part of the stack comes first
   And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isLR" is null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isPC" is true
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null
@@ -102,8 +100,6 @@ Scenario: Unhandled JS error with native stacktrace
 
   # the native part of the stack comes first
   And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isLR" is null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isPC" is true
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null


### PR DESCRIPTION
`isLR` and `isPC` have changed as a result of https://github.com/bugsnag/bugsnag-cocoa/pull/1470 and it no longer seems viable to assert them here