### PR TITLE
[PLAT-10581] Fix react native tests on macos 10-15 servers

### DIFF
--- a/.buildkite/react-native-cli-pipeline.yml
+++ b/.buildkite/react-native-cli-pipeline.yml
@@ -377,7 +377,7 @@ steps:
         key: "rn-cli-0-60-ipa"
         timeout_in_minutes: 30
         agents:
-          queue: "ms-mac-10-15-5"
+          queue: "macos-10.15"
         env:
           DEBUG: true
           LANG: "en_US.UTF-8"
@@ -390,7 +390,7 @@ steps:
         key: "rn-cli-0-61-ipa"
         timeout_in_minutes: 30
         agents:
-          queue: "ms-mac-10-15-5"
+          queue: "macos-10.15"
         env:
           DEBUG: true
           LANG: "en_US.UTF-8"
@@ -403,7 +403,7 @@ steps:
         key: "rn-cli-0-62-ipa"
         timeout_in_minutes: 30
         agents:
-          queue: "ms-mac-10-15-5"
+          queue: "macos-10.15"
         env:
           DEBUG: true
           LANG: "en_US.UTF-8"

--- a/.buildkite/react-native-ios-pipeline.yml
+++ b/.buildkite/react-native-ios-pipeline.yml
@@ -10,7 +10,7 @@ steps:
         key: "rn-0-60-ipa"
         timeout_in_minutes: 60
         agents:
-          queue: "ms-mac-10-15-5"
+          queue: "macos-10.15"
         env:
           REACT_NATIVE_VERSION: rn0.60
           LANG: "en_US.UTF-8"
@@ -91,7 +91,7 @@ steps:
         key: "react-navigation-0-60-ipa"
         timeout_in_minutes: 60
         agents:
-          queue: "ms-mac-10-15-5"
+          queue: "macos-10.15"
         env:
           REACT_NATIVE_VERSION: rn0.60
           JS_SOURCE_DIR: "react_navigation_js"
@@ -123,7 +123,7 @@ steps:
         key: "react-native-navigation-0-60-ipa"
         timeout_in_minutes: 60
         agents:
-          queue: "ms-mac-10-15-5"
+          queue: "macos-10.15"
         env:
           REACT_NATIVE_VERSION: rn0.60
           JS_SOURCE_DIR: "react_native_navigation_js"


### PR DESCRIPTION
## Goal

Run react native tests across the whole `macos-10.15` ci queue

## Changeset

Fixed missing certificates on ms-mac-10-15-6

## Testing

Covered by CI