### PR TITLE
[PLAT-7663] Fix state/metadata set in renderer config not being cleared 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - (plugin-express|plugin-koa|plugin-restify) Fix parts of request metadata being missing from some events [#1879](https://github.com/bugsnag/bugsnag-js/pull/1879)
 - (plugin-aws-lambda) Fix a bug when used with a server plugin (Express, Koa or Restify) causing internal callbacks to be added multiple times and reporting the wrong request data [#1887](https://github.com/bugsnag/bugsnag-js/pull/1887)
-- (plugin-electron-renderer-client-state-updates) Fix a bug where state set in renderer config could not be cleared or updated [1893](https://github.com/bugsnag/bugsnag-js/pull/1893)
+- (plugin-electron-renderer-client-state-updates) Fix a bug where state set in renderer config could not be cleared or updated [#1893](https://github.com/bugsnag/bugsnag-js/pull/1893)
 
 ## v7.18.2 (2022-11-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - (plugin-express|plugin-koa|plugin-restify) Fix parts of request metadata being missing from some events [#1879](https://github.com/bugsnag/bugsnag-js/pull/1879)
 - (plugin-aws-lambda) Fix a bug when used with a server plugin (Express, Koa or Restify) causing internal callbacks to be added multiple times and reporting the wrong request data [#1887](https://github.com/bugsnag/bugsnag-js/pull/1887)
+- (plugin-electron-renderer-client-state-updates) Fix a bug where state set in renderer config could not be cleared or updated [1893](https://github.com/bugsnag/bugsnag-js/pull/1893)
 
 ## v7.18.2 (2022-11-01)
 

--- a/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
+++ b/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
@@ -52,6 +52,13 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
       client._logger.error(e)
     }
 
+    // Clear synched state from the renderer config
+    client._metadata = {}
+    client._featuresIndex = {}
+    client._features = []
+    client._context = undefined
+    client._user = {}
+
     // use main process state once configured properties are synched
 
     client.getContext = safeExec(client, BugsnagIpcRenderer, 'getContext')

--- a/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
+++ b/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
@@ -202,6 +202,25 @@ describe('clientStateUpdatesPlugin', () => {
       })
     })
 
+    it('does not store state in renderer client', () => {
+      const mockBugsnagIpcRenderer = {
+        update: jest.fn()
+      }
+
+      const client = new Client({
+        apiKey: '123',
+        metadata: { section: { key: 'value' } },
+        featureFlags: [{ name: 'abc' }, { name: 'xyz', variant: '123' }],
+        context: 'renderer config',
+        user: { id: 'ab23' }
+      }, undefined, [clientStateUpdatesPlugin(mockBugsnagIpcRenderer)])
+
+      expect(client._metadata).toEqual({})
+      expect(client._user).toEqual({})
+      expect(client._features).toStrictEqual([])
+      expect(client._context).toEqual(undefined)
+    })
+
     it('starts sessions', () => {
       const mockBugsnagIpcRenderer = { startSession: jest.fn() }
 

--- a/test/electron/features/renderer-config.feature
+++ b/test/electron/features/renderer-config.feature
@@ -16,3 +16,25 @@ Feature: Setting config options in renderers
             | property | config                      |
             | appType  | { "appType": "real great" } |
             | codeBundleId  | { "codeBundleId": "1.0.0-r0123" } |
+            | user  | { "user": { "id": "3", "name": "Bugs Nag", "email": "bugs.nag@bugsnag.com" } } |
+            | context  | { "context": "renderer context" } |
+            | metadata  | { "metadata": { "renderer": { "key": "value" } } } |
+
+    Scenario Outline: Clearing config options set in renderer config
+        Given I launch an app with configuration:
+            | renderer_config | <config> |
+        When I click "renderer-<property>"
+        And I click "renderer-notify"
+        Then the total requests received by the server matches:
+            | events  | 1        |
+        Then the headers of every event request contains:
+            | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+            | Content-Type      | application/json                 |
+            | Bugsnag-Integrity | {BODY_SHA1}                      |
+        Then the contents of an event request matches "renderer/config/<property>.json"
+
+        Examples:
+            | property | config                      |
+            | clear-user  | { "user": { "id": "3", "name": "Bugs Nag", "email": "bugs.nag@bugsnag.com" } } |
+            | clear-context  | { "context": "renderer context" } |
+            | clear-metadata  | { "metadata": { "renderer": { "key": "value" } } } |

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -62,7 +62,7 @@
     <ul>
         <li><a href="#" id="renderer-clear-user">Clear user data in renderer</a></li>
         <li><a href="#" id="renderer-clear-context">Clear context in renderer</a></li>
-        <li><a href="#" id="renderer-clear-metadata">Clear metadata in renderer</a></li>
+        <li><a href="#" id="renderer-clear-metadata">Clear "renderer" metadata section</a></li>
     </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -60,9 +60,9 @@
         <li><a href="#" id="renderer-clear-feature-flags-now">immediately clear feature flags in renderer</a></li>
     </ul>
     <ul>
-        <li><a href="#" id="renderer-clear-user">Clear user data set in renderer config</a></li>
-        <li><a href="#" id="renderer-clear-context">Clear context set in renderer config</a></li>
-        <li><a href="#" id="renderer-clear-metadata">Clear metadata set in renderer config</a></li>
+        <li><a href="#" id="renderer-clear-user">Clear user data in renderer</a></li>
+        <li><a href="#" id="renderer-clear-context">Clear context in renderer</a></li>
+        <li><a href="#" id="renderer-clear-metadata">Clear metadata in renderer</a></li>
     </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -59,5 +59,10 @@
         <li><a href="#" id="main-process-clear-feature-flags-now" onclick="RunnerAPI.mainProcessClearFeatureFlagsNow()">immediately clear feature flags in main process</a></li>
         <li><a href="#" id="renderer-clear-feature-flags-now">immediately clear feature flags in renderer</a></li>
     </ul>
+    <ul>
+        <li><a href="#" id="renderer-clear-user">Clear user data set in renderer config</a></li>
+        <li><a href="#" id="renderer-clear-context">Clear context set in renderer config</a></li>
+        <li><a href="#" id="renderer-clear-metadata">Clear metadata set in renderer config</a></li>
+    </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -89,7 +89,7 @@ document.getElementById('renderer-clear-user').onclick = () => {
 }
 
 document.getElementById('renderer-clear-context').onclick = () => {
-  Bugsnag.setContext(null)
+  Bugsnag.setContext()
 }
 
 document.getElementById('renderer-clear-metadata').onclick = () => {

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -83,3 +83,15 @@ document.getElementById('renderer-clear-feature-flags-now').onclick = () => {
 }
 
 Bugsnag.addFeatureFlag('from renderer at runtime 2')
+
+document.getElementById('renderer-clear-user').onclick = () => {
+  Bugsnag.setUser('', '', '')
+}
+
+document.getElementById('renderer-clear-context').onclick = () => {
+  Bugsnag.setContext(null)
+}
+
+document.getElementById('renderer-clear-metadata').onclick = () => {
+  Bugsnag.clearMetadata('renderer')
+}

--- a/test/electron/fixtures/app/renderer.js
+++ b/test/electron/fixtures/app/renderer.js
@@ -85,7 +85,7 @@ document.getElementById('renderer-clear-feature-flags-now').onclick = () => {
 Bugsnag.addFeatureFlag('from renderer at runtime 2')
 
 document.getElementById('renderer-clear-user').onclick = () => {
-  Bugsnag.setUser('', '', '')
+  Bugsnag.setUser()
 }
 
 document.getElementById('renderer-clear-context').onclick = () => {

--- a/test/electron/fixtures/events/renderer/config/clear-context.json
+++ b/test/electron/fixtures/events/renderer/config/clear-context.json
@@ -1,0 +1,92 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 31,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/config/clear-context.json
+++ b/test/electron/fixtures/events/renderer/config/clear-context.json
@@ -31,6 +31,7 @@
       "user": {
         "id": "{REGEX:[0-9a-f]{64}}"
       },
+      "context": "Runner",
       "metaData": {
         "app": {
           "name": "Runner",

--- a/test/electron/fixtures/events/renderer/config/clear-metadata.json
+++ b/test/electron/fixtures/events/renderer/config/clear-metadata.json
@@ -1,0 +1,92 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 31,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/config/clear-metadata.json
+++ b/test/electron/fixtures/events/renderer/config/clear-metadata.json
@@ -43,7 +43,8 @@
             "width": "{TYPE:number}",
             "height": "{TYPE:number}"
           }
-        }
+        },
+        "renderer": "{TYPE:undefined}"
       },
       "severity": "warning",
       "unhandled": false,

--- a/test/electron/fixtures/events/renderer/config/clear-user.json
+++ b/test/electron/fixtures/events/renderer/config/clear-user.json
@@ -1,0 +1,92 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 31,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/config/clear-user.json
+++ b/test/electron/fixtures/events/renderer/config/clear-user.json
@@ -29,7 +29,9 @@
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
       "user": {
-        "id": "{REGEX:[0-9a-f]{64}}"
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "name": "{TYPE:undefined}",
+        "email": "{TYPE:undefined}"
       },
       "metaData": {
         "app": {

--- a/test/electron/fixtures/events/renderer/config/context.json
+++ b/test/electron/fixtures/events/renderer/config/context.json
@@ -1,0 +1,93 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "context": "renderer context",
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 31,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/config/metadata.json
+++ b/test/electron/fixtures/events/renderer/config/metadata.json
@@ -1,0 +1,95 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "renderer": {
+          "key": "value"
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 31,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}

--- a/test/electron/fixtures/events/renderer/config/user.json
+++ b/test/electron/fixtures/events/renderer/config/user.json
@@ -1,0 +1,94 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "version": "1.0.2",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "3",
+        "name": "Bugs Nag",
+        "email": "bugs.nag@bugsnag.com"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "state",
+          "name": "App became ready",
+          "timestamp": "{TIMESTAMP}"
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 created",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1
+          }
+        },
+        {
+          "type": "state",
+          "name": "Browser window 1 was shown",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "id": 1,
+            "title": "Runner"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "{REGEX:ALERT!$}",
+          "errorClass": "Error",
+          "stacktrace": [
+            {
+              "lineNumber": 31,
+              "file": "./renderer.js"
+            }
+          ],
+          "type": "electronrendererjs"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Any state/metadata that was added in a renderer's configuration could no be removed from that renderer

This is because we send the renderer config values to the main process, but they were also stored locally in the renderer client (because it’s using the same code as all other JS platforms)

This means both the renderer and main processes had a copy of the state, but methods like `clearMetadata` and `clearFeatureFlags` only talk to the main process

This affected `user`, `context` `metadata` and `featureFlags` config

## Changeset

Updated `plugin-electron-renderer-client-state-updates`  to clear any state from the renderer client once it has been synched to the main process

## Testing

- Manually tested clearing `user`, `context` `metadata` and `featureFlags` set in renderer config
- Added a unit test to ensure that this state is not stored in the renderer client 
- Added integration tests to ensure that any state set in the renderer config can be cleared and will not be attached to subsequent events from that renderer