### PR TITLE
[PLAT-8736] add getFeatureFlags method to event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- Added `getFeatureFlags()` to error events [#1815](https://github.com/bugsnag/bugsnag-js/pull/1815)
+
 ## v7.17.4 (2022-09-08)
 
 ### Changed

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -158,4 +158,18 @@ describe('browser notifier', () => {
     Bugsnag.start(API_KEY)
     expect(Bugsnag.isStarted()).toBe(true)
   })
+
+  it('enables accessing feature flags from events passed to onError callback', (done) => {
+    const Bugsnag = getBugsnag()
+    Bugsnag.start(API_KEY)
+    Bugsnag.addFeatureFlag('feature 1', '1.0')
+    Bugsnag.notify(new Error('test error'), (event) => {
+      event.addFeatureFlag('feature 2', '2.0')
+      expect(event.getFeatureFlags()).toStrictEqual([
+        { featureFlag: 'feature 1', variant: '1.0' },
+        { featureFlag: 'feature 2', variant: '2.0' }
+      ])
+      done()
+    })
+  })
 })

--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -64,6 +64,10 @@ class Event {
     featureFlagDelegate.merge(this._features, featureFlags, this._featuresIndex)
   }
 
+  getFeatureFlags () {
+    return featureFlagDelegate.toEventApi(this._features)
+  }
+
   clearFeatureFlag (name) {
     featureFlagDelegate.clear(this._features, this._featuresIndex, name)
   }
@@ -97,7 +101,7 @@ class Event {
       metaData: this._metadata,
       user: this._user,
       session: this._session,
-      featureFlags: featureFlagDelegate.toEventApi(this._features)
+      featureFlags: this.getFeatureFlags()
     }
   }
 }

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -180,6 +180,17 @@ describe('@bugsnag/core/event', () => {
   })
 
   describe('feature flags', () => {
+    describe('#getFeatureFlags', () => {
+      it('returns an array of feature flags', () => {
+        const event = new Event('Err', 'super bad error', [])
+
+        event.addFeatureFlag('old feature')
+        event.addFeatureFlag('new feature', '1.0.0')
+
+        expect(event.getFeatureFlags()).toStrictEqual([{ featureFlag: 'old feature' }, { featureFlag: 'new feature', variant: '1.0.0' }])
+      })
+    })
+
     describe('#addFeatureFlag', () => {
       it('adds the given flag/variant combination', () => {
         const event = new Event('Err', 'bad', [])

--- a/packages/core/types/event.d.ts
+++ b/packages/core/types/event.d.ts
@@ -48,6 +48,7 @@ declare class Event {
   public clearMetadata(section: string, key?: string): void
 
   // feature flags
+  public getFeatureFlags(): FeatureFlag[]
   public addFeatureFlag(name: string, variant?: string | null): void
   public addFeatureFlags(featureFlags: FeatureFlag[]): void
   public clearFeatureFlag(name: string): void


### PR DESCRIPTION
## Goal

To enable reading feature flags attached to a specific event passed to `onError` or `onSend`

## Testing

Unit test added to event in core