### PR TITLE
Fix CI pipeline

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -38,6 +38,7 @@ steps:
       # BitBar tests
       #
       - label: ":bitbar: {{matrix}} Browser tests"
+        skip: Skipped pending PLAT-10093
         depends_on: "browser-maze-runner"
         matrix:
           - firefox_latest
@@ -59,6 +60,7 @@ steps:
         concurrency_group: "bitbar-web"
 
       - label: ":bitbar: ie_11 Browser tests"
+        skip: Skipped pending PLAT-10093
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -96,6 +96,11 @@ steps:
           - iphone_13
           - android_s8 # Android 7
           - firefox_78
+          # TODO: Remove these as part of PLAT-10093
+          - ie_11
+          - chrome_latest
+          - firefox_latest
+          - edge_latest
         depends_on: "browser-maze-runner"
         timeout_in_minutes: 30
         plugins:

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -58,6 +58,7 @@ steps:
               - "./test/browser/maze_output/failed/**/*"
         concurrency: 5
         concurrency_group: "bitbar-web"
+        concurrency_method: eager
 
       - label: ":bitbar: ie_11 Browser tests"
         skip: Skipped pending PLAT-10093
@@ -76,6 +77,7 @@ steps:
               - "./test/browser/maze_output/failed/**/*"
         concurrency: 5
         concurrency_group: "bitbar-web"
+        concurrency_method: eager
         env:
           HOST: "localhost" # IE11 needs the host set to localhost for some reason
 
@@ -97,7 +99,6 @@ steps:
           - android_s8 # Android 7
           - firefox_78
           # TODO: Remove these as part of PLAT-10093
-          - ie_11
           - chrome_latest
           - firefox_latest
           - edge_latest
@@ -116,3 +117,25 @@ steps:
               - "./test/browser/maze_output/failed/**/*"
         concurrency: 2
         concurrency_group: "browserstack"
+        concurrency_method: eager
+
+      # TODO: Remove this as part of PLAT-10093
+      - label: ":browserstack: ie_11 tests"
+        depends_on: "browser-maze-runner"
+        timeout_in_minutes: 30
+        plugins:
+          docker-compose#v3.9.0:
+            pull: browser-maze-runner
+            run: browser-maze-runner
+            use-aliases: true
+            command:
+              - --farm=bs
+              - --browser=ie_11
+          artifacts#v1.5.0:
+            upload:
+              - "./test/browser/maze_output/failed/**/*"
+        concurrency: 2
+        concurrency_group: "browserstack"
+        concurrency_method: eager
+        env:
+          HOST: "localhost" # IE11 needs the host set to localhost for some reason

--- a/test/node/features/fixtures/corporate-proxy/Dockerfile
+++ b/test/node/features/fixtures/corporate-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:latest
 RUN npm install -g proxy
 CMD proxy
 EXPOSE 3128

--- a/test/node/features/fixtures/corporate-proxy/Dockerfile
+++ b/test/node/features/fixtures/corporate-proxy/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:latest
-RUN npm install -g proxy
+RUN npm install -g proxy@1.0.2
 CMD proxy
 EXPOSE 3128


### PR DESCRIPTION
## Goal

Fix the Node and Browser tests.

## Design

There is still some kind of problem running the secure tunnel with BitBar, so those browser tests are returning to BrowserStack for the time being.

A failing Node test has been fixed by pinning the version of `proxy` being used to 1.0.2 - sidestepping a breaking change in v2.

## Testing

Covered by CI.