### PR TITLE
bump peer dependencies for v8

### DIFF
--- a/bin/local-test-util
+++ b/bin/local-test-util
@@ -138,7 +138,8 @@ async function installNotifiers (notifier) {
   await ex(`npm`, [
     `install`,
     `--no-package-lock`,
-    `--no-save`
+    `--no-save`,
+    `--legacy-peer-deps`
   ].concat(notifier
     ? [
       `../../../../bugsnag-${notifier}-${require(`../packages/${notifier}/package.json`).version}.tgz`
@@ -161,6 +162,7 @@ async function installNgNotifier (notifier) {
     `install`,
     `--no-package-lock`,
     `--no-save`,
+    `--legacy-peer-deps`,
     `../../../../../../bugsnag-browser-${require('../packages/browser/package.json').version}.tgz`,
     `../../../../../../bugsnag-js-${require('../packages/js/package.json').version}.tgz`,
     `../../../../../../bugsnag-node-${require('../packages/node/package.json').version}.tgz`,

--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -26,12 +26,12 @@ RUN npm pack --verbose packages/web-worker/
 COPY test/browser/features test/browser/features
 
 WORKDIR /app/test/browser/features/fixtures
-RUN npm install --no-package-lock --no-save ../../../../bugsnag-browser-*.tgz
-RUN npm install --no-package-lock --no-save ../../../../bugsnag-plugin-react-*.tgz
-RUN npm install --no-package-lock --no-save ../../../../bugsnag-plugin-vue-*.tgz
-RUN npm install --no-package-lock --no-save ../../../../bugsnag-web-worker-*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps ../../../../bugsnag-browser-*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps ../../../../bugsnag-plugin-react-*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps ../../../../bugsnag-plugin-vue-*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps ../../../../bugsnag-web-worker-*.tgz
 WORKDIR plugin_angular/ng
-RUN npm install --no-package-lock --no-save \
+RUN npm install --no-package-lock --no-save --legacy-peer-deps \
   ../../../../../../bugsnag-plugin-angular-*.tgz  \
   ../../../../../../bugsnag-node-*.tgz \
   ../../../../../../bugsnag-browser-*.tgz \

--- a/dockerfiles/Dockerfile.react-native-android-builder
+++ b/dockerfiles/Dockerfile.react-native-android-builder
@@ -14,6 +14,7 @@ ARG REG_NPM_EMAIL
 RUN echo "_auth=$REG_BASIC_CREDENTIAL" >> ~/.npmrc
 RUN echo "email=$REG_NPM_EMAIL" >> ~/.npmrc
 RUN echo "always-auth=true" >> ~/.npmrc
+RUN echo "legacy-peer-deps=true" >> ~/.npmrc
 
 # gradle / artifactory auth
 ARG MAVEN_REPO_URL

--- a/dockerfiles/Dockerfile.react-native-cli-android-builder
+++ b/dockerfiles/Dockerfile.react-native-cli-android-builder
@@ -22,6 +22,7 @@ RUN echo "registry=$REGISTRY_URL" >> ~/.npmrc
 RUN echo "_auth=$REG_BASIC_CREDENTIAL" >> ~/.npmrc
 RUN echo "email=$REG_NPM_EMAIL" >> ~/.npmrc
 RUN echo "always-auth=true" >> ~/.npmrc
+RUN echo "legacy-peer-deps=true" >> ~/.npmrc
 
 # Now copy in all the files needed to build
 COPY .git .git

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -30,7 +30,6 @@
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.0.1",
     "@bugsnag/delivery-x-domain-request": "^8.0.0-alpha.0",
     "@bugsnag/delivery-xml-http-request": "^8.0.0-alpha.0",
     "@bugsnag/plugin-app-duration": "^8.0.0-alpha.0",

--- a/packages/delivery-electron/package.json
+++ b/packages/delivery-electron/package.json
@@ -22,7 +22,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/core": "^7 || ^8",
     "@bugsnag/electron-network-status": "^8.0.0"
   }
 }

--- a/packages/delivery-electron/package.json
+++ b/packages/delivery-electron/package.json
@@ -22,7 +22,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8",
+    "@bugsnag/core": "^8",
     "@bugsnag/electron-network-status": "^8.0.0"
   }
 }

--- a/packages/delivery-electron/package.json
+++ b/packages/delivery-electron/package.json
@@ -22,7 +22,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8",
+    "@bugsnag/core": "^7 || ^8",
     "@bugsnag/electron-network-status": "^8.0.0"
   }
 }

--- a/packages/delivery-electron/package.json
+++ b/packages/delivery-electron/package.json
@@ -22,7 +22,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2",
-    "@bugsnag/electron-network-status": "^7.10.0"
+    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/electron-network-status": "^8.0.0"
   }
 }

--- a/packages/delivery-fetch/package.json
+++ b/packages/delivery-fetch/package.json
@@ -17,6 +17,6 @@
         "@bugsnag/core": "^8.0.0-alpha.0"
     },
     "peerDependencies": {
-        "@bugsnag/core": "^8.0.0"
+        "@bugsnag/core": "^7 || ^8"
     }
 }

--- a/packages/delivery-fetch/package.json
+++ b/packages/delivery-fetch/package.json
@@ -17,6 +17,6 @@
         "@bugsnag/core": "^8.0.0-alpha.0"
     },
     "peerDependencies": {
-        "@bugsnag/core": "^7.0.0"
+        "@bugsnag/core": "^8.0.0"
     }
 }

--- a/packages/delivery-fetch/package.json
+++ b/packages/delivery-fetch/package.json
@@ -17,6 +17,6 @@
         "@bugsnag/core": "^8.0.0-alpha.0"
     },
     "peerDependencies": {
-        "@bugsnag/core": "^7 || ^8"
+        "@bugsnag/core": "^8"
     }
 }

--- a/packages/delivery-fetch/package.json
+++ b/packages/delivery-fetch/package.json
@@ -17,6 +17,6 @@
         "@bugsnag/core": "^8.0.0-alpha.0"
     },
     "peerDependencies": {
-        "@bugsnag/core": "^8"
+        "@bugsnag/core": "^7 || ^8"
     }
 }

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/delivery-node/package.json
+++ b/packages/delivery-node/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/delivery-react-native/package.json
+++ b/packages/delivery-react-native/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-react-native/package.json
+++ b/packages/delivery-react-native/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-react-native/package.json
+++ b/packages/delivery-react-native/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/delivery-react-native/package.json
+++ b/packages/delivery-react-native/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/delivery-x-domain-request/package.json
+++ b/packages/delivery-x-domain-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/delivery-xml-http-request/package.json
+++ b/packages/delivery-xml-http-request/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/electron-network-status/package.json
+++ b/packages/electron-network-status/package.json
@@ -11,7 +11,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "repository": {
     "type": "git",

--- a/packages/electron-network-status/package.json
+++ b/packages/electron-network-status/package.json
@@ -11,7 +11,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "repository": {
     "type": "git",

--- a/packages/electron-network-status/package.json
+++ b/packages/electron-network-status/package.json
@@ -11,7 +11,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "repository": {
     "type": "git",

--- a/packages/electron-network-status/package.json
+++ b/packages/electron-network-status/package.json
@@ -11,7 +11,7 @@
     "@bugsnag/plugin-electron-client-state-manager": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.10.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/in-flight/package.json
+++ b/packages/in-flight/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/in-flight/package.json
+++ b/packages/in-flight/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/in-flight/package.json
+++ b/packages/in-flight/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/in-flight/package.json
+++ b/packages/in-flight/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -40,6 +40,6 @@
     "zone.js": "^0.8.26"
   },
   "peerDependencies": {
-    "@bugsnag/js": "^7.0.0"
+    "@bugsnag/js": "^8.0.0"
   }
 }

--- a/packages/plugin-app-duration/package.json
+++ b/packages/plugin-app-duration/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-app-duration/package.json
+++ b/packages/plugin-app-duration/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-app-duration/package.json
+++ b/packages/plugin-app-duration/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-app-duration/package.json
+++ b/packages/plugin-app-duration/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -33,6 +33,6 @@
     "express": "^4.18.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -33,6 +33,6 @@
     "express": "^4.18.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -33,6 +33,6 @@
     "express": "^4.18.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-aws-lambda/package.json
+++ b/packages/plugin-aws-lambda/package.json
@@ -33,6 +33,6 @@
     "express": "^4.18.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-context/package.json
+++ b/packages/plugin-browser-context/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-context/package.json
+++ b/packages/plugin-browser-context/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-context/package.json
+++ b/packages/plugin-browser-context/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-browser-context/package.json
+++ b/packages/plugin-browser-context/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-browser-device/package.json
+++ b/packages/plugin-browser-device/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-device/package.json
+++ b/packages/plugin-browser-device/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-browser-device/package.json
+++ b/packages/plugin-browser-device/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-browser-device/package.json
+++ b/packages/plugin-browser-device/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-request/package.json
+++ b/packages/plugin-browser-request/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-browser-request/package.json
+++ b/packages/plugin-browser-request/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-request/package.json
+++ b/packages/plugin-browser-request/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-request/package.json
+++ b/packages/plugin-browser-request/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-browser-session/package.json
+++ b/packages/plugin-browser-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-session/package.json
+++ b/packages/plugin-browser-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-browser-session/package.json
+++ b/packages/plugin-browser-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-browser-session/package.json
+++ b/packages/plugin-browser-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-client-ip/package.json
+++ b/packages/plugin-client-ip/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-client-ip/package.json
+++ b/packages/plugin-client-ip/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-client-ip/package.json
+++ b/packages/plugin-client-ip/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-client-ip/package.json
+++ b/packages/plugin-client-ip/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-console-breadcrumbs/package.json
+++ b/packages/plugin-console-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-console-breadcrumbs/package.json
+++ b/packages/plugin-console-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-console-breadcrumbs/package.json
+++ b/packages/plugin-console-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-console-breadcrumbs/package.json
+++ b/packages/plugin-console-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-contextualize/package.json
+++ b/packages/plugin-contextualize/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-contextualize/package.json
+++ b/packages/plugin-contextualize/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-contextualize/package.json
+++ b/packages/plugin-contextualize/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-contextualize/package.json
+++ b/packages/plugin-contextualize/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-app-breadcrumbs/package.json
+++ b/packages/plugin-electron-app-breadcrumbs/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app-breadcrumbs/package.json
+++ b/packages/plugin-electron-app-breadcrumbs/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app-breadcrumbs/package.json
+++ b/packages/plugin-electron-app-breadcrumbs/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app-breadcrumbs/package.json
+++ b/packages/plugin-electron-app-breadcrumbs/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app/package.json
+++ b/packages/plugin-electron-app/package.json
@@ -32,7 +32,7 @@
     "bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app/package.json
+++ b/packages/plugin-electron-app/package.json
@@ -32,7 +32,7 @@
     "bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app/package.json
+++ b/packages/plugin-electron-app/package.json
@@ -32,7 +32,7 @@
     "bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-app/package.json
+++ b/packages/plugin-electron-app/package.json
@@ -32,7 +32,7 @@
     "bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-client-state-manager/package.json
+++ b/packages/plugin-electron-client-state-manager/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-electron-client-state-manager/package.json
+++ b/packages/plugin-electron-client-state-manager/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-electron-client-state-manager/package.json
+++ b/packages/plugin-electron-client-state-manager/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-electron-client-state-manager/package.json
+++ b/packages/plugin-electron-client-state-manager/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-client-state-persistence/package.json
+++ b/packages/plugin-electron-client-state-persistence/package.json
@@ -44,6 +44,6 @@
     "@types/bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-client-state-persistence/package.json
+++ b/packages/plugin-electron-client-state-persistence/package.json
@@ -44,6 +44,6 @@
     "@types/bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-electron-client-state-persistence/package.json
+++ b/packages/plugin-electron-client-state-persistence/package.json
@@ -44,6 +44,6 @@
     "@types/bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-electron-client-state-persistence/package.json
+++ b/packages/plugin-electron-client-state-persistence/package.json
@@ -44,6 +44,6 @@
     "@types/bindings": "^1.5.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-electron-deliver-minidumps/package.json
+++ b/packages/plugin-electron-deliver-minidumps/package.json
@@ -26,7 +26,7 @@
     "@bugsnag/electron-network-status": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8",
+    "@bugsnag/core": "^8",
     "@bugsnag/electron-network-status": "^8.0.0"
   },
   "author": "Bugsnag",

--- a/packages/plugin-electron-deliver-minidumps/package.json
+++ b/packages/plugin-electron-deliver-minidumps/package.json
@@ -26,8 +26,8 @@
     "@bugsnag/electron-network-status": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2",
-    "@bugsnag/electron-network-status": "^7.10.0"
+    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/electron-network-status": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-deliver-minidumps/package.json
+++ b/packages/plugin-electron-deliver-minidumps/package.json
@@ -26,7 +26,7 @@
     "@bugsnag/electron-network-status": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8",
+    "@bugsnag/core": "^7 || ^8",
     "@bugsnag/electron-network-status": "^8.0.0"
   },
   "author": "Bugsnag",

--- a/packages/plugin-electron-deliver-minidumps/package.json
+++ b/packages/plugin-electron-deliver-minidumps/package.json
@@ -26,7 +26,7 @@
     "@bugsnag/electron-network-status": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/core": "^7 || ^8",
     "@bugsnag/electron-network-status": "^8.0.0"
   },
   "author": "Bugsnag",

--- a/packages/plugin-electron-device/package.json
+++ b/packages/plugin-electron-device/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-device/package.json
+++ b/packages/plugin-electron-device/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-device/package.json
+++ b/packages/plugin-electron-device/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-device/package.json
+++ b/packages/plugin-electron-device/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-ipc/package.json
+++ b/packages/plugin-electron-ipc/package.json
@@ -19,7 +19,7 @@
     "dist/preload.bundle.js"
   ],
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-electron-ipc/package.json
+++ b/packages/plugin-electron-ipc/package.json
@@ -19,7 +19,7 @@
     "dist/preload.bundle.js"
   ],
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-electron-ipc/package.json
+++ b/packages/plugin-electron-ipc/package.json
@@ -19,7 +19,7 @@
     "dist/preload.bundle.js"
   ],
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-electron-ipc/package.json
+++ b/packages/plugin-electron-ipc/package.json
@@ -19,7 +19,7 @@
     "dist/preload.bundle.js"
   ],
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-electron-net-breadcrumbs/package.json
+++ b/packages/plugin-electron-net-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-net-breadcrumbs/package.json
+++ b/packages/plugin-electron-net-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-net-breadcrumbs/package.json
+++ b/packages/plugin-electron-net-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-net-breadcrumbs/package.json
+++ b/packages/plugin-electron-net-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-network-status/package.json
+++ b/packages/plugin-electron-network-status/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-network-status/package.json
+++ b/packages/plugin-electron-network-status/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-network-status/package.json
+++ b/packages/plugin-electron-network-status/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-network-status/package.json
+++ b/packages/plugin-electron-network-status/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-power-monitor-breadcrumbs/package.json
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-power-monitor-breadcrumbs/package.json
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-power-monitor-breadcrumbs/package.json
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-power-monitor-breadcrumbs/package.json
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-preload-error/package.json
+++ b/packages/plugin-electron-preload-error/package.json
@@ -19,7 +19,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-preload-error/package.json
+++ b/packages/plugin-electron-preload-error/package.json
@@ -19,7 +19,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-preload-error/package.json
+++ b/packages/plugin-electron-preload-error/package.json
@@ -19,7 +19,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-preload-error/package.json
+++ b/packages/plugin-electron-preload-error/package.json
@@ -19,7 +19,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-process-info/package.json
+++ b/packages/plugin-electron-process-info/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-process-info/package.json
+++ b/packages/plugin-electron-process-info/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-process-info/package.json
+++ b/packages/plugin-electron-process-info/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-process-info/package.json
+++ b/packages/plugin-electron-process-info/package.json
@@ -17,7 +17,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-renderer-client-state-updates/package.json
+++ b/packages/plugin-electron-renderer-client-state-updates/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-electron-renderer-client-state-updates/package.json
+++ b/packages/plugin-electron-renderer-client-state-updates/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-electron-renderer-client-state-updates/package.json
+++ b/packages/plugin-electron-renderer-client-state-updates/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-electron-renderer-client-state-updates/package.json
+++ b/packages/plugin-electron-renderer-client-state-updates/package.json
@@ -22,6 +22,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-renderer-event-data/package.json
+++ b/packages/plugin-electron-renderer-event-data/package.json
@@ -24,7 +24,7 @@
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8",
+    "@bugsnag/core": "^7 || ^8",
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-renderer-event-data/package.json
+++ b/packages/plugin-electron-renderer-event-data/package.json
@@ -24,7 +24,7 @@
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8",
+    "@bugsnag/core": "^8",
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-renderer-event-data/package.json
+++ b/packages/plugin-electron-renderer-event-data/package.json
@@ -24,7 +24,7 @@
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/core": "^7 || ^8",
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-renderer-event-data/package.json
+++ b/packages/plugin-electron-renderer-event-data/package.json
@@ -24,7 +24,7 @@
     "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2",
-    "@bugsnag/plugin-electron-renderer-strip-project-root": "^7.10.0-alpha.1"
+    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/plugin-electron-renderer-strip-project-root": "^8.0.0"
   }
 }

--- a/packages/plugin-electron-screen-breadcrumbs/package.json
+++ b/packages/plugin-electron-screen-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-screen-breadcrumbs/package.json
+++ b/packages/plugin-electron-screen-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-screen-breadcrumbs/package.json
+++ b/packages/plugin-electron-screen-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-screen-breadcrumbs/package.json
+++ b/packages/plugin-electron-screen-breadcrumbs/package.json
@@ -18,7 +18,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-session/package.json
+++ b/packages/plugin-electron-session/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-session/package.json
+++ b/packages/plugin-electron-session/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-session/package.json
+++ b/packages/plugin-electron-session/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-electron-session/package.json
+++ b/packages/plugin-electron-session/package.json
@@ -21,7 +21,7 @@
     "@bugsnag/electron-test-helpers": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-inline-script-content/package.json
+++ b/packages/plugin-inline-script-content/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-interaction-breadcrumbs/package.json
+++ b/packages/plugin-interaction-breadcrumbs/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-interaction-breadcrumbs/package.json
+++ b/packages/plugin-interaction-breadcrumbs/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-interaction-breadcrumbs/package.json
+++ b/packages/plugin-interaction-breadcrumbs/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-interaction-breadcrumbs/package.json
+++ b/packages/plugin-interaction-breadcrumbs/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-intercept/package.json
+++ b/packages/plugin-intercept/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-intercept/package.json
+++ b/packages/plugin-intercept/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-intercept/package.json
+++ b/packages/plugin-intercept/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-intercept/package.json
+++ b/packages/plugin-intercept/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-internal-callback-marker/package.json
+++ b/packages/plugin-internal-callback-marker/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-internal-callback-marker/package.json
+++ b/packages/plugin-internal-callback-marker/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.9.2"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-internal-callback-marker/package.json
+++ b/packages/plugin-internal-callback-marker/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-internal-callback-marker/package.json
+++ b/packages/plugin-internal-callback-marker/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-koa/package.json
+++ b/packages/plugin-koa/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-navigation-breadcrumbs/package.json
+++ b/packages/plugin-navigation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-network-breadcrumbs/package.json
+++ b/packages/plugin-network-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-device/package.json
+++ b/packages/plugin-node-device/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-node-in-project/package.json
+++ b/packages/plugin-node-in-project/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-node-in-project/package.json
+++ b/packages/plugin-node-in-project/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-in-project/package.json
+++ b/packages/plugin-node-in-project/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-in-project/package.json
+++ b/packages/plugin-node-in-project/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-node-surrounding-code/package.json
+++ b/packages/plugin-node-surrounding-code/package.json
@@ -25,6 +25,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-node-uncaught-exception/package.json
+++ b/packages/plugin-node-uncaught-exception/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-node-uncaught-exception/package.json
+++ b/packages/plugin-node-uncaught-exception/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-uncaught-exception/package.json
+++ b/packages/plugin-node-uncaught-exception/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-uncaught-exception/package.json
+++ b/packages/plugin-node-uncaught-exception/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-node-unhandled-rejection/package.json
+++ b/packages/plugin-node-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-node-unhandled-rejection/package.json
+++ b/packages/plugin-node-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-unhandled-rejection/package.json
+++ b/packages/plugin-node-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-node-unhandled-rejection/package.json
+++ b/packages/plugin-node-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-event-sync/package.json
+++ b/packages/plugin-react-native-event-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-event-sync/package.json
+++ b/packages/plugin-react-native-event-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-event-sync/package.json
+++ b/packages/plugin-react-native-event-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-event-sync/package.json
+++ b/packages/plugin-react-native-event-sync/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-global-error-handler/package.json
+++ b/packages/plugin-react-native-global-error-handler/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-global-error-handler/package.json
+++ b/packages/plugin-react-native-global-error-handler/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-global-error-handler/package.json
+++ b/packages/plugin-react-native-global-error-handler/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-global-error-handler/package.json
+++ b/packages/plugin-react-native-global-error-handler/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -24,7 +24,7 @@
     "react-native-navigation": "^7.0.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8",
+    "@bugsnag/core": "^8",
     "react-native-navigation": "2 - 7"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -24,7 +24,7 @@
     "react-native-navigation": "^7.0.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8",
+    "@bugsnag/core": "^7 || ^8",
     "react-native-navigation": "2 - 7"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -24,7 +24,7 @@
     "react-native-navigation": "^7.0.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/core": "^7 || ^8",
     "react-native-navigation": "2 - 7"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-native-navigation/package.json
+++ b/packages/plugin-react-native-navigation/package.json
@@ -24,7 +24,7 @@
     "react-native-navigation": "^7.0.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0",
+    "@bugsnag/core": "^8.0.0",
     "react-native-navigation": "2 - 7"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-orientation-breadcrumbs/package.json
+++ b/packages/plugin-react-native-orientation-breadcrumbs/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-session/package.json
+++ b/packages/plugin-react-native-session/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-unhandled-rejection/package.json
+++ b/packages/plugin-react-native-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "promise": "^8.0.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-react-native-unhandled-rejection/package.json
+++ b/packages/plugin-react-native-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "promise": "^8.0.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-react-native-unhandled-rejection/package.json
+++ b/packages/plugin-react-native-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "promise": "^8.0.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-native-unhandled-rejection/package.json
+++ b/packages/plugin-react-native-unhandled-rejection/package.json
@@ -21,6 +21,6 @@
     "promise": "^8.0.2"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-react-navigation/package.json
+++ b/packages/plugin-react-navigation/package.json
@@ -31,7 +31,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0",
+    "@bugsnag/core": "^7 || ^8",
     "@react-navigation/native": "^5.0 || ^6.0"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-navigation/package.json
+++ b/packages/plugin-react-navigation/package.json
@@ -31,7 +31,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8",
+    "@bugsnag/core": "^8",
     "@react-navigation/native": "^5.0 || ^6.0"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-navigation/package.json
+++ b/packages/plugin-react-navigation/package.json
@@ -31,7 +31,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8",
+    "@bugsnag/core": "^7 || ^8",
     "@react-navigation/native": "^5.0 || ^6.0"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react-navigation/package.json
+++ b/packages/plugin-react-navigation/package.json
@@ -31,7 +31,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0",
+    "@bugsnag/core": "^8.0.0",
     "@react-navigation/native": "^5.0 || ^6.0"
   },
   "peerDependenciesMeta": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-restify/package.json
+++ b/packages/plugin-restify/package.json
@@ -24,7 +24,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0",

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-server-session/package.json
+++ b/packages/plugin-server-session/package.json
@@ -23,6 +23,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-simple-throttle/package.json
+++ b/packages/plugin-simple-throttle/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-simple-throttle/package.json
+++ b/packages/plugin-simple-throttle/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-simple-throttle/package.json
+++ b/packages/plugin-simple-throttle/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-simple-throttle/package.json
+++ b/packages/plugin-simple-throttle/package.json
@@ -21,6 +21,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-stackframe-path-normaliser/package.json
+++ b/packages/plugin-stackframe-path-normaliser/package.json
@@ -14,7 +14,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0"

--- a/packages/plugin-stackframe-path-normaliser/package.json
+++ b/packages/plugin-stackframe-path-normaliser/package.json
@@ -14,7 +14,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0"

--- a/packages/plugin-stackframe-path-normaliser/package.json
+++ b/packages/plugin-stackframe-path-normaliser/package.json
@@ -14,7 +14,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0"

--- a/packages/plugin-stackframe-path-normaliser/package.json
+++ b/packages/plugin-stackframe-path-normaliser/package.json
@@ -14,7 +14,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "devDependencies": {
     "@bugsnag/core": "^8.0.0-alpha.0"

--- a/packages/plugin-strip-project-root/package.json
+++ b/packages/plugin-strip-project-root/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-strip-project-root/package.json
+++ b/packages/plugin-strip-project-root/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-strip-project-root/package.json
+++ b/packages/plugin-strip-project-root/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-strip-project-root/package.json
+++ b/packages/plugin-strip-project-root/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-strip-query-string/package.json
+++ b/packages/plugin-strip-query-string/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-strip-query-string/package.json
+++ b/packages/plugin-strip-query-string/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-strip-query-string/package.json
+++ b/packages/plugin-strip-query-string/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-strip-query-string/package.json
+++ b/packages/plugin-strip-query-string/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -27,7 +27,7 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   },
   "peerDependenciesMeta": {
     "@bugsnag/core": {

--- a/packages/plugin-window-onerror/package.json
+++ b/packages/plugin-window-onerror/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-window-onerror/package.json
+++ b/packages/plugin-window-onerror/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-window-onerror/package.json
+++ b/packages/plugin-window-onerror/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-window-onerror/package.json
+++ b/packages/plugin-window-onerror/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/plugin-window-unhandled-rejection/package.json
+++ b/packages/plugin-window-unhandled-rejection/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8.0.0"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-window-unhandled-rejection/package.json
+++ b/packages/plugin-window-unhandled-rejection/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^8"
+    "@bugsnag/core": "^7 || ^8"
   }
 }

--- a/packages/plugin-window-unhandled-rejection/package.json
+++ b/packages/plugin-window-unhandled-rejection/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7 || ^8"
+    "@bugsnag/core": "^8"
   }
 }

--- a/packages/plugin-window-unhandled-rejection/package.json
+++ b/packages/plugin-window-unhandled-rejection/package.json
@@ -20,6 +20,6 @@
     "@bugsnag/core": "^8.0.0-alpha.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^8.0.0"
   }
 }

--- a/packages/react-native-cli/package-lock.json
+++ b/packages/react-native-cli/package-lock.json
@@ -1,988 +1,988 @@
 {
-	"name": "@bugsnag/react-native-cli",
-	"version": "8.0.0-alpha.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "@bugsnag/react-native-cli",
-			"version": "8.0.0-alpha.0",
-			"license": "MIT",
-			"dependencies": {
-				"command-line-args": "^5.1.1",
-				"command-line-usage": "^6.1.0",
-				"consola": "^2.15.0",
-				"detect-indent": "^6.1.0",
-				"glob": "^7.1.6",
-				"plist": "^3.0.1",
-				"prompts": "^2.4.0",
-				"semver": "^7.5.4",
-				"xcode": "^3.0.1"
-			},
-			"bin": {
-				"bugsnag-react-native-cli": "bin/cli"
-			},
-			"devDependencies": {
-				"@types/command-line-args": "^5.0.0",
-				"@types/command-line-usage": "^5.0.1",
-				"@types/glob": "^8.1.0",
-				"@types/prompts": "^2.0.9",
-				"@types/semver": "^7.5.0",
-				"typescript": "^4.1.3"
-			}
-		},
-		"node_modules/@types/command-line-args": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
-			"integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
-			"dev": true
-		},
-		"node_modules/@types/command-line-usage": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
-			"integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
-			"dev": true
-		},
-		"node_modules/@types/glob": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-			"dev": true,
-			"dependencies": {
-				"@types/minimatch": "^5.1.2",
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/minimatch": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "14.14.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-			"integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
-			"dev": true
-		},
-		"node_modules/@types/prompts": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
-			"integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
-		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
-			"dev": true
-		},
-		"node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/array-back": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/big-integer": {
-			"version": "1.6.48",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/bplist-creator": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
-			"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-			"dependencies": {
-				"stream-buffers": "~2.2.0"
-			}
-		},
-		"node_modules/bplist-parser": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-			"dependencies": {
-				"big-integer": "^1.6.44"
-			},
-			"engines": {
-				"node": ">= 5.10.0"
-			}
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"node_modules/command-line-args": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-			"dependencies": {
-				"array-back": "^3.0.1",
-				"find-replace": "^3.0.0",
-				"lodash.camelcase": "^4.3.0",
-				"typical": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/command-line-usage": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
-			"integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
-			"dependencies": {
-				"array-back": "^4.0.0",
-				"chalk": "^2.4.2",
-				"table-layout": "^1.0.0",
-				"typical": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/command-line-usage/node_modules/array-back": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/command-line-usage/node_modules/typical": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"node_modules/consola": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
-			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
-		},
-		"node_modules/deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/detect-indent": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/find-replace": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-			"dependencies": {
-				"array-back": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"node_modules/glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/plist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-			"dependencies": {
-				"base64-js": "^1.2.3",
-				"xmlbuilder": "^9.0.7",
-				"xmldom": "0.1.x"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/prompts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
-			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
-			"dependencies": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/reduce-flatten": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/simple-plist": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
-			"integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
-			"dependencies": {
-				"bplist-creator": "0.0.8",
-				"bplist-parser": "0.2.0",
-				"plist": "^3.0.1"
-			}
-		},
-		"node_modules/sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-		},
-		"node_modules/stream-buffers": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
-			"engines": {
-				"node": ">= 0.10.0"
-			}
-		},
-		"node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/table-layout": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
-			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
-			"dependencies": {
-				"array-back": "^4.0.1",
-				"deep-extend": "~0.6.0",
-				"typical": "^5.2.0",
-				"wordwrapjs": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/table-layout/node_modules/array-back": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/table-layout/node_modules/typical": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typical": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/uuid": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-			"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/wordwrapjs": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
-			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
-			"dependencies": {
-				"reduce-flatten": "^2.0.0",
-				"typical": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/wordwrapjs/node_modules/typical": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"node_modules/xcode": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-			"integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-			"dependencies": {
-				"simple-plist": "^1.1.0",
-				"uuid": "^7.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-			"deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-			"engines": {
-				"node": ">=0.1"
-			}
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		}
-	},
-	"dependencies": {
-		"@types/command-line-args": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
-			"integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
-			"dev": true
-		},
-		"@types/command-line-usage": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
-			"integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
-			"dev": true
-		},
-		"@types/glob": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-			"dev": true,
-			"requires": {
-				"@types/minimatch": "^5.1.2",
-				"@types/node": "*"
-			}
-		},
-		"@types/minimatch": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "14.14.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-			"integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
-			"dev": true
-		},
-		"@types/prompts": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
-			"integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
-			"dev": true
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
-		"array-back": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
-		"big-integer": {
-			"version": "1.6.48",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
-		},
-		"bplist-creator": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
-			"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-			"requires": {
-				"stream-buffers": "~2.2.0"
-			}
-		},
-		"bplist-parser": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-			"requires": {
-				"big-integer": "^1.6.44"
-			}
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"command-line-args": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-			"requires": {
-				"array-back": "^3.0.1",
-				"find-replace": "^3.0.0",
-				"lodash.camelcase": "^4.3.0",
-				"typical": "^4.0.0"
-			}
-		},
-		"command-line-usage": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
-			"integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
-			"requires": {
-				"array-back": "^4.0.0",
-				"chalk": "^2.4.2",
-				"table-layout": "^1.0.0",
-				"typical": "^5.2.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
-				},
-				"typical": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
-				}
-			}
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"consola": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
-			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-		},
-		"detect-indent": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"find-replace": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-			"requires": {
-				"array-back": "^3.0.1"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
-		},
-		"lodash.camelcase": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"plist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-			"requires": {
-				"base64-js": "^1.2.3",
-				"xmlbuilder": "^9.0.7",
-				"xmldom": "0.1.x"
-			}
-		},
-		"prompts": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
-			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
-			"requires": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			}
-		},
-		"reduce-flatten": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
-		},
-		"semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"requires": {
-				"lru-cache": "^6.0.0"
-			}
-		},
-		"simple-plist": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
-			"integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
-			"requires": {
-				"bplist-creator": "0.0.8",
-				"bplist-parser": "0.2.0",
-				"plist": "^3.0.1"
-			}
-		},
-		"sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-		},
-		"stream-buffers": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
-		"table-layout": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
-			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
-			"requires": {
-				"array-back": "^4.0.1",
-				"deep-extend": "~0.6.0",
-				"typical": "^5.2.0",
-				"wordwrapjs": "^4.0.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
-				},
-				"typical": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
-				}
-			}
-		},
-		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-			"dev": true
-		},
-		"typical": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
-		},
-		"uuid": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-			"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-		},
-		"wordwrapjs": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
-			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
-			"requires": {
-				"reduce-flatten": "^2.0.0",
-				"typical": "^5.0.0"
-			},
-			"dependencies": {
-				"typical": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
-				}
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"xcode": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-			"integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-			"requires": {
-				"simple-plist": "^1.1.0",
-				"uuid": "^7.0.3"
-			}
-		},
-		"xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-		},
-		"xmldom": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		}
-	}
+  "name": "@bugsnag/react-native-cli",
+  "version": "8.0.0-alpha.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bugsnag/react-native-cli",
+      "version": "7.16.5",
+      "license": "MIT",
+      "dependencies": {
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "consola": "^2.15.0",
+        "detect-indent": "^6.1.0",
+        "glob": "^7.1.6",
+        "plist": "^3.0.1",
+        "prompts": "^2.4.0",
+        "semver": "^7.5.4",
+        "xcode": "^3.0.1"
+      },
+      "bin": {
+        "bugsnag-react-native-cli": "bin/cli"
+      },
+      "devDependencies": {
+        "@types/command-line-args": "^5.0.0",
+        "@types/command-line-usage": "^5.0.1",
+        "@types/glob": "^8.1.0",
+        "@types/prompts": "^2.0.9",
+        "@types/semver": "^7.5.0",
+        "typescript": "^4.1.3"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+      "dev": true
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+      "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+      "dev": true
+    },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+      "dev": true
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
+      "integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "dependencies": {
+        "stream-buffers": "~2.2.0"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "dependencies": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+      "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+      "dependencies": {
+        "array-back": "^4.0.0",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/consola": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "dependencies": {
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^9.0.7",
+        "xmldom": "0.1.x"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-plist": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
+      "integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
+      "dependencies": {
+        "bplist-creator": "0.0.8",
+        "bplist-parser": "0.2.0",
+        "plist": "^3.0.1"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/xcode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+      "dependencies": {
+        "simple-plist": "^1.1.0",
+        "uuid": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+      "engines": {
+        "node": ">=0.1"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  },
+  "dependencies": {
+    "@types/command-line-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+      "dev": true
+    },
+    "@types/command-line-usage": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+      "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+      "dev": true
+    },
+    "@types/prompts": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
+      "integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
+    "bplist-creator": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+      "requires": {
+        "stream-buffers": "~2.2.0"
+      }
+    },
+    "bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "requires": {
+        "big-integer": "^1.6.44"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+      "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+      "requires": {
+        "array-back": "^4.0.0",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "consola": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "plist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "requires": {
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^9.0.7",
+        "xmldom": "0.1.x"
+      }
+    },
+    "prompts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
+    "semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "simple-plist": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
+      "integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
+      "requires": {
+        "bplist-creator": "0.0.8",
+        "bplist-parser": "0.2.0",
+        "plist": "^3.0.1"
+      }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table-layout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+    },
+    "uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+    },
+    "wordwrapjs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.0.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xcode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+      "requires": {
+        "simple-plist": "^1.1.0",
+        "uuid": "^7.0.3"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
 }

--- a/packages/react-native-cli/package-lock.json
+++ b/packages/react-native-cli/package-lock.json
@@ -1,988 +1,988 @@
 {
-  "name": "@bugsnag/react-native-cli",
-  "version": "8.0.0-alpha.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "@bugsnag/react-native-cli",
-      "version": "7.16.5",
-      "license": "MIT",
-      "dependencies": {
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^6.1.0",
-        "consola": "^2.15.0",
-        "detect-indent": "^6.1.0",
-        "glob": "^7.1.6",
-        "plist": "^3.0.1",
-        "prompts": "^2.4.0",
-        "semver": "^7.5.4",
-        "xcode": "^3.0.1"
-      },
-      "bin": {
-        "bugsnag-react-native-cli": "bin/cli"
-      },
-      "devDependencies": {
-        "@types/command-line-args": "^5.0.0",
-        "@types/command-line-usage": "^5.0.1",
-        "@types/glob": "^8.1.0",
-        "@types/prompts": "^2.0.9",
-        "@types/semver": "^7.5.0",
-        "typescript": "^4.1.3"
-      }
-    },
-    "node_modules/@types/command-line-args": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
-      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
-      "dev": true
-    },
-    "node_modules/@types/command-line-usage": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
-      "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
-      "dev": true
-    },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "14.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
-      "dev": true
-    },
-    "node_modules/@types/prompts": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
-      "integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
-      "dev": true
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/bplist-creator": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
-      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-      "dependencies": {
-        "stream-buffers": "~2.2.0"
-      }
-    },
-    "node_modules/bplist-parser": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-      "dependencies": {
-        "big-integer": "^1.6.44"
-      },
-      "engines": {
-        "node": ">= 5.10.0"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "node_modules/command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "dependencies": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
-      "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
-      "dependencies": {
-        "array-back": "^4.0.0",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/consola": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
-      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-      "dependencies": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
-      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-plist": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
-      "integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
-      "dependencies": {
-        "bplist-creator": "0.0.8",
-        "bplist-parser": "0.2.0",
-        "plist": "^3.0.1"
-      }
-    },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-    },
-    "node_modules/stream-buffers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/table-layout": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
-      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
-      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/xcode": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-      "dependencies": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "engines": {
-        "node": ">=0.1"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    }
-  },
-  "dependencies": {
-    "@types/command-line-args": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
-      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
-      "dev": true
-    },
-    "@types/command-line-usage": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
-      "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
-      "dev": true
-    },
-    "@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
-    "@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "14.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
-      "dev": true
-    },
-    "@types/prompts": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
-      "integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
-    },
-    "bplist-creator": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
-      "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-      "requires": {
-        "stream-buffers": "~2.2.0"
-      }
-    },
-    "bplist-parser": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-      "requires": {
-        "big-integer": "^1.6.44"
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "requires": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
-    },
-    "command-line-usage": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
-      "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
-      "requires": {
-        "array-back": "^4.0.0",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.0",
-        "typical": "^5.2.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
-        },
-        "typical": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
-        }
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "consola": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
-      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
-    "detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "requires": {
-        "array-back": "^3.0.1"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-      "requires": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
-      }
-    },
-    "prompts": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
-      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
-      "requires": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      }
-    },
-    "reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
-    },
-    "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "simple-plist": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
-      "integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
-      "requires": {
-        "bplist-creator": "0.0.8",
-        "bplist-parser": "0.2.0",
-        "plist": "^3.0.1"
-      }
-    },
-    "sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-    },
-    "stream-buffers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "table-layout": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
-      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
-      "requires": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
-        },
-        "typical": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
-        }
-      }
-    },
-    "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "dev": true
-    },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
-    },
-    "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-    },
-    "wordwrapjs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
-      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
-      "requires": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.0.0"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "xcode": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-      "requires": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    }
-  }
+	"name": "@bugsnag/react-native-cli",
+	"version": "8.0.0-alpha.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@bugsnag/react-native-cli",
+			"version": "8.0.0-alpha.0",
+			"license": "MIT",
+			"dependencies": {
+				"command-line-args": "^5.1.1",
+				"command-line-usage": "^6.1.0",
+				"consola": "^2.15.0",
+				"detect-indent": "^6.1.0",
+				"glob": "^7.1.6",
+				"plist": "^3.0.1",
+				"prompts": "^2.4.0",
+				"semver": "^7.5.4",
+				"xcode": "^3.0.1"
+			},
+			"bin": {
+				"bugsnag-react-native-cli": "bin/cli"
+			},
+			"devDependencies": {
+				"@types/command-line-args": "^5.0.0",
+				"@types/command-line-usage": "^5.0.1",
+				"@types/glob": "^8.1.0",
+				"@types/prompts": "^2.0.9",
+				"@types/semver": "^7.5.0",
+				"typescript": "^4.1.3"
+			}
+		},
+		"node_modules/@types/command-line-args": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+			"integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+			"dev": true
+		},
+		"node_modules/@types/command-line-usage": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+			"integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+			"dev": true
+		},
+		"node_modules/@types/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "^5.1.2",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/minimatch": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "14.14.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+			"integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+			"dev": true
+		},
+		"node_modules/@types/prompts": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
+			"integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/semver": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"dev": true
+		},
+		"node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/array-back": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/bplist-creator": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+			"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+			"dependencies": {
+				"stream-buffers": "~2.2.0"
+			}
+		},
+		"node_modules/bplist-parser": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+			"dependencies": {
+				"big-integer": "^1.6.44"
+			},
+			"engines": {
+				"node": ">= 5.10.0"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"node_modules/command-line-args": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+			"dependencies": {
+				"array-back": "^3.0.1",
+				"find-replace": "^3.0.0",
+				"lodash.camelcase": "^4.3.0",
+				"typical": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/command-line-usage": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+			"integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+			"dependencies": {
+				"array-back": "^4.0.0",
+				"chalk": "^2.4.2",
+				"table-layout": "^1.0.0",
+				"typical": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/command-line-usage/node_modules/array-back": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/command-line-usage/node_modules/typical": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"node_modules/consola": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/detect-indent": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/find-replace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+			"dependencies": {
+				"array-back": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"node_modules/glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plist": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+			"dependencies": {
+				"base64-js": "^1.2.3",
+				"xmlbuilder": "^9.0.7",
+				"xmldom": "0.1.x"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/prompts": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/reduce-flatten": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/simple-plist": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
+			"integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
+			"dependencies": {
+				"bplist-creator": "0.0.8",
+				"bplist-parser": "0.2.0",
+				"plist": "^3.0.1"
+			}
+		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+		},
+		"node_modules/stream-buffers": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+			"engines": {
+				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/table-layout": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+			"dependencies": {
+				"array-back": "^4.0.1",
+				"deep-extend": "~0.6.0",
+				"typical": "^5.2.0",
+				"wordwrapjs": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/table-layout/node_modules/array-back": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/table-layout/node_modules/typical": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/typical": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+			"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/wordwrapjs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+			"dependencies": {
+				"reduce-flatten": "^2.0.0",
+				"typical": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/wordwrapjs/node_modules/typical": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"node_modules/xcode": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+			"integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+			"dependencies": {
+				"simple-plist": "^1.1.0",
+				"uuid": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/xmldom": {
+			"version": "0.1.31",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+			"deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+			"engines": {
+				"node": ">=0.1"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	},
+	"dependencies": {
+		"@types/command-line-args": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+			"integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+			"dev": true
+		},
+		"@types/command-line-usage": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+			"integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+			"dev": true
+		},
+		"@types/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+			"dev": true,
+			"requires": {
+				"@types/minimatch": "^5.1.2",
+				"@types/node": "*"
+			}
+		},
+		"@types/minimatch": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "14.14.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+			"integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+			"dev": true
+		},
+		"@types/prompts": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.9.tgz",
+			"integrity": "sha512-TORZP+FSjTYMWwKadftmqEn6bziN5RnfygehByGsjxoK5ydnClddtv6GikGWPvCm24oI+YBwck5WDxIIyNxUrA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/semver": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"array-back": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+			"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
+		"big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+		},
+		"bplist-creator": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+			"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
+			"requires": {
+				"stream-buffers": "~2.2.0"
+			}
+		},
+		"bplist-parser": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+			"requires": {
+				"big-integer": "^1.6.44"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"command-line-args": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+			"requires": {
+				"array-back": "^3.0.1",
+				"find-replace": "^3.0.0",
+				"lodash.camelcase": "^4.3.0",
+				"typical": "^4.0.0"
+			}
+		},
+		"command-line-usage": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+			"integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+			"requires": {
+				"array-back": "^4.0.0",
+				"chalk": "^2.4.2",
+				"table-layout": "^1.0.0",
+				"typical": "^5.2.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"consola": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+			"integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+		},
+		"detect-indent": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"find-replace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+			"requires": {
+				"array-back": "^3.0.1"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"plist": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+			"integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+			"requires": {
+				"base64-js": "^1.2.3",
+				"xmlbuilder": "^9.0.7",
+				"xmldom": "0.1.x"
+			}
+		},
+		"prompts": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+			"requires": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			}
+		},
+		"reduce-flatten": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+			"integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+		},
+		"semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
+		},
+		"simple-plist": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
+			"integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
+			"requires": {
+				"bplist-creator": "0.0.8",
+				"bplist-parser": "0.2.0",
+				"plist": "^3.0.1"
+			}
+		},
+		"sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+		},
+		"stream-buffers": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"table-layout": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+			"integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+			"requires": {
+				"array-back": "^4.0.1",
+				"deep-extend": "~0.6.0",
+				"typical": "^5.2.0",
+				"wordwrapjs": "^4.0.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+					"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+				},
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
+		"typescript": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"dev": true
+		},
+		"typical": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+			"integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+		},
+		"uuid": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+			"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+		},
+		"wordwrapjs": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+			"integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+			"requires": {
+				"reduce-flatten": "^2.0.0",
+				"typical": "^5.0.0"
+			},
+			"dependencies": {
+				"typical": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+					"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xcode": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+			"integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+			"requires": {
+				"simple-plist": "^1.1.0",
+				"uuid": "^7.0.3"
+			}
+		},
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+		},
+		"xmldom": {
+			"version": "0.1.31",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	}
 }

--- a/scripts/react-native-cli-helper.js
+++ b/scripts/react-native-cli-helper.js
@@ -26,7 +26,7 @@ module.exports = {
       common.run('npm install', true)
 
       // Install and run the CLI
-      const installCommand = `npm install @bugsnag/react-native-cli@${version}`
+      const installCommand = `npm install @bugsnag/react-native-cli@${version} --legacy-peer-deps`
       common.run(installCommand, true)
 
       // Use Expect to run the init command interactively
@@ -79,7 +79,7 @@ module.exports = {
       common.run('npm install', true)
 
       // Install and run the CLI
-      const installCommand = `npm install @bugsnag/react-native-cli@${version}`
+      const installCommand = `npm install @bugsnag/react-native-cli@${version} --legacy-peer-deps`
       common.run(installCommand, true)
 
       // Use Expect to run the init command interactively

--- a/scripts/react-native-helper.js
+++ b/scripts/react-native-helper.js
@@ -35,7 +35,7 @@ module.exports = {
       common.run(`npm install --registry ${registryUrl}`, true)
 
       // Install notifier
-      const command = `npm install @bugsnag/react-native@${version}  --registry ${registryUrl}`
+      const command = `npm install @bugsnag/react-native@${version}  --registry ${registryUrl} --legacy-peer-deps`
       common.run(command, true)
 
       // Install any required secondary files

--- a/scripts/react-native-helper.js
+++ b/scripts/react-native-helper.js
@@ -97,7 +97,7 @@ module.exports = {
 
       // Install notifier
       console.log(`Installing notifier: ${version}`)
-      const command = `npm install @bugsnag/react-native@${version}  --registry ${registryUrl}`
+      const command = `npm install @bugsnag/react-native@${version}  --registry ${registryUrl} --legacy-peer-deps`
       common.run(command, true)
 
       // Install any required secondary files

--- a/test/node/features/fixtures/cause/Dockerfile
+++ b/test/node/features/fixtures/cause/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/connect/Dockerfile
+++ b/test/node/features/fixtures/connect/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-express*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz bugsnag-plugin-express*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/contextualize/Dockerfile
+++ b/test/node/features/fixtures/contextualize/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/express/Dockerfile
+++ b/test/node/features/fixtures/express/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-express*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz bugsnag-plugin-express*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/handled/Dockerfile
+++ b/test/node/features/fixtures/handled/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/koa-1x/Dockerfile
+++ b/test/node/features/fixtures/koa-1x/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-koa*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz bugsnag-plugin-koa*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/koa/Dockerfile
+++ b/test/node/features/fixtures/koa/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-koa*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz bugsnag-plugin-koa*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/project_root/Dockerfile
+++ b/test/node/features/fixtures/project_root/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/proxy/Dockerfile
+++ b/test/node/features/fixtures/proxy/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/restify/Dockerfile
+++ b/test/node/features/fixtures/restify/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-restify*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz bugsnag-plugin-restify*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/sessions/Dockerfile
+++ b/test/node/features/fixtures/sessions/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/surrounding_code/Dockerfile
+++ b/test/node/features/fixtures/surrounding_code/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/unhandled/Dockerfile
+++ b/test/node/features/fixtures/unhandled/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz

--- a/test/node/features/fixtures/webpack/Dockerfile
+++ b/test/node/features/fixtures/webpack/Dockerfile
@@ -8,5 +8,5 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save --legacy-peer-deps bugsnag-node*.tgz
 RUN npm run build

--- a/test/react-native-cli/features/fixtures/Dockerfile
+++ b/test/react-native-cli/features/fixtures/Dockerfile
@@ -9,6 +9,6 @@ COPY . /app
 
 WORKDIR /app
 
-RUN npm i -g bugsnag-react-native-cli-*.tgz
+RUN npm i -g bugsnag-react-native-cli-*.tgz --legacy-peer-deps
 
 ENTRYPOINT ["/bin/sh"]

--- a/test/react-native-cli/features/fixtures/rn0_60/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_60/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_61/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_61/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_62/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_62/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_63/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_63/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_63_expo_ejected/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_64/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_64/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_65/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_65/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_66/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_66/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_67/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_67/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_67_hermes/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_67_hermes/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native-cli/features/fixtures/rn0_69/.npmrc
+++ b/test/react-native-cli/features/fixtures/rn0_69/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_native_navigation_js/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-npm i @bugsnag/plugin-react-native-navigation@$BUGSNAG_VERSION --registry=$REGISTRY_URL
+npm i @bugsnag/plugin-react-native-navigation@$BUGSNAG_VERSION --legacy-peer-deps --registry=$REGISTRY_URL
 
 if [ "$REACT_NATIVE_VERSION" == "rn0.60" ]; then
-   npm i react-native-navigation@7.0.0
+   npm i react-native-navigation@7.0.0 --legacy-peer-deps 
 elif [ "$REACT_NATIVE_VERSION" == "rn0.66" ]; then
-   npm i react-native-navigation@7.29.1
+   npm i react-native-navigation@7.29.1 --legacy-peer-deps 
 else
-   npm i react-native-navigation@^7.30.0
+   npm i react-native-navigation@^7.30.0 --legacy-peer-deps 
 fi
 
 npx rnn-link

--- a/test/react-native/features/fixtures/app/react_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_navigation_js/install.sh
@@ -1,29 +1,29 @@
-npm install @bugsnag/plugin-react-navigation@$BUGSNAG_VERSION --registry=$REGISTRY_URL
+npm install @bugsnag/plugin-react-navigation@$BUGSNAG_VERSION --legacy-peer-deps --registry=$REGISTRY_URL
 
 if [ "$REACT_NATIVE_VERSION" = "rn0.60" ]; then
-    npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
-    npm install @react-navigation/native@^5.9 --registry=$REGISTRY_URL
-    npm install @react-navigation/stack@^5.14 --registry=$REGISTRY_URL
-    npm install react-native-gesture-handler@^1.10 --registry=$REGISTRY_URL
-    npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
-    npm install react-native-safe-area-context@^3.1 --registry=$REGISTRY_URL
-    npm install react-native-screens@^2.18 --registry=$REGISTRY_URL
+    npm install @react-native-community/masked-view@^0.1 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install @react-navigation/native@^5.9 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install @react-navigation/stack@^5.14 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-gesture-handler@^1.10 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-reanimated@^1.13 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-safe-area-context@^3.1 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-screens@^2.18 --legacy-peer-deps --registry=$REGISTRY_URL
 elif [ "$REACT_NATIVE_VERSION" = "rn0.66" ] || [ "$REACT_NATIVE_VERSION" = "rn0.67" ] || [ "$REACT_NATIVE_VERSION" = "rn0.68-hermes" ]; then
-    npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
-    npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
-    npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
+    npm install @react-native-community/masked-view@^0.1 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install @react-navigation/native@^6.0 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install @react-navigation/stack@^6.0 --legacy-peer-deps --registry=$REGISTRY_URL
     # gesture-handler locked to avoid Kotlin version conflicts, see "Important changes" at:
     # https://github.com/software-mansion/react-native-gesture-handler/releases/tag/2.7.0
-    npm install react-native-gesture-handler@2.6.2 --registry=$REGISTRY_URL
-    npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
-    npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
-    npm install react-native-screens@3.10 --registry=$REGISTRY_URL
+    npm install react-native-gesture-handler@2.6.2 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-reanimated@^1.13 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-safe-area-context@3.3 --legacy-peer-deps --registry=$REGISTRY_URL
+    npm install react-native-screens@3.10 --legacy-peer-deps --registry=$REGISTRY_URL
 else
-  npm install @react-native-community/masked-view@^0.1 --registry=$REGISTRY_URL
-      npm install @react-navigation/native@^6.0 --registry=$REGISTRY_URL
-      npm install @react-navigation/stack@^6.0 --registry=$REGISTRY_URL
-      npm install react-native-gesture-handler@^2.2 --registry=$REGISTRY_URL
-      npm install react-native-reanimated@^1.13 --registry=$REGISTRY_URL
-      npm install react-native-safe-area-context@3.3 --registry=$REGISTRY_URL
-      npm install react-native-screens@3.10 --registry=$REGISTRY_URL
+  npm install @react-native-community/masked-view@^0.1 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install @react-navigation/native@^6.0 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install @react-navigation/stack@^6.0 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install react-native-gesture-handler@^2.2 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install react-native-reanimated@^1.13 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install react-native-safe-area-context@3.3 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install react-native-screens@3.10 --legacy-peer-deps --registry=$REGISTRY_URL
 fi


### PR DESCRIPTION
When lerna create a new version it does not update peer dependencies. So this PR does it manually.