### PR TITLE
Bump React Navigation tests to run of RN 0.69

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,6 +108,7 @@ steps:
       - buildkite-agent pipeline upload .buildkite/browser-pipeline.yml
 
   - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: ELECTRON STEPS :large_blue_circle: :large_blue_circle: :large_blue_circle:"
+    skip: Skipped pending PLAT-10345
     commands:
       - buildkite-agent pipeline upload .buildkite/electron-pipeline.yml
 

--- a/.buildkite/react-native-android-pipeline.yml
+++ b/.buildkite/react-native-android-pipeline.yml
@@ -148,7 +148,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":android: RN 0.60 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.60 Android 11 end-to-end tests"
         depends_on: "rn-0-60-apk"
         timeout_in_minutes: 60
         plugins:
@@ -173,7 +173,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: RN 0.66 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.66 Android 11 end-to-end tests"
         depends_on: "rn-0-66-apk"
         timeout_in_minutes: 60
         plugins:
@@ -198,7 +198,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: RN 0.67 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.67 Android 11 end-to-end tests"
         depends_on: "rn-0-67-apk"
         timeout_in_minutes: 60
         plugins:
@@ -224,7 +224,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: RN 0.69 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.69 Android 11 end-to-end tests"
         depends_on: "rn-0-69-apk"
         timeout_in_minutes: 60
         plugins:
@@ -250,7 +250,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: RN 0.68 (Hermes) Android 12 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.68 (Hermes) Android 12 end-to-end tests"
         depends_on: "rn-0-68-hermes-apk"
         timeout_in_minutes: 60
         plugins:
@@ -276,7 +276,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: react-navigation 0.60 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-navigation 0.60 Android 11 end-to-end tests"
         depends_on: "react-navigation-0-60-apk"
         timeout_in_minutes: 60
         plugins:
@@ -300,7 +300,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: react-navigation 0.66 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-navigation 0.66 Android 11 end-to-end tests"
         depends_on: "react-navigation-0-66-apk"
         timeout_in_minutes: 60
         plugins:
@@ -324,7 +324,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: react-native-navigation 0.60 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-native-navigation 0.60 Android 11 end-to-end tests"
         depends_on: "react-native-navigation-0-60-apk"
         timeout_in_minutes: 60
         plugins:
@@ -348,7 +348,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":android: react-native-navigation 0.66 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-native-navigation 0.66 Android 11 end-to-end tests"
         depends_on: "react-native-navigation-0-66-apk"
         timeout_in_minutes: 60
         plugins:

--- a/.buildkite/react-native-android-pipeline.yml
+++ b/.buildkite/react-native-android-pipeline.yml
@@ -100,20 +100,20 @@ steps:
         artifact_paths:
           - build/r_navigation_0.60.apk
 
-      - label: ":android: Build react-navigation 0.66 apk"
-        key: "react-navigation-0-66-apk"
+      - label: ":android: Build react-navigation 0.69 apk"
+        key: "react-navigation-0-69-apk"
         depends_on:
           - "android-builder-image"
         timeout_in_minutes: 60
         env:
-          REACT_NATIVE_VERSION: "rn0.66"
+          REACT_NATIVE_VERSION: "rn0.69"
           JS_SOURCE_DIR: "react_navigation_js"
-          ARTEFACT_NAME: "r_navigation_0.66"
+          ARTEFACT_NAME: "r_navigation_0.69"
         plugins:
           - docker-compose#v4.12.0:
               run: react-native-android-builder
         artifact_paths:
-          - build/r_navigation_0.66.apk
+          - build/r_navigation_0.69.apk
 
       - label: ":android: Build react-native-navigation 0.60 apk"
         key: "react-native-navigation-0-60-apk"
@@ -300,19 +300,19 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: react-navigation 0.66 Android end-to-end tests"
-        depends_on: "react-navigation-0-66-apk"
+      - label: ":bitbar: :android: react-navigation 0.69 Android end-to-end tests"
+        depends_on: "react-navigation-0-69-apk"
         timeout_in_minutes: 60
         plugins:
           artifacts#v1.9.0:
-            download: "build/r_navigation_0.66.apk"
+            download: "build/r_navigation_0.69.apk"
             upload: ./test/react-native/maze_output/**/*
           docker-compose#v4.7.0:
             pull: react-native-maze-runner
             run: react-native-maze-runner
             service-ports: true
             command:
-            - --app=build/r_navigation_0.66.apk
+            - --app=build/r_navigation_0.69.apk
             - --farm=bb
             - --device=ANDROID_10|ANDROID_11|ANDROID_12
             - --a11y-locator

--- a/.buildkite/react-native-android-pipeline.yml
+++ b/.buildkite/react-native-android-pipeline.yml
@@ -148,7 +148,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":bitbar: :android: RN 0.60 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.60 Android end-to-end tests"
         depends_on: "rn-0-60-apk"
         timeout_in_minutes: 60
         plugins:
@@ -173,7 +173,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: RN 0.66 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.66 Android end-to-end tests"
         depends_on: "rn-0-66-apk"
         timeout_in_minutes: 60
         plugins:
@@ -198,7 +198,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: RN 0.67 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.67 Android end-to-end tests"
         depends_on: "rn-0-67-apk"
         timeout_in_minutes: 60
         plugins:
@@ -224,7 +224,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: RN 0.69 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.69 Android end-to-end tests"
         depends_on: "rn-0-69-apk"
         timeout_in_minutes: 60
         plugins:
@@ -250,7 +250,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: RN 0.68 (Hermes) Android 12 end-to-end tests"
+      - label: ":bitbar: :android: RN 0.68 (Hermes) Android end-to-end tests"
         depends_on: "rn-0-68-hermes-apk"
         timeout_in_minutes: 60
         plugins:
@@ -276,7 +276,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: react-navigation 0.60 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-navigation 0.60 Android end-to-end tests"
         depends_on: "react-navigation-0-60-apk"
         timeout_in_minutes: 60
         plugins:
@@ -300,7 +300,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: react-navigation 0.66 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-navigation 0.66 Android end-to-end tests"
         depends_on: "react-navigation-0-66-apk"
         timeout_in_minutes: 60
         plugins:
@@ -324,7 +324,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: react-native-navigation 0.60 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-native-navigation 0.60 Android end-to-end tests"
         depends_on: "react-native-navigation-0-60-apk"
         timeout_in_minutes: 60
         plugins:
@@ -348,7 +348,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: :android: react-native-navigation 0.66 Android 11 end-to-end tests"
+      - label: ":bitbar: :android: react-native-navigation 0.66 Android end-to-end tests"
         depends_on: "react-native-navigation-0-66-apk"
         timeout_in_minutes: 60
         plugins:

--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -519,7 +519,7 @@ steps:
       #
       # Init, build and notify end-to-end tests - Android
       #
-      - label: ":runner: RN 0.60 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.60 Android end-to-end tests"
         depends_on: "rn-cli-0-60-apk"
         timeout_in_minutes: 10
         plugins:
@@ -542,7 +542,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.61 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.61 Android end-to-end tests"
         depends_on: "rn-cli-0-61-apk"
         timeout_in_minutes: 10
         plugins:
@@ -565,7 +565,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.62 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.62 Android end-to-end tests"
         depends_on: "rn-cli-0-62-apk"
         timeout_in_minutes: 10
         plugins:
@@ -588,7 +588,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.63 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.63 Android end-to-end tests"
         depends_on: "rn-cli-0-63-apk"
         timeout_in_minutes: 10
         plugins:
@@ -611,7 +611,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.63 Expo (ejected) Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.63 Expo (ejected) Android end-to-end tests"
         depends_on: "rn-cli-0-63-expo-ejected-apk"
         timeout_in_minutes: 10
         plugins:
@@ -634,7 +634,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.64 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.64 Android end-to-end tests"
         depends_on: "rn-cli-0-64-apk"
         timeout_in_minutes: 10
         plugins:
@@ -657,7 +657,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.65 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.65 Android end-to-end tests"
         depends_on: "rn-cli-0-65-apk"
         timeout_in_minutes: 10
         plugins:
@@ -680,7 +680,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.66 Android end-to-end tests"
+      - label: ":bitbar: :android: RN 0.66 Android end-to-end tests"
         depends_on: "rn-cli-0-66-apk"
         timeout_in_minutes: 10
         plugins:
@@ -703,7 +703,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.67 Android end-to-end tests (Non-hermes)"
+      - label: ":bitbar: :android: RN 0.67 Android end-to-end tests (Non-hermes)"
         depends_on: "rn-cli-0-67-apk"
         timeout_in_minutes: 10
         plugins:
@@ -726,7 +726,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":runner: RN 0.67 Android end-to-end tests (Hermes)"
+      - label: ":bitbar: :android: RN 0.67 Android end-to-end tests (Hermes)"
         depends_on: "rn-cli-0-67-hermes-apk"
         timeout_in_minutes: 10
         plugins:
@@ -749,7 +749,7 @@ steps:
         concurrency_group: 'bitbar-app'
         concurrency_method: eager
 
-      - label: ":bitbar: RN 0.69 Android end-to-end tests (Non-hermes)"
+      - label: ":bitbar: :android: RN 0.69 Android end-to-end tests (Non-hermes)"
         depends_on: "rn-cli-0-69-apk"
         timeout_in_minutes: 10
         plugins:
@@ -775,7 +775,7 @@ steps:
       #
       # Init, build and notify end-to-end tests - iOS
       #
-      - label: ":runner: RN 0.60 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.60 iOS end-to-end tests"
         depends_on: "rn-cli-0-60-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -796,7 +796,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.61 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.61 iOS end-to-end tests"
         depends_on: "rn-cli-0-61-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -817,7 +817,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.62 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.62 iOS end-to-end tests"
         depends_on: "rn-cli-0-62-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -838,7 +838,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.63 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.63 iOS end-to-end tests"
         depends_on: "rn-cli-0-63-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -859,7 +859,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.63 Expo (ejected) iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.63 Expo (ejected) iOS end-to-end tests"
         depends_on: "rn-cli-0-63-expo-ejected-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -880,7 +880,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.64 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.64 iOS end-to-end tests"
         depends_on: "rn-cli-0-64-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -901,7 +901,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.65 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.65 iOS end-to-end tests"
         depends_on: "rn-cli-0-65-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -922,7 +922,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.66 iOS end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.66 iOS end-to-end tests"
         depends_on: "rn-cli-0-66-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -943,7 +943,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.67 iOS end-to-end tests (Non-hermes)"
+      - label: ":browserstack: :ios: RN 0.67 iOS end-to-end tests (Non-hermes)"
         depends_on: "rn-cli-0-67-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -964,7 +964,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.67 iOS end-to-end tests (Hermes)"
+      - label: ":browserstack: :ios: RN 0.67 iOS end-to-end tests (Hermes)"
         depends_on: "rn-cli-0-67-hermes-ipa"
         timeout_in_minutes: 10
         plugins:
@@ -985,7 +985,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":runner: RN 0.69 iOS end-to-end tests (Non-hermes)"
+      - label: ":browserstack: :ios: RN 0.69 iOS end-to-end tests (Non-hermes)"
         depends_on: "rn-cli-0-69-ipa"
         timeout_in_minutes: 10
         plugins:

--- a/.buildkite/react-native-ios-pipeline.yml
+++ b/.buildkite/react-native-ios-pipeline.yml
@@ -99,7 +99,7 @@ steps:
           ARTEFACT_NAME: "r_navigation_0.69"
           LANG: "en_US.UTF-8"
           DEVELOPER_DIR: "/Applications/Xcode13.app"
-        artifact_paths: build/r_navigation_0.66.ipa
+        artifact_paths: build/r_navigation_0.69.ipa
         commands:
           - npm run test:build-react-native-ios
 

--- a/.buildkite/react-native-ios-pipeline.yml
+++ b/.buildkite/react-native-ios-pipeline.yml
@@ -140,7 +140,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":ios: RN 0.60 iOS 12 end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.60 iOS 12 end-to-end tests"
         depends_on: "rn-0-60-ipa"
         timeout_in_minutes: 60
         plugins:
@@ -164,7 +164,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":ios: RN 0.66 iOS 14 end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.66 iOS 14 end-to-end tests"
         depends_on: "rn-0-66-ipa"
         timeout_in_minutes: 60
         plugins:
@@ -188,7 +188,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":ios: RN 0.67 iOS 14 end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.67 iOS 14 end-to-end tests"
         depends_on: "rn-0-67-ipa"
         timeout_in_minutes: 60
         plugins:
@@ -213,7 +213,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":ios: RN 0.69 iOS 14 end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.69 iOS 14 end-to-end tests"
         depends_on: "rn-0-69-ipa"
         timeout_in_minutes: 60
         plugins:
@@ -238,7 +238,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
       #
-      - label: ":ios: RN 0.68 (hermes) iOS 14 end-to-end tests"
+      - label: ":browserstack: :ios: RN 0.68 (hermes) iOS 14 end-to-end tests"
         depends_on: "rn-0-68-hermes-ipa"
         timeout_in_minutes: 60
         plugins:
@@ -264,7 +264,7 @@ steps:
         concurrency_method: eager
 
       # See: PLAT-5173
-      - label: ":ios: react-navigation 0.60 iOS 13 end-to-end tests"
+      - label: ":browserstack: :ios: react-navigation 0.60 iOS 13 end-to-end tests"
         skip: "See PLAT-5173"
         depends_on: "react-navigation-0-60-ipa"
         timeout_in_minutes: 60
@@ -288,7 +288,7 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":ios: react-navigation 0.66 iOS 14 end-to-end tests"
+      - label: ":browserstack: :ios: react-navigation 0.66 iOS 14 end-to-end tests"
         depends_on: "react-navigation-0-66-ipa"
         timeout_in_minutes: 60
         plugins:
@@ -312,7 +312,7 @@ steps:
         concurrency_method: eager
 
       # See: PLAT-5173
-      - label: ":ios: react-native-navigation 0.60 iOS 13 end-to-end tests"
+      - label: ":browserstack: :ios: react-native-navigation 0.60 iOS 13 end-to-end tests"
         skip: "See PLAT-5173"
         depends_on: "react-native-navigation-0-60-ipa"
         timeout_in_minutes: 60
@@ -337,7 +337,7 @@ steps:
         concurrency_method: eager
 
       # See: PLAT-5173
-      - label: ":ios: react-native-navigation 0.66 iOS 13 end-to-end tests"
+      - label: ":browserstack: :ios: react-native-navigation 0.66 iOS 13 end-to-end tests"
         skip: "See PLAT-5173"
         depends_on: "react-native-navigation-0-66-ipa"
         timeout_in_minutes: 60

--- a/.buildkite/react-native-ios-pipeline.yml
+++ b/.buildkite/react-native-ios-pipeline.yml
@@ -88,15 +88,15 @@ steps:
         commands:
           - npm run test:build-react-native-ios
 
-      - label: ":ios: Build react-navigation 0.66 ipa"
-        key: "react-navigation-0-66-ipa"
+      - label: ":ios: Build react-navigation 0.69 ipa"
+        key: "react-navigation-0-69-ipa"
         timeout_in_minutes: 60
         agents:
           queue: "opensource-arm-mac-cocoa-12"
         env:
-          REACT_NATIVE_VERSION: rn0.66
+          REACT_NATIVE_VERSION: rn0.69
           JS_SOURCE_DIR: "react_navigation_js"
-          ARTEFACT_NAME: "r_navigation_0.66"
+          ARTEFACT_NAME: "r_navigation_0.69"
           LANG: "en_US.UTF-8"
           DEVELOPER_DIR: "/Applications/Xcode13.app"
         artifact_paths: build/r_navigation_0.66.ipa
@@ -264,7 +264,7 @@ steps:
         concurrency_method: eager
 
       # See: PLAT-5173
-      - label: ":browserstack: :ios: react-navigation 0.60 iOS 13 end-to-end tests"
+      - label: ":browserstack: :ios: react-navigation 0.60 iOS 12 end-to-end tests"
         skip: "See PLAT-5173"
         depends_on: "react-navigation-0-60-ipa"
         timeout_in_minutes: 60
@@ -288,19 +288,19 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
 
-      - label: ":browserstack: :ios: react-navigation 0.66 iOS 14 end-to-end tests"
-        depends_on: "react-navigation-0-66-ipa"
+      - label: ":browserstack: :ios: react-navigation 0.69 iOS 14 end-to-end tests"
+        depends_on: "react-navigation-0-69-ipa"
         timeout_in_minutes: 60
         plugins:
           artifacts#v1.5.0:
-            download: "build/r_navigation_0.66.ipa"
+            download: "build/r_navigation_0.69.ipa"
             upload: ./test/react-native/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-maze-runner
             run: react-native-maze-runner
             use-aliases: true
             command:
-              - --app=build/r_navigation_0.66.ipa
+              - --app=build/r_navigation_0.69.ipa
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator

--- a/test/react-native/features/fixtures/rn0.69/android/build.gradle
+++ b/test/react-native/features/fixtures/rn0.69/android/build.gradle
@@ -53,3 +53,9 @@ allprojects {
         maven { url 'https://www.jitpack.io' }
     }
 }
+
+subprojects { subproject ->
+    if(project['name'] == 'react-native-reanimated'){
+        project.configurations { compile { } }
+    }
+}


### PR DESCRIPTION
## Goal

Fix the build pipeline by bump React Navigation tests to run on RN 0.69.

## Changeset

Electron tests are skipped pending further investigation.

## Testing

Covered by CI.