### PR TITLE
Update NextJS example with correct options for IgnorePlugin

### DIFF
--- a/examples/js/nextjs/next.config.js
+++ b/examples/js/nextjs/next.config.js
@@ -17,7 +17,7 @@ module.exports = {
     // Avoid including '@bugsnag/plugin-aws-lambda' module in the client side bundle
     // See https://arunoda.me/blog/ssr-and-server-only-modules
     if (!isServer) {
-      config.plugins.push(new webpack.IgnorePlugin(/@bugsnag\/plugin-aws-lambda/));
+      config.plugins.push(new webpack.IgnorePlugin({resourceRegExp: /@bugsnag\/plugin-aws-lambda/}));
     }
 
     // Upload source maps on production build


### PR DESCRIPTION
Adds in an explicit key for NextJS example for webpack IgnorePlugin.

Was throwing errors without, and matches the [official documentation](https://webpack.js.org/plugins/ignore-plugin/)