### PR TITLE
Update browser tests to use iphone_x

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -263,7 +263,7 @@ steps:
         concurrency: 2
         concurrency_group: "browserstack"
 
-      - label: ":iphone: iOS 10.3 Browser tests"
+      - label: ":iphone: iOS 11 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:
@@ -273,7 +273,7 @@ steps:
             use-aliases: true
             command:
               - --farm=bs
-              - --browser=iphone_7
+              - --browser=iphone_x
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -181,7 +181,7 @@ safari_16:
     lineNumber: 18
     columnNumber: 25
 
-iphone_7:
+iphone_x:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: "Can't find variable: foo"

--- a/test/browser/features/fixtures/web_worker/worker_notify_error/index.html
+++ b/test/browser/features/fixtures/web_worker/worker_notify_error/index.html
@@ -9,6 +9,20 @@
     </script>
   </head>
   <body>
+    <div id="debugDiv"></div>
+    <script>
+      if (typeof console  != "undefined") 
+        if (typeof console.log != 'undefined')
+            console.olog = console.log
+        else
+            console.olog = function() {}
+
+      console.log = function(message) {
+          console.olog(message)
+          $('#debugDiv').append('<p>' + message + '</p>')
+      }
+      console.error = console.debug = console.info =  console.log
+    </script>
     <script>
         var worker = new Worker('worker.js')
         worker.onmessage = function () { worker.postMessage({ type: 'bugsnag-notify' }) } 

--- a/test/browser/features/web_worker.feature
+++ b/test/browser/features/web_worker.feature
@@ -2,7 +2,7 @@
 @skip_ie_8 @skip_ie_9
 
 # browsers that currently throw errors in our test fixtures 
-@skip_ie_10 @skip_ie_11 @skip_chrome_43 @skip_edge_17 @skip_safari_10 @skip_iphone_7
+@skip_ie_10 @skip_ie_11 @skip_chrome_43 @skip_edge_17 @skip_safari_10
 
 Feature: worker notifier
 


### PR DESCRIPTION
## Goal

To fix flakey iPhone end to end test fixtures

## Design

iOS 10 is now long out of support and causes a high number of flakes in our CI pipeline

## Changeset

- Updated iOS 13.4 browser test to use iOS 11 on iPhone X
- Updated browser error yaml