### PR TITLE
[PLAT-8912] Review session definition

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -244,18 +244,7 @@ steps:
         concurrency: 5
         concurrency_group: 'browserstack'
 
-      - label: ':android: Android 5.0 Browser tests'
-        timeout_in_minutes: 20
-        plugins:
-          docker-compose#v3.9.0:
-            pull: browser-maze-runner-v6
-            run: browser-maze-runner-v6
-            use-aliases: true
-            command:
-              - --farm=bs
-              - --browser=android_s6
-        concurrency: 5
-        concurrency_group: 'browserstack'
+      # Skipping Android 5 due to test environment stability issues
 
       - label: ':android: Android 6.0 Browser tests'
         timeout_in_minutes: 20

--- a/.github/workflows/test-electron.yml
+++ b/.github/workflows/test-electron.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        electron: [ '^11.2.0' ]
+        electron: [ '^12.0.0', '^20.0.0' ]
         node-version: [12, 14]
-        os: [ ubuntu-20.04, windows-2019, macos-10.15 ]
+        os: [ ubuntu-20.04, windows-2019, macos-11 ]
         exclude:
           - os: macos-10.15
             node-version: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- (plugin-navigation-breadcrumbs) calling `pushState` or `replaceState` no longer triggers a new session [#1820](https://github.com/bugsnag/bugsnag-js/pull/1820)
+- (plugin-navigation-breadcrumbs) calling `pushState` or `replaceState` no longer triggers a new session when `autoTrackSessions` is enabled [#1820](https://github.com/bugsnag/bugsnag-js/pull/1820)
 
 ## v7.18.0 (2022-09-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ### Changed
 
+- (react-native) Update bugsnag-cocoa from v6.23.1 to [v6.24.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6240-2022-10-05)
 - (plugin-navigation-breadcrumbs) calling `pushState` or `replaceState` no longer triggers a new session when `autoTrackSessions` is enabled [#1820](https://github.com/bugsnag/bugsnag-js/pull/1820)
 
 ## v7.18.0 (2022-09-22)
 
 ### Changed
 
-- (react-native) Update bugsnag-cocoa from v6.22.3 to [v6.23.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6230-2022-09-14)
+- (react-native) Update bugsnag-cocoa from v6.22.3 to [v6.23.1](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6231-2022-09-21)
 - Added `getFeatureFlags()` to error events [#1815](https://github.com/bugsnag/bugsnag-js/pull/1815)
 
 ## v7.17.4 (2022-09-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (plugin-navigation-breadcrumbs) calling `pushState` or `replaceState` no longer triggers a new session [#1820](https://github.com/bugsnag/bugsnag-js/pull/1820)
+
 ## v7.18.0 (2022-09-22)
 
 ### Changed

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -180,7 +180,6 @@ describe('browser notifier', () => {
       const resetEventCount = jest.spyOn(client, 'resetEventCount')
 
       window.history.pushState('', '', 'new-url')
-
       expect(resetEventCount).toHaveBeenCalled()
 
       resetEventCount.mockReset()
@@ -193,11 +192,25 @@ describe('browser notifier', () => {
       const resetEventCount = jest.spyOn(client, 'resetEventCount')
 
       window.history.replaceState('', '', 'new-url')
-
       expect(resetEventCount).not.toHaveBeenCalled()
 
       resetEventCount.mockReset()
       resetEventCount.mockRestore()
+    })
+
+    it('does not start unnecessary sessions', () => {
+      const Bugsnag = getBugsnag()
+      const client = Bugsnag.createClient('API_KEY')
+      const startSession = jest.spyOn(client, 'startSession')
+
+      window.history.replaceState('', '', 'new-url')
+      expect(startSession).not.toHaveBeenCalled()
+
+      window.history.pushState('', '', 'new-url')
+      expect(startSession).not.toHaveBeenCalled()
+
+      startSession.mockReset()
+      startSession.mockRestore()
     })
   })
 })

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -172,4 +172,32 @@ describe('browser notifier', () => {
       done()
     })
   })
+
+  describe('navigation breadcrumbs', () => {
+    it('resets events on pushState', () => {
+      const Bugsnag = getBugsnag()
+      const client = Bugsnag.createClient('API_KEY')
+      const resetEventCount = jest.spyOn(client, 'resetEventCount')
+
+      window.history.pushState('', '', 'new-url')
+
+      expect(resetEventCount).toHaveBeenCalled()
+
+      resetEventCount.mockReset()
+      resetEventCount.mockRestore()
+    })
+
+    it('does not reset events on replaceState', () => {
+      const Bugsnag = getBugsnag()
+      const client = Bugsnag.createClient('API_KEY')
+      const resetEventCount = jest.spyOn(client, 'resetEventCount')
+
+      window.history.replaceState('', '', 'new-url')
+
+      expect(resetEventCount).not.toHaveBeenCalled()
+
+      resetEventCount.mockReset()
+      resetEventCount.mockRestore()
+    })
+  })
 })

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -27,9 +27,8 @@ module.exports = (win = window) => {
       }, true)
 
       // the only way to know about replaceState/pushState is to wrap them… >_<
-
-      if (win.history.replaceState) wrapHistoryFn(client, win.history, 'replaceState', win)
       if (win.history.pushState) wrapHistoryFn(client, win.history, 'pushState', win)
+      if (win.history.replaceState) wrapHistoryFn(client, win.history, 'replaceState', win, true)
     }
   }
 
@@ -63,12 +62,12 @@ const stateChangeToMetadata = (win, state, title, url) => {
   return { title, state, prevState: getCurrentState(win), to: url || currentPath, from: currentPath }
 }
 
-const wrapHistoryFn = (client, target, fn, win) => {
+const wrapHistoryFn = (client, target, fn, win, resetEventCount = false) => {
   const orig = target[fn]
   target[fn] = (state, title, url) => {
     client.leaveBreadcrumb(`History ${fn}`, stateChangeToMetadata(win, state, title, url), 'navigation')
     // if throttle plugin is in use, reset the event sent count
-    if (typeof client.resetEventCount === 'function') client.resetEventCount()
+    if (resetEventCount && typeof client.resetEventCount === 'function') client.resetEventCount()
     // Internet Explorer will convert `undefined` to a string when passed, causing an unintended redirect
     // to '/undefined'. therefore we only pass the url if it's not undefined.
     orig.apply(target, [state, title].concat(url !== undefined ? url : []))

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -27,8 +27,8 @@ module.exports = (win = window) => {
       }, true)
 
       // the only way to know about replaceState/pushState is to wrap them… >_<
-      if (win.history.pushState) wrapHistoryFn(client, win.history, 'pushState', win)
-      if (win.history.replaceState) wrapHistoryFn(client, win.history, 'replaceState', win, true)
+      if (win.history.pushState) wrapHistoryFn(client, win.history, 'pushState', win, true)
+      if (win.history.replaceState) wrapHistoryFn(client, win.history, 'replaceState', win)
     }
   }
 

--- a/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
+++ b/packages/plugin-navigation-breadcrumbs/navigation-breadcrumbs.js
@@ -69,8 +69,6 @@ const wrapHistoryFn = (client, target, fn, win) => {
     client.leaveBreadcrumb(`History ${fn}`, stateChangeToMetadata(win, state, title, url), 'navigation')
     // if throttle plugin is in use, reset the event sent count
     if (typeof client.resetEventCount === 'function') client.resetEventCount()
-    // if the client is operating in auto session-mode, a new route should trigger a new session
-    if (client._config.autoTrackSessions) client.startSession()
     // Internet Explorer will convert `undefined` to a string when passed, causing an unintended redirect
     // to '/undefined'. therefore we only pass the url if it's not undefined.
     orig.apply(target, [state, title].concat(url !== undefined ? url : []))

--- a/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
+++ b/packages/plugin-navigation-breadcrumbs/test/navigation-breadcrumbs.test.ts
@@ -51,23 +51,6 @@ describe('plugin: navigation breadcrumbs', () => {
     expect(c._breadcrumbs.length).toBe(0)
   })
 
-  it('should start a new session if autoTrackSessions=true', () => {
-    const { winHandlers, docHandlers, window } = getMockWindow()
-    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin(window)] })
-    c._sessionDelegate = {
-      startSession: jest.fn(),
-      pauseSession: noop,
-      resumeSession: id
-    }
-    winHandlers.load.forEach((h) => h.call(window))
-    docHandlers.DOMContentLoaded.forEach((h) => h.call(window.document))
-    window.history.replaceState({}, 'bar', 'network-breadcrumb-test.html')
-    expect(c._sessionDelegate.startSession).toHaveBeenCalledWith(c, expect.objectContaining({
-      id: expect.any(String),
-      startedAt: expect.any(Date)
-    }))
-  })
-
   it('should not start a new session if autoTrackSessions=false', () => {
     const { winHandlers, docHandlers, window } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', autoTrackSessions: false, plugins: [plugin(window)] })

--- a/test/react-native/features/fixtures/app/react_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_navigation_js/install.sh
@@ -8,12 +8,22 @@ if [ "$REACT_NATIVE_VERSION" = "rn0.60" ]; then
     npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
     npm install react-native-safe-area-context@^3.1 --registry=$REGISTRY_URL
     npm install react-native-screens@^2.18 --registry=$REGISTRY_URL
-else
+elif [ "$REACT_NATIVE_VERSION" = "rn0.66" ] || [ "$REACT_NATIVE_VERSION" = "rn0.67" ] || [ "$REACT_NATIVE_VERSION" = "rn0.68-hermes" ]; then
     npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
     npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
     npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
-    npm install react-native-gesture-handler@^2.2 --registry=$REGISTRY_URL
+    # gesture-handler locked to avoid Kotlin version conflicts, see "Important changes" at:
+    # https://github.com/software-mansion/react-native-gesture-handler/releases/tag/2.7.0
+    npm install react-native-gesture-handler@2.6.2 --registry=$REGISTRY_URL
     npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
     npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
     npm install react-native-screens@3.10 --registry=$REGISTRY_URL
+else
+  npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
+      npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
+      npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
+      npm install react-native-gesture-handler@^2.2 --registry=$REGISTRY_URL
+      npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
+      npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
+      npm install react-native-screens@3.10 --registry=$REGISTRY_URL
 fi


### PR DESCRIPTION
## Goal

To prevent `replaceState` or `pushState` from starting a new session. Ensuring Bugsnag sessions in the browser will start when, and only when, a page is loaded and Bugsnag is started.

## Changeset

Updated `wrapHistoryFn` to no longer start a new session
Updated `wrapHistoryFn` to accept a `resetEventCount` parameter, enabled on `pushState`

## Testing

Removed tests to check when a new session is started