### PR TITLE
Lock `react-native-gesture-handler` verion in the RN test fixture

### DIFF
--- a/test/react-native/features/fixtures/app/react_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_navigation_js/install.sh
@@ -8,12 +8,22 @@ if [ "$REACT_NATIVE_VERSION" = "rn0.60" ]; then
     npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
     npm install react-native-safe-area-context@^3.1 --registry=$REGISTRY_URL
     npm install react-native-screens@^2.18 --registry=$REGISTRY_URL
-else
+elif [ "$REACT_NATIVE_VERSION" = "rn0.66" ] || [ "$REACT_NATIVE_VERSION" = "rn0.67" ] || [ "$REACT_NATIVE_VERSION" = "rn0.68-hermes" ]; then
     npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
     npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
     npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
-    npm install react-native-gesture-handler@^2.2 --registry=$REGISTRY_URL
+    # gesture-handler locked to avoid Kotlin version conflicts, see "Important changes" at:
+    # https://github.com/software-mansion/react-native-gesture-handler/releases/tag/2.7.0
+    npm install react-native-gesture-handler@2.6.2 --registry=$REGISTRY_URL
     npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
     npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
     npm install react-native-screens@3.10 --registry=$REGISTRY_URL
+else
+  npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
+      npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
+      npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
+      npm install react-native-gesture-handler@^2.2 --registry=$REGISTRY_URL
+      npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
+      npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
+      npm install react-native-screens@3.10 --registry=$REGISTRY_URL
 fi


### PR DESCRIPTION
## Goal
Avoid Kotlin version conflicts in the ReactNative test fixtures.

## Changeset
Lock `react-native-gesture-handler` to version `2.6.2` which still uses Kotlin `1.4` for the `0.66`, `0.67`, and `0.68` test fixtures. The `0.69` test fixture uses Kotlin `1.6` and should be compatible with the latest `react-native-gesture-handler` versions.

## Testing
The `react-navigation` Android test fixtures build without compiler errors from Kotlin incompatibilities.