### PR TITLE
Separate request method and url in network breadcrumbs metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@
 
 ### Changed
 
-- (plugin-navigation-breadcrumbs) calling `pushState` or `replaceState` no longer triggers a new session when `autoTrackSessions` is enabled [#1820](https://github.com/bugsnag/bugsnag-js/pull/1820)
-- (plugin-contextualize) reimplement without relying on the deprecated node Domain API. From Node 16+ unhandled promise rejections are also supported [#1924](https://github.com/bugsnag/bugsnag-js/pull/1924)
+- (plugin-navigation-breadcrumbs) Calling `pushState` or `replaceState` no longer triggers a new session when `autoTrackSessions` is enabled [#1820](https://github.com/bugsnag/bugsnag-js/pull/1820)
+- (plugin-contextualize) Reimplement without relying on the deprecated node Domain API. From Node 16+ unhandled promise rejections are also supported [#1924](https://github.com/bugsnag/bugsnag-js/pull/1924)
+- (plugin-network-breadcrumbs, plugin-electron-net-breadcrumbs) *Breaking change*: The `request` metadata field in network breadcrumbs has been renamed to `url` and is no longer pre-pended with the HTTP method [#1988](https://github.com/bugsnag/bugsnag-js/pull/1988)
+- (plugin-network-breadcrumbs, plugin-electron-net-breadcrumbs) Added `method` metadata field to network breadcrumbs [#1988](https://github.com/bugsnag/bugsnag-js/pull/1988)
+- (plugin-network-breadcrumbs, plugin-electron-net-breadcrumbs) Added `duration` metadata field to network breadcrumbs [#1903](https://github.com/bugsnag/bugsnag-js/pull/1903)
 
 ## TBD
 

--- a/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
+++ b/packages/plugin-electron-net-breadcrumbs/net-breadcrumbs.js
@@ -53,7 +53,12 @@ module.exports = net => ({
 
         client.leaveBreadcrumb(
           `net.request ${success ? 'succeeded' : 'failed'}`,
-          { request: `${method} ${url}`, status: response.statusCode, duration: getDuration(requestStart) },
+          {
+            method: String(method),
+            url: String(url),
+            status: response.statusCode,
+            duration: getDuration(requestStart)
+          },
           BREADCRUMB_REQUEST
         )
       })
@@ -61,7 +66,11 @@ module.exports = net => ({
       request.on('abort', () => {
         client.leaveBreadcrumb(
           'net.request aborted',
-          { request: `${method} ${url}`, duration: getDuration(requestStart) },
+          {
+            method: String(method),
+            url: String(url),
+            duration: getDuration(requestStart)
+          },
           BREADCRUMB_REQUEST
         )
       })
@@ -69,7 +78,12 @@ module.exports = net => ({
       request.on('error', (error) => {
         client.leaveBreadcrumb(
           'net.request error',
-          { request: `${method} ${url}`, error: error.message, duration: getDuration(requestStart) },
+          {
+            method: String(method),
+            url: String(url),
+            error: error.message,
+            duration: getDuration(requestStart)
+          },
           BREADCRUMB_REQUEST
         )
       })

--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -42,9 +42,16 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       request.end()
     })
 
+    const expectedMetadata = expect.objectContaining({
+      method: 'GET',
+      url: `${url}/`,
+      status,
+      duration: expect.any(Number)
+    })
+
     const expected = new Breadcrumb(
       `net.request ${successOrFailure}`,
-      { request: `GET ${url}/`, status, duration: expect.any(Number) },
+      expectedMetadata,
       'request'
     )
 
@@ -72,9 +79,16 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       request.end()
     })
 
+    const expectedMetadata = expect.objectContaining({
+      method,
+      url,
+      status,
+      duration: expect.any(Number)
+    })
+
     const expected = new Breadcrumb(
       `net.request ${successOrFailure}`,
-      { request: `${method} ${url}`, status, duration: expect.any(Number) },
+      expectedMetadata,
       'request'
     )
 
@@ -105,9 +119,16 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       request.end()
     })
 
+    const expectedMetadata = expect.objectContaining({
+      method: 'GET',
+      url: `http://localhost:${currentServer.port}/`,
+      status,
+      duration: expect.any(Number)
+    })
+
     const expected = new Breadcrumb(
       `net.request ${successOrFailure}`,
-      { request: `GET http://localhost:${currentServer.port}/`, status, duration: expect.any(Number) },
+      expectedMetadata,
       'request'
     )
 
@@ -128,9 +149,11 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       request.abort()
     })
 
+    const expectedMetadata = expect.objectContaining({ url: `${url}/`, method: 'GET' })
+
     const expected = new Breadcrumb(
       'net.request aborted',
-      { request: `GET ${url}/` },
+      expectedMetadata,
       'request'
     )
 
@@ -151,9 +174,11 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       request.abort()
     })
 
+    const expectedMetadata = expect.objectContaining({ url: `${url}/`, method: 'GET' })
+
     const expected = new Breadcrumb(
       'net.request aborted',
-      { request: `GET ${url}/` },
+      expectedMetadata,
       'request'
     )
 
@@ -180,9 +205,16 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       request.end()
     })
 
+    const expectedMetadata = expect.objectContaining({
+      method: 'GET',
+      url,
+      error: "Attempted to redirect, but redirect policy was 'error'",
+      duration: expect.any(Number)
+    })
+
     const expected = new Breadcrumb(
       'net.request error',
-      { request: `GET ${url}`, error: "Attempted to redirect, but redirect policy was 'error'", duration: expect.any(Number) },
+      expectedMetadata,
       'request'
     )
 
@@ -302,9 +334,16 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       }, 500)
     })
 
+    const expectedMetadata = expect.objectContaining({
+      method: 'POST',
+      url,
+      status: 200,
+      duration: expect.any(Number)
+    })
+
     const expected = new Breadcrumb(
       'net.request succeeded',
-      { request: `POST ${url}`, status: 200, duration: expect.any(Number) },
+      expectedMetadata,
       'request'
     )
 
@@ -340,9 +379,16 @@ describe.skip('plugin: electron net breadcrumbs', () => {
       }, 500)
     })
 
+    const expectedMetadata = expect.objectContaining({
+      method: 'POST',
+      url,
+      status: 200,
+      duration: expect.any(Number)
+    })
+
     const expected = new Breadcrumb(
       'net.request succeeded',
-      { request: `POST ${url}`, status: 200, duration: expect.any(Number) },
+      expectedMetadata,
       'request'
     )
 

--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -77,8 +77,9 @@ module.exports = (_ignoredUrls = [], win = window) => {
           return
         }
         const metadata = {
-          status: status,
-          request: `${method} ${url}`,
+          status,
+          method: String(method),
+          url: String(url),
           duration: duration
         }
         if (status >= 400) {
@@ -102,7 +103,8 @@ module.exports = (_ignoredUrls = [], win = window) => {
 
         // failed to contact server
         client.leaveBreadcrumb('XMLHttpRequest error', {
-          request: `${method} ${url}`,
+          method: String(method),
+          url: String(url),
           duration: duration
         }, BREADCRUMB_TYPE)
       }
@@ -165,8 +167,9 @@ module.exports = (_ignoredUrls = [], win = window) => {
 
       const handleFetchSuccess = (response, method, url, duration) => {
         const metadata = {
+          method: String(method),
           status: response.status,
-          request: `${method} ${url}`,
+          url: String(url),
           duration: duration
         }
         if (response.status >= 400) {
@@ -178,7 +181,7 @@ module.exports = (_ignoredUrls = [], win = window) => {
       }
 
       const handleFetchError = (method, url, duration) => {
-        client.leaveBreadcrumb('fetch() error', { request: `${method} ${url}`, duration: duration }, BREADCRUMB_TYPE)
+        client.leaveBreadcrumb('fetch() error', { method: String(method), url: String(url), duration: duration }, BREADCRUMB_TYPE)
       }
     }
   }

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -81,7 +81,8 @@ describe('plugin: network breadcrumbs', () => {
       message: 'XMLHttpRequest succeeded',
       metadata: {
         status: 200,
-        request: 'GET /',
+        method: 'GET',
+        url: '/',
         duration: expect.any(Number)
       }
     }))
@@ -116,7 +117,8 @@ describe('plugin: network breadcrumbs', () => {
       message: 'XMLHttpRequest failed',
       metadata: {
         status: 404,
-        request: 'GET /this-does-not-exist',
+        method: 'GET',
+        url: '/this-does-not-exist',
         duration: expect.any(Number)
       }
     }))
@@ -138,7 +140,8 @@ describe('plugin: network breadcrumbs', () => {
       type: 'request',
       message: 'XMLHttpRequest error',
       metadata: {
-        request: 'GET https://another-domain.xyz/',
+        method: 'GET',
+        url: 'https://another-domain.xyz/',
         duration: expect.any(Number)
       }
     }))
@@ -192,7 +195,8 @@ describe('plugin: network breadcrumbs', () => {
       message: 'XMLHttpRequest succeeded',
       metadata: {
         status: 200,
-        request: 'GET https://example.com',
+        method: 'GET',
+        url: 'https://example.com',
         duration: expect.any(Number)
       }
     }))
@@ -220,7 +224,8 @@ describe('plugin: network breadcrumbs', () => {
       type: 'request',
       message: 'XMLHttpRequest error',
       metadata: {
-        request: 'GET https://example.com',
+        method: 'GET',
+        url: 'https://example.com',
         duration: expect.any(Number)
       }
     }))
@@ -240,7 +245,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /',
+          method: 'GET',
+          url: '/',
           duration: expect.any(Number)
         }
       }))
@@ -262,7 +268,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 405,
-          request: 'null /',
+          method: 'null',
+          url: '/',
           duration: expect.any(Number)
         }
       }))
@@ -286,7 +293,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /',
+          method: 'GET',
+          url: '/',
           duration: expect.any(Number)
         }
       }))
@@ -310,7 +318,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'PUT /',
+          method: 'PUT',
+          url: '/',
           duration: expect.any(Number)
         }
       }))
@@ -332,7 +341,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 404,
-          request: 'GET null',
+          method: 'GET',
+          url: 'null',
           duration: expect.any(Number)
         }
       }))
@@ -354,7 +364,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /',
+          method: 'GET',
+          url: '/',
           duration: expect.any(Number)
         }
       }))
@@ -376,7 +387,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 404,
-          request: 'GET undefined',
+          method: 'GET',
+          url: 'undefined',
           duration: expect.any(Number)
         }
       }))
@@ -398,7 +410,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'PUT /foo',
+          method: 'PUT',
+          url: '/foo',
           duration: expect.any(Number)
         }
       }))
@@ -420,7 +433,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 405,
-          request: 'null /foo',
+          method: 'null',
+          url: '/foo',
           duration: expect.any(Number)
         }
       }))
@@ -442,7 +456,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() succeeded',
         metadata: {
           status: 200,
-          request: 'GET /foo',
+          method: 'GET',
+          url: '/foo',
           duration: expect.any(Number)
         }
       }))
@@ -464,7 +479,8 @@ describe('plugin: network breadcrumbs', () => {
         message: 'fetch() failed',
         metadata: {
           status: 404,
-          request: 'GET /does-not-exist',
+          method: 'GET',
+          url: '/does-not-exist',
           duration: expect.any(Number)
         }
       }))
@@ -485,7 +501,8 @@ describe('plugin: network breadcrumbs', () => {
         type: 'request',
         message: 'fetch() error',
         metadata: {
-          request: 'GET https://another-domain.xyz/foo/bar',
+          method: 'GET',
+          url: 'https://another-domain.xyz/foo/bar',
           duration: expect.any(Number)
         }
       }))

--- a/test/browser/features/fixtures/network_breadcrumbs/json/fetch_failure.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/fetch_failure.json
@@ -4,7 +4,8 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 404,
-        "request": "GET i_dont_exist.html",
+        "method": "GET",
+        "url": "i_dont_exist.html",
         "duration": "NUMBER"
     }
 }

--- a/test/browser/features/fixtures/network_breadcrumbs/json/fetch_success.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/fetch_success.json
@@ -4,7 +4,8 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 200,
-        "request": "GET fetch_success.html",
+        "method": "GET",
+        "url": "fetch_success.html",
         "duration": "NUMBER"
     }
 }

--- a/test/browser/features/fixtures/network_breadcrumbs/json/xhr_failure.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/xhr_failure.json
@@ -4,7 +4,8 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 404,
-        "request": "GET i_dont_exist.html",
+        "method": "GET",
+        "url": "i_dont_exist.html",
         "duration": "NUMBER"
     }
 }

--- a/test/browser/features/fixtures/network_breadcrumbs/json/xhr_success.json
+++ b/test/browser/features/fixtures/network_breadcrumbs/json/xhr_success.json
@@ -4,7 +4,8 @@
     "timestamp": "^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:[\\d\\.]+Z?$",
     "metaData": {
         "status": 200,
-        "request": "GET xhr_success.html",
+        "method": "GET",
+        "url": "xhr_success.html",
         "duration": "NUMBER"
     }
 }

--- a/test/electron/fixtures/events/main/breadcrumbs/network/error.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/error.json
@@ -60,7 +60,8 @@
           "name": "net.request error",
           "timestamp": "{TIMESTAMP}",
           "metaData": {
-            "request": "GET http://locahost:65536/",
+            "method": "GET",
+            "url": "http://locahost:65536/",
             "status": "{TYPE:undefined}",
             "duration": "{TYPE:number}"
           }

--- a/test/electron/fixtures/events/main/breadcrumbs/network/get-failure.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/get-failure.json
@@ -60,7 +60,8 @@
           "name": "net.request failed",
           "timestamp": "{TIMESTAMP}",
           "metaData": {
-            "request": "{REGEX:^GET http:\\/\\/localhost:\\d{4}\\/fail$}",
+            "method": "GET",
+            "url": "{REGEX:^http:\\/\\/localhost:\\d{4}\\/fail$}",
             "status": 404,
             "duration": "{TYPE:number}"
           }

--- a/test/electron/fixtures/events/main/breadcrumbs/network/get-success.json
+++ b/test/electron/fixtures/events/main/breadcrumbs/network/get-success.json
@@ -60,7 +60,8 @@
           "name": "net.request succeeded",
           "timestamp": "{TIMESTAMP}",
           "metaData": {
-            "request": "{REGEX:^GET http:\\/\\/localhost:\\d{4}\\/success$}",
+            "method": "GET",
+            "url": "{REGEX:^http:\\/\\/localhost:\\d{4}\\/success$}",
             "status": 200,
             "duration": "{TYPE:number}"
           }


### PR DESCRIPTION
## Goal

- (Breaking change) Rename the `request` metadata field to `url` to match the notifier spec - the value of this is now the request URL without the method prepended.
- Add a separate `method` metadata field to record the request method (e.g. GET or POST) 
