### PR TITLE
Relax test to allow more than 1 session to be sent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,7 +209,7 @@ services:
       - ./test/react-native/maze_output:/app/maze_output
 
   react-native-cli-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v6-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
     environment:
       BUILDKITE:
       BUILDKITE_BRANCH:

--- a/test/react-native-cli/Gemfile
+++ b/test/react-native-cli/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'cocoapods'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.3.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.4.0'
 
 # Use a branch of Maze Runner
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/use-maze-check'

--- a/test/react-native-cli/Gemfile.lock
+++ b/test/react-native-cli/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 224d073b18e5469eac67b05ec55be2dad8d37033
-  tag: v7.3.0
+  revision: fc5e8c39582b067743ffb18c946f2c9e8fd27311
+  tag: v7.4.0
   specs:
-    bugsnag-maze-runner (7.3.0)
+    bugsnag-maze-runner (7.4.0)
       appium_lib (~> 12.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)

--- a/test/react-native-cli/features/run-app-tests/run-and-notify.feature
+++ b/test/react-native-cli/features/run-app-tests/run-and-notify.feature
@@ -1,7 +1,7 @@
 Feature: Tests for running a React Native app that was initialized using the Bugsnag React Native CLI
 
 Scenario: A built, CLI initialized, app sends JavaScript and Native handled errors
-  When I wait to receive a session
+  When I wait to receive at least 1 session
   Then the session is valid for the session reporting API version "1.0" for the React Native notifier
 
   And I notify a handled JavaScript error


### PR DESCRIPTION
## Goal

Avoid a test flake caused by automation jitters by allowing more than 1 session to be sent.

## Design

It is possible for more than one session to be sent due to "jitters" from Appium causing it to launch more than once in quick succession.  The case shouldn't care about this - it just cares that an app built with Bugsnag basically works (is able to sent sessions and errors).

## Testing

Covered by CI.