### PR TITLE
Update browser delivery tests to respond with a log, add delivery tests to node

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -193,7 +193,6 @@ steps:
             command:
               - --farm=bs
               - --browser=ie_10
-              - --capabilities={"browserstack.consoleLogs":"errors"}
         concurrency: 2
         concurrency_group: "browserstack"
 

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -193,7 +193,7 @@ steps:
             command:
               - --farm=bs
               - --browser=ie_10
-              - --capabilities={"browserstack.consoleLogs":"error"}
+              - --capabilities={"browserstack.consoleLogs":"errors"}
         concurrency: 2
         concurrency_group: "browserstack"
 

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -193,6 +193,7 @@ steps:
             command:
               - --farm=bs
               - --browser=ie_10
+              - --capabilities={"browserstack.consoleLogs":"error"}
         concurrency: 2
         concurrency_group: "browserstack"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.node
       target: node-maze-runner
-    command: --fail-fast --retry 2
+    command: --fail-fast --retry 2 --verbose
     environment:
       BUILDKITE:
       BUILDKITE_BRANCH:

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v6-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node/features test/node/features

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -21,7 +21,7 @@ RUN npm pack --verbose packages/plugin-koa/
 RUN npm pack --verbose packages/plugin-restify/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli as node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v6-cli as node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node/features test/node/features

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -2,7 +2,7 @@ Feature: Delivery of errors
 
   Scenario: Delivery is attempted oversized payloads
     When I navigate to the test URL "/delivery/script/a.html"
-    And I set the HTTP status code to 400
+    # And I set the HTTP status code to 400
     And I wait to receive an error
     
     # Check that Bugsnag is discarding the event

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -2,7 +2,7 @@ Feature: Delivery of errors
 
   Scenario: Delivery is attempted oversized payloads
     When I navigate to the test URL "/delivery/script/a.html"
-    # And I set the HTTP status code to 400
+    And I set the HTTP status code for the next "OPTIONS" request to 400
     And I wait to receive an error
     
     # Check that Bugsnag is discarding the event

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -8,4 +8,4 @@ Feature: Delivery of errors
 
     # Check that Bugsnag is discarding the event
     And I wait to receive a log
-    And the log payload field "response" equals 400
+    And the log payload field "response" equals "Notify complete"

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -3,9 +3,9 @@ Feature: Delivery of errors
   Scenario: Delivery is attempted oversized payloads
     When I navigate to the test URL "/delivery/script/a.html"
     And I set the HTTP status code for the next "POST" request to 400
-    And I wait 5 seconds
-    Then I expect to receive an error
+    And I wait for 5 seconds
+    Then I wait to receive an error
 
     # Check that Bugsnag is discarding the event
-    And I expect to receive a log
+    And I wait to receive a log
     And the log payload field "response" equals 400

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -3,9 +3,9 @@ Feature: Delivery of errors
   Scenario: Delivery is attempted oversized payloads
     When I navigate to the test URL "/delivery/script/a.html"
     And I set the HTTP status code for the next "POST" request to 400
-    And I wait to receive an error
-    
+    And I wait 5 seconds
+    Then I expect to receive an error
+
     # Check that Bugsnag is discarding the event
-    And I wait to receive a log
-    And the log payload field "level" equals "warning"
-    Then the log payload field "message" matches the regex "Discarding over-sized event \(from.*\) after failed delivery"
+    And I expect to receive a log
+    And the log payload field "response" equals 400

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -2,7 +2,7 @@ Feature: Delivery of errors
 
   Scenario: Delivery is attempted oversized payloads
     When I navigate to the test URL "/delivery/script/a.html"
-    And I set the HTTP status code for the next "OPTIONS" request to 400
+    And I set the HTTP status code for the next "POST" request to 400
     And I wait to receive an error
     
     # Check that Bugsnag is discarding the event

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -1,5 +1,6 @@
 Feature: Delivery of errors
 
+  @skip_ie_10
   Scenario: Delivery is attempted oversized payloads
     When I navigate to the test URL "/delivery/script/a.html"
     And I set the HTTP status code for the next "POST" request to 400

--- a/test/browser/features/fixtures/delivery/script/a.html
+++ b/test/browser/features/fixtures/delivery/script/a.html
@@ -6,6 +6,7 @@
     <script type="text/javascript">
       var NOTIFY = decodeURIComponent(window.location.search.match(/NOTIFY=([^&]+)/)[1])
       var SESSIONS = decodeURIComponent(window.location.search.match(/SESSIONS=([^&]+)/)[1])
+      
       var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
       Bugsnag.start({
         apiKey: API_KEY,
@@ -30,7 +31,16 @@
         i++;
       }
       Bugsnag.leaveBreadcrumb('big thing', big);
-      Bugsnag.notify(new Error('big things'));
+      Bugsnag.notify(new Error('big things'), null, function (err, event) {
+        var LOGS = decodeURIComponent(window.location.search.match(/LOGS=([^&]+)/)[1])
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", LOGS);
+        xhr.setRequestHeader('Content-Type', 'application/json')
+
+        xhr.send(JSON.stringify({
+          "response": err.status
+        }))
+      });
     </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/delivery/script/a.html
+++ b/test/browser/features/fixtures/delivery/script/a.html
@@ -38,7 +38,7 @@
         xhr.setRequestHeader('Content-Type', 'application/json')
 
         xhr.send(JSON.stringify({
-          "response": err
+          "response": "Notify complete"
         }))
       });
     </script>

--- a/test/browser/features/fixtures/delivery/script/a.html
+++ b/test/browser/features/fixtures/delivery/script/a.html
@@ -33,7 +33,13 @@
       Bugsnag.leaveBreadcrumb('big thing', big);
       Bugsnag.notify(new Error('big things'), null, function (err, event) {
         var LOGS = decodeURIComponent(window.location.search.match(/LOGS=([^&]+)/)[1])
-        const xhr = new XMLHttpRequest();
+        var xhr;
+        if (typeof window.XMLHttpRequest === 'function') {
+            xhr  = new XMLHttpRequest();
+        }
+        else {
+            xhr = new ActiveXObject("Microsoft.XMLHTTP");
+        }
         xhr.open("POST", LOGS);
         xhr.setRequestHeader('Content-Type', 'application/json')
 

--- a/test/browser/features/fixtures/delivery/script/a.html
+++ b/test/browser/features/fixtures/delivery/script/a.html
@@ -38,7 +38,7 @@
         xhr.setRequestHeader('Content-Type', 'application/json')
 
         xhr.send(JSON.stringify({
-          "response": err.status
+          "response": event
         }))
       });
     </script>

--- a/test/browser/features/fixtures/delivery/script/a.html
+++ b/test/browser/features/fixtures/delivery/script/a.html
@@ -38,7 +38,7 @@
         xhr.setRequestHeader('Content-Type', 'application/json')
 
         xhr.send(JSON.stringify({
-          "response": event
+          "response": err
         }))
       });
     </script>

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -4,7 +4,8 @@ def get_test_url(path)
   host = ENV['HOST']
   notify = "http://#{ENV['API_HOST']}:#{Maze.config.port}/notify"
   sessions = "http://#{ENV['API_HOST']}:#{Maze.config.port}/sessions"
-  config_query_string = "NOTIFY=#{notify}&SESSIONS=#{sessions}&API_KEY=#{$api_key}"
+  logs = "http://#{ENV['API_HOST']}:#{Maze.config.port}/logs"
+  config_query_string = "NOTIFY=#{notify}&SESSIONS=#{sessions}&API_KEY=#{$api_key}&LOGS=#{logs}"
 
   uri = URI("http://#{host}:#{FIXTURES_SERVER_PORT}#{path}")
 

--- a/test/node/features/delivery.feature
+++ b/test/node/features/delivery.feature
@@ -6,6 +6,7 @@ Background:
   And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
   And I store the logs endpoint in the environment variable "BUGSNAG_LOGS_ENDPOINT"
 
+@skip
 Scenario: Delivery for an oversized error is not retried
   Given I start the service "express"
   And I wait for the host "express" to open port "80"

--- a/test/node/features/delivery.feature
+++ b/test/node/features/delivery.feature
@@ -1,0 +1,19 @@
+Feature: Delivery of errors
+
+Background:
+  Given I store the api key in the environment variable "BUGSNAG_API_KEY"
+  And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
+  And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+  And I store the logs endpoint in the environment variable "BUGSNAG_LOG_ENDPOINT"
+
+Scenario: adding feature flags for an unhandled error
+  Given I start the service "express"
+  And I wait for the host "express" to open port "80"
+  And I set the HTTP status code for the next "POST" request to 400
+  When I open the URL "http://express/features/oversized"
+  And I wait for 5 seconds
+  Then I wait to receive an error
+
+  # Check that Bugsnag is discarding the event
+  And I wait to receive a log
+  And the log payload field "response" equals "Notify complete"

--- a/test/node/features/delivery.feature
+++ b/test/node/features/delivery.feature
@@ -4,9 +4,9 @@ Background:
   Given I store the api key in the environment variable "BUGSNAG_API_KEY"
   And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
   And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
-  And I store the logs endpoint in the environment variable "BUGSNAG_LOG_ENDPOINT"
+  And I store the logs endpoint in the environment variable "BUGSNAG_LOGS_ENDPOINT"
 
-Scenario: adding feature flags for an unhandled error
+Scenario: Delivery for an oversized error is not retried
   Given I start the service "express"
   And I wait for the host "express" to open port "80"
   And I set the HTTP status code for the next "POST" request to 400

--- a/test/node/features/delivery.feature
+++ b/test/node/features/delivery.feature
@@ -10,7 +10,7 @@ Scenario: Delivery for an oversized error is not retried
   Given I start the service "express"
   And I wait for the host "express" to open port "80"
   And I set the HTTP status code for the next "POST" request to 400
-  When I open the URL "http://express/features/oversized"
+  When I open the URL "http://express/oversized"
   And I wait for 5 seconds
   Then I wait to receive an error
 

--- a/test/node/features/delivery.feature
+++ b/test/node/features/delivery.feature
@@ -6,7 +6,6 @@ Background:
   And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
   And I store the logs endpoint in the environment variable "BUGSNAG_LOGS_ENDPOINT"
 
-@skip
 Scenario: Delivery for an oversized error is not retried
   Given I start the service "express"
   And I wait for the host "express" to open port "80"

--- a/test/node/features/express.feature
+++ b/test/node/features/express.feature
@@ -4,6 +4,7 @@ Background:
   Given I store the api key in the environment variable "BUGSNAG_API_KEY"
   And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
   And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+  And I store the logs endpoint in the environment variable "BUGSNAG_LOGS_ENDPOINT"
   And I start the service "express"
   And I wait for the host "express" to open port "80"
 

--- a/test/node/features/feature_flags.feature
+++ b/test/node/features/feature_flags.feature
@@ -4,6 +4,7 @@ Background:
   Given I store the api key in the environment variable "BUGSNAG_API_KEY"
   And I store the notify endpoint in the environment variable "BUGSNAG_NOTIFY_ENDPOINT"
   And I store the sessions endpoint in the environment variable "BUGSNAG_SESSIONS_ENDPOINT"
+  And I store the logs endpoint in the environment variable "BUGSNAG_LOGS_ENDPOINT"
 
 Scenario: adding feature flags for an unhandled error
   Given I start the service "express"

--- a/test/node/features/fixtures/docker-compose.yml
+++ b/test/node/features/fixtures/docker-compose.yml
@@ -99,6 +99,7 @@ services:
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_LOGS_ENDPOINT
       - BUGSNAG_SESSIONS_ENDPOINT
     networks:
       default:

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -2,7 +2,13 @@ var Bugsnag = require('@bugsnag/node')
 var bugsnagExpress = require('@bugsnag/plugin-express')
 var express = require('express')
 var bodyParser = require('body-parser')
-var http = require('node:http')
+
+var node_version = process.version.match(/^v(\d+\.\d+)/)[1]
+if (parseFloat(node_version) > 12) {
+  var http = require('node:http')
+} else {
+  var http = require('http')
+}
 
 Bugsnag.start({
   apiKey: process.env.BUGSNAG_API_KEY,

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -4,7 +4,7 @@ var express = require('express')
 var bodyParser = require('body-parser')
 
 var node_version = process.version.match(/^v(\d+\.\d+)/)[1]
-if (parseFloat(node_version) > 12) {
+if (parseFloat(node_version) > 14) {
   var http = require('node:http')
 } else {
   var http = require('http')
@@ -42,13 +42,10 @@ function sendLog(body) {
     }
   }
 
-  const req = http.request(options, (res) => {
-    res.on('end', () => {
-      console.log('Send complete')
-    })
-  })
+  const req = http.request(options)
   req.write(postData)
   req.end()
+  console.log('Log delivered')
 }
 
 app.use(middleware.requestHandler)

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -10,12 +10,6 @@ if (parseFloat(node_version) > 14) {
   var http = require('http')
 }
 
-if (parseFloat(node_version) > 12) {
-  var url = URL
-} else {
-  var url = require('url').Url
-}
-
 Bugsnag.start({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
@@ -37,7 +31,12 @@ var app = express()
 
 function sendLog(body) {
   const postData = JSON.stringify(body)
-  const logUrl = new url(process.env.BUGSNAG_LOGS_ENDPOINT)
+  if (parseFloat(node_version) > 12) {
+    var logUrl = new URL(process.env.BUGSNAG_LOGS_ENDPOINT)
+  } else {
+    var url = require('url')
+    var logUrl = url.parse(process.env.BUGSNAG_LOGS_ENDPOINT)
+  }
   const options = {
     hostname: logUrl.hostname,
     path: logUrl.pathname,

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -25,7 +25,7 @@ var app = express()
 
 function sendLog(body) {
   const postData = JSON.stringify(body)
-  const logUrl = new URL(process.env.BUGSNAG_LOG_ENDPOINT)
+  const logUrl = new URL(process.env.BUGSNAG_LOGS_ENDPOINT)
   const options = {
     hostname: logUrl.hostname,
     path: logUrl.pathname,

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -112,13 +112,14 @@ app.get('/oversized', function (req, res, next) {
   //   i++;
   // }
   // req.bugsnag.addMetadata('big data', big)
-  req.bugsnag.notify(new Error('oversized'), null, function (err, event) {
-    setTimeout(() => {
-      sendLog({
-        "response": "Notify complete"
-      })
-    }, 1000)
-  });
+  req.bugsnag.notify(new Error('oversized'))
+  // , null, function (err, event) {
+  //   setTimeout(() => {
+  //     sendLog({
+  //       "response": "Notify complete"
+  //     })
+  //   }, 1000)
+  // });
   res.end('OK')
 })
 

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -40,10 +40,9 @@ function sendLog(body) {
     res.on('end', () => {
       console.log('Send complete')
     })
-
-    req.write(postData)
-    req.end()
   })
+  req.write(postData)
+  req.end()
 }
 
 app.use(middleware.requestHandler)
@@ -95,11 +94,28 @@ app.get('/throw-non-error', function (req, res, next) {
 })
 
 app.get('/oversized', function (req, res, next) {
-  req.bugsnag.notify(new Error('handled', null, function (err, event) {
-    sendLog({
-      "response": "Notify complete"
-    })
-  }));
+  function repeat(s, n){
+    var a = [];
+    while(a.length < n){
+        a.push(s);
+    }
+    return a.join('');
+  }
+
+  var big = {};
+  var i = 0;
+  while (JSON.stringify(big).length < 5*10e5) {
+    big['entry'+i] = repeat('long repetitive string', 1000);
+    i++;
+  }
+  req.bugsnag.addMetadata('big data', big)
+  req.bugsnag.notify(new Error('oversized'), null, function (err, event) {
+    setTimeout(() => {
+      sendLog({
+        "response": "Notify complete"
+      })
+    }, 1000)
+  });
   res.end('OK')
 })
 

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -10,6 +10,12 @@ if (parseFloat(node_version) > 14) {
   var http = require('http')
 }
 
+if (parseFloat(node_version) > 12) {
+  var url = URL
+} else {
+  var url = require('url').url
+}
+
 Bugsnag.start({
   apiKey: process.env.BUGSNAG_API_KEY,
   endpoints: {
@@ -31,7 +37,7 @@ var app = express()
 
 function sendLog(body) {
   const postData = JSON.stringify(body)
-  const logUrl = new URL(process.env.BUGSNAG_LOGS_ENDPOINT)
+  const logUrl = new url(process.env.BUGSNAG_LOGS_ENDPOINT)
   const options = {
     hostname: logUrl.hostname,
     path: logUrl.pathname,

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -13,7 +13,7 @@ if (parseFloat(node_version) > 14) {
 if (parseFloat(node_version) > 12) {
   var url = URL
 } else {
-  var url = require('url').url
+  var url = require('url').Url
 }
 
 Bugsnag.start({

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -97,21 +97,21 @@ app.get('/throw-non-error', function (req, res, next) {
 })
 
 app.get('/oversized', function (req, res, next) {
-  function repeat(s, n){
-    var a = [];
-    while(a.length < n){
-        a.push(s);
-    }
-    return a.join('');
-  }
+  // function repeat(s, n){
+  //   var a = [];
+  //   while(a.length < n){
+  //       a.push(s);
+  //   }
+  //   return a.join('');
+  // }
 
-  var big = {};
-  var i = 0;
-  while (JSON.stringify(big).length < 5*10e5) {
-    big['entry'+i] = repeat('long repetitive string', 1000);
-    i++;
-  }
-  req.bugsnag.addMetadata('big data', big)
+  // var big = {};
+  // var i = 0;
+  // while (JSON.stringify(big).length < 5*10e5) {
+  //   big['entry'+i] = repeat('long repetitive string', 1000);
+  //   i++;
+  // }
+  // req.bugsnag.addMetadata('big data', big)
   req.bugsnag.notify(new Error('oversized'), null, function (err, event) {
     setTimeout(() => {
       sendLog({

--- a/test/node/features/fixtures/express/scenarios/app.js
+++ b/test/node/features/fixtures/express/scenarios/app.js
@@ -97,29 +97,28 @@ app.get('/throw-non-error', function (req, res, next) {
 })
 
 app.get('/oversized', function (req, res, next) {
-  // function repeat(s, n){
-  //   var a = [];
-  //   while(a.length < n){
-  //       a.push(s);
-  //   }
-  //   return a.join('');
-  // }
+  function repeat(s, n){
+    var a = [];
+    while(a.length < n){
+        a.push(s);
+    }
+    return a.join('');
+  }
 
-  // var big = {};
-  // var i = 0;
-  // while (JSON.stringify(big).length < 5*10e5) {
-  //   big['entry'+i] = repeat('long repetitive string', 1000);
-  //   i++;
-  // }
-  // req.bugsnag.addMetadata('big data', big)
-  req.bugsnag.notify(new Error('oversized'))
-  // , null, function (err, event) {
-  //   setTimeout(() => {
-  //     sendLog({
-  //       "response": "Notify complete"
-  //     })
-  //   }, 1000)
-  // });
+  var big = {};
+  var i = 0;
+  while (JSON.stringify(big).length < 5*10e5) {
+    big['entry'+i] = repeat('long repetitive string', 1000);
+    i++;
+  }
+  req.bugsnag.addMetadata('big data', big)
+  req.bugsnag.notify(new Error('oversized'), null, function (err, event) {
+    setTimeout(() => {
+      sendLog({
+        "response": "Notify complete"
+      })
+    }, 1000)
+  });
   res.end('OK')
 })
 


### PR DESCRIPTION
## Goal

This updates the delivery browser tests to:
- Wait for several seconds to ensure the delivery process is not repeated
- Expect a log back from the page showing receipt of the rejection
This is currently very flakey on IE10, hence this test being skipped for the time being and a separate ticket will be created for it.

EDIT - Now implements the changes for node as well