### PR TITLE
Use android.namespace to support projects using AGP 8

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -24,6 +24,10 @@ android {
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
+    if (android.hasProperty('namespace')) {
+        namespace 'com.bugsnag.reactnative'
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)


### PR DESCRIPTION
## Goal
Support for ReactNative projects using AGP, which moved the app namespace out of the `AndroidManifest.xml` and into `build.gradle`.

## Changelog
Added a conditional definition of the project `namespace` if the Android Gradle Plugin supports it. This allows us to remain backwards compatible with older versions of AGP.

## Testing
Tested manually with an AGP 8 compatible project, relied on existing tests for backwards compatibility testing.