### PR TITLE
Fix Electron `onSendError` callbacks not being called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - (react-native) Update bugsnag-cocoa from v6.25.2 to [v6.26.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6262-2023-04-20)
 - (delivery-xml-http-request) Ensure delivery errors are passed to the post report callback [#1938](https://github.com/bugsnag/bugsnag-js/pull/1938)
 
+### Fixed
+
+- (electron) Fix `onSendError` callbacks not being called [#1999](https://github.com/bugsnag/bugsnag-js/pull/1999)
+
 ## 7.20.1 (2023-02-08)
 
 ### Changes

--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -46,7 +46,7 @@ module.exports = (app, net, filestore, NativeClient) => ({
 
     const { sendMinidump } = sendMinidumpFactory(net, client)
     const queue = new MinidumpQueue(filestore)
-    const loop = new MinidumpDeliveryLoop(sendMinidump, client._config.onSend, queue, client._logger)
+    const loop = new MinidumpDeliveryLoop(sendMinidump, client._config.onSendError, queue, client._logger)
 
     app.whenReady().then(() => {
       const stateManagerPlugin = client.getPlugin('clientStateManager')

--- a/packages/plugin-electron-deliver-minidumps/event-serialisation.js
+++ b/packages/plugin-electron-deliver-minidumps/event-serialisation.js
@@ -1,0 +1,138 @@
+const Event = require('@bugsnag/core/event')
+const Session = require('@bugsnag/core/session')
+const Breadcrumb = require('@bugsnag/core/breadcrumb')
+
+const supportedProperties = [
+  'app',
+  'breadcrumbs',
+  'context',
+  'device',
+  'featureFlags',
+  'groupingHash',
+  'metaData',
+  'request',
+  'session',
+  'severity',
+  'unhandled',
+  'user'
+]
+
+function hasValueForProperty (object, name) {
+  if (!Object.prototype.hasOwnProperty.call(object, name)) {
+    return false
+  }
+
+  const value = object[name]
+
+  if (typeof value === 'undefined' || value === null) {
+    return false
+  }
+
+  if (Array.isArray(value) && value.length === 0) {
+    return false
+  }
+
+  if (typeof value === 'object' && Object.keys(value).length === 0) {
+    return false
+  }
+
+  return true
+}
+
+function serialiseEvent (event) {
+  const json = event.toJSON()
+  const serialisedEvent = {}
+
+  for (let i = 0; i < supportedProperties.length; ++i) {
+    const property = supportedProperties[i]
+
+    if (!hasValueForProperty(json, property)) {
+      continue
+    }
+
+    // breadcrumbs and session information need to be encoded further
+    if (property === 'breadcrumbs') {
+      serialisedEvent.breadcrumbs = json.breadcrumbs.map(breadcrumb => breadcrumb.toJSON())
+    } else if (property === 'session') {
+      serialisedEvent.session = json.session.toJSON()
+    } else if (property === 'metaData') {
+      serialisedEvent.metadata = json[property]
+    } else {
+      serialisedEvent[property] = json[property]
+    }
+  }
+
+  // set the severityReason if the severity was changed
+  // 'severity' is not set by default so if it's present then the user must have
+  // set it in a callback
+  if (serialisedEvent.severity) {
+    serialisedEvent.severityReason = { type: 'userCallbackSetSeverity' }
+  }
+
+  return serialisedEvent
+}
+
+function deserialiseEvent (json, minidumpPath) {
+  if (!json || typeof json !== 'object') {
+    return
+  }
+
+  const event = new Event('Native Crash', 'Event created for a native crash', [], {})
+
+  if (hasValueForProperty(json, 'app')) {
+    event.app = json.app
+  }
+
+  if (hasValueForProperty(json, 'breadcrumbs')) {
+    event.breadcrumbs = json.breadcrumbs.map(
+      breadcrumb => new Breadcrumb(
+        breadcrumb.name,
+        breadcrumb.metaData,
+        breadcrumb.type,
+        new Date(breadcrumb.timestamp)
+      )
+    )
+  }
+
+  if (hasValueForProperty(json, 'context')) {
+    event.context = json.context
+  }
+
+  if (hasValueForProperty(json, 'device')) {
+    event.device = json.device
+  }
+
+  if (hasValueForProperty(json, 'featureFlags')) {
+    for (let i = 0; i < json.featureFlags.length; ++i) {
+      const flag = json.featureFlags[i]
+
+      event.addFeatureFlag(flag.featureFlag, flag.variant)
+    }
+  }
+
+  if (hasValueForProperty(json, 'metadata')) {
+    event._metadata = json.metadata
+  }
+
+  if (hasValueForProperty(json, 'session')) {
+    const session = new Session()
+    session.id = json.session.id
+    session.startedAt = new Date(json.session.startedAt)
+    session._handled = json.session.events.handled
+    session._unhandled = json.session.events.unhandled
+
+    event._session = session
+  }
+
+  if (hasValueForProperty(json, 'user')) {
+    event._user = json.user
+  }
+
+  // this doesn't exist on the Event class, but could be helpful in onSendError
+  // callbacks as it allows the user to find the related minidump
+  event.minidumpPath = minidumpPath
+
+  return event
+}
+
+module.exports = { serialiseEvent, deserialiseEvent }

--- a/packages/plugin-electron-deliver-minidumps/minidump-loop.js
+++ b/packages/plugin-electron-deliver-minidumps/minidump-loop.js
@@ -42,17 +42,16 @@ module.exports = class MinidumpDeliveryLoop {
       try {
         await this._sendMinidump(minidump.minidumpPath, event)
 
-        // if we had a successful delivery - remove the minidump from the queue, and schedule the next
+        // if we had a successful delivery - remove the minidump from the queue
         this._minidumpQueue.remove(minidump)
       } catch (e) {
         this._onerror(e, minidump)
-      } finally {
-        this._scheduleSelf()
       }
     } else {
       this._minidumpQueue.remove(minidump)
-      this._scheduleSelf()
     }
+
+    this._scheduleSelf()
   }
 
   async _deliverNextMinidump () {

--- a/packages/plugin-electron-deliver-minidumps/package.json
+++ b/packages/plugin-electron-deliver-minidumps/package.json
@@ -13,6 +13,7 @@
   },
   "files": [
     "deliver-minidumps.js",
+    "event-serialisation.js",
     "minidump-loop.js",
     "minidump-queue.js",
     "send-minidump.js"

--- a/test/electron/features/feature-flags.feature
+++ b/test/electron/features/feature-flags.feature
@@ -224,7 +224,8 @@ Scenario: feature flags are attached to native crashes from the main process
         | minidumps | 0 |
         | sessions  | 1 |
     When I click "main-process-crash"
-    And I launch an app
+    And I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
         | events    | 0 |
         | minidumps | 1 |
@@ -250,7 +251,8 @@ Scenario: feature flags can be cleared entirely in the main process with a nativ
         | sessions  | 1 |
     When I click "main-process-clear-feature-flags-now"
     And I click "main-process-crash"
-    And I launch an app
+    And I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
         | events    | 0 |
         | minidumps | 1 |
@@ -265,7 +267,7 @@ Scenario: feature flags can be cleared entirely in the main process with a nativ
 
 Scenario: feature flags are attached to native crashes from a renderer process
     Given I launch an app with configuration:
-        | bugsnag         | feature-flags                                            |
+        | bugsnag         | feature-flags-on-send-error                              |
         | renderer_config | { "featureFlags": [{ "name": "from renderer config" }] } |
     Then the total requests received by the server matches:
         | events    | 0 |
@@ -289,7 +291,7 @@ Scenario: feature flags are attached to native crashes from a renderer process
 
 Scenario: feature flags can be cleared entirely in a renderer process with a native crash
     Given I launch an app with configuration:
-        | bugsnag         | feature-flags                                            |
+        | bugsnag         | feature-flags-on-send-error                              |
         | renderer_config | { "featureFlags": [{ "name": "from renderer config" }] } |
     Then the total requests received by the server matches:
         | events    | 0 |

--- a/test/electron/features/native-crash.feature
+++ b/test/electron/features/native-crash.feature
@@ -1,14 +1,14 @@
 Feature: Native Errors
 
   Scenario: A minidump is uploaded on native error
-    When I launch an app
+    Given I launch an app
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 0 |
       | sessions  | 1 |
-
     When I click "main-process-crash"
-    And I launch an app
+    And I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 1 |
@@ -17,16 +17,16 @@ Feature: Native Errors
     And minidump request 0 contains a form field named "event" matching "minidump-event.json"
 
   Scenario: A native error occurs after a handled event
-    When I launch an app
-    And I click "custom-breadcrumb"
+    Given I launch an app
+    When I click "custom-breadcrumb"
     And I click "main-notify"
     Then the total requests received by the server matches:
       | events    | 1 |
       | minidumps | 0 |
       | sessions  | 1 |
-
     When I click "main-process-crash"
-    And I launch an app
+    And I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
       | events    | 1 |
       | minidumps | 1 |
@@ -41,14 +41,12 @@ Feature: Native Errors
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 1 |
-
     When I click "main-process-crash"
     And I launch an app with no network
     Then the total requests received by the server matches:
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 1 |
-
     When the app gains network connectivity
     Then the total requests received by the server matches:
       | events    | 0 |
@@ -62,14 +60,12 @@ Feature: Native Errors
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 0 |
-
     When I click "main-process-crash"
     And I launch an app
     Then the total requests received by the server matches:
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 0 |
-
     When I click "main-process-crash"
     And the server becomes reachable
     And I launch an app
@@ -86,14 +82,12 @@ Feature: Native Errors
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 0 |
-
     When I click "main-process-crash"
     And I launch an app with no network
     Then the total requests received by the server matches:
       | minidumps | 0 |
       | events    | 0 |
       | sessions  | 0 |
-
     When I click "main-process-crash"
     And I launch an app
     Then the total requests received by the server matches:
@@ -102,12 +96,12 @@ Feature: Native Errors
       | sessions  | 4 |
 
   Scenario: Crash in the renderer process
-    When I launch an app
+    Given I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 0 |
       | sessions  | 1 |
-
     When I click "renderer-process-crash"
     Then the total requests received by the server matches:
       | events    | 0 |
@@ -117,15 +111,16 @@ Feature: Native Errors
     And minidump request 0 contains a form field named "event" matching "minidump-event.json"
 
   Scenario: Crash in the renderer and main processes
-    When I launch an app
+    Given I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 0 |
       | sessions  | 1 |
-
     When I click "renderer-and-main-process-crashes"
     And I wait for 2 seconds
-    And I launch an app
+    When I launch an app with configuration:
+      | bugsnag | on-send-error |
     Then the total requests received by the server matches:
       | events    | 0 |
       | minidumps | 2 |

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -138,7 +138,7 @@ Then('minidump request {int} has no feature flags', async (index) => {
 
   expect(actual).toHaveProperty('events')
   expect(actual.events).toHaveLength(1)
-  expect(actual.events[0]).toHaveProperty('featureFlags', [])
+  expect(actual.events[0]).not.toHaveProperty('featureFlags')
 })
 
 Then('the total requests received by the server matches:', async (data) => {

--- a/test/electron/fixtures/app/configs/feature-flags-on-send-error.js
+++ b/test/electron/fixtures/app/configs/feature-flags-on-send-error.js
@@ -1,0 +1,4 @@
+const featureFlagsConfig = require('./feature-flags')
+const onSendErrorConfig = require('./on-send-error')
+
+module.exports = () => Object.assign({}, featureFlagsConfig(), onSendErrorConfig())

--- a/test/electron/fixtures/app/configs/on-send-error.js
+++ b/test/electron/fixtures/app/configs/on-send-error.js
@@ -1,0 +1,9 @@
+module.exports = () => {
+  return {
+    onSendError (event) {
+      event.context = 'checkout page'
+      event.addMetadata('account', { type: 'VIP', verified: true })
+      event.addMetadata('account', 'status', "it's complicated")
+    }
+  }
+}

--- a/test/electron/fixtures/events/minidump-event.json
+++ b/test/electron/fixtures/events/minidump-event.json
@@ -31,6 +31,7 @@
           }
         }
       ],
+      "context": "checkout page",
       "device": {
         "runtimeVersions": {
           "node": "{TYPE:string}",
@@ -42,6 +43,11 @@
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
       "metadata": {
+        "account": {
+          "type": "VIP",
+          "verified": true,
+          "status": "it's complicated"
+        },
         "app": {
           "name": "Runner",
           "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"

--- a/test/electron/fixtures/events/minidump-plus-handled-event.json
+++ b/test/electron/fixtures/events/minidump-plus-handled-event.json
@@ -31,6 +31,7 @@
           }
         }
       ],
+      "context": "checkout page",
       "device": {
         "runtimeVersions": {
           "node": "{TYPE:string}",
@@ -42,6 +43,11 @@
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
       "metadata": {
+        "account": {
+          "type": "VIP",
+          "verified": true,
+          "status": "it's complicated"
+        },
         "app": {
           "name": "Runner",
           "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"

--- a/test/electron/fixtures/events/second-minidump-event.json
+++ b/test/electron/fixtures/events/second-minidump-event.json
@@ -42,6 +42,11 @@
         "osVersion": "{REGEX:\\d+\\.\\d+}"
       },
       "metadata": {
+        "account": {
+          "type": "VIP",
+          "verified": true,
+          "status": "it's complicated"
+        },
         "app": {
           "name": "Runner",
           "CFBundleVersion": "{PLATFORM_MACOS:1.0.2}"


### PR DESCRIPTION
## Goal

The `onSendError` configuration option was not being passed down to the minidump delivery loop and so was not being called

Were this to work, it would also have been passed the an Event in its JSON serialised form rather than a real Event object (see equivalent option in [Android](https://docs.bugsnag.com/platforms/android/configuration-options/#addonsend) & [Cocoa](https://docs.bugsnag.com/platforms/ios/customizing-error-reports/#updating-events-using-callbacks))

This PR fixes the bug causing `onSendError` to not be applied and deserialises the Event JSON into an Event object