### PR TITLE
Fix Electron unhandled secondary errors during delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - (electron) Fix startup crash when using Electron v26+ on Linux [#2022](https://github.com/bugsnag/bugsnag-js/pull/2022)
 
+- (electron) Fix unhandled secondary errors during delivery [#2025](https://github.com/bugsnag/bugsnag-js/pull/2025)
+
 ## 7.22.0 (2023-09-13)
 
 ### Changes

--- a/packages/delivery-electron/test/delivery.test-main.ts
+++ b/packages/delivery-electron/test/delivery.test-main.ts
@@ -337,6 +337,60 @@ describe('delivery: electron', () => {
     })
   })
 
+  it('ignores secondary request/response errors after a response is received', done => {
+    const payload = {
+      events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]
+    } as unknown as EventDeliveryPayload
+
+    const err = new Error('Error after response received')
+
+    // create a mock response object that emits an error event
+    const response = {
+      statusCode: 407,
+      statusMessage: STATUS_CODES[407],
+      on (_event: any, cb: any) {
+        if (_event === 'error') {
+          cb(err)
+        }
+      }
+    }
+
+    let requestErrorCallback: any = () => {}
+
+    // create a mock net instance that will return a response and also emit errors
+    const net = {
+      request: (opts: any, responseCallback: any) => ({
+        on (_event: any, cb: any) {
+          if (_event === 'error') {
+            requestErrorCallback = cb
+          }
+        },
+        write () {},
+        end () {
+          responseCallback(response)
+          requestErrorCallback(err)
+        }
+      })
+    }
+
+    const logger = { error: jest.fn(), info: jest.fn() }
+    const config = {
+      apiKey: 'aaaaaaaa',
+      endpoints: { notify: 'http://localhost:9999/events/' },
+      redactedKeys: []
+    }
+
+    delivery(filestore, net, app)(makeClient(config, logger)).sendEvent(payload, (err: any) => {
+      expect(err).toBe(err)
+      expect(err.isRetryable).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith('event failed to send…\n', err.stack)
+      expect(logger.error).toHaveBeenCalledTimes(1)
+      expect(enqueueSpy).not.toHaveBeenCalled()
+
+      done()
+    })
+  })
+
   it('handles uncaught exceptions during event delivery', done => {
     const payload = {
       events: [{ errors: [{ errorClass: 'Error', errorMessage: 'foo is not a function' }] }]

--- a/packages/plugin-electron-deliver-minidumps/send-minidump.js
+++ b/packages/plugin-electron-deliver-minidumps/send-minidump.js
@@ -8,6 +8,8 @@ module.exports = (net, client) => {
   const send = (opts, formData) => {
     return new Promise((resolve, reject) => {
       const req = net.request(opts, response => {
+        response.on('error', reject)
+
         if (isOk(response)) {
           resolve()
         } else {

--- a/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
+++ b/packages/plugin-electron-deliver-minidumps/test/send-minidump.test.ts
@@ -24,7 +24,7 @@ describe('electron-minidump-delivery: sendMinidump', () => {
   it('sends minidump successfully', async () => {
     const net = {
       request: jest.fn().mockImplementation((_, handle) => {
-        handle({ statusCode: 200 })
+        handle({ statusCode: 200, on: (event, cb) => {} })
       })
     }
 
@@ -48,7 +48,7 @@ describe('electron-minidump-delivery: sendMinidump', () => {
   it('marks server error as retry', async () => {
     const net = {
       request: jest.fn().mockImplementation((opts, handle) => {
-        handle({ statusCode: 500 })
+        handle({ statusCode: 500, on: (event, cb) => {} })
       })
     }
 
@@ -62,7 +62,7 @@ describe('electron-minidump-delivery: sendMinidump', () => {
   it('marks bad request as no-retry', async () => {
     const net = {
       request: jest.fn().mockImplementation((opts, handle) => {
-        handle({ statusCode: 400 })
+        handle({ statusCode: 400, on: (event, cb) => {} })
       })
     }
 
@@ -77,7 +77,7 @@ describe('electron-minidump-delivery: sendMinidump', () => {
     let minidumpFile
     const net = {
       request: jest.fn().mockImplementation((_, handle) => {
-        handle({ statusCode: 200 })
+        handle({ statusCode: 200, on: (event, cb) => {} })
       })
     }
 


### PR DESCRIPTION
## Goal

Fixes #2023  

In some cases (e.g. proxy authentication errors) Electron net will emit error events on both the request and response after the response is received.

If these are not handled this results in further uncaught exceptions, causing a potentially infinite loop of failed requests - if the error response has already been handled these secondary errors should be ignored.