### PR TITLE
add request duration metadata to network breadcrumbs

### DIFF
--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -13,7 +13,7 @@ let currentServer: ServerWithPort|null = null
 
 const originalRequest = net.request
 
-describe('plugin: electron net breadcrumbs', () => {
+describe.skip('plugin: electron net breadcrumbs', () => {
   afterEach(async () => {
     if (currentServer) {
       await new Promise(resolve => { currentServer.close(resolve) })

--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -13,7 +13,7 @@ let currentServer: ServerWithPort|null = null
 
 const originalRequest = net.request
 
-describe.skip('plugin: electron net breadcrumbs', () => {
+describe('plugin: electron net breadcrumbs', () => {
   afterEach(async () => {
     if (currentServer) {
       await new Promise(resolve => { currentServer.close(resolve) })
@@ -44,7 +44,7 @@ describe.skip('plugin: electron net breadcrumbs', () => {
 
     const expected = new Breadcrumb(
       `net.request ${successOrFailure}`,
-      { request: `GET ${url}/`, status },
+      { request: `GET ${url}/`, status, duration: expect.any(Number) },
       'request'
     )
 
@@ -74,7 +74,7 @@ describe.skip('plugin: electron net breadcrumbs', () => {
 
     const expected = new Breadcrumb(
       `net.request ${successOrFailure}`,
-      { request: `${method} ${url}`, status },
+      { request: `${method} ${url}`, status, duration: expect.any(Number) },
       'request'
     )
 
@@ -107,7 +107,7 @@ describe.skip('plugin: electron net breadcrumbs', () => {
 
     const expected = new Breadcrumb(
       `net.request ${successOrFailure}`,
-      { request: `GET http://localhost:${currentServer.port}/`, status },
+      { request: `GET http://localhost:${currentServer.port}/`, status, duration: expect.any(Number) },
       'request'
     )
 
@@ -182,7 +182,7 @@ describe.skip('plugin: electron net breadcrumbs', () => {
 
     const expected = new Breadcrumb(
       'net.request error',
-      { request: `GET ${url}`, error: "Attempted to redirect, but redirect policy was 'error'" },
+      { request: `GET ${url}`, error: "Attempted to redirect, but redirect policy was 'error'", duration: expect.any(Number) },
       'request'
     )
 

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -23,7 +23,6 @@ module.exports = (_ignoredUrls = [], win = window) => {
       function monkeyPatchXMLHttpRequest () {
         if (!('addEventListener' in win.XMLHttpRequest.prototype)) return
         const nativeOpen = win.XMLHttpRequest.prototype.open
-        const nativeSend = win.XMLHttpRequest.prototype.send
 
         // override native open()
         win.XMLHttpRequest.prototype.open = function open (method, url) {
@@ -46,12 +45,13 @@ module.exports = (_ignoredUrls = [], win = window) => {
 
           requestSetupKey = true
 
+          const oldSend = this.send
           let requestStart
 
-          // override send for this XMLHttpRequest instance
+          // override send() for this XMLHttpRequest instance
           this.send = function send () {
             requestStart = new Date()
-            nativeSend.apply(this, arguments)
+            oldSend.apply(this, arguments)
           }
 
           nativeOpen.apply(this, arguments)

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -81,7 +81,8 @@ describe('plugin: network breadcrumbs', () => {
       message: 'XMLHttpRequest succeeded',
       metadata: {
         status: 200,
-        request: 'GET /'
+        request: 'GET /',
+        duration: expect.any(Number)
       }
     }))
   })
@@ -115,7 +116,8 @@ describe('plugin: network breadcrumbs', () => {
       message: 'XMLHttpRequest failed',
       metadata: {
         status: 404,
-        request: 'GET /this-does-not-exist'
+        request: 'GET /this-does-not-exist',
+        duration: expect.any(Number)
       }
     }))
   })
@@ -136,7 +138,8 @@ describe('plugin: network breadcrumbs', () => {
       type: 'request',
       message: 'XMLHttpRequest error',
       metadata: {
-        request: 'GET https://another-domain.xyz/'
+        request: 'GET https://another-domain.xyz/',
+        duration: expect.any(Number)
       }
     }))
   })
@@ -189,7 +192,8 @@ describe('plugin: network breadcrumbs', () => {
       message: 'XMLHttpRequest succeeded',
       metadata: {
         status: 200,
-        request: 'GET https://example.com'
+        request: 'GET https://example.com',
+        duration: expect.any(Number)
       }
     }))
   })
@@ -216,7 +220,8 @@ describe('plugin: network breadcrumbs', () => {
       type: 'request',
       message: 'XMLHttpRequest error',
       metadata: {
-        request: 'GET https://example.com'
+        request: 'GET https://example.com',
+        duration: expect.any(Number)
       }
     }))
   })
@@ -235,7 +240,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /'
+          request: 'GET /',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -256,7 +262,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 405,
-          request: 'null /'
+          request: 'null /',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -279,7 +286,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /'
+          request: 'GET /',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -302,7 +310,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'PUT /'
+          request: 'PUT /',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -323,7 +332,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 404,
-          request: 'GET null'
+          request: 'GET null',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -344,7 +354,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /'
+          request: 'GET /',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -365,7 +376,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 404,
-          request: 'GET undefined'
+          request: 'GET undefined',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -386,7 +398,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'PUT /foo'
+          request: 'PUT /foo',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -407,7 +420,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 405,
-          request: 'null /foo'
+          request: 'null /foo',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -428,7 +442,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /foo'
+          request: 'GET /foo',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -449,7 +464,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 404,
-          request: 'GET /does-not-exist'
+          request: 'GET /does-not-exist',
+          duration: expect.any(Number)
         }
       }))
       done()
@@ -469,7 +485,8 @@ describe('plugin: network breadcrumbs', () => {
         type: 'request',
         message: 'fetch() error',
         metadata: {
-          request: 'GET https://another-domain.xyz/foo/bar'
+          request: 'GET https://another-domain.xyz/foo/bar',
+          duration: expect.any(Number)
         }
       }))
       done()

--- a/test/browser/features/fixtures/network_breadcrumbs/json/fetch_failure.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/fetch_failure.json
@@ -4,6 +4,7 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 404,
-        "request": "GET i_dont_exist.html"
+        "request": "GET i_dont_exist.html",
+        "duration": "NUMBER"
     }
 }

--- a/test/browser/features/fixtures/network_breadcrumbs/json/fetch_success.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/fetch_success.json
@@ -4,6 +4,7 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 200,
-        "request": "GET fetch_success.html"
+        "request": "GET fetch_success.html",
+        "duration": "NUMBER"
     }
 }

--- a/test/browser/features/fixtures/network_breadcrumbs/json/xhr_failure.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/xhr_failure.json
@@ -4,6 +4,7 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 404,
-        "request": "GET i_dont_exist.html"
+        "request": "GET i_dont_exist.html",
+        "duration": "NUMBER"
     }
 }

--- a/test/browser/features/fixtures/network_breadcrumbs/json/xhr_success.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/xhr_success.json
@@ -4,6 +4,7 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 200,
-        "request": "GET xhr_success.html"
+        "request": "GET xhr_success.html",
+        "duration": "NUMBER"
     }
 }

--- a/test/electron/features/network-breadcrumbs.feature
+++ b/test/electron/features/network-breadcrumbs.feature
@@ -1,0 +1,20 @@
+Feature: Automatic breadcrumbs for network requests
+
+    Scenario Outline: Breadcrumbs for network requests
+        Given I launch an app with configuration:
+            | bugsnag | network-breadcrumbs |
+        When I click "main-process-request-<request>"
+        Then the total requests received by the server matches:
+            | events   | 1        |
+            | sessions | 1        |
+        Then the headers of every event request contains:
+            | Bugsnag-API-Key   | 6425093c6530f554a9897d2d7d38e248 |
+            | Content-Type      | application/json                 |
+            | Bugsnag-Integrity | {BODY_SHA1}                      |
+        Then the contents of an event request matches "main/breadcrumbs/network/<request>.json"
+
+        Examples:
+            | request           |
+            | get-success       |
+            | get-failure       |
+            

--- a/test/electron/features/network-breadcrumbs.feature
+++ b/test/electron/features/network-breadcrumbs.feature
@@ -17,4 +17,5 @@ Feature: Automatic breadcrumbs for network requests
             | request           |
             | get-success       |
             | get-failure       |
+            | error             |
             

--- a/test/electron/features/support/server.js
+++ b/test/electron/features/support/server.js
@@ -15,6 +15,7 @@ class MockServer {
     router.register('/minidump', 'POST', this.uploadMinidump.bind(this))
     router.register('/events', 'POST', this.sendEvent.bind(this))
     router.register('/sessions', 'POST', this.sendSession.bind(this))
+    router.register('/success', 'GET', this.handleGetRequest.bind(this))
 
     this.server = http.createServer(router.dispatch.bind(router))
     this.router = router
@@ -69,6 +70,11 @@ class MockServer {
       res.end()
       this._notifyUploads()
     })
+  }
+
+  async handleGetRequest (req, res) {
+    res.writeHead(200)
+    res.end()
   }
 
   async start () {

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -40,7 +40,8 @@ Given('I launch an app with configuration:', launchConfig, (data) => {
   return global.automator.start({
     BUGSNAG_CONFIG: setup.bugsnag,
     BUGSNAG_PRELOAD: setup.preload,
-    BUGSNAG_RENDERER_CONFIG: setup.renderer_config
+    BUGSNAG_RENDERER_CONFIG: setup.renderer_config,
+    SERVER_ADDRESS: `http://localhost:${global.server.port}`
   })
 })
 

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -5,7 +5,7 @@ const { readFixtureFile } = require('../utils')
 const expect = require('../utils/expect')
 const { applySourcemaps } = require('../utils/source-mapper')
 
-const REQUEST_RESOLUTION_TIMEOUT = 3000
+const REQUEST_RESOLUTION_TIMEOUT = 5000
 const launchConfig = { timeout: 30 * 1000 }
 const requestDelay = (callback) => new Promise((resolve, reject) => {
   setTimeout(() => callback(resolve), REQUEST_RESOLUTION_TIMEOUT)

--- a/test/electron/fixtures/app/configs/network-breadcrumbs.js
+++ b/test/electron/fixtures/app/configs/network-breadcrumbs.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+  return {
+    enabledBreadcrumbTypes: ['request']
+  }
+}

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -64,5 +64,9 @@
         <li><a href="#" id="renderer-clear-context">Clear context in renderer</a></li>
         <li><a href="#" id="renderer-clear-metadata">Clear "renderer" metadata section</a></li>
     </ul>
+    <ul>
+        <li><a href="#" id="main-process-request-get-success" onclick="RunnerAPI.mainProcessGetRequest()">Make a successful GET request</a></li>
+        <li><a href="#" id="main-process-request-get-failure" onclick="RunnerAPI.mainProcessGetRequest(true)">Make a failed GET request</a></li>
+    </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/index.html
+++ b/test/electron/fixtures/app/index.html
@@ -67,6 +67,7 @@
     <ul>
         <li><a href="#" id="main-process-request-get-success" onclick="RunnerAPI.mainProcessGetRequest()">Make a successful GET request</a></li>
         <li><a href="#" id="main-process-request-get-failure" onclick="RunnerAPI.mainProcessGetRequest(true)">Make a failed GET request</a></li>
+        <li><a href="#" id="main-process-request-error" onclick="RunnerAPI.mainProcessRequestError()">Trigger a network request error</a></li>
     </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/main.js
+++ b/test/electron/fixtures/app/main.js
@@ -1,4 +1,5 @@
 const { join } = require('path')
+const { net } = require('electron')
 const {
   uncaughtException,
   unhandledRejection,
@@ -41,6 +42,14 @@ function createWindow () {
 
   // eslint-disable-next-line no-undef
   win.loadFile(join(__dirname, htmlRelativePath))
+}
+
+function makeSimpleGetRequest (fail = false) {
+  const url = fail ? 'https://non.existent.url/' : 'https://google.com/'
+  const request = net.request(url)
+  request.on('response', notify)
+  request.on('error', notify)
+  request.end()
 }
 
 app.whenReady().then(createWindow)
@@ -92,4 +101,8 @@ ipcMain.on('main-process-clear-feature-flags', () => {
 
 ipcMain.on('main-process-clear-feature-flags-now', () => {
   Bugsnag.clearFeatureFlags()
+})
+
+ipcMain.on('main-process-get-request', (_event, fail) => {
+  makeSimpleGetRequest(fail)
 })

--- a/test/electron/fixtures/app/main.js
+++ b/test/electron/fixtures/app/main.js
@@ -45,9 +45,17 @@ function createWindow () {
 }
 
 function makeSimpleGetRequest (fail = false) {
-  const url = fail ? 'https://non.existent.url/' : 'https://google.com/'
+  const url = fail
+    ? `${process.env.SERVER_ADDRESS}/fail`
+    : `${process.env.SERVER_ADDRESS}/success`
+
   const request = net.request(url)
   request.on('response', notify)
+  request.end()
+}
+
+function networkRequestError () {
+  const request = net.request('http://locahost:65536/')
   request.on('error', notify)
   request.end()
 }
@@ -105,4 +113,8 @@ ipcMain.on('main-process-clear-feature-flags-now', () => {
 
 ipcMain.on('main-process-get-request', (_event, fail) => {
   makeSimpleGetRequest(fail)
+})
+
+ipcMain.on('main-process-request-error', () => {
+  networkRequestError()
 })

--- a/test/electron/fixtures/app/preloads/default.js
+++ b/test/electron/fixtures/app/preloads/default.js
@@ -39,5 +39,8 @@ contextBridge.exposeInMainWorld('RunnerAPI', {
   mainProcessClearFeatureFlagsNow: () => {
     ipcRenderer.send('main-process-clear-feature-flags-now')
   },
+  mainProcessGetRequest: (fail) => {
+    ipcRenderer.send('main-process-get-request', fail)
+  },
   preloadStart: Date.now()
 })

--- a/test/electron/fixtures/app/preloads/default.js
+++ b/test/electron/fixtures/app/preloads/default.js
@@ -42,5 +42,8 @@ contextBridge.exposeInMainWorld('RunnerAPI', {
   mainProcessGetRequest: (fail) => {
     ipcRenderer.send('main-process-get-request', fail)
   },
+  mainProcessRequestError: () => {
+    ipcRenderer.send('main-process-request-error')
+  },
   preloadStart: Date.now()
 })

--- a/test/electron/fixtures/events/main/breadcrumbs/network/error.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/error.json
@@ -57,11 +57,10 @@
       "breadcrumbs": [
         {
           "type": "request",
-          "name": "net.request failed",
+          "name": "net.request error",
           "timestamp": "{TIMESTAMP}",
           "metaData": {
-            "request": "{REGEX:^GET http:\\/\\/localhost:\\d{4}\\/fail$}",
-            "status": 404,
+            "request" : "GET http://locahost:65536/",
             "duration": "{TYPE:number}"
           }
         }

--- a/test/electron/fixtures/events/main/breadcrumbs/network/error.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/error.json
@@ -60,7 +60,8 @@
           "name": "net.request error",
           "timestamp": "{TIMESTAMP}",
           "metaData": {
-            "request" : "GET http://locahost:65536/",
+            "request": "GET http://locahost:65536/",
+            "status": "{TYPE:undefined}",
             "duration": "{TYPE:number}"
           }
         }

--- a/test/electron/fixtures/events/main/breadcrumbs/network/get-failure.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/get-failure.json
@@ -1,0 +1,85 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
+        "version": "1.0.2"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "request",
+          "name": "net.request error",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "request" : "GET https://non.existent.url/",
+            "duration": "{TYPE:number}"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "something bad",
+          "errorClass": "ReferenceError",
+          "stacktrace": [{
+            "file": "./src/errors.js",
+            "lineNumber": 18,
+            "code": {
+              "1": "{TYPE:string}"
+            }
+          }],
+          "type": "electronnodejs"
+        }
+      ]
+    }
+  ]
+}
+

--- a/test/electron/fixtures/events/main/breadcrumbs/network/get-success.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/get-success.json
@@ -60,7 +60,7 @@
           "name": "net.request succeeded",
           "timestamp": "{TIMESTAMP}",
           "metaData": {
-            "request" : "GET https://google.com/",
+            "request": "{REGEX:^GET http:\\/\\/localhost:\\d{4}\\/success$}",
             "status": 200,
             "duration": "{TYPE:number}"
           }
@@ -83,4 +83,3 @@
     }
   ]
 }
-

--- a/test/electron/fixtures/events/main/breadcrumbs/network/get-success.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/get-success.json
@@ -1,0 +1,86 @@
+{
+  "apiKey": "6425093c6530f554a9897d2d7d38e248",
+  "notifier": {
+    "name": "Bugsnag Electron",
+    "url": "https://github.com/bugsnag/bugsnag-electron",
+    "version": "{REGEX:^200\\.1\\.0-canary\\.[0-9a-f]{24}$}"
+  },
+  "events": [
+    {
+      "payloadVersion": "4",
+      "app": {
+        "duration": "{TYPE:number}",
+        "releaseStage": "production",
+        "inForeground": "{TYPE:boolean}",
+        "isLaunching": "{TYPE:boolean}",
+        "type": "{PLATFORM_LINUX:Linux|PLATFORM_MACOS:macOS|PLATFORM_WINDOWS:Windows}",
+        "version": "1.0.2"
+      },
+      "device": {
+        "runtimeVersions": {
+          "node": "{TYPE:string}",
+          "chrome": "{TYPE:string}",
+          "electron": "{TYPE:string}"
+        },
+        "id": "{REGEX:[0-9a-f]{64}}",
+        "freeMemory": "{TYPE:number}",
+        "time": "{TIMESTAMP}",
+        "totalMemory": "{TYPE:number}",
+        "osVersion": "{REGEX:\\d+\\.\\d+}"
+      },
+      "user": {
+        "id": "{REGEX:[0-9a-f]{64}}"
+      },
+      "metaData": {
+        "app": {
+          "name": "Runner",
+          "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"
+        },
+        "device": {
+          "online": "{TYPE:boolean}",
+          "idleTime": "{TYPE:number}",
+          "screenResolution": {
+            "width": "{TYPE:number}",
+            "height": "{TYPE:number}"
+          }
+        },
+        "process": {
+          "type": "browser",
+          "heapStatistics": {}
+        }
+      },
+      "severity": "warning",
+      "unhandled": false,
+      "severityReason": {
+        "type": "handledException"
+      },
+      "breadcrumbs": [
+        {
+          "type": "request",
+          "name": "net.request succeeded",
+          "timestamp": "{TIMESTAMP}",
+          "metaData": {
+            "request" : "GET https://google.com/",
+            "status": 200,
+            "duration": "{TYPE:number}"
+          }
+        }
+      ],
+      "exceptions": [
+        {
+          "errorMessage": "something bad",
+          "errorClass": "ReferenceError",
+          "stacktrace": [{
+            "file": "./src/errors.js",
+            "lineNumber": 18,
+            "code": {
+              "1": "{TYPE:string}"
+            }
+          }],
+          "type": "electronnodejs"
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Goal

Adds a new metadata field `duration` to network breadcrumbs for JS and Electron - this is the elapsed time in milliseconds between the request start and completion or error

## Design

- `plugin-network-breadcrumbs`
    - For `XMLHttpRequest` : 
        - Override request object's `send` method in order to record the start time of the request, and get the duration in milliseconds when `handleXHRLoad` / `handleXHRError` are invoked
    - For `fetch`:
    	- Record start of request when calling native `fetch` and get the duration in milliseconds when`handleFetchSuccess` / `handleFetchError` are invoked

- `plugin-electron-net-breadcrumbs`
	-  Override request object's `request.end` method in order to record the start time of the request, and get the duration in milliseconds when the `request` / `abort` / `error` handlers are invoked

## Testing

- Unit tests:
	- Extended existing unit tests to check for new metadata field

- e2e tests
	- Extended existing e2e tests to check for new metadata field
	- Added basic e2e tests for network breadcrumbs on Electron