### PR TITLE
Update BitBar tests to use the latest version of Edge

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -90,7 +90,7 @@ steps:
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":edge: v106 Browser tests"
+      - label: ":edge: v107 Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:
@@ -100,7 +100,7 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=edge_106
+              - --browser=edge_107
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -37,7 +37,7 @@ steps:
       #
       # BitBar tests
       #
-      - label: ":firefox: v107 Browser tests"
+      - label: ":firefox: Firefox Latest Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:
@@ -47,14 +47,14 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=firefox_107
+              - --browser=firefox_latest
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":chrome: v108 Browser tests"
+      - label: ":chrome: Latest Chrome Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:
@@ -64,7 +64,7 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=chrome_108
+              - --browser=chrome_latest
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"
@@ -90,7 +90,7 @@ steps:
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":edge: Browser tests"
+      - label: ":edge: Latest Edge Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -90,7 +90,7 @@ steps:
         concurrency: 5
         concurrency_group: "bitbar-web"
 
-      - label: ":edge: v107 Browser tests"
+      - label: ":edge: Browser tests"
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:
@@ -100,7 +100,7 @@ steps:
             use-aliases: true
             command:
               - --farm=bb
-              - --browser=edge_107
+              - --browser=edge_latest
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -417,7 +417,7 @@ chrome_108:
     lineNumber: 18
     columnNumber: 7
 
-edge_106:
+edge_107:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -391,7 +391,7 @@ chrome_72:
 
 # BitBar exclusive
 
-chrome_108:
+chrome_latest:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -443,7 +443,7 @@ edge_latest:
     lineNumber: 18
     columnNumber: 7
 
-firefox_107:
+firefox_latest:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -417,32 +417,6 @@ chrome_108:
     lineNumber: 18
     columnNumber: 7
 
-edge_107:
-  handled:
-    errorClass: 'ReferenceError'
-    errorMessage: 'foo is not defined'
-  unhandled_syntax:
-    errorClass: 'SyntaxError'
-    errorMessage: "Unexpected token '!'"
-    lineNumber: 18
-    columnNumber: 13
-    file: '/unhandled/script/a.html'
-  unhandled_thrown:
-    errorClass: 'Error'
-    errorMessage: "bad things"
-    lineNumber: 18
-    columnNumber: 13
-  unhandled_undefined_function:
-    errorClass: 'ReferenceError'
-    errorMessage: nevergoingtoexist_notinamillionyears is not defined
-    lineNumber: 18
-    columnNumber: 7
-  unhandled_malformed_uri:
-    errorClass: 'URIError'
-    errorMessage: URI malformed
-    lineNumber: 18
-    columnNumber: 7
-
 firefox_107:
   handled:
     errorClass: 'ReferenceError'

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -417,6 +417,32 @@ chrome_108:
     lineNumber: 18
     columnNumber: 7
 
+edge_latest:
+  handled:
+    errorClass: 'ReferenceError'
+    errorMessage: 'foo is not defined'
+  unhandled_syntax:
+    errorClass: 'SyntaxError'
+    errorMessage: "Unexpected token '!'"
+    lineNumber: 18
+    columnNumber: 13
+    file: '/unhandled/script/a.html'
+  unhandled_thrown:
+    errorClass: 'Error'
+    errorMessage: "bad things"
+    lineNumber: 18
+    columnNumber: 13
+  unhandled_undefined_function:
+    errorClass: 'ReferenceError'
+    errorMessage: nevergoingtoexist_notinamillionyears is not defined
+    lineNumber: 18
+    columnNumber: 7
+  unhandled_malformed_uri:
+    errorClass: 'URIError'
+    errorMessage: URI malformed
+    lineNumber: 18
+    columnNumber: 7
+
 firefox_107:
   handled:
     errorClass: 'ReferenceError'


### PR DESCRIPTION
## Goal

Edge version 106 has been removed from the BitBar capabilities creator, this change updates the target version to the latest supported version of Edge in BitBar