### PR TITLE
Bump browser versions

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -37,7 +37,7 @@ steps:
       #
       # BitBar tests
       #
-      - label: ":firefox: 101 Browser tests"
+      - label: ":firefox: v107 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 20
         plugins:
@@ -47,11 +47,11 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=firefox_101
+              - --browser=firefox_107
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":chrome: v102 Browser tests"
+      - label: ":chrome: v108 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 20
         plugins:
@@ -61,7 +61,7 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=chrome_102
+              - --browser=chrome_108
         concurrency: 5
         concurrency_group: "bitbar-web"
 
@@ -81,7 +81,7 @@ steps:
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":edge: v102 Browser tests"
+      - label: ":edge: v106 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 20
         plugins:
@@ -91,11 +91,11 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=edge_102
+              - --browser=edge_106
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":safari: 15 Browser tests"
+      - label: ":safari: 16 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 20
         plugins:
@@ -105,7 +105,7 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=safari_15
+              - --browser=safari_16
         concurrency: 5
         concurrency_group: "bitbar-web"
 

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -103,58 +103,6 @@ ie_11:
     lineNumber: 18
     columnNumber: 7
 
-edge_14:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: "'foo' is undefined"
-  unhandled_syntax:
-    errorClass: 'Error'
-    errorMessage: "Expected ';'"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: "'nevergoingtoexist_notinamillionyears' is undefined"
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: "The URI to be decoded is not a valid encoding"
-    lineNumber: 18
-    columnNumber: 7
-
-edge_15:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: "'foo' is undefined"
-  unhandled_syntax:
-    errorClass: 'Error'
-    errorMessage: "Expected ';'"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: "'nevergoingtoexist_notinamillionyears' is undefined"
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: "The URI to be decoded is not a valid encoding"
-    lineNumber: 18
-    columnNumber: 7
-
 edge_17:
   handled:
     errorClass: 'ReferenceError'
@@ -181,55 +129,7 @@ edge_17:
     lineNumber: 18
     columnNumber: 7
 
-safari_6:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: "Can't find variable: foo"
-  unhandled_syntax:
-    errorClass: 'Error'
-    errorMessage: "SyntaxError: Unexpected token '!'"
-    lineNumber: 18
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "Error: bad things"
-    lineNumber: 18
-  unhandled_undefined_function:
-    errorClass: 'Error'
-    errorMessage: "ReferenceError: Can't find variable: nevergoingtoexist_notinamillionyears"
-    lineNumber: 18
-  unhandled_malformed_uri:
-    errorClass: 'Error'
-    errorMessage: "URIError: URI error"
-    lineNumber: 18
-
 safari_10:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: "Can't find variable: foo"
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token '!'. Parse error."
-    lineNumber: 18
-    columnNumber: 0
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 22
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: "Can't find variable: nevergoingtoexist_notinamillionyears"
-    lineNumber: 18
-    columnNumber: 43
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI error
-    lineNumber: 18
-    columnNumber: 25
-
-safari_13:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: "Can't find variable: foo"
@@ -332,33 +232,8 @@ iphone_13:
     errorMessage: URI error
     lineNumber: 18
     columnNumber: 25
-android_nexus5:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token '!'"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI malformed
-    lineNumber: 18
-    columnNumber: 7
 
-android_s6:
+android_nexus5:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -436,54 +311,6 @@ android_s8:
     lineNumber: 18
     columnNumber: 7
 
-firefox_30:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'Error'
-    errorMessage: "SyntaxError: missing ; before statement"
-    lineNumber: 18
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "Error: bad things"
-    lineNumber: 18
-  unhandled_undefined_function:
-    errorClass: 'Error'
-    errorMessage: "ReferenceError: nevergoingtoexist_notinamillionyears is not defined"
-    lineNumber: 18
-  unhandled_malformed_uri:
-    errorClass: 'Error'
-    errorMessage: "URIError: malformed URI sequence"
-    lineNumber: 18
-
-firefox_56:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "missing ; before statement"
-    lineNumber: 18
-    columnNumber: 12
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: malformed URI sequence
-    lineNumber: 18
-    columnNumber: 7
-
 firefox_78:
   handled:
     errorClass: 'ReferenceError'
@@ -510,111 +337,7 @@ firefox_78:
     lineNumber: 18
     columnNumber: 25
 
-firefox_latest:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "unexpected token: '!'"
-    lineNumber: 18
-    columnNumber: 12
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: malformed URI sequence
-    lineNumber: 18
-    columnNumber: 25
-
-chrome_30:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token !"
-    lineNumber: 18
-    columnNumber: 12
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI malformed
-    lineNumber: 18
-    columnNumber: 6
-
 chrome_43:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token !"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI malformed
-    lineNumber: 18
-    columnNumber: 7
-
-chrome_53:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token !"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI malformed
-    lineNumber: 18
-    columnNumber: 7
-
-chrome_61:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -647,32 +370,6 @@ chrome_72:
   unhandled_syntax:
     errorClass: 'SyntaxError'
     errorMessage: "Unexpected token !"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI malformed
-    lineNumber: 18
-    columnNumber: 7
-
-chrome_latest:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token '!'"
     lineNumber: 18
     columnNumber: 13
     file: '/unhandled/script/a.html'

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -255,7 +255,7 @@ safari_13:
     lineNumber: 18
     columnNumber: 25
 
-safari_15:
+safari_16:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: "Can't find variable: foo"
@@ -694,7 +694,7 @@ chrome_latest:
 
 # BitBar exclusive
 
-chrome_102:
+chrome_108:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -720,7 +720,7 @@ chrome_102:
     lineNumber: 18
     columnNumber: 7
 
-edge_102:
+edge_106:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -746,7 +746,7 @@ edge_102:
     lineNumber: 18
     columnNumber: 7
 
-firefox_101:
+firefox_107:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'


### PR DESCRIPTION
## Goal

Bump the browser versions we run tests against for modern browsers to:

| browser | old version | new version |
|---------|-------------|-------------|
| firefox | 101 | 107 |
| chrome | 102 | 108 |
| edge | 102 | 106[^1] |
| safari | 15 | 16 |

[^1]: Edge 108 is out but not available on BitBar yet