### PR TITLE
[PLAT-10694] Fix inline script metadata in Safari 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - (electron) Fix `onSendError` callbacks not being called [#1999](https://github.com/bugsnag/bugsnag-js/pull/1999)
+- (plugin-inline-script-content) Ensure script metadata is added in Safari 16 [#1998](https://github.com/bugsnag/bugsnag-js/pull/1998)
 
 ## 7.20.1 (2023-02-08)
 

--- a/packages/plugin-inline-script-content/inline-script-content.js
+++ b/packages/plugin-inline-script-content/inline-script-content.js
@@ -66,8 +66,11 @@ module.exports = (doc = document, win = window) => ({
 
       const frame = event.errors[0].stacktrace[0]
 
+      // remove hash and query string from url
+      const cleanUrl = (url) => url.replace(/#.*$/, '').replace(/\?.*$/, '')
+
       // if frame.file exists and is not the original location of the page, this can't be an inline script
-      if (frame && frame.file && frame.file.replace(/#.*$/, '') !== originalLocation.replace(/#.*$/, '')) return
+      if (frame && frame.file && cleanUrl(frame.file) !== cleanUrl(originalLocation)) return
 
       // grab the last script known to have run
       const currentScript = getCurrentScript()

--- a/test/browser/features/inline_script.feature
+++ b/test/browser/features/inline_script.feature
@@ -1,6 +1,5 @@
 Feature: Inline script detection
 
-  @skip_safari_16 # PLAT-10694 document.currentScript is null on versions greater than 16.3
   Scenario: loading Bugsnag before scripts have run
     When I navigate to the test URL "/inline_script/script/a.html"
     Then I wait to receive an error
@@ -21,7 +20,6 @@ Feature: Inline script detection
     And event 0 is handled
     And the event "metaData.script" is null
 
-  @skip_safari_16 # PLAT-10694 document.currentScript is null on versions greater than 16.3
   Scenario: inline script detected after location change
     When I navigate to the test URL "/navigation/script/a.html"
     And the test should run in this browser


### PR DESCRIPTION
## Goal

Update inline script url comparison to ensure metadata is added in Safari 16.5 where the value of `stack.frame` no longer includes a query string

## Design

Remove query string from url for inline script detection