### PR TITLE
Run Lerna bootstrap after copying packages into Docker containers

### DIFF
--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -11,8 +11,8 @@ RUN npm install
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json ./
 ADD min_packages.tar .
 COPY bin ./bin
-RUN npx lerna bootstrap
 COPY packages ./packages
+RUN npx lerna bootstrap
 RUN npm run build
 
 RUN npm pack --verbose packages/js/

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -11,8 +11,8 @@ RUN npm install --unsafe-perm
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json ./
 ADD min_packages.tar .
 COPY bin ./bin
-RUN npx lerna bootstrap
 COPY scripts ./scripts
 COPY test ./test
 COPY packages ./packages
+RUN npx lerna bootstrap
 RUN npm run build

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -11,8 +11,8 @@ RUN npm install
 COPY babel.config.js lerna.json .eslintignore .eslintrc.js jest.config.js tsconfig.json ./
 ADD min_packages.tar .
 COPY bin ./bin
-RUN npx lerna bootstrap
 COPY packages ./packages
+RUN npx lerna bootstrap
 RUN npm run build
 
 RUN npm pack --verbose packages/node/


### PR DESCRIPTION
## Goal

Fix the broken Docker image build steps.

## Design

It seemed to start failing after an update to our Buildkite Elastic CI Stack for AWS:
```
1.506 lerna ERR! lerna EACCES: permission denied, rename '/app/packages/plugin-react-navigation/package.json' -> '/app/packages/plugin-react-navigation/package.json.lerna_backup'
```

I assume that a new version of Docker meant that file paths not existing in the container are not treated different.  If Lerna is renaming files like then then it seems reasonable that the files should exist in the first place in the contrainer.

## Changeset

Copying of `packages` into the containers moved to before the `lerna bootstrap`.

## Testing

Covered by CI.