### PR TITLE
ci(browser): remove android 5 env

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -244,18 +244,7 @@ steps:
         concurrency: 5
         concurrency_group: 'browserstack'
 
-      - label: ':android: Android 5.0 Browser tests'
-        timeout_in_minutes: 20
-        plugins:
-          docker-compose#v3.9.0:
-            pull: browser-maze-runner-v6
-            run: browser-maze-runner-v6
-            use-aliases: true
-            command:
-              - --farm=bs
-              - --browser=android_s6
-        concurrency: 5
-        concurrency_group: 'browserstack'
+      # Skipping Android 5 due to test environment stability issues
 
       - label: ':android: Android 6.0 Browser tests'
         timeout_in_minutes: 20


### PR DESCRIPTION
This configuration in particular seems to be incredibly unstable, doing more to reduce confidence in the test suite rather than shore up confidence in the changes being made. Builds hang after "Starting Selenium driver" somewhat consistently, then timing out after maximum wait time.

Some recent examples:

* https://buildkite.com/bugsnag/bugsnag-js-browser/builds/2677#018364be-9339-4b60-ac93-8e6df37ba792
* https://buildkite.com/bugsnag/bugsnag-js-browser/builds/2684#0183667b-b10e-4a10-9390-52e25b3f725f
* https://buildkite.com/bugsnag/bugsnag-js-browser/builds/2689#01837982-63a7-49a1-a76b-95589934c1d9
* https://buildkite.com/bugsnag/bugsnag-js-browser/builds/2691#01837f1f-3fe9-4d06-bd8d-fce070950c7a

Similar issues occur in the Safari 15 build, but given its the only representation for tests against that browser (and was at least *somewhat* more stable), did not warrant the same response.