### PR TITLE
Rationalise BitBar CI concurrency group

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -58,8 +58,8 @@ steps:
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"
-        concurrency: 5
-        concurrency_group: "bitbar-web"
+        concurrency: 25
+        concurrency_group: "bitbar"
         concurrency_method: eager
 
 # Skipped pending PLAT-10590
@@ -85,8 +85,8 @@ steps:
 #          artifacts#v1.5.0:
 #            upload:
 #              - "./test/browser/maze_output/failed/**/*"
-#        concurrency: 5
-#        concurrency_group: "bitbar-web"
+#        concurrency: 25
+#        concurrency_group: "bitbar"
 #        concurrency_method: eager
 
       - label: ":bitbar: ie_11 Browser tests"
@@ -106,8 +106,8 @@ steps:
           artifacts#v1.5.0:
             upload:
               - "./test/browser/maze_output/failed/**/*"
-        concurrency: 5
-        concurrency_group: "bitbar-web"
+        concurrency: 25
+        concurrency_group: "bitbar"
         concurrency_method: eager
         env:
           HOST: "localhost" # IE11 needs the host set to localhost for some reason

--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -77,7 +77,7 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: "bitbar-app"
+        concurrency_group: "bitbar"
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.72 (New Arch) Android 12 end-to-end tests"
@@ -103,5 +103,5 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: "bitbar-app"
+        concurrency_group: "bitbar"
         concurrency_method: eager

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -197,7 +197,7 @@ steps:
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.66 Android end-to-end tests"
@@ -222,7 +222,7 @@ steps:
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.67 Android end-to-end tests"
@@ -248,7 +248,7 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.69 Android end-to-end tests"
@@ -274,7 +274,7 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.68 (Hermes) Android end-to-end tests"
@@ -300,7 +300,7 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.71 (Old Arch) Android 12 end-to-end tests"
@@ -376,7 +376,7 @@ steps:
               - --aws-public-ip
               - features/navigation.feature
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: react-navigation 0.69 Android end-to-end tests"
@@ -400,7 +400,7 @@ steps:
               - --aws-public-ip
               - features/navigation.feature
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: react-native-navigation 0.60 Android end-to-end tests"
@@ -424,7 +424,7 @@ steps:
               - --aws-public-ip
               - features/navigation.feature
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: react-native-navigation 0.66 Android end-to-end tests"
@@ -448,5 +448,5 @@ steps:
               - --aws-public-ip
               - features/navigation.feature
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -326,7 +326,7 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: "bitbar-app"
+        concurrency_group: "bitbar"
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.71 (New Arch) Android 12 end-to-end tests"
@@ -352,7 +352,7 @@ steps:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
         concurrency: 25
-        concurrency_group: "bitbar-app"
+        concurrency_group: "bitbar"
         concurrency_method: eager
 
       - label: ":bitbar: :android: react-navigation 0.60 Android end-to-end tests"

--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -510,7 +510,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.61 Android end-to-end tests"
@@ -533,7 +533,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.62 Android end-to-end tests"
@@ -556,7 +556,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.63 Android end-to-end tests"
@@ -579,7 +579,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.63 Expo (ejected) Android end-to-end tests"
@@ -602,7 +602,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.64 Android end-to-end tests"
@@ -625,7 +625,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.65 Android end-to-end tests"
@@ -648,7 +648,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.66 Android end-to-end tests"
@@ -671,7 +671,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":bitbar: :android: RN 0.67 Android end-to-end tests (Non-hermes)"
@@ -694,7 +694,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       - label: ":runner: RN 0.69 Android end-to-end tests (Non-hermes)"
@@ -717,7 +717,7 @@ steps:
               - --aws-public-ip
               - features/run-app-tests
         concurrency: 25
-        concurrency_group: 'bitbar-app'
+        concurrency_group: 'bitbar'
         concurrency_method: eager
 
       #


### PR DESCRIPTION
## Goal

NOTE: Please let me merge this PR myself, it needs to be merged as the same time as several others to avoid unnecessary failures on CI.

Rationalise the Buildkite concurrency group used to control access to BitBar across all of our repos.

## Design

We were using separate groups fro web and device usage, when in fact they are counted towards the same usage limit.  All groups are now being renamed to simply 'bitbar' with a limit of 25.

The main mistake that I could make here is missing an instance of the old groups (`bitbar-app` and `bitbar-web`, so I am using the global find and replace function of my IDE.

## Changeset

Buildkite concurrency group changes only.

## Testing

Verified by peer review.  