### PR TITLE
Bump Expo triggers to 47, 48 and 49

### DIFF
--- a/.buildkite/browser-pipeline.yml
+++ b/.buildkite/browser-pipeline.yml
@@ -62,31 +62,32 @@ steps:
         concurrency_group: "bitbar-web"
         concurrency_method: eager
 
-      - label: ":bitbar: {{matrix}} Browser tests (EU hub)"
-        matrix:
+# Skipped pending PLAT-10590
+#      - label: ":bitbar: {{matrix}} Browser tests (EU hub)"
+#        matrix:
 #          - chrome_43
 #          - chrome_72
-          - firefox_78
-        depends_on: "browser-maze-runner-bb"
-        timeout_in_minutes: 30
-        plugins:
-          docker-compose#v4.12.0:
-            pull: browser-maze-runner-bb
-            run: browser-maze-runner-bb
-            service-ports: true
-            use-aliases: true
-            command:
-              - "--farm=bb"
-              - "--browser={{matrix}}"
-              - "--no-tunnel"
-              - "--aws-public-ip"
-              - "--selenium-server=https://eu-desktop-hub.bitbar.com/wd/hub"
-          artifacts#v1.5.0:
-            upload:
-              - "./test/browser/maze_output/failed/**/*"
-        concurrency: 5
-        concurrency_group: "bitbar-web"
-        concurrency_method: eager
+#          - firefox_78
+#        depends_on: "browser-maze-runner-bb"
+#        timeout_in_minutes: 30
+#        plugins:
+#          docker-compose#v4.12.0:
+#            pull: browser-maze-runner-bb
+#            run: browser-maze-runner-bb
+#            service-ports: true
+#            use-aliases: true
+#            command:
+#              - "--farm=bb"
+#              - "--browser={{matrix}}"
+#              - "--no-tunnel"
+#              - "--aws-public-ip"
+#              - "--selenium-server=https://eu-desktop-hub.bitbar.com/wd/hub"
+#          artifacts#v1.5.0:
+#            upload:
+#              - "./test/browser/maze_output/failed/**/*"
+#        concurrency: 5
+#        concurrency_group: "bitbar-web"
+#        concurrency_method: eager
 
       - label: ":bitbar: ie_11 Browser tests"
         depends_on: "browser-maze-runner-bb"
@@ -128,6 +129,7 @@ steps:
           # TODO: Move these to BitBar
           - chrome_43
           - chrome_72
+          - firefox_78
         depends_on: "browser-maze-runner-bs"
         timeout_in_minutes: 30
         plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,22 +149,22 @@ steps:
         # a branch name that's safe to use as a docker cache identifier
         BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME: "${BRANCH_NAME}"
 
-  - label: "@bugsnag/expo v47-next"
+  - label: "@bugsnag/expo v48/next"
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:
-      branch: "v47/next"
+      branch: "v48/next"
       env:
         BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
         BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"
         # a branch name that's safe to use as a docker cache identifier
         BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME: "${BRANCH_NAME}"
 
-  - label: "@bugsnag/expo v46-next"
+  - label: "@bugsnag/expo v47/next"
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:
-      branch: "v46-next"
+      branch: "v47/next"
       env:
         BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
         BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
## Goal

Bump Expo triggers to 47, 48 and 49 (once HEAD is Expo 49).

## Design

We could merge this before v49 is ready, we will just be running the v48 tests twice.  The problem we have is that the v46 branch build is broken and not worth fixing given how close v49 is.

## Testing

Covered by CI.