### PR TITLE
Move React-native CLI android tests to using BitBar.

### DIFF
--- a/.buildkite/react-native-android-pipeline.yml
+++ b/.buildkite/react-native-android-pipeline.yml
@@ -287,10 +287,18 @@ steps:
             pull: react-native-maze-runner
             run: react-native-maze-runner
             service-ports: true
+<<<<<<< HEAD
             command:
             - --app=build/r_navigation_0.60.apk
             - --farm=bb
             - --device=ANDROID_10|ANDROID_11|ANDROID_12
+=======
+            use-aliases: true
+            command:
+            - --app=build/r_navigation_0.60.apk
+            - --farm=bs
+            - --device=ANDROID_11
+>>>>>>> 2671d967d (Trial run of android pipeline on BitBar)
             - --a11y-locator
             - --fail-fast
             - --no-tunnel

--- a/.buildkite/react-native-android-pipeline.yml
+++ b/.buildkite/react-native-android-pipeline.yml
@@ -287,18 +287,10 @@ steps:
             pull: react-native-maze-runner
             run: react-native-maze-runner
             service-ports: true
-<<<<<<< HEAD
             command:
             - --app=build/r_navigation_0.60.apk
             - --farm=bb
             - --device=ANDROID_10|ANDROID_11|ANDROID_12
-=======
-            use-aliases: true
-            command:
-            - --app=build/r_navigation_0.60.apk
-            - --farm=bs
-            - --device=ANDROID_11
->>>>>>> 2671d967d (Trial run of android pipeline on BitBar)
             - --a11y-locator
             - --fail-fast
             - --no-tunnel

--- a/.buildkite/react-native-android-pipeline.yml
+++ b/.buildkite/react-native-android-pipeline.yml
@@ -101,6 +101,7 @@ steps:
           - build/r_navigation_0.60.apk
 
       - label: ":android: Build react-navigation 0.66 apk"
+        skip: Pending PLAT-10343
         key: "react-navigation-0-66-apk"
         depends_on:
           - "android-builder-image"
@@ -301,6 +302,7 @@ steps:
         concurrency_method: eager
 
       - label: ":android: react-navigation 0.66 Android 11 end-to-end tests"
+        skip: Pending PLAT-10343
         depends_on: "react-navigation-0-66-apk"
         timeout_in_minutes: 60
         plugins:

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -523,231 +523,253 @@ steps:
         depends_on: "rn-cli-0-60-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_60.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_60.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.61 Android end-to-end tests"
         depends_on: "rn-cli-0-61-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_61.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_61.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.62 Android end-to-end tests"
         depends_on: "rn-cli-0-62-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_62.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_62.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.63 Android end-to-end tests"
         depends_on: "rn-cli-0-63-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_63.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_63.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.63 Expo (ejected) Android end-to-end tests"
         depends_on: "rn-cli-0-63-expo-ejected-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_63_expo_ejected.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_63_expo_ejected.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.64 Android end-to-end tests"
         depends_on: "rn-cli-0-64-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_64.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_64.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.65 Android end-to-end tests"
         depends_on: "rn-cli-0-65-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_65.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_65.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.66 Android end-to-end tests"
         depends_on: "rn-cli-0-66-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_66.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_66.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.67 Android end-to-end tests (Non-hermes)"
         depends_on: "rn-cli-0-67-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_67.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_67.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       - label: ":runner: RN 0.67 Android end-to-end tests (Hermes)"
         depends_on: "rn-cli-0-67-hermes-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_67_hermes.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_67_hermes.apk
-              - --farm=bs
-              - --device=ANDROID_12_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.69 Android end-to-end tests (Non-hermes)"
+      - label: ":bitbar: RN 0.69 Android end-to-end tests (Non-hermes)"
         depends_on: "rn-cli-0-69-apk"
         timeout_in_minutes: 10
         plugins:
-          artifacts#v1.5.0:
+          artifacts#v1.9.0:
             download: "build/rn0_69.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
-            use-aliases: true
+            service-ports: true
             command:
               - --app=build/rn0_69.apk
-              - --farm=bs
-              - --device=ANDROID_11_0
+              - --farm=bb
+              - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --a11y-locator
+              - --no-tunnel
+              - --aws-public-ip
               - features/run-app-tests
-        concurrency: 5
-        concurrency_group: "browserstack-app"
+        concurrency: 25
+        concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
       #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,10 +209,20 @@ services:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
     environment:
       <<: *common-environment
+      BITBAR_USERNAME:
+      BITBAR_ACCESS_KEY:
+      HERMES:
+    ports:
+      - "9000-9499:9339"
+    networks:
+      default:
+        aliases:
+          - maze-runner
     volumes:
       - ./build:/app/build
       - ./test/react-native-cli/features/:/app/features/
       - ./test/react-native-cli/maze_output:/app/maze_output
+      - /var/run/docker.sock:/var/run/docker.sock
 
   release:
     build:

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -34,6 +34,12 @@ module.exports = {
       const initCommand = `./rn-cli-init-android.sh ${version} ${rnVersion}`
       common.run(initCommand, true)
 
+      // Use Perl to replace the Bugsnag start command to use a loaded configuration
+      const applicationPath = `android/app/src/main/java/com/${rnVersion}/`
+      common.changeDir(`${destFixtures}/${rnVersion}/${applicationPath}`)
+      const perlCommand = 'perl -pi -e "s/Bugsnag.start\\(this\\);/Bugsnag.start\\(this, createConfiguration\\(\\)\\);/g" MainApplication.java'
+      common.run(perlCommand, true)
+
       // Native layer
       common.changeDir(`${destFixtures}/${rnVersion}/android`)
       common.run('./gradlew assembleRelease', true)

--- a/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
+++ b/test/react-native-cli/features/fixtures/rn-cli-init-android.sh
@@ -35,7 +35,7 @@ expect "Enter version of the Bugsnag Android Gradle plugin you want to use"
 send -- \r
 
 expect "What is your Bugsnag project API key?"
-send -- 1234567890ABCDEF1234567890ABCDEF\r
+send -- "1234567890ABCDEF1234567890ABCDEF\r"
 
 expect "Do you want to automatically upload JavaScript source maps as part of the Xcode build?"
 send -- n

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -193,6 +194,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     if (enableHermes) {
       def hermesPath = "../../node_modules/hermesvm/android/";

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_60;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.util.Log;
+
+import java.util.Map;
 
 import com.facebook.react.PackageList;
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
@@ -44,5 +48,17 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/src/main/java/com/rn0_60/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_60
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000 // An extended timeout to allow appium to add the config file
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_60/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.3.61"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
@@ -14,6 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.1")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -184,6 +185,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_61;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
@@ -43,6 +47,18 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 
   /**

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/src/main/java/com/rn0_61/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_61
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_61/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.3.61"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
@@ -13,6 +15,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.2")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -194,6 +195,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_62;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -43,5 +47,17 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/src/main/java/com/rn0_62/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_62
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_62/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.3.61"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
@@ -13,6 +15,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.2")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -187,6 +188,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_63;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -43,5 +47,17 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/src/main/java/com/rn0_63/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_63
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_63/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "29.0.2"
         minSdkVersion = 16
         compileSdkVersion = 29
@@ -13,6 +15,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -132,7 +133,7 @@ android {
     }
 
     defaultConfig {
-        applicationId 'com.bugsnag.rn0_63_expo_ejected'
+        applicationId 'com.rn0_63_expo_ejected'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
@@ -187,6 +188,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     addUnimodulesDependencies()
 

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/AndroidManifest.xml
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.bugsnag.rn0_63_expo_ejected">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.rn0_63_expo_ejected">
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
@@ -30,7 +30,7 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="com.bugsnag.rn0_63_expo_ejected"/>
+        <data android:scheme="com.rn0_63_expo_ejected"/>
       </intent-filter>
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/CrashyModule.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/CrashyModule.java
@@ -1,4 +1,4 @@
-package com.bugsnag.rn0_63_expo_ejected;
+package com.rn0_63_expo_ejected;
 
 import com.bugsnag.android.Bugsnag;
 

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/CrashyPackage.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/CrashyPackage.java
@@ -1,4 +1,4 @@
-package com.bugsnag.rn0_63_expo_ejected;
+package com.rn0_63_expo_ejected;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/MainActivity.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/MainActivity.java
@@ -1,4 +1,4 @@
-package com.bugsnag.rn0_63_expo_ejected;
+package com.rn0_63_expo_ejected;
 
 import android.content.Intent;
 import android.os.Bundle;

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/MainApplication.java
@@ -1,8 +1,10 @@
-package com.bugsnag.rn0_63_expo_ejected;
+package com.rn0_63_expo_ejected;
 
 import android.app.Application;
 import android.content.Context;
 import android.net.Uri;
+import android.util.Log;
+import java.util.Map;
 
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
@@ -11,7 +13,9 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
-import com.bugsnag.rn0_63_expo_ejected.generated.BasePackageList;
+import com.rn0_63_expo_ejected.generated.BasePackageList;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 
 import org.unimodules.adapters.react.ReactAdapterPackage;
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
@@ -92,5 +96,17 @@ public class MainApplication extends Application implements ReactApplication {
     if (!BuildConfig.DEBUG) {
       UpdatesController.initialize(this);
     }
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_63_expo_ejected
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/generated/BasePackageList.java
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/app/src/main/java/com/rn0_63_expo_ejected/generated/BasePackageList.java
@@ -1,4 +1,4 @@
-package com.bugsnag.rn0_63_expo_ejected.generated;
+package com.rn0_63_expo_ejected.generated;
 
 import java.util.Arrays;
 import java.util.List;

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
         compileSdkVersion = 30
@@ -13,6 +15,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.1.0")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/ios/rn0_63_expo_ejected.xcodeproj/project.pbxproj
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/ios/rn0_63_expo_ejected.xcodeproj/project.pbxproj
@@ -340,7 +340,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.bugsnag.rn0-63-expo-ejected";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rn0-63-expo-ejected";
 				PRODUCT_NAME = rn0_63_expo_ejected;
 				SWIFT_OBJC_BRIDGING_HEADER = "rn0_63_expo_ejected/rn0_63_expo_ejected-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -368,7 +368,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.bugsnag.rn0-63-expo-ejected";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rn0-63-expo-ejected";
 				PRODUCT_NAME = rn0_63_expo_ejected;
 				SWIFT_OBJC_BRIDGING_HEADER = "rn0_63_expo_ejected/rn0_63_expo_ejected-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/test/react-native-cli/features/fixtures/rn0_64/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -187,6 +188,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/MainApplication.java
@@ -1,13 +1,17 @@
 package com.rn0_64;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import android.util.Log;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -43,5 +47,17 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 }

--- a/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/app/src/main/java/com/rn0_64/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_64
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_64/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_64/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
         compileSdkVersion = 29
@@ -14,6 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.1.0")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/fixtures/rn0_65/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_65/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -182,6 +183,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_65/android/app/src/main/java/com/rn0_65/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_65/android/app/src/main/java/com/rn0_65/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_65;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -46,6 +50,18 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 
   /**

--- a/test/react-native-cli/features/fixtures/rn0_65/android/app/src/main/java/com/rn0_65/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_65/android/app/src/main/java/com/rn0_65/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_65
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_65/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_65/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
@@ -14,6 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.1")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/fixtures/rn0_66/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_66/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -192,6 +193,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_66/android/app/src/main/java/com/rn0_66/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_66/android/app/src/main/java/com/rn0_66/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_66;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -46,6 +50,18 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 
   /**

--- a/test/react-native-cli/features/fixtures/rn0_66/android/app/src/main/java/com/rn0_66/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_66/android/app/src/main/java/com/rn0_66/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_66
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_66/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_66/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
@@ -14,6 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.2")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/fixtures/rn0_67/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_67/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -192,6 +193,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_67/android/app/src/main/java/com/rn0_67/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_67/android/app/src/main/java/com/rn0_67/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_67;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -46,6 +50,18 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 
   /**

--- a/test/react-native-cli/features/fixtures/rn0_67/android/app/src/main/java/com/rn0_67/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_67/android/app/src/main/java/com/rn0_67/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_67
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_67/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_67/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
@@ -14,6 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.2")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/fixtures/rn0_67_hermes/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_67_hermes/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -192,6 +193,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_67_hermes/android/app/src/main/java/com/rn0_67_hermes/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_67_hermes/android/app/src/main/java/com/rn0_67_hermes/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_67_hermes;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -46,6 +50,18 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 
   /**

--- a/test/react-native-cli/features/fixtures/rn0_67_hermes/android/app/src/main/java/com/rn0_67_hermes/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_67_hermes/android/app/src/main/java/com/rn0_67_hermes/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_67_hermes
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_67_hermes/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_67_hermes/android/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     ext {
+        kotlin_version = "1.4.30"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
@@ -14,6 +16,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.2")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/fixtures/rn0_69/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_69/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply plugin: "kotlin-android"
 
 import com.android.build.OutputFile
 
@@ -260,6 +261,7 @@ dependencies {
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 

--- a/test/react-native-cli/features/fixtures/rn0_69/android/app/src/main/java/com/rn0_69/MainApplication.java
+++ b/test/react-native-cli/features/fixtures/rn0_69/android/app/src/main/java/com/rn0_69/MainApplication.java
@@ -1,7 +1,11 @@
 package com.rn0_69;
 
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
+import java.util.Map;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
@@ -58,6 +62,18 @@ public class MainApplication extends Application implements ReactApplication {
     ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  private Configuration createConfiguration() {
+    TestUtils testUtils = new TestUtils();
+    Map<String, String> defaultParams = testUtils.loadDefaultParams(this);
+    Configuration config = new Configuration(defaultParams.get("apiKey"));
+    String mazeAddress = testUtils.getMazeRunnerAddress(this);
+    String notifyEndpoint = "http://" + mazeAddress + "/notify";
+    String sessionEndpoint = "http://" + mazeAddress + "/sessions";
+    config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
+    config.addMetadata("default", defaultParams);
+    return config;
   }
 
   /**

--- a/test/react-native-cli/features/fixtures/rn0_69/android/app/src/main/java/com/rn0_69/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_69/android/app/src/main/java/com/rn0_69/TestUtils.kt
@@ -16,7 +16,7 @@ const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
 class TestUtils {
 
     fun getMazeRunnerAddress(context: Context): String {
-        val externalFilesDir = File("/sdcard/Android/data/com.rn0_69/files")
+        val externalFilesDir = context.getExternalFilesDir(null)
         val configFile = File(externalFilesDir, "fixture_config.json")
         var mazeAddress: String? = null
         Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")

--- a/test/react-native-cli/features/fixtures/rn0_69/android/app/src/main/java/com/rn0_69/TestUtils.kt
+++ b/test/react-native-cli/features/fixtures/rn0_69/android/app/src/main/java/com/rn0_69/TestUtils.kt
@@ -1,0 +1,70 @@
+package com.rn0_69
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+
+const val CONFIG_FILE_TIMEOUT = 15000
+const val BUGSNAG_NS = "com.bugsnag.android"
+const val API_KEY = "$BUGSNAG_NS.API_KEY"
+const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
+
+class TestUtils {
+
+    fun getMazeRunnerAddress(context: Context): String {
+        val externalFilesDir = File("/sdcard/Android/data/com.rn0_69/files")
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        var mazeAddress: String? = null
+        Log.i("Bugsnag", "Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollEnd = System.currentTimeMillis() + CONFIG_FILE_TIMEOUT
+        while (System.currentTimeMillis() < pollEnd) {
+            if (configFile.exists()) {
+                val fileContents = configFile.readText()
+                val fixtureConfig = runCatching { JSONObject(fileContents) }.getOrNull()
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                if (!mazeAddress.isNullOrBlank()) {
+                    Log.i("Bugsnag", "Maze Runner address set from config file: $mazeAddress")
+                    break
+                }
+            }
+
+            Thread.sleep(250)
+        }
+        if (mazeAddress.isNullOrBlank()) {
+            Log.i("Bugsnag", "Failed to read Maze Runner address from config file, reverting to legacy address")
+            mazeAddress = "bs-local.com:9339"
+        }
+        return mazeAddress
+    }
+
+    fun loadDefaultParams(ctx: Context): Map<String, String?> {
+        try {
+            val packageManager = ctx.packageManager
+            val packageName = ctx.packageName
+            val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            val data = ai.metaData
+            if (data != null) {
+                val default_metadata = hashMapOf(
+                    "apiKey" to data.getString(API_KEY),
+                    "notify" to data.getString(ENDPOINT_NOTIFY),
+                    "sessions" to data.getString(ENDPOINT_SESSIONS)
+                )
+                return default_metadata
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
+        }
+        return emptyMap()
+    }
+
+    private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
+        return jsonObject?.optString(key) ?: ""
+    }
+
+}

--- a/test/react-native-cli/features/fixtures/rn0_69/android/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_69/android/build.gradle
@@ -4,6 +4,8 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
+        kotlin_version = "1.6.0"
+        RNNKotlinVersion = kotlin_version
         buildToolsVersion = "31.0.0"
         minSdkVersion = 21
         compileSdkVersion = 31
@@ -23,8 +25,10 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.1.1")
+        classpath("com.bugsnag:bugsnag-android-gradle-plugin:7.+")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/test/react-native-cli/features/steps/steps.rb
+++ b/test/react-native-cli/features/steps/steps.rb
@@ -61,8 +61,8 @@ def find_cli_helper_script
 end
 
 When('I build the Android app') do
-  path = find_cli_helper_script
-  $logger.info `node -e 'require("#{path}").buildAndroid("./features/fixtures", "./local-build")'`
+  script_path = find_cli_helper_script
+  $logger.info `node -e 'require("#{script_path}").buildAndroid("./features/fixtures", "./local-build")'`
 end
 
 When('I build the iOS app') do
@@ -209,11 +209,7 @@ Then('the iOS app contains the bugsnag initialisation code') do
 end
 
 def get_android_main_application_path(current_fixture)
-  if current_fixture.include? 'expo_ejected'
-    "android/app/src/main/java/com/bugsnag/#{current_fixture}/MainApplication.java"
-  else
-    "android/app/src/main/java/com/#{current_fixture}/MainApplication.java"
-  end
+  "android/app/src/main/java/com/#{current_fixture}/MainApplication.java"
 end
 
 Then('the Android app contains the bugsnag initialisation code') do


### PR DESCRIPTION
## Goal

To switch react-native-cli tests running on Android to use BitBar as a device farm provider instead of BrowserStack.

### Changes

- Docker-compose definitions and pipeline files have been updated in line with Bugsnag-Android to enable the test harness to provide the test fixture with its remote address.
- New methods have been added to the native side of the tests to:
  - Load the maze-runner added config file and acquire the maze-runner endpoint from it
  - Convert the original configuration (as provided by the CLI script) into metadata and attach it to the Bugsnag payloads
- The build script has been updated to find and replace the `Bugsnag.start` with default arguments (as added by the CLI script) with a line that calls a new method, creating the custom configuration with the above attributes.
