### PR TITLE
Fix in-flight being unable to track event requests made by cloned clients

### DIFF
--- a/packages/core/lib/clone-client.js
+++ b/packages/core/lib/clone-client.js
@@ -1,5 +1,7 @@
 const assign = require('./es-utils/assign')
 
+const onCloneCallbacks = []
+
 module.exports = (client) => {
   const clone = new client.Client({}, {}, [], client._notifier)
 
@@ -25,5 +27,9 @@ module.exports = (client) => {
   clone._delivery = client._delivery
   clone._sessionDelegate = client._sessionDelegate
 
+  onCloneCallbacks.forEach(callback => { callback(clone) })
+
   return clone
 }
+
+module.exports.registerCallback = callback => { onCloneCallbacks.push(callback) }

--- a/packages/core/test/lib/clone-client.test.ts
+++ b/packages/core/test/lib/clone-client.test.ts
@@ -287,4 +287,91 @@ describe('@bugsnag/core/lib/clone-client', () => {
       expect(cloned._sessionDelegate).toBe(original._sessionDelegate)
     })
   })
+
+  describe('registerCallback', () => {
+    it('allows registering callbacks that are called when a client is cloned', () => {
+      const callback1 = jest.fn()
+      const callback2 = jest.fn()
+      const callback3 = jest.fn()
+
+      clone.registerCallback(callback1)
+      clone.registerCallback(callback2)
+      clone.registerCallback(callback3)
+
+      const original = new Client({ apiKey })
+
+      expect(callback1).not.toHaveBeenCalled()
+      expect(callback2).not.toHaveBeenCalled()
+      expect(callback3).not.toHaveBeenCalled()
+
+      clone(original)
+
+      expect(callback1).toHaveBeenCalledTimes(1)
+      expect(callback2).toHaveBeenCalledTimes(1)
+      expect(callback3).toHaveBeenCalledTimes(1)
+
+      clone(original)
+
+      expect(callback1).toHaveBeenCalledTimes(2)
+      expect(callback2).toHaveBeenCalledTimes(2)
+      expect(callback3).toHaveBeenCalledTimes(2)
+    })
+
+    it('passes the clone to the callbacks', () => {
+      const callback1 = jest.fn()
+      const callback2 = jest.fn()
+      const callback3 = jest.fn()
+
+      clone.registerCallback(callback1)
+      clone.registerCallback(callback2)
+      clone.registerCallback(callback3)
+
+      const original = new Client({ apiKey })
+
+      expect(callback1).not.toHaveBeenCalled()
+      expect(callback2).not.toHaveBeenCalled()
+      expect(callback3).not.toHaveBeenCalled()
+
+      const cloned = clone(original)
+
+      expect(callback1).toHaveBeenCalledWith(cloned)
+      expect(callback2).toHaveBeenCalledWith(cloned)
+      expect(callback3).toHaveBeenCalledWith(cloned)
+
+      const cloned2 = clone(original)
+
+      expect(callback1).toHaveBeenCalledWith(cloned2)
+      expect(callback2).toHaveBeenCalledWith(cloned2)
+      expect(callback3).toHaveBeenCalledWith(cloned2)
+
+      // the callbacks should not be called with the original client
+      expect(callback1).not.toHaveBeenCalledWith(original)
+      expect(callback2).not.toHaveBeenCalledWith(original)
+      expect(callback3).not.toHaveBeenCalledWith(original)
+    })
+
+    it('calls callbacks in the order they are registered', () => {
+      const order: string[] = []
+
+      const callback1 = () => { order.push('callback1') }
+      const callback2 = () => { order.push('callback2') }
+      const callback3 = () => { order.push('callback3') }
+
+      clone.registerCallback(callback1)
+      clone.registerCallback(callback2)
+      clone.registerCallback(callback3)
+
+      const original = new Client({ apiKey })
+
+      expect(order).toEqual([])
+
+      clone(original)
+
+      expect(order).toEqual(['callback1', 'callback2', 'callback3'])
+
+      clone(original)
+
+      expect(order).toEqual(['callback1', 'callback2', 'callback3', 'callback1', 'callback2', 'callback3'])
+    })
+  })
 })


### PR DESCRIPTION
## Goal

The in-flight package was unable to track event requests made by cloned clients because the `_notify` monkey patch was not copied over to the clones. This is actually a good thing because the monkey patch holds onto a reference to the original client, so it would have been broken even if the clone got the patch

I've added support for "on clone callbacks" in clone-client, which other packages can register to be notified when a client is cloned. The in-flight package can then register a callback to patch any new clones

This was only a problem for events as the session request tracking is done via the session delegate and this is copied straight onto the clone, so is shared by both clients