### PR TITLE
Pin React Native Navigation for RN 0.66

### DIFF
--- a/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
@@ -2,11 +2,12 @@
 
 npm i @bugsnag/plugin-react-native-navigation@$BUGSNAG_VERSION --registry=$REGISTRY_URL
 
-if [ "$REACT_NATIVE_VERSION" == "rn0.60" ];
-then
+if [ "$REACT_NATIVE_VERSION" == "rn0.60" ]; then
    npm i react-native-navigation@7.0.0
+elif [ "$REACT_NATIVE_VERSION" == "rn0.66" ]; then
+   npm i react-native-navigation@7.29.1
 else
-   npm i react-native-navigation@^7.15.0
+   npm i react-native-navigation@^7.30.0
 fi
 
 npx rnn-link


### PR DESCRIPTION
## Goal

Fix the pipeline build by pinning react-native-navigation to 7.29.1 for React Native 0.66.

## Design

Although we don't fully understand why it has happened, the release of RNN 7.30.0 broke the test fixture build.

Separate to this PR we should bumpy the version of RN that we run the RNN tests on (I tried 0.68 and 0.69 in the run up to this, but both builds failed for different reasons).

## Testing

Covered by CI.