### PR TITLE
[PLAT-11132] update unhandled_syntax column number on firefox_latest

### DIFF
--- a/test/browser/features/fixtures/browser_errors.yml
+++ b/test/browser/features/fixtures/browser_errors.yml
@@ -451,7 +451,7 @@ firefox_latest:
     errorClass: 'SyntaxError'
     errorMessage: "unexpected token: '!'"
     lineNumber: 18
-    columnNumber: 12
+    columnNumber: 13
     file: '/unhandled/script/a.html'
   unhandled_thrown:
     errorClass: 'Error'


### PR DESCRIPTION
## Goal

Since version 118, Firefox has changed the way it reports column numbers, which breaks our end to end tests. This change fixes assertions for tests using the latest version of Firefox.

https://hg.mozilla.org/mozilla-central/rev/b4cb88d106bd