### PR TITLE
Reinstate browser testing on Android 4

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -8,7 +8,6 @@ steps:
         plugins:
           - artifacts#v1.5.0:
               download: min_packages.tar
-              build: ${BUILDKITE_TRIGGERED_FROM_BUILD_ID}
           - docker-compose#v3.9.0:
               build:
                 - browser-maze-runner
@@ -18,6 +17,22 @@ steps:
           - docker-compose#v3.9.0:
               push:
                 - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
+
+      - label:  ":docker: Build legacy browser maze runner image"
+        key: "browser-maze-runner-legacy"
+        timeout_in_minutes: 20
+        plugins:
+          - artifacts#v1.5.0:
+              download: min_packages.tar
+          - docker-compose#v3.9.0:
+              build:
+                - browser-maze-runner-legacy
+              image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+              cache-from:
+                - browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
+          - docker-compose#v3.9.0:
+              push:
+                - browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
 
       #
       # BitBar tests
@@ -97,6 +112,20 @@ steps:
       #
       # BrowserStack tests
       #
+      - label: ":android: Android 4.4 Browser tests"
+        depends_on: "browser-maze-runner-legacy"
+        timeout_in_minutes: 20
+        plugins:
+          docker-compose#v3.9.0:
+            pull: browser-maze-runner-legacy
+            run: browser-maze-runner-legacy
+            use-aliases: true
+            command:
+              - --farm=bs
+              - --browser=android_nexus5
+        concurrency: 5
+        concurrency_group: "browserstack"
+
       - label: ":chrome: v43 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 20
@@ -226,22 +255,6 @@ steps:
           HOST: "bs-local.com"
         concurrency: 5
         concurrency_group: "browserstack"
-
-      - label: ":android: Android 4.4 Browser tests"
-        depends_on: "browser-maze-runner"
-        timeout_in_minutes: 20
-        plugins:
-          docker-compose#v3.9.0:
-            pull: browser-maze-runner-legacy
-            run: browser-maze-runner-legacy
-            use-aliases: true
-            command:
-              - --farm=bs
-              - --browser=android_nexus5
-        concurrency: 5
-        concurrency_group: "browserstack"
-
-      # Skipping Android 5 due to test environment stability issues
 
       - label: ":android: Android 6.0 Browser tests"
         depends_on: "browser-maze-runner"

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -229,12 +229,11 @@ steps:
 
       - label: ":android: Android 4.4 Browser tests"
         depends_on: "browser-maze-runner"
-        skip: Skipped pending PLAT-9069
         timeout_in_minutes: 20
         plugins:
           docker-compose#v3.9.0:
-            pull: browser-maze-runner
-            run: browser-maze-runner
+            pull: browser-maze-runner-legacy
+            run: browser-maze-runner-legacy
             use-aliases: true
             command:
               - --farm=bs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,45 @@ services:
         aliases:
           - maze-runner
 
+  browser-maze-runner-legacy:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.browser
+      target: browser-maze-runner-legacy
+      args:
+        - BUILDKITE_BUILD_NUMBER
+    environment:
+      BUILDKITE:
+      BUILDKITE_BRANCH:
+      BUILDKITE_BUILD_CREATOR:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_BUILD_URL:
+      BUILDKITE_LABEL:
+      BUILDKITE_MESSAGE:
+      BUILDKITE_PIPELINE_NAME:
+      BUILDKITE_REPO:
+      BUILDKITE_RETRY_COUNT:
+      BUILDKITE_STEP_KEY:
+      MAZE_BUGSNAG_API_KEY:
+      MAZE_TMS_URI:
+      MAZE_TMS_TOKEN:
+      DEBUG:
+      BROWSER_STACK_USERNAME:
+      BROWSER_STACK_ACCESS_KEY:
+      BROWSER_STACK_BROWSERS_USERNAME:
+      BROWSER_STACK_BROWSERS_ACCESS_KEY:
+      BROWSER_STACK_DEVICES_USERNAME:
+      BROWSER_STACK_DEVICES_ACCESS_KEY:
+      USE_LEGACY_DRIVER: 1
+      HOST: "${HOST:-maze-runner}"
+      API_HOST: "${API_HOST:-maze-runner}"
+    env_file:
+      - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
+    networks:
+      default:
+        aliases:
+          - maze-runner
+
   node-maze-runner:
     build:
       context: .

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -44,8 +44,14 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 # it makes the COPY later on much faster if we don't have them
 RUN rm -fr **/*/node_modules/
 
-# The maze-runner browser tests
+# The maze-runner browser tests (W3C protocol)
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli as browser-maze-runner
+
+COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
+WORKDIR /app/test/browser
+
+# The maze-runner legacy browser tests (JSON-WP protocol)
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli-legacy as browser-maze-runner-legacy
 
 COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
 WORKDIR /app/test/browser


### PR DESCRIPTION
## Goal

Reinstate testing on the Android 4 browser, which was removed recently due to lack of support for the legacy JSON-WP protocol for browsers in Maze Runner v7.

## Design

Support for JSON-WP has now been added back into Maze Runner v7.  To harness it we need to use a separate Docker image, hence the extra step in the Buildkite pipeline and entry in `docker-compose.yml`.

## Testing

Covered by CI.