### PR TITLE
Move Electron tests on Node 14 to Buildkite

### DIFF
--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -1,9 +1,28 @@
 steps:
 
   #
-  # License audit
+  # Node 14
   #
-  - label: 'Electron tests - macOS - Node 14'
+  - label: 'Electron 12 tests - macOS - Node 14'
+    timeout_in_minutes: 40
+    agents:
+      queue: macos-11
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      ELECTRON_VERSION: "^12.0.0"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      START_LOCAL_NPM: 1
+      VERBOSE: 1
+    commands:
+      - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
+      - npm ci --no-audit --progress=false
+      - npx lerna bootstrap
+      - npm run build:electron
+      - defaults write com.apple.CrashReporter DialogType none
+      - npm run test:unit:electron-runner
+      - npm run test:electron
+
+  - label: 'Electron 20 tests - macOS - Node 14'
     timeout_in_minutes: 40
     agents:
       queue: macos-11
@@ -14,7 +33,7 @@ steps:
       START_LOCAL_NPM: 1
       VERBOSE: 1
     commands:
-      - npm install electron@^20.0.0 --no-audit --progress=false --no-save
+      - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
       - npm ci --no-audit --progress=false
       - npx lerna bootstrap
       - npm run build:electron

--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -1,0 +1,22 @@
+steps:
+
+  #
+  # License audit
+  #
+  - label: 'Electron tests - macOS - Node 14'
+    timeout_in_minutes: 40
+    agents:
+      queue: macos-12-arm
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      START_LOCAL_NPM: 1
+      ELECTRON_VERSION: "^20.0.0"
+      VERBOSE: 1
+    commands:
+      - npm install electron@^20.0.0 --no-audit --progress=false --no-save
+      - npm ci --no-audit --progress=false
+      - npx lerna bootstrap
+      - npm run build:electron
+      - defaults write com.apple.CrashReporter DialogType none
+      - npm run test:unit:electron-runner
+      - npm run test:electron

--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -8,9 +8,10 @@ steps:
     agents:
       queue: macos-12-arm
     env:
+      DEVELOPER_DIR: "/Applications/Xcode14.app"
+      ELECTRON_VERSION: "^20.0.0"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       START_LOCAL_NPM: 1
-      ELECTRON_VERSION: "^20.0.0"
       VERBOSE: 1
     commands:
       - npm install electron@^20.0.0 --no-audit --progress=false --no-save

--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -6,9 +6,9 @@ steps:
   - label: 'Electron tests - macOS - Node 14'
     timeout_in_minutes: 40
     agents:
-      queue: macos-12-arm
+      queue: macos-11
     env:
-      DEVELOPER_DIR: "/Applications/Xcode14.app"
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
       ELECTRON_VERSION: "^20.0.0"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       START_LOCAL_NPM: 1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,14 @@ steps:
       commit: '${BUILDKITE_COMMIT}'
       message: '${BUILDKITE_MESSAGE}'
 
+  - label: 'Trigger Electron pipeline'
+    if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"
+    trigger: 'bugsnag-js-electron'
+    build:
+      branch: '${BUILDKITE_BRANCH}'
+      commit: '${BUILDKITE_COMMIT}'
+      message: '${BUILDKITE_MESSAGE}'
+
   - label: 'Trigger Node pipeline'
     if: build.env("BUILD_RN_WITH_LATEST_NATIVES") != "true"
     depends_on: 'package-js'

--- a/.github/workflows/test-electron.yml
+++ b/.github/workflows/test-electron.yml
@@ -10,10 +10,7 @@ jobs:
       matrix:
         electron: [ '^12.0.0', '^20.0.0' ]
         node-version: [12, 14]
-        os: [ ubuntu-20.04, windows-2019, macos-11 ]
-        exclude:
-          - os: macos-10.15
-            node-version: 14
+        os: [ ubuntu-20.04, windows-2019 ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Goal

Moves the Electron tests on Node 14 from Github Actions to Buildkite.

## Design

For now the macOS tests on Node 12 has been removed, pending the implementation of PLAT-9094.

## Testing

Covered by CI.