### PR TITLE
Reinstate macOS Electron tests on Node 12

### DIFF
--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -11,19 +11,19 @@ steps:
       DEVELOPER_DIR: "/Applications/Xcode12.app"
       NODE_VERSION: "{{matrix.node_version}}"
       ELECTRON_VERSION: "{{matrix.electron_version}}"
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      START_LOCAL_NPM: 1
-      VERBOSE: 1
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+      START_LOCAL_NPM: "1"
+      VERBOSE: "1"
     matrix:
       setup:
         electron_version:
-          - "12.0.0"
-          - "20.0.0"
+          - "^12.0.0"
+          - "^20.0.0"
         node_version:
           - "12"
           - "14"
     commands:
-      - node -v
+      - echo "Running on Node `node -v`"
       - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
       - npm ci --no-audit --progress=false
       - npx lerna bootstrap

--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -5,36 +5,27 @@ steps:
       #
       # Node 14
       #
-      - label: "Electron 12 tests - macOS - Node 14"
+      - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
         timeout_in_minutes: 40
         agents:
           queue: macos-11
         env:
           DEVELOPER_DIR: "/Applications/Xcode12.app"
-          ELECTRON_VERSION: "^12.0.0"
+          NODE_VERSION: "{{matrix.node_version}}"
+          ELECTRON_VERSION: "{{matrix.electron_version}}"
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           START_LOCAL_NPM: 1
           VERBOSE: 1
+        matrix:
+          setup:
+            electron_version:
+              - "^12.0.0"
+              - "^20.0.0"
+            node_version:
+              - "12"
+              - "14"
         commands:
-          - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
-          - npm ci --no-audit --progress=false
-          - npx lerna bootstrap
-          - npm run build:electron
-          - defaults write com.apple.CrashReporter DialogType none
-          - npm run test:unit:electron-runner
-          - npm run test:electron
-
-      - label: "Electron 20 tests - macOS - Node 14"
-        timeout_in_minutes: 40
-        agents:
-          queue: macos-11
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode12.app"
-          ELECTRON_VERSION: "^20.0.0"
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-          START_LOCAL_NPM: 1
-          VERBOSE: 1
-        commands:
+          - node -v
           - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
           - npm ci --no-audit --progress=false
           - npx lerna bootstrap

--- a/.buildkite/electron-pipeline.yml
+++ b/.buildkite/electron-pipeline.yml
@@ -1,35 +1,33 @@
 steps:
 
-  - group: "Electron Tests"
-    steps:
-      #
-      # Node 14
-      #
-      - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
-        timeout_in_minutes: 40
-        agents:
-          queue: macos-11
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode12.app"
-          NODE_VERSION: "{{matrix.node_version}}"
-          ELECTRON_VERSION: "{{matrix.electron_version}}"
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-          START_LOCAL_NPM: 1
-          VERBOSE: 1
-        matrix:
-          setup:
-            electron_version:
-              - "^12.0.0"
-              - "^20.0.0"
-            node_version:
-              - "12"
-              - "14"
-        commands:
-          - node -v
-          - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
-          - npm ci --no-audit --progress=false
-          - npx lerna bootstrap
-          - npm run build:electron
-          - defaults write com.apple.CrashReporter DialogType none
-          - npm run test:unit:electron-runner
-          - npm run test:electron
+  #
+  # Node 14
+  #
+  - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
+    timeout_in_minutes: 40
+    agents:
+      queue: macos-11
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode12.app"
+      NODE_VERSION: "{{matrix.node_version}}"
+      ELECTRON_VERSION: "{{matrix.electron_version}}"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      START_LOCAL_NPM: 1
+      VERBOSE: 1
+    matrix:
+      setup:
+        electron_version:
+          - "12.0.0"
+          - "20.0.0"
+        node_version:
+          - "12"
+          - "14"
+    commands:
+      - node -v
+      - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save
+      - npm ci --no-audit --progress=false
+      - npx lerna bootstrap
+      - npm run build:electron
+      - defaults write com.apple.CrashReporter DialogType none
+      - npm run test:unit:electron-runner
+      - npm run test:electron


### PR DESCRIPTION
## Goal

Re-add e2e tests for Electron on macOS using Node 12.

## Design

This also changes to using Buildkite build matrices, which saves having the same block of commands copied out 4 times.

## Testing

Covered by CI.