### PR TITLE
Use resourceRegExp in IgnorePlugin

### DIFF
--- a/examples/js/nextjs/next.config.js
+++ b/examples/js/nextjs/next.config.js
@@ -17,7 +17,7 @@ module.exports = {
     // Avoid including '@bugsnag/plugin-aws-lambda' module in the client side bundle
     // See https://arunoda.me/blog/ssr-and-server-only-modules
     if (!isServer) {
-      config.plugins.push(new webpack.IgnorePlugin(/@bugsnag\/plugin-aws-lambda/));
+      config.plugins.push(new webpack.IgnorePlugin({resourceRegExp: /@bugsnag\/plugin-aws-lambda/}));
     }
 
     // Upload source maps on production build


### PR DESCRIPTION
Appeases webpack IgnorePlugin

## Goal

To prevent Webpack errors in Webpack v5+.

## Design

In line with the [official documentation](https://webpack.js.org/plugins/ignore-plugin/)

## Changeset

`next.config.js`

`config.plugins.push(new webpack.IgnorePlugin(/@bugsnag\/plugin-aws-lambda/));`
is now
`config.plugins.push(new webpack.IgnorePlugin({resourceRegExp: /@bugsnag\/plugin-aws-lambda/}));`

## Testing

Ran Webpack build using `v5.75.0` and `v4.46.0`. Source maps uploaded and able to symbolicate stacktraces. No errors observed.