### PR TITLE
Trigger builds on all maintained Expo branches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,12 +136,35 @@ steps:
     commands:
       - buildkite-agent pipeline upload .buildkite/react-native-cli-pipeline.yml
 
-  - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: EXPO PIPELINE :large_blue_circle: :large_blue_circle: :large_blue_circle:"
+  - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: EXPO 46 PIPELINE :large_blue_circle: :large_blue_circle: :large_blue_circle:"
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:
+      branch: v46-next
       env:
         BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
         BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"
-        # a branch name that"s safe to use as a docker cache identifier
+        # a branch name that's safe to use as a docker cache identifier
+        BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME: "${BRANCH_NAME}"
+
+  - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: EXPO 45 PIPELINE :large_blue_circle: :large_blue_circle: :large_blue_circle:"
+    depends_on: "publish-js"
+    trigger: "bugsnag-expo"
+    build:
+      branch: v45-next
+      env:
+        BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
+        BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"
+        # a branch name that's safe to use as a docker cache identifier
+        BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME: "${BRANCH_NAME}"
+
+  - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: EXPO 44 PIPELINE :large_blue_circle: :large_blue_circle: :large_blue_circle:"
+    depends_on: "publish-js"
+    trigger: "bugsnag-expo"
+    build:
+      branch: v44-next
+      env:
+        BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
+        BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"
+        # a branch name that's safe to use as a docker cache identifier
         BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME: "${BRANCH_NAME}"


### PR DESCRIPTION
## Goal

Trigger a build of all three maintained Expo branches (currently for version 44 to 46) on a CI run.

## Design

This should ensure that none of the actively supported version of Expo are broken by a change to the JS notifier.

## Testing

Covered by CI.