### PR TITLE
Remove code coverage from pr diff bot

### DIFF
--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -24,10 +24,8 @@ jobs:
           npm ci
           npx lerna bootstrap
           npm run build
-          npm run test:coverage
           cat packages/browser/dist/bugsnag.min.js | wc -c > .diff/size-before-minified
           cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .diff/size-before-gzipped
-          cp coverage/coverage-summary.json .diff/coverage-before.json
 
       - name: Checkout PR branch
         uses: actions/checkout@v1
@@ -41,10 +39,8 @@ jobs:
           npm ci
           npx lerna bootstrap
           npm run build
-          npm run test:coverage
           cat packages/browser/dist/bugsnag.min.js | wc -c > .diff/size-after-minified
           cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .diff/size-after-gzipped
-          cp coverage/coverage-summary.json .diff/coverage-after.json
 
       - name: Run danger
         uses: danger/danger-js@9.1.6

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,18 +1,15 @@
 /* global markdown */
 
 const { readFileSync } = require('fs')
-const coverageDiff = require('coverage-diff')
 
 const before = {
   minified: parseInt(readFileSync(`${__dirname}/.diff/size-before-minified`, 'utf8').trim()),
-  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-before-gzipped`, 'utf8').trim()),
-  coverage: JSON.parse(readFileSync(`${__dirname}/.diff/coverage-before.json`, 'utf8'))
+  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-before-gzipped`, 'utf8').trim())
 }
 
 const after = {
   minified: parseInt(readFileSync(`${__dirname}/.diff/size-after-minified`, 'utf8').trim()),
-  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-after-gzipped`, 'utf8').trim()),
-  coverage: JSON.parse(readFileSync(`${__dirname}/.diff/coverage-after.json`, 'utf8'))
+  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-after-gzipped`, 'utf8').trim())
 }
 
 const formatKbs = (n) => `${(n / 1000).toFixed(2)} kB`
@@ -36,5 +33,5 @@ markdown(`
 
 ### code coverage diff
 
-${coverageDiff.diff(before.coverage, after.coverage).results}
+<_temporarily disabled_>
 `)


### PR DESCRIPTION
## Goal

This is getting stuck somewhere while running the tests, so I've temporarily disabled the code coverage checks to allow the browser size check to run