### PR TITLE
Skip Vue2 tests on Internet Explorer 

### DIFF
--- a/test/browser/features/plugin_vue.feature
+++ b/test/browser/features/plugin_vue.feature
@@ -1,7 +1,7 @@
 @plugin_vue
 Feature: Vue support
 
-  @skip_ie_8
+  @skip_ie_8 @skip_ie_9 @skip_ie_10
   Scenario: basic error handler usage
     When I navigate to the test URL "/plugin_vue/webpack4/index.html"
     Then I wait to receive an error


### PR DESCRIPTION
## Goal

To unblock failing test scenarios due to breaking changes in internet explorer support (use of WeakMap) introduced in [Vue 2.7.11](https://github.com/vuejs/vue/blob/main/CHANGELOG.md#2711-2022-10-11)