### PR TITLE
Remove use of legacy Maze Runner image

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -18,22 +18,6 @@ steps:
               push:
                 - browser-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
 
-      - label:  ":docker: Build legacy browser maze runner image"
-        key: "browser-maze-runner-legacy"
-        timeout_in_minutes: 20
-        plugins:
-          - artifacts#v1.5.0:
-              download: min_packages.tar
-          - docker-compose#v3.9.0:
-              build:
-                - browser-maze-runner-legacy
-              image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
-              cache-from:
-                - browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-          - docker-compose#v3.9.0:
-              push:
-                - browser-maze-runner-legacy:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-
       #
       # BitBar tests
       #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,47 +62,6 @@ services:
     volumes:
       - ./test/browser/maze_output:/app/test/browser/maze_output
 
-  browser-maze-runner-legacy:
-    build:
-      context: .
-      dockerfile: dockerfiles/Dockerfile.browser
-      target: browser-maze-runner-legacy
-      args:
-        - BUILDKITE_BUILD_NUMBER
-    environment:
-      BUILDKITE:
-      BUILDKITE_BRANCH:
-      BUILDKITE_BUILD_CREATOR:
-      BUILDKITE_BUILD_NUMBER:
-      BUILDKITE_BUILD_URL:
-      BUILDKITE_LABEL:
-      BUILDKITE_MESSAGE:
-      BUILDKITE_PIPELINE_NAME:
-      BUILDKITE_REPO:
-      BUILDKITE_RETRY_COUNT:
-      BUILDKITE_STEP_KEY:
-      MAZE_BUGSNAG_API_KEY:
-      MAZE_TMS_URI:
-      MAZE_TMS_TOKEN:
-      DEBUG:
-      BROWSER_STACK_USERNAME:
-      BROWSER_STACK_ACCESS_KEY:
-      BROWSER_STACK_BROWSERS_USERNAME:
-      BROWSER_STACK_BROWSERS_ACCESS_KEY:
-      BROWSER_STACK_DEVICES_USERNAME:
-      BROWSER_STACK_DEVICES_ACCESS_KEY:
-      USE_LEGACY_DRIVER: 1
-      HOST: "${HOST:-maze-runner}"
-      API_HOST: "${API_HOST:-maze-runner}"
-    env_file:
-      - ${DOCKER_ENV_FILE:-test/browser/features/fixtures/null_env}
-    networks:
-      default:
-        aliases:
-          - maze-runner
-    volumes:
-      - ./test/browser/maze_output:/app/test/browser/maze_output
-
   node-maze-runner:
     build:
       context: .

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -51,9 +51,3 @@ FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7
 
 COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
 WORKDIR /app/test/browser
-
-# The maze-runner legacy browser tests (JSON-WP protocol)
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli-legacy as browser-maze-runner-legacy
-
-COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
-WORKDIR /app/test/browser


### PR DESCRIPTION
## Goal

Remove use of legacy Maze Runner image.  It isn't needed and removal of its use should allow us to simplify things in Maze Runner itself.

## Testing

Covered by CI.