### PR TITLE
PLAT-9499 - Add unhandled promise rejection functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - (delivery-fetch) Create fetch based delivery package [#1894](https://github.com/bugsnag/bugsnag-js/pull/1894)
 - (web-worker) Create web-worker notifier package [#1896](https://github.com/bugsnag/bugsnag-js/pull/1896)
 - (plugin-browser-device) Refactor parameters for improved guarding [#1896](https://github.com/bugsnag/bugsnag-js/pull/1896)
+- (web-worker) Add unhandled promise rejection plugin [#1907](https://github.com/bugsnag/bugsnag-js/pull/1907)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - (delivery-fetch) Create fetch based delivery package [#1894](https://github.com/bugsnag/bugsnag-js/pull/1894)
 - (web-worker) Create web-worker notifier package [#1896](https://github.com/bugsnag/bugsnag-js/pull/1896)
 - (plugin-browser-device) Refactor parameters for improved guarding [#1896](https://github.com/bugsnag/bugsnag-js/pull/1896)
-- (web-worker) Add unhandled promise rejection plugin [#1907](https://github.com/bugsnag/bugsnag-js/pull/1907)
 
 ### Fixed
 

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -27,6 +27,7 @@
         "@bugsnag/plugin-browser-device": "^7.18.0",
         "@bugsnag/plugin-client-ip": "^7.18.0",
         "@bugsnag/plugin-window-onerror": "^7.18.0",
+        "@bugsnag/plugin-window-unhandled-rejection": "^7.18.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.9.3",
         "webpack": "^5.75.0",

--- a/packages/web-worker/src/notifier.js
+++ b/packages/web-worker/src/notifier.js
@@ -1,3 +1,4 @@
+/* eslint-env worker, serviceworker */
 
 import Client from '@bugsnag/core/client'
 import { schema as coreSchema } from '@bugsnag/core/config'
@@ -26,8 +27,8 @@ export const Bugsnag = {
       pluginClientIp,
       pluginBrowserDevice(navigator, null),
       pluginPreventDiscard,
-      pluginWindowOnError(self, 'worker onerror'), // eslint-disable-line no-undef
-      pluginWindowUnhandledRejection(self) // eslint-disable-line no-undef
+      pluginWindowOnError(self, 'worker onerror'),
+      pluginWindowUnhandledRejection(self)
     ]
 
     // configure a client with user supplied options

--- a/packages/web-worker/src/notifier.js
+++ b/packages/web-worker/src/notifier.js
@@ -4,6 +4,7 @@ import { schema as coreSchema } from '@bugsnag/core/config'
 import delivery from '@bugsnag/delivery-fetch'
 import pluginClientIp from '@bugsnag/plugin-client-ip'
 import pluginWindowOnError from '@bugsnag/plugin-window-onerror'
+import pluginWindowUnhandledRejection from '@bugsnag/plugin-window-unhandled-rejection'
 import config from './config'
 import pluginBrowserDevice from '@bugsnag/plugin-browser-device'
 import pluginPreventDiscard from './prevent-discard'
@@ -21,8 +22,13 @@ export const Bugsnag = {
     if (typeof opts === 'string') opts = { apiKey: opts }
     if (!opts) opts = {}
 
-    // eslint-disable-next-line no-undef
-    const internalPlugins = [pluginClientIp, pluginBrowserDevice(navigator, null), pluginPreventDiscard, pluginWindowOnError(self, 'worker onerror')]
+    const internalPlugins = [
+      pluginClientIp,
+      pluginBrowserDevice(navigator, null),
+      pluginPreventDiscard,
+      pluginWindowOnError(self, 'worker onerror'), // eslint-disable-line no-undef
+      pluginWindowUnhandledRejection(self) // eslint-disable-line no-undef
+    ]
 
     // configure a client with user supplied options
     const bugsnag = new Client(opts, schema, internalPlugins, { name, version, url })

--- a/test/browser/features/fixtures/web_worker/unhandled_promise_rejection/index.html
+++ b/test/browser/features/fixtures/web_worker/unhandled_promise_rejection/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script type="text/javascript">
+      var NOTIFY = decodeURIComponent(window.location.search.match(/NOTIFY=([^&]+)/)[1])
+      var SESSIONS = decodeURIComponent(window.location.search.match(/SESSIONS=([^&]+)/)[1])
+      var API_KEY = decodeURIComponent(window.location.search.match(/API_KEY=([^&]+)/)[1])
+    </script>
+  </head>
+  <body>
+    <script>
+        var worker = new Worker('worker.js', { type: 'module' })
+        worker.onmessage = function () { worker.postMessage({ type: 'bugsnag-notify' }) } 
+        worker.postMessage({ type: 'bugsnag-start', payload: { NOTIFY, SESSIONS, API_KEY } })
+    </script>
+  </body>
+</html>

--- a/test/browser/features/fixtures/web_worker/unhandled_promise_rejection/worker.js
+++ b/test/browser/features/fixtures/web_worker/unhandled_promise_rejection/worker.js
@@ -1,0 +1,21 @@
+import Bugsnag from "/node_modules/@bugsnag/web-worker/dist/notifier.js"
+
+onmessage = function (e) {
+    const { type, payload } = e.data
+    switch (type) {
+        case 'bugsnag-start':
+            Bugsnag.start({
+                apiKey: payload.API_KEY,
+                endpoints: {
+                    notify: payload.NOTIFY,
+                    sessions: payload.SESSIONS
+                }
+            })
+            postMessage('bugsnag-ready')
+            break;
+        case 'bugsnag-notify':
+            Promise.reject(new Error('broken promises'))
+            break;
+        default:
+    } 
+}

--- a/test/browser/features/web_worker.feature
+++ b/test/browser/features/web_worker.feature
@@ -21,3 +21,11 @@ Scenario: setting collectUserIp option to false
   Then the error is a valid browser payload for the error reporting API
   And the event "request.clientIp" equals "[REDACTED]"
   And the event "user.id" equals "[REDACTED]"
+
+Scenario: unhandled promise rejection
+  When I navigate to the test URL "/web_worker/unhandled_promise_rejection"
+  And I wait to receive an error
+  Then the error is a valid browser payload for the error reporting API
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "broken promises"
+  And event 0 is unhandled


### PR DESCRIPTION
## Goal

Add unhandled promise rejection functionality to the web-worker notifier

## Design

Implement the existing unhandled promise rejection plugin for browsers, passing `self` instead of `window`

## Testing

- e2e test added to check unhandled promise rejections are reported