### PR TITLE
Interaction breadcrumb hanging

### DIFF
--- a/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
+++ b/packages/plugin-interaction-breadcrumbs/interaction-breadcrumbs.js
@@ -21,12 +21,23 @@ module.exports = (win = window) => ({
   }
 })
 
-// extract text content from a element
-const getNodeText = el => {
+const trimStart = /^\s+/
+const trimEnd = /(^|[^\s])\s+$/
+
+function getNodeText (el) {
   let text = el.textContent || el.innerText || ''
-  if (!text && (el.type === 'submit' || el.type === 'button')) text = el.value
-  text = text.replace(/^\s+|\s+$/g, '') // trim whitespace
-  return truncate(text, 140)
+
+  if (!text && (el.type === 'submit' || el.type === 'button')) {
+    text = el.value
+  }
+
+  text = text.replace(trimStart, '').replace(trimEnd, '$1')
+
+  if (text.length > 140) {
+    return text.slice(0, 135) + '(...)'
+  }
+
+  return text
 }
 
 // Create a label from tagname, id and css class of the element
@@ -51,10 +62,4 @@ function getNodeSelector (el, win) {
   // try prepending the parent node selector
   if (el.parentNode) return `${getNodeSelector(el.parentNode, win)} > ${parts.join('')}`
   return parts.join('')
-}
-
-function truncate (value, length) {
-  const ommision = '(...)'
-  if (value && value.length <= length) return value
-  return value.slice(0, length - ommision.length) + ommision
 }

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
@@ -213,4 +213,40 @@ describe('plugin: interaction breadcrumbs', () => {
       )
     ])
   })
+
+  it('can read text from the value of an empty "submit" input', () => {
+    document.body.innerHTML = '<input type="submit" value="  some text  ">'
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('input')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'some text', targetSelector: 'INPUT' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
+
+  it('can read text from the value of an empty "button" input', () => {
+    document.body.innerHTML = '<input type="button" value="  some text  ">'
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('input')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'some text', targetSelector: 'INPUT' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
 })

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
@@ -3,78 +3,43 @@ import plugin from '../'
 import Client from '@bugsnag/core/client'
 
 describe('plugin: interaction breadcrumbs', () => {
-  it('should drop a breadcrumb when an element is clicked', () => {
-    const { window, winHandlers, els } = getMockWindow()
+  beforeEach(() => {
+    document.body.innerHTML = '<div><button class="button">Click me</button></div>'
+  })
+
+  it('should be enabled by default', () => {
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin(window)] })
-    winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c._breadcrumbs.length).toBe(1)
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toHaveLength(1)
   })
 
   it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
-    const { window, winHandlers, els } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [], plugins: [plugin(window)] })
-    winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c._breadcrumbs.length).toBe(0)
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toHaveLength(0)
   })
 
   it('should be enabled when enabledBreadcrumbTypes=["user"]', () => {
-    const { window, winHandlers, els } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['user'], plugins: [plugin(window)] })
-    winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c._breadcrumbs.length).toBe(1)
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toHaveLength(1)
   })
 
   it('should be enabled when enabledBreadcrumbTypes=null', () => {
-    const { window, winHandlers, els } = getMockWindow()
     const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
-    winHandlers.click.forEach(fn => fn.call(window, { target: els[0] }))
-    expect(c._breadcrumbs.length).toBe(1)
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toHaveLength(1)
   })
 })
-
-const getMockWindow = () => {
-  const els = [
-    {
-      tagName: 'BUTTON',
-      className: 'button',
-      textContent: 'Click me',
-      parentNode: null
-    },
-    {
-      tagName: 'BUTTON',
-      className: 'button',
-      textContent: 'or me',
-      parentNode: null
-    }
-  ]
-
-  const parent = {
-    tagName: 'DIV',
-    id: 'buttons',
-    childNodes: els,
-    className: '',
-    parentNode: null
-  } as any
-
-  parent.parentNode = { childNodes: [parent] }
-  els.forEach(el => { el.parentNode = parent })
-
-  const winHandlers: { [key: string]: Array<(event: any) => void> } = { click: [] }
-  const window = {
-    addEventListener: function (evt: string, handler: (event: any) => void) {
-      winHandlers[evt] = winHandlers[evt] ? winHandlers[evt].concat(handler) : [handler]
-    },
-    document: {
-      querySelectorAll: function (query: string) {
-        switch (query) {
-          case 'BUTTON.button': return els
-          case 'BUTTON.button:nth-child(1)': return [els[0]]
-          case 'DIV#buttons': return [parent]
-          default: return []
-        }
-      }
-    }
-  } as unknown as Window & typeof globalThis
-
-  return { els, window, winHandlers }
-}

--- a/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
+++ b/packages/plugin-interaction-breadcrumbs/test/interaction-breadcrumbs.test.ts
@@ -1,6 +1,7 @@
 import plugin from '../'
 
 import Client from '@bugsnag/core/client'
+import Breadcrumb from '@bugsnag/core/breadcrumb'
 
 describe('plugin: interaction breadcrumbs', () => {
   beforeEach(() => {
@@ -41,5 +42,144 @@ describe('plugin: interaction breadcrumbs', () => {
     document.querySelector('button')!.click()
 
     expect(c._breadcrumbs).toHaveLength(1)
+  })
+
+  it("includes the target's text and selector", () => {
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'Click me', targetSelector: 'BUTTON.button' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
+
+  it('strips leading and trailing whitespace in target text', () => {
+    document.body.innerHTML = `
+      <button>
+
+        hello there
+
+      </button>
+    `
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'hello there', targetSelector: 'BUTTON' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
+
+  it('includes 140 characters of text', () => {
+    document.body.innerHTML = `
+      <button>
+
+        ${'a'.repeat(140)}
+
+      </button>
+    `
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'a'.repeat(140), targetSelector: 'BUTTON' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
+
+  it('truncates to 135 characters of text + "(...)" when text is too long', () => {
+    document.body.innerHTML = `
+      <button>
+
+        ${'a'.repeat(141)}
+
+      </button>
+    `
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'a'.repeat(135) + '(...)', targetSelector: 'BUTTON' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
+
+  it("doesn't strip whitespace between words", () => {
+    document.body.innerHTML = `
+      <button>
+
+        a          b          c
+
+      </button>
+    `
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        { targetText: 'a          b          c', targetSelector: 'BUTTON' },
+        'user',
+        expect.any(Date)
+      )
+    ])
+  })
+
+  it("doesn't strip trailing whitespace after the character limit", () => {
+    document.body.innerHTML = `
+      <button>
+
+        a          b ${' '.repeat(200)} c
+
+      </button>
+    `
+
+    const c = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin(window)] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.querySelector('button')!.click()
+
+    expect(c._breadcrumbs).toStrictEqual([
+      new Breadcrumb(
+        'UI click',
+        {
+          targetText: 'a          b                                                                                                                           (...)',
+          targetSelector: 'BUTTON'
+        },
+        'user',
+        expect.any(Date)
+      )
+    ])
   })
 })


### PR DESCRIPTION
## Goal

Fixes an issue where the interaction breadcrumb plugin could hang when an element had a huge amount of whitespace in between non-whitespace characters, e.g.:

```
<button>[whitespace] a [whitespace] b [whitespace]</button>
```

This would completely freeze the page until the regex finished, which could take multiple seconds

See #1945