### PR TITLE
Move Firefox 78 to BitBar

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -64,8 +64,8 @@ steps:
 
       - label: ":bitbar: {{matrix}} Browser tests (EU hub)"
         matrix:
-          - chrome_43
-          - chrome_72
+#          - chrome_43
+#          - chrome_72
           - firefox_78
         depends_on: "browser-maze-runner-bb"
         timeout_in_minutes: 30
@@ -125,6 +125,9 @@ steps:
           - iphone_7   # iOS 10
           - iphone_13
           - android_s8 # Android 7
+          # TODO: Move these to BitBar
+          - chrome_43
+          - chrome_72
         depends_on: "browser-maze-runner-bs"
         timeout_in_minutes: 30
         plugins:

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -122,9 +122,9 @@ steps:
           - edge_17
           - safari_10
           - safari_16
-          - iphone_7   # iOS 10
-          - iphone_13
-          - android_s8 # Android 7
+          - ios_10
+          - ios_15
+          - android_7
           # TODO: Move these to BitBar
           - chrome_43
           - chrome_72

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -37,11 +37,33 @@ steps:
       #
       # BitBar tests
       #
-      - label: ":bitbar: {{matrix}} Browser tests"
+      - label: ":bitbar: {{matrix}} Browser tests (US hub)"
         matrix:
           - firefox_latest
           - chrome_latest
           - edge_latest
+        depends_on: "browser-maze-runner-bb"
+        timeout_in_minutes: 30
+        plugins:
+          docker-compose#v4.12.0:
+            pull: browser-maze-runner-bb
+            run: browser-maze-runner-bb
+            service-ports: true
+            use-aliases: true
+            command:
+              - "--farm=bb"
+              - "--browser={{matrix}}"
+              - "--no-tunnel"
+              - "--aws-public-ip"
+          artifacts#v1.5.0:
+            upload:
+              - "./test/browser/maze_output/failed/**/*"
+        concurrency: 5
+        concurrency_group: "bitbar-web"
+        concurrency_method: eager
+
+      - label: ":bitbar: {{matrix}} Browser tests (EU hub)"
+        matrix:
           - chrome_43
           - chrome_72
           - firefox_78
@@ -54,10 +76,11 @@ steps:
             service-ports: true
             use-aliases: true
             command:
-              - --farm=bb
-              - --browser={{matrix}}
-              - --no-tunnel
-              - --aws-public-ip
+              - "--farm=bb"
+              - "--browser={{matrix}}"
+              - "--no-tunnel"
+              - "--aws-public-ip"
+              - "--selenium-server=https://eu-desktop-hub.bitbar.com/wd/hub"
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"
@@ -75,10 +98,10 @@ steps:
             service-ports: true
             use-aliases: true
             command:
-              - --farm=bb
-              - --browser=ie_11
-              - --no-tunnel
-              - --aws-public-ip
+              - "--farm=bb"
+              - "--browser=ie_11"
+              - "--no-tunnel"
+              - "--aws-public-ip"
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"
@@ -110,8 +133,8 @@ steps:
             run: browser-maze-runner-bs
             use-aliases: true
             command:
-              - --farm=bs
-              - --browser={{matrix}}
+              - "--farm=bs"
+              - "--browser={{matrix}}"
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"

--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -42,6 +42,9 @@ steps:
           - firefox_latest
           - chrome_latest
           - edge_latest
+          - chrome_43
+          - chrome_72
+          - firefox_78
         depends_on: "browser-maze-runner-bb"
         timeout_in_minutes: 30
         plugins:
@@ -90,8 +93,6 @@ steps:
       #
       - label: ":browserstack: {{matrix}} tests"
         matrix:
-          - chrome_43
-          - chrome_72
           - ie_8
           - ie_9
           - ie_10
@@ -101,7 +102,6 @@ steps:
           - iphone_7   # iOS 10
           - iphone_13
           - android_s8 # Android 7
-          - firefox_78
         depends_on: "browser-maze-runner-bs"
         timeout_in_minutes: 30
         plugins:

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -47,7 +47,7 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 RUN rm -fr **/*/node_modules/
 
 # The maze-runner browser tests (W3C protocol)
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli as browser-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli as browser-maze-runner
 
 COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
 WORKDIR /app/test/browser

--- a/test/browser/Gemfile
+++ b/test/browser/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~> 7.0'
+gem 'bugsnag-maze-runner', '~> 8.0'
 
 # Use a branch of Maze Runner
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/use-maze-check'

--- a/test/browser/Gemfile.lock
+++ b/test/browser/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       selenium-webdriver (~> 4.2, < 4.6)
     bugsnag (6.25.2)
       concurrent-ruby (~> 1.0)
-    bugsnag-maze-runner (7.33.0)
+    bugsnag-maze-runner (8.0.0)
       appium_lib (~> 12.0.0)
       appium_lib_core (~> 5.4.0)
       bugsnag (~> 6.24)
@@ -89,10 +89,10 @@ GEM
     optimist (3.0.1)
     os (1.0.1)
     power_assert (2.0.3)
-    racc (1.6.2)
+    racc (1.7.1)
     rack (2.2.7)
     rake (12.3.3)
-    regexp_parser (2.8.0)
+    regexp_parser (2.8.1)
     rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.5.0)
@@ -121,7 +121,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bugsnag-maze-runner (~> 7.0)
+  bugsnag-maze-runner (~> 8.0)
 
 BUNDLED WITH
-   2.2.20
+   2.3.0

--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -181,7 +181,7 @@ safari_16:
     lineNumber: 18
     columnNumber: 25
 
-iphone_7:
+ios_10:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: "Can't find variable: foo"
@@ -207,7 +207,7 @@ iphone_7:
     lineNumber: 18
     columnNumber: 25
 
-iphone_13:
+ios_15:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: "Can't find variable: foo"
@@ -233,7 +233,7 @@ iphone_13:
     lineNumber: 18
     columnNumber: 25
 
-android_nexus5:
+android_4:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -259,7 +259,7 @@ android_nexus5:
     lineNumber: 18
     columnNumber: 7
 
-android_s7:
+android_6:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'
@@ -285,7 +285,7 @@ android_s7:
     lineNumber: 18
     columnNumber: 7
 
-android_s8:
+android_7:
   handled:
     errorClass: 'ReferenceError'
     errorMessage: 'foo is not defined'

--- a/test/browser/features/sessions.feature
+++ b/test/browser/features/sessions.feature
@@ -9,4 +9,4 @@ Scenario: tracking sessions by default
 Scenario: autoTrackSessions=false
   When I navigate to the test URL "/sessions/script/b.html"
   And I wait for 2 seconds
-  Then I should receive no requests
+  Then I should receive no sessions

--- a/test/browser/features/web_worker.feature
+++ b/test/browser/features/web_worker.feature
@@ -2,7 +2,7 @@
 @skip_ie_8 @skip_ie_9
 
 # browsers that currently throw errors in our test fixtures 
-@skip_ie_10 @skip_ie_11 @skip_chrome_43 @skip_edge_17 @skip_safari_10 @skip_iphone_7
+@skip_ie_10 @skip_ie_11 @skip_chrome_43 @skip_edge_17 @skip_safari_10 @skip_ios_10
 
 Feature: worker notifier
 
@@ -46,4 +46,3 @@ Feature: worker notifier
     When I navigate to the test URL "/web_worker/auto_track_sessions"
     And I wait to receive a session
     Then the session is a valid browser payload for the session tracking API
-    


### PR DESCRIPTION
## Goal

Move Firefox 78 to BitBar, reducing the load on BrowserStack slots.

## Design

We should also be able to mover Chrome 43 and 72, but they are not working on BB right now for some reason - ticket raised.

## Changeset

Includes upgrading to Maze Runner v8.

## Testing

Covered ny CI.