### PR TITLE
Release v7.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- (react-native) Update bugsnag-cocoa from v6.20.0 to [v6.22.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6222-2022-08-17)
+- (react-native) Update bugsnag-cocoa from v6.20.0 to [v6.22.3](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6223-2022-09-01)
 - (react-native) Update bugsnag-android from v5.24.0 to [v5.26.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5260-2022-08-18)
 - Refactor feature flags to maintain insertion order [#1802](https://github.com/bugsnag/bugsnag-js/pull/1802)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## v7.18.0 (2022-09-22)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (react-native) Update bugsnag-cocoa from v6.22.3 to [v6.23.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6230-2022-09-14)
+
 ## v7.17.4 (2022-09-08)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - (react-native) Update bugsnag-cocoa from v6.22.3 to [v6.23.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6230-2022-09-14)
+- Added `getFeatureFlags()` to error events [#1815](https://github.com/bugsnag/bugsnag-js/pull/1815)
 
 ## v7.17.4 (2022-09-08)
 

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -158,4 +158,18 @@ describe('browser notifier', () => {
     Bugsnag.start(API_KEY)
     expect(Bugsnag.isStarted()).toBe(true)
   })
+
+  it('enables accessing feature flags from events passed to onError callback', (done) => {
+    const Bugsnag = getBugsnag()
+    Bugsnag.start(API_KEY)
+    Bugsnag.addFeatureFlag('feature 1', '1.0')
+    Bugsnag.notify(new Error('test error'), (event) => {
+      event.addFeatureFlag('feature 2', '2.0')
+      expect(event.getFeatureFlags()).toStrictEqual([
+        { featureFlag: 'feature 1', variant: '1.0' },
+        { featureFlag: 'feature 2', variant: '2.0' }
+      ])
+      done()
+    })
+  })
 })

--- a/packages/core/event.js
+++ b/packages/core/event.js
@@ -64,6 +64,10 @@ class Event {
     featureFlagDelegate.merge(this._features, featureFlags, this._featuresIndex)
   }
 
+  getFeatureFlags () {
+    return featureFlagDelegate.toEventApi(this._features)
+  }
+
   clearFeatureFlag (name) {
     featureFlagDelegate.clear(this._features, this._featuresIndex, name)
   }
@@ -97,7 +101,7 @@ class Event {
       metaData: this._metadata,
       user: this._user,
       session: this._session,
-      featureFlags: featureFlagDelegate.toEventApi(this._features)
+      featureFlags: this.getFeatureFlags()
     }
   }
 }

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -180,6 +180,17 @@ describe('@bugsnag/core/event', () => {
   })
 
   describe('feature flags', () => {
+    describe('#getFeatureFlags', () => {
+      it('returns an array of feature flags', () => {
+        const event = new Event('Err', 'super bad error', [])
+
+        event.addFeatureFlag('old feature')
+        event.addFeatureFlag('new feature', '1.0.0')
+
+        expect(event.getFeatureFlags()).toStrictEqual([{ featureFlag: 'old feature' }, { featureFlag: 'new feature', variant: '1.0.0' }])
+      })
+    })
+
     describe('#addFeatureFlag', () => {
       it('adds the given flag/variant combination', () => {
         const event = new Event('Err', 'bad', [])

--- a/packages/core/types/event.d.ts
+++ b/packages/core/types/event.d.ts
@@ -48,6 +48,7 @@ declare class Event {
   public clearMetadata(section: string, key?: string): void
 
   // feature flags
+  public getFeatureFlags(): FeatureFlag[]
   public addFeatureFlag(name: string, variant?: string | null): void
   public addFeatureFlags(featureFlags: FeatureFlag[]): void
   public clearFeatureFlag(name: string): void

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -8,25 +8,11 @@
 
 #import "BugsnagEventDeserializer.h"
 
-#import "Bugsnag+Private.h"
-#import "BugsnagAppWithState+Private.h"
-#import "BugsnagBreadcrumb+Private.h"
-#import "BugsnagClient+Private.h"
-#import "BugsnagDeviceWithState+Private.h"
-#import "BugsnagError+Private.h"
-#import "BugsnagEvent+Private.h"
-#import "BugsnagHandledState.h"
-#import "BugsnagSessionTracker.h"
-#import "BugsnagStackframe+Private.h"
-#import "BugsnagStacktrace.h"
-#import "BugsnagThread+Private.h"
-#import "BugsnagUser+Private.h"
+#import "BugsnagInternals.h"
 
 @implementation BugsnagEventDeserializer
 
 - (BugsnagEvent *)deserializeEvent:(NSDictionary *)payload {
-    BugsnagClient *client = [Bugsnag client];
-    BugsnagSession *session = client.sessionTracker.runningSession;
     BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:payload[@"metadata"]];
 
     BugsnagHandledState *handledState = [self deserializeHandledState:payload];
@@ -40,7 +26,7 @@
                                                 breadcrumbs:[self deserializeBreadcrumbs:payload[@"breadcrumbs"]]
                                                      errors:@[[BugsnagError new]]
                                                     threads:[self deserializeThreads:payload[@"threads"]]
-                                                    session:session];
+                                                    session:nil /* set by -[BugsnagClient notifyInternal:block:] */];
     event.context = payload[@"context"];
     event.groupingHash = payload[@"groupingHash"];
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativeEmitter.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativeEmitter.m
@@ -1,8 +1,6 @@
 #import "BugsnagReactNativeEmitter.h"
 
-#import "Bugsnag+Private.h"
-#import "BugsnagClient+Private.h"
-#import "BugsnagUser+Private.h"
+#import "BugsnagInternals.h"
 
 @implementation BugsnagReactNativeEmitter
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
@@ -1,6 +1,6 @@
 #import "BugsnagReactNativePlugin.h"
 
-#import "BugsnagClient+Private.h"
+#import "BugsnagInternals.h"
 
 //
 // BugsnagReactNativePlugin is instantiated by bugsnag-cocoa during its startup:

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -74,8 +74,6 @@ Scenario: Handled JS error with native stacktrace
 
   # the native part of the stack comes first
   And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isLR" is null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isPC" is true
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null
@@ -102,8 +100,6 @@ Scenario: Unhandled JS error with native stacktrace
 
   # the native part of the stack comes first
   And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isLR" is null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.isPC" is true
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
   And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null


### PR DESCRIPTION
## v7.18.0 (2022-09-22)

### Changed

- (react-native) Update bugsnag-cocoa from v6.22.3 to [v6.23.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6230-2022-09-14)
- Added `getFeatureFlags()` to error events [#1815](https://github.com/bugsnag/bugsnag-js/pull/1815)
