### PR TITLE
Do not trigger pipelines using async

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,7 +59,6 @@ steps:
       branch: '${BUILDKITE_BRANCH}'
       commit: '${BUILDKITE_COMMIT}'
       message: '${BUILDKITE_MESSAGE}'
-    async: true
 
   - label: 'Trigger Node pipeline'
     if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"
@@ -69,7 +68,6 @@ steps:
       branch: '${BUILDKITE_BRANCH}'
       commit: '${BUILDKITE_COMMIT}'
       message: '${BUILDKITE_MESSAGE}'
-    async: true
 
   - label: 'Trigger Expo pipeline'
     if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"
@@ -91,7 +89,6 @@ steps:
       branch: '${BUILDKITE_BRANCH}'
       commit: '${BUILDKITE_COMMIT}'
       message: '${BUILDKITE_MESSAGE}'
-    async: true
 
   - label: 'Trigger React Native CLI pipeline'
     if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"
@@ -103,7 +100,6 @@ steps:
       branch: '${BUILDKITE_BRANCH}'
       commit: '${BUILDKITE_COMMIT}'
       message: '${BUILDKITE_MESSAGE}'
-    async: true
 
   - label: ':aws-lambda: AWS Lambda tests'
     if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"


### PR DESCRIPTION
## Goal

Do not trigger pipelines using async.

## Design

Use of `async` is no longer needed given that we use `depends_on` to form a dependency tree (as opposed to simple "gates" in a sequently pipeline).  Using `async:` also means that failures in the triggered pipeline are not fed back to the main pipeline.

## Testing

Covered by CI.