### PR TITLE
Bump Expo versions under test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -152,7 +152,7 @@ steps:
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:
-      branch: "v46-next"
+      branch: "v47/next"
       env:
         BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
         BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"
@@ -163,7 +163,7 @@ steps:
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:
-      branch: "v45-next"
+      branch: "v46-next"
       env:
         BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
         BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
## Goal

Bump Expo versions under test.  The latest is currently v48.

## Testing

Covered by CI.