### PR TITLE
add more e2e tests for async error handling in koa

### DIFF
--- a/test/node/features/express.feature
+++ b/test/node/features/express.feature
@@ -33,6 +33,9 @@ Scenario: an asynchronous thrown error in a route
   And the exception "message" equals "async"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://express/async"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: an error passed to next(err)
   Then I open the URL "http://express/next"
@@ -45,6 +48,9 @@ Scenario: an error passed to next(err)
   And the exception "message" equals "next"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://express/next"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: a synchronous promise rejection in a route
   Then I open the URL "http://express/rejection-sync"
@@ -57,6 +63,9 @@ Scenario: a synchronous promise rejection in a route
   And the exception "message" equals "reject sync"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://express/rejection-sync"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: an asynchronous promise rejection in a route
   Then I open the URL "http://express/rejection-async"
@@ -69,6 +78,9 @@ Scenario: an asynchronous promise rejection in a route
   And the exception "message" equals "reject async"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://express/rejection-async"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: a string passed to next(err)
   Then I open the URL "http://express/string-as-error"
@@ -80,6 +92,9 @@ Scenario: a string passed to next(err)
   And the exception "errorClass" equals "InvalidError"
   And the exception "message" matches "^express middleware received a non-error\."
   And the exception "type" equals "nodejs"
+  And the event "request.url" equals "http://express/string-as-error"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: throwing non-Error error
   Then I open the URL "http://express/throw-non-error"
@@ -91,6 +106,9 @@ Scenario: throwing non-Error error
   And the exception "errorClass" equals "InvalidError"
   And the exception "message" matches "^express middleware received a non-error\."
   And the exception "type" equals "nodejs"
+  And the event "request.url" equals "http://express/throw-non-error"
+  And the event "request.httpMethod" equals "GET"
+  And the event "request.clientIp" is not null
 
 Scenario: a handled error passed to req.bugsnag.notify()
   Then I open the URL "http://express/handled"

--- a/test/node/features/fixtures/koa/scenarios/app.js
+++ b/test/node/features/fixtures/koa/scenarios/app.js
@@ -39,15 +39,13 @@ app.use(middleware.requestHandler)
 
 app.use(bodyParser());
 
-const erroneous = () => new Promise((resolve, reject) => reject(new Error('async noooop')))
-
 app.use(async (ctx, next) => {
   if (ctx.path === '/') {
     ctx.body = 'ok'
   } else if (ctx.path === '/err') {
     throw new Error('noooop')
-  } else if (ctx.path === '/async-err') {
-    await erroneous()
+  } else if (ctx.path === '/promise-rejection') {
+    await Promise.reject(new Error('async noooop'))
   } else if (ctx.path === '/ctx-throw') {
     ctx.throw(500, 'thrown')
   } else if (ctx.path === '/ctx-throw-400') {
@@ -59,6 +57,21 @@ app.use(async (ctx, next) => {
     await next()
   } else if (ctx.path === '/bodytest') {
     throw new Error('request body')
+  } else if (ctx.path === '/throw-async-callback') {
+    setTimeout(function () {
+      throw new Error('error in async callback')
+    }, 100)
+    ctx.body = 'ok'
+  } else if (ctx.path === '/reject-async-callback') {
+    setTimeout(function () {
+      Promise.reject(new Error('reject in async callback')).catch(next)
+    }, 100)
+    ctx.body = 'ok'
+  } else if (ctx.path === '/unhandled-reject-async-callback') {
+    setTimeout(function () {
+      Promise.reject(new Error('unhandled reject in async callback'))
+    }, 100)
+    ctx.body = 'ok'
   } else {
     await next()
   }

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -25,8 +25,8 @@ Scenario: a synchronous thrown error in a route
   And the event "metaData.error_handler.before" is true
   And the event "metaData.error_handler.after" is null
 
-Scenario: an asynchronous thrown error in a route
-  Then I open the URL "http://koa/async-err" and get a 500 response
+Scenario: a promise rejection in a route
+  Then I open the URL "http://koa/promise-rejection" and get a 500 response
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -120,3 +120,33 @@ Scenario: adding body to request metadata
   And the event "request.httpVersion" equals "1.1"
   And the event "metaData.error_handler.before" is true
   And the event "metaData.error_handler.after" is null
+
+Scenario: a thrown error in an async callback
+  Then I open the URL "http://koa/throw-async-callback" and get a 200 response
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledException"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "error in async callback"
+  And the event "request.url" equals "http://koa/throw-async-callback"
+  And the event "request.httpMethod" equals "GET"
+
+Scenario: a handled promise rejection in an async callback
+  Then I open the URL "http://koa/reject-async-callback" and get a 200 response
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledException"
+  And the exception "errorClass" equals "Error"
+
+Scenario: an unhandled promise rejection in an async callback
+  Then I open the URL "http://koa/unhandled-reject-async-callback" and get a 200 response
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledException"
+  And the exception "errorClass" equals "Error"


### PR DESCRIPTION
## Goal

Verify whether or not we currently capture async errors in koa application that occur outside the koa application flow

## Design

Mimics similar coverage we have for express. The expectation is that these tests will fail because the koa plugin is not currently using the domain-based solution to capture errors in such scenarios.

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->