### PR TITLE
add autoTrackSessions to web-worker notifier and disable as default

### DIFF
--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -25,6 +25,7 @@
         "@bugsnag/core": "^7.18.0",
         "@bugsnag/delivery-fetch": "^7.18.0",
         "@bugsnag/plugin-browser-device": "^7.18.0",
+        "@bugsnag/plugin-browser-session": "^7.18.0",
         "@bugsnag/plugin-client-ip": "^7.18.0",
         "@bugsnag/plugin-window-onerror": "^7.18.0",
         "@bugsnag/plugin-window-unhandled-rejection": "^7.18.0",

--- a/packages/web-worker/src/config.js
+++ b/packages/web-worker/src/config.js
@@ -12,7 +12,11 @@ module.exports = {
       (typeof console !== 'undefined' && typeof console.debug === 'function')
         ? getPrefixedConsole()
         : undefined
-  })
+  }),
+  autoTrackSessions: {
+    ...schema.autoTrackSessions,
+    defaultValue: val => false
+  }
 }
 
 const getPrefixedConsole = () => {

--- a/packages/web-worker/src/notifier.js
+++ b/packages/web-worker/src/notifier.js
@@ -38,7 +38,9 @@ export const Bugsnag = {
 
     bugsnag._logger.debug('Loaded!')
 
-    return bugsnag
+    return bugsnag._config.autoTrackSessions
+      ? bugsnag.startSession()
+      : bugsnag
   },
   start: (opts) => {
     if (Bugsnag._client) {

--- a/packages/web-worker/src/notifier.js
+++ b/packages/web-worker/src/notifier.js
@@ -8,6 +8,7 @@ import pluginWindowOnError from '@bugsnag/plugin-window-onerror'
 import pluginWindowUnhandledRejection from '@bugsnag/plugin-window-unhandled-rejection'
 import config from './config'
 import pluginBrowserDevice from '@bugsnag/plugin-browser-device'
+import pluginBrowserSession from '@bugsnag/plugin-browser-session'
 import pluginPreventDiscard from './prevent-discard'
 
 const name = 'Bugsnag Web Worker'
@@ -24,8 +25,9 @@ export const Bugsnag = {
     if (!opts) opts = {}
 
     const internalPlugins = [
-      pluginClientIp,
       pluginBrowserDevice(navigator, null),
+      pluginBrowserSession,
+      pluginClientIp,
       pluginPreventDiscard,
       pluginWindowOnError(self, 'worker onerror'),
       pluginWindowUnhandledRejection(self)

--- a/packages/web-worker/test/notifier.test.ts
+++ b/packages/web-worker/test/notifier.test.ts
@@ -82,6 +82,43 @@ describe('worker notifier', () => {
     Bugsnag.start(testConfig)
     expect(Bugsnag.isStarted()).toBe(true)
   })
+
+  describe('session management', () => {
+    it('successfully starts a session', (done) => {
+      const Bugsnag = getBugsnag()
+      Bugsnag.start(API_KEY)
+      Bugsnag.startSession()
+
+      expect(typedGlobal.fetch).toHaveBeenCalledWith('https://sessions.bugsnag.com', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Bugsnag-Api-Key': API_KEY,
+          'Bugsnag-Payload-Version': '1',
+          'Bugsnag-Sent-At': expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          'Content-Type': 'application/json'
+        })
+      }))
+
+      done()
+    })
+
+    it('automatically starts a session', (done) => {
+      const Bugsnag = getBugsnag()
+      Bugsnag.start({ apiKey: API_KEY, autoTrackSessions: true })
+
+      expect(typedGlobal.fetch).toHaveBeenCalledWith('https://sessions.bugsnag.com', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Bugsnag-Api-Key': API_KEY,
+          'Bugsnag-Payload-Version': '1',
+          'Bugsnag-Sent-At': expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          'Content-Type': 'application/json'
+        })
+      }))
+
+      done()
+    })
+  })
 })
 
 describe('prevent-discard', () => {

--- a/packages/web-worker/test/notifier.test.ts
+++ b/packages/web-worker/test/notifier.test.ts
@@ -87,6 +87,9 @@ describe('worker notifier', () => {
     it('successfully starts a session', (done) => {
       const Bugsnag = getBugsnag()
       Bugsnag.start(API_KEY)
+
+      expect(typedGlobal.fetch).not.toHaveBeenCalled()
+
       Bugsnag.startSession()
 
       expect(typedGlobal.fetch).toHaveBeenCalledWith('https://sessions.bugsnag.com', expect.objectContaining({

--- a/test/browser/features/fixtures/web_worker/auto_track_sessions/index.html
+++ b/test/browser/features/fixtures/web_worker/auto_track_sessions/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script type="text/javascript">
+      var NOTIFY = decodeURIComponent(window.location.search.match(/NOTIFY=([^&]+)/)[1])
+      var SESSIONS = decodeURIComponent(window.location.search.match(/SESSIONS=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+    </script>
+  </head>
+  <body>
+    <script>
+        var worker = new Worker('worker.js', { type: 'module' })
+        worker.postMessage({ type: 'bugsnag-start', payload: { NOTIFY, SESSIONS, API_KEY } })
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/web_worker/auto_track_sessions/worker.js
+++ b/test/browser/features/fixtures/web_worker/auto_track_sessions/worker.js
@@ -1,0 +1,18 @@
+import Bugsnag from "/node_modules/@bugsnag/web-worker/dist/notifier.js"
+
+onmessage = function (e) {
+    const { type, payload } = e.data
+    switch (type) {
+        case 'bugsnag-start':
+            Bugsnag.start({
+                apiKey: payload.API_KEY,
+                autoTrackSessions: true,
+                endpoints: {
+                    notify: payload.NOTIFY,
+                    sessions: payload.SESSIONS
+                }
+            })
+            break;
+        default:
+    } 
+}

--- a/test/browser/features/web_worker.feature
+++ b/test/browser/features/web_worker.feature
@@ -8,12 +8,14 @@ Scenario: notifying from within a worker
   Then the error is a valid browser payload for the error reporting API
   And the exception "errorClass" equals "Error"
   And the exception "errorMessage" equals "I am an error"
+  And I should receive no sessions
 
 Scenario: unhandled error in worker
   When I navigate to the test URL "/web_worker/worker_unhandled_error"
   And I wait to receive an error
   Then the error is a valid browser payload for the error reporting API
   And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+  And I should receive no sessions
 
 Scenario: setting collectUserIp option to false
   When I navigate to the test URL "/web_worker/ip_redaction"
@@ -21,6 +23,7 @@ Scenario: setting collectUserIp option to false
   Then the error is a valid browser payload for the error reporting API
   And the event "request.clientIp" equals "[REDACTED]"
   And the event "user.id" equals "[REDACTED]"
+  And I should receive no sessions
 
 Scenario: unhandled promise rejection
   When I navigate to the test URL "/web_worker/unhandled_promise_rejection"
@@ -29,6 +32,7 @@ Scenario: unhandled promise rejection
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "broken promises"
   And event 0 is unhandled
+  And I should receive no sessions
 
 Scenario: setting autoTrackSessions option to true
   When I navigate to the test URL "/web_worker/auto_track_sessions"

--- a/test/browser/features/web_worker.feature
+++ b/test/browser/features/web_worker.feature
@@ -29,3 +29,9 @@ Scenario: unhandled promise rejection
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "broken promises"
   And event 0 is unhandled
+
+Scenario: setting autoTrackSessions option to true
+  When I navigate to the test URL "/web_worker/auto_track_sessions"
+  And I wait to receive a session
+  Then the session is a valid browser payload for the session tracking API
+  


### PR DESCRIPTION
## Goal

Add the ability to start and auto track sessions from the `web-worker` notifier

## Testing

- Unit tests for `Bugsnag.startSession()`
- Unit tests for `autoTrackSession` config option
- End to end test for `autoTrackSession` config option