### PR TITLE
Do not pin Appium version without reason

### DIFF
--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -55,7 +55,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -80,7 +79,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"

--- a/.buildkite/full/react-native-ios-pipeline.full.yml
+++ b/.buildkite/full/react-native-ios-pipeline.full.yml
@@ -186,7 +186,6 @@ steps:
               - --farm=bs
               - --device=IOS_12
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -210,7 +209,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -234,7 +232,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -259,7 +256,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -284,7 +280,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -309,7 +304,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -334,7 +328,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
@@ -361,7 +354,6 @@ steps:
               - --farm=bs
               - --device=IOS_12
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
               - features/navigation.feature
         concurrency: 5
@@ -384,7 +376,6 @@ steps:
               - --farm=bs
               - --device=IOS_14
               - --a11y-locator
-              - --appium-version=1.21.0
               - --fail-fast
               - features/navigation.feature
         concurrency: 5
@@ -408,7 +399,6 @@ steps:
               - --app=build/r_native_navigation_0.60.ipa
               - --farm=bs
               - --device=IOS_13
-              - --appium-version=1.18.0
               - --a11y-locator
               - --fail-fast
               - features/navigation.feature
@@ -434,7 +424,6 @@ steps:
               - --farm=bs
               - --device=IOS_13
               - --a11y-locator
-              - --appium-version=1.18.0
               - --fail-fast
               - features/navigation.feature
         concurrency: 5

--- a/test/react-native/TESTING.md
+++ b/test/react-native/TESTING.md
@@ -78,7 +78,6 @@ particular, these commands need the `BrowserStackLocal` binary (available
     bundle exec maze-runner --app=../../build/${REACT_NATIVE_VERSION}.ipa \
                             --farm=bs \
                             --device=IOS_13 \
-                            --appium-version=1.18.0 \
                             --a11y-locator \
                             features/app.feature
     ```


### PR DESCRIPTION
## Goal

Prevent future issues from Appium 1 being deprecated - use the default Appium version provided by the device farm, unless we specifically need a specific version.

## Testing

Covered by a full CI run.