### PR TITLE
Ensure RN build steps fail if build command is unsuccessful

### DIFF
--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -6,71 +6,81 @@ const fs = require('fs')
 
 module.exports = {
   buildAndroid: function buildAndroid (sourceFixturesIn, destFixturesIn) {
-    const baseDir = process.env.PWD
-    const sourceFixtures = `${baseDir}/${sourceFixturesIn}`
-    const destFixtures = `${baseDir}/${destFixturesIn}`
-    const version = process.env.NOTIFIER_VERSION || common.determineVersion()
-    const rnVersion = process.env.REACT_NATIVE_VERSION
+    try {
+      const baseDir = process.env.PWD
+      const sourceFixtures = `${baseDir}/${sourceFixturesIn}`
+      const destFixtures = `${baseDir}/${destFixturesIn}`
+      const version = process.env.NOTIFIER_VERSION || common.determineVersion()
+      const rnVersion = process.env.REACT_NATIVE_VERSION
 
-    console.log(`Installing CLI version: ${version}`)
+      console.log(`Installing CLI version: ${version}`)
 
-    // Copy in files required from the host (just the Android ones)
-    common.run(`mkdir -p ${destFixtures}/${rnVersion}`)
-    common.run(`rsync -av --no-recursive ${sourceFixtures}/* ${destFixtures}`, true)
-    common.run(`rsync -av --no-recursive ${sourceFixtures}/${rnVersion}/* ${destFixtures}/${rnVersion}`, true)
-    common.run(`rsync -av ${sourceFixtures}/${rnVersion}/android ${destFixtures}/${rnVersion}`, true)
+      // Copy in files required from the host (just the Android ones)
+      common.run(`mkdir -p ${destFixtures}/${rnVersion}`)
+      common.run(`rsync -av --no-recursive ${sourceFixtures}/* ${destFixtures}`, true)
+      common.run(`rsync -av --no-recursive ${sourceFixtures}/${rnVersion}/* ${destFixtures}/${rnVersion}`, true)
+      common.run(`rsync -av ${sourceFixtures}/${rnVersion}/android ${destFixtures}/${rnVersion}`, true)
 
-    // JavaScript layer
-    common.changeDir(`${destFixtures}/${rnVersion}`)
-    common.run('npm install', true)
+      // JavaScript layer
+      common.changeDir(`${destFixtures}/${rnVersion}`)
+      common.run('npm install', true)
 
-    // Install and run the CLI
-    const installCommand = `npm install @bugsnag/react-native-cli@${version}`
-    common.run(installCommand, true)
+      // Install and run the CLI
+      const installCommand = `npm install @bugsnag/react-native-cli@${version}`
+      common.run(installCommand, true)
 
-    // Use Expect to run the init command interactively
-    common.changeDir(`${destFixtures}`)
-    const initCommand = `./rn-cli-init-android.sh ${version} ${rnVersion}`
-    common.run(initCommand, true)
+      // Use Expect to run the init command interactively
+      common.changeDir(`${destFixtures}`)
+      const initCommand = `./rn-cli-init-android.sh ${version} ${rnVersion}`
+      common.run(initCommand, true)
 
-    // Native layer
-    common.changeDir(`${destFixtures}/${rnVersion}/android`)
-    common.run('./gradlew assembleRelease', true)
+      // Native layer
+      common.changeDir(`${destFixtures}/${rnVersion}/android`)
+      common.run('./gradlew assembleRelease', true)
 
-    // Finally, copy the APK back to the host
-    common.run(`mkdir -p ${baseDir}/build`)
-    fs.copyFileSync(`${destFixtures}/${rnVersion}/android/app/build/outputs/apk/release/app-release.apk`,
-      `${baseDir}/build/${rnVersion}.apk`)
+      // Finally, copy the APK back to the host
+      common.run(`mkdir -p ${baseDir}/build`)
+      fs.copyFileSync(`${destFixtures}/${rnVersion}/android/app/build/outputs/apk/release/app-release.apk`,
+        `${baseDir}/build/${rnVersion}.apk`)
+    } catch (e) {
+      console.error(e, e.stack)
+      process.exit(1)
+    }
   },
   buildIOS: function buildIOS () {
-    const version = process.env.NOTIFIER_VERSION || common.determineVersion()
-    const rnVersion = process.env.REACT_NATIVE_VERSION
-    const fixturesDir = 'features/fixtures'
-    const targetDir = `${fixturesDir}/${rnVersion}`
-    const initialDir = process.cwd()
+    try {
+      const version = process.env.NOTIFIER_VERSION || common.determineVersion()
+      const rnVersion = process.env.REACT_NATIVE_VERSION
+      const fixturesDir = 'features/fixtures'
+      const targetDir = `${fixturesDir}/${rnVersion}`
+      const initialDir = process.cwd()
 
-    // We're not in docker so check RN version is set
-    if (rnVersion === undefined) {
-      throw new Error('REACT_NATIVE_VERSION environment variable must be set')
+      // We're not in docker so check RN version is set
+      if (rnVersion === undefined) {
+        throw new Error('REACT_NATIVE_VERSION environment variable must be set')
+      }
+
+      // JavaScript layer
+      common.changeDir(`${targetDir}`)
+      common.run('npm install', true)
+
+      // Install and run the CLI
+      const installCommand = `npm install @bugsnag/react-native-cli@${version}`
+      common.run(installCommand, true)
+
+      // Use Expect to run the init command interactively
+      common.changeDir(`${initialDir}/${fixturesDir}`)
+      common.run(`./rn-cli-init-ios.sh ${version} ${rnVersion}`, true)
+
+      // Clean and build the archive
+      common.changeDir(`${initialDir}/${fixturesDir}/${rnVersion}/ios`)
+      common.run(`rm -rf ../${rnVersion}.xcarchive`, true)
+      common.run('pod install || pod install --repo-update', true)
+      const archiveCmd = `xcrun xcodebuild -scheme "${rnVersion}" -workspace "${rnVersion}.xcworkspace" -configuration Release -archivePath "../${rnVersion}.xcarchive" -allowProvisioningUpdates archive`
+      common.run(archiveCmd, true)
+    } catch (e) {
+      console.error(e, e.stack)
+      process.exit(1)
     }
-
-    // JavaScript layer
-    common.changeDir(`${targetDir}`)
-    common.run('npm install', true)
-
-    // Install and run the CLI
-    const installCommand = `npm install @bugsnag/react-native-cli@${version}`
-    common.run(installCommand, true)
-
-    // Use Expect to run the init command interactively
-    common.changeDir(`${initialDir}/${fixturesDir}`)
-    common.run(`./rn-cli-init-ios.sh ${version} ${rnVersion}`, true)
-
-    // Clean and build the archive
-    common.changeDir(`${initialDir}/${fixturesDir}/${rnVersion}/ios`)
-    common.run(`rm -rf ../${rnVersion}.xcarchive`, true)
-    common.run('pod install || pod install --repo-update', true)
-    const archiveCmd = `xcrun xcodebuild -scheme "${rnVersion}" -workspace "${rnVersion}.xcworkspace" -configuration Release -archivePath "../${rnVersion}.xcarchive" -allowProvisioningUpdates archive`
-    common.run(archiveCmd, true)
   }
 }


### PR DESCRIPTION
## Goal

Ensure RN build steps fail if command is unsuccessful.

## Design

The underlying JavaScript method `common.run` throw an exception if a build command doesn't end with an exit code of 0.  However, this was not being fed back to the exit code of the whole build method being invoked - meaning that failed builds would not be marked as such on Buildkite (instead the test step would fail with a confusing error).

## Changeset

Exception handlers added to the Android/iOS build methods for RN/RN CLI test fixtures.

## Testing

Seen to be effectively working prior to raising this PR (as it turns out one of the RN build steps has actually been failing for a number of days - now fixed).