### PR TITLE
Drop testing on Android 4 browser

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -110,23 +110,6 @@ steps:
       #
       # BrowserStack tests
       #
-      - label: ":android: Android 4.4 Browser tests"
-        depends_on: "browser-maze-runner-legacy"
-        timeout_in_minutes: 30
-        plugins:
-          docker-compose#v3.9.0:
-            pull: browser-maze-runner-legacy
-            run: browser-maze-runner-legacy
-            use-aliases: true
-            command:
-              - --farm=bs
-              - --browser=android_nexus5
-          artifacts#v1.5.0:
-            upload:
-              - "./test/browser/maze_output/failed/**/*"
-        concurrency: 5
-        concurrency_group: "browserstack"
-
       - label: ":chrome: v43 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
@@ -300,23 +283,6 @@ steps:
           HOST: "bs-local.com"
         concurrency: 5
         concurrency_group: "browserstack"
-
-      # - label: ":android: Android 6.0 Browser tests"
-      #   depends_on: "browser-maze-runner"
-      #   timeout_in_minutes: 30
-      #   plugins:
-      #     docker-compose#v3.9.0:
-      #       pull: browser-maze-runner
-      #       run: browser-maze-runner
-      #       use-aliases: true
-      #       command:
-      #         - --farm=bs
-      #         - --browser=android_s7
-      #     artifacts#v1.5.0:
-      #       upload:
-      #         - "./test/browser/maze_output/failed/**/*"
-      #   concurrency: 5
-      #   concurrency_group: "browserstack"
 
       - label: ":android: Android 7.0 Browser tests"
         depends_on: "browser-maze-runner"


### PR DESCRIPTION
## Goal

Drop testing on Android 4 browser.

## Design

BrowserStack are no longer able to provide the Android 4 device for browser testing.

We will have to make do with Android 7 as the earliest Android browser we can test on.

## Testing

Covered by CI.