### PR TITLE
fix(electron): Do not sync to NativeClient when `autoDetectErrors` or `nativeCrashes` are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Changed
 
-- (react-native) Update bugsnag-android from v5.28.4 to [v5.31.3](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#5313-2023-11-06)
+- (react-native) Update bugsnag-android from v5.28.4 to [v5.31.3](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5313-2023-11-06)
 - (react-native) Update bugsnag-cocoa from v6.26.2 to [v6.27.3](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6273-2023-11-15)
+
+### Fixed
+
+- (electron) Do not sync to NativeClient when `autoDetectErrors` or `nativeCrashes` are disabled [#2040](https://github.com/bugsnag/bugsnag-js/pull/2040)
 
 ## 7.22.1 (2023-10-31)
 

--- a/packages/electron-test-helpers/src/client.ts
+++ b/packages/electron-test-helpers/src/client.ts
@@ -11,8 +11,8 @@ interface ClientTestHelpers {
 export function makeClientForPlugin ({
   config = {},
   schema = {},
-  plugin = undefined
-}: { config?: object, schema?: object, plugin?: Plugin } = {}): ClientTestHelpers {
+  plugins = []
+}: { config?: object, schema?: object, plugins?: Plugin[] } = {}): ClientTestHelpers {
   const client = new Client(
     {
       apiKey: 'abcabcabcabcabcabcabc1234567890f',
@@ -20,7 +20,7 @@ export function makeClientForPlugin ({
       ...config
     },
     { ...defaultSchema, ...schema },
-    plugin !== undefined ? [plugin] : []
+    plugins
   )
 
   let lastSession: SessionPayload

--- a/packages/plugin-electron-client-state-persistence/client-state-persistence.js
+++ b/packages/plugin-electron-client-state-persistence/client-state-persistence.js
@@ -1,9 +1,15 @@
 const featureFlagDelegate = require('@bugsnag/core/lib/feature-flag-delegate')
 
+const isEnabledFor = client => client._config.autoDetectErrors && client._config.enabledErrorTypes.nativeCrashes
+
 module.exports = {
   NativeClient: require('bindings')('bugsnag_pecsp_bindings'),
   plugin: (NativeClient) => ({
     load: (client) => {
+      if (!isEnabledFor(client)) {
+        return
+      }
+
       client.addOnBreadcrumb(breadcrumb => {
         try {
           NativeClient.leaveBreadcrumb(breadcrumb)

--- a/packages/plugin-electron-client-state-persistence/package.json
+++ b/packages/plugin-electron-client-state-persistence/package.json
@@ -41,7 +41,8 @@
   "devDependencies": {
     "@bugsnag/core": "^7.19.0",
     "@bugsnag/plugin-electron-client-state-manager": "^7.19.0",
-    "@types/bindings": "^1.5.0"
+    "@types/bindings": "^1.5.0",
+    "@bugsnag/electron-test-helpers": "^7.19.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.9.2"

--- a/packages/plugin-electron-client-state-persistence/test/client-state-persistence.test.ts
+++ b/packages/plugin-electron-client-state-persistence/test/client-state-persistence.test.ts
@@ -1,114 +1,94 @@
-import Client from '@bugsnag/core/client'
 import { plugin } from '../'
-import { Breadcrumb, Logger } from '@bugsnag/core'
+import { Breadcrumb } from '@bugsnag/core'
 import stateManager from '@bugsnag/plugin-electron-client-state-manager'
+import { makeClientForPlugin } from '@bugsnag/electron-test-helpers'
+
+const schema = {
+  enabledErrorTypes: {
+    defaultValue: () => ({
+      unhandledExceptions: true,
+      unhandledRejections: true,
+      nativeCrashes: true
+    }),
+    allowPartialObject: true,
+    validate: value => true
+  }
+}
+
+function makeClient (NativeClient: object, config?: object) {
+  return makeClientForPlugin({ plugins: [stateManager, plugin(NativeClient)], schema, config })
+}
 
 describe('plugin: electron client sync', () => {
   it('updates context', done => {
-    const c = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({
-          updateContext: (update: any) => {
-            expect(update).toBe('1234')
-            done()
-          }
-        })
-      ]
+    const { client } = makeClient({
+      updateContext: (update: any) => {
+        expect(update).toBe('1234')
+        done()
+      }
     })
-    c.setContext('1234')
+    client.setContext('1234')
   })
 
   it('updates metadata', done => {
-    const c = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({
-          updateMetadata: (key: string, updates: any) => {
-            expect(key).toBe('widget')
-            expect(updates).toEqual({
-              id: '14',
-              count: 340
-            })
-            done()
-          }
+    const { client } = makeClient({
+      updateMetadata: (key: string, updates: any) => {
+        expect(key).toBe('widget')
+        expect(updates).toEqual({
+          id: '14',
+          count: 340
         })
-      ]
+        done()
+      }
     })
-    c.addMetadata('widget', { id: '14', count: 340 })
-    expect(c.getMetadata('widget')).toEqual({ id: '14', count: 340 })
+    client.addMetadata('widget', { id: '14', count: 340 })
+    expect(client.getMetadata('widget')).toEqual({ id: '14', count: 340 })
   })
 
   it('clears metadata', done => {
-    const c = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({
-          addMetadata: () => {},
-          clearMetadata: () => {}
-        })
-      ]
+    const { client } = makeClient({
+      addMetadata: () => {},
+      clearMetadata: () => {}
     })
-    c.addMetadata('widget', { id: '14', count: 340 })
-    expect(c.getMetadata('widget')).toEqual({ id: '14', count: 340 })
-    c.clearMetadata('widget', 'count')
-    expect(c.getMetadata('widget', 'count')).toBeUndefined()
-    c.clearMetadata('widget')
-    expect(c.getMetadata('widget')).toBeUndefined()
+    client.addMetadata('widget', { id: '14', count: 340 })
+    expect(client.getMetadata('widget')).toEqual({ id: '14', count: 340 })
+    client.clearMetadata('widget', 'count')
+    expect(client.getMetadata('widget', 'count')).toBeUndefined()
+    client.clearMetadata('widget')
+    expect(client.getMetadata('widget')).toBeUndefined()
     done()
   })
 
   it('updates user', done => {
-    const c = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({
-          updateUser: (id: string, email: string, name: string) => {
-            expect(id).toBe('1234')
-            expect(name).toBe('Ben')
-            expect(email).toBe('user@example.com')
-            done()
-          }
-        })
-      ]
+    const { client } = makeClient({
+      updateUser: (id: string, email: string, name: string) => {
+        expect(id).toBe('1234')
+        expect(name).toBe('Ben')
+        expect(email).toBe('user@example.com')
+        done()
+      }
     })
-    c.setUser('1234', 'user@example.com', 'Ben')
-    expect(c.getUser()).toEqual({ id: '1234', name: 'Ben', email: 'user@example.com' })
+    client.setUser('1234', 'user@example.com', 'Ben')
+    expect(client.getUser()).toEqual({ id: '1234', name: 'Ben', email: 'user@example.com' })
   })
 
   it('syncs breadcrumbs', (done) => {
-    const c = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({
-          leaveBreadcrumb: ({ message, metadata, type, timestamp }: Breadcrumb) => {
-            expect(message).toBe('Spin')
-            expect(type).toBe('manual')
-            expect(metadata).toEqual({ direction: 'ccw', deg: '90' })
-            expect(timestamp).toBeTruthy()
-            done()
-          }
-        })
-      ]
+    const { client } = makeClient({
+      leaveBreadcrumb: ({ message, metadata, type, timestamp }: Breadcrumb) => {
+        expect(message).toBe('Spin')
+        expect(type).toBe('manual')
+        expect(metadata).toEqual({ direction: 'ccw', deg: '90' })
+        expect(timestamp).toBeTruthy()
+        done()
+      }
     })
-    c.leaveBreadcrumb('Spin', { direction: 'ccw', deg: '90' })
+    client.leaveBreadcrumb('Spin', { direction: 'ccw', deg: '90' })
   })
 
   it('does not sync breadcrumbs that are cancelled by an onBreadcrumb callback', () => {
     const NativeClient = { leaveBreadcrumb: jest.fn() }
 
-    const client = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin(NativeClient)
-      ]
-    })
+    const { client } = makeClient(NativeClient)
 
     client.addOnBreadcrumb(breadcrumb => {
       if (breadcrumb.message === 'skip me') {
@@ -138,13 +118,7 @@ describe('plugin: electron client sync', () => {
   it('updates feature flags', () => {
     const updateFeatureFlags = jest.fn()
 
-    const client = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({ updateFeatureFlags })
-      ]
-    })
+    const { client } = makeClient({ updateFeatureFlags })
 
     client.addFeatureFlag('a', 'b')
     client.addFeatureFlags([{ name: 'c', variant: null }, { name: 'd', variant: 'e' }])
@@ -163,13 +137,7 @@ describe('plugin: electron client sync', () => {
   it('clears a single feature flag', () => {
     const updateFeatureFlags = jest.fn()
 
-    const client = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({ updateFeatureFlags })
-      ]
-    })
+    const { client } = makeClient({ updateFeatureFlags })
 
     client.addFeatureFlag('a', 'b')
     client.addFeatureFlags([{ name: 'c', variant: null }, { name: 'd', variant: 'e' }])
@@ -193,13 +161,7 @@ describe('plugin: electron client sync', () => {
   it('clears all feature flags', () => {
     const updateFeatureFlags = jest.fn()
 
-    const client = new Client({
-      apiKey: 'api_key',
-      plugins: [
-        stateManager,
-        plugin({ updateFeatureFlags })
-      ]
-    })
+    const { client } = makeClient({ updateFeatureFlags })
 
     client.addFeatureFlag('a', 'b')
     client.addFeatureFlags([{ name: 'c', variant: null }, { name: 'd', variant: 'e' }])
@@ -217,81 +179,113 @@ describe('plugin: electron client sync', () => {
     expect(updateFeatureFlags).toHaveBeenNthCalledWith(3, [])
   })
 
-  function loggingClient (NativeClient: object): [Client, Logger] {
-    const logger = {
-      debug: jest.fn(),
-      warn: jest.fn(),
-      info: jest.fn(),
-      error: jest.fn()
-    }
-    const client = new Client({
-      apiKey: 'api_key',
-      plugins: [stateManager, plugin(NativeClient)],
-      logger
-    })
-    return [client, logger]
-  }
-
   it('logs errors thrown from updating context', () => {
-    const [client, logger] = loggingClient({
+    const { client } = makeClient({
       updateContext: () => { throw new Error('wrong thing') }
     })
+
     client.setContext('some invalid context')
-    const error = logger.error as jest.Mock<Function>
+    const error = client._logger.error as jest.Mock<Function>
     expect(error.mock.calls.length).toBe(1)
     expect(error.mock.calls[0][0].message).toContain('wrong thing')
   })
 
   it('logs errors thrown from adding breadcrumbs', () => {
-    const [client, logger] = loggingClient({
+    const { client } = makeClient({
       leaveBreadcrumb: () => { throw new Error('wrong thing') }
     })
     client.leaveBreadcrumb('Spin', { direction: 'ccw', deg: '90' })
-    const error = logger.error as jest.Mock<Function>
+    const error = client._logger.error as jest.Mock<Function>
     expect(error.mock.calls.length).toBe(1)
     expect(error.mock.calls[0][0].message).toContain('wrong thing')
   })
 
   it('logs errors thrown from adding metadata', () => {
-    const [client, logger] = loggingClient({
+    const { client } = makeClient({
       updateMetadata: () => { throw new Error('wrong thing') }
     })
     client.addMetadata('widget', { id: '14', count: 340 })
-    const error = logger.error as jest.Mock<Function>
+    const error = client._logger.error as jest.Mock<Function>
     expect(error.mock.calls.length).toBe(1)
     expect(error.mock.calls[0][0].message).toContain('wrong thing')
   })
 
   it('logs errors thrown from clearing metadata', () => {
-    const [client, logger] = loggingClient({
+    const { client } = makeClient({
       updateMetadata: () => { throw new Error('wrong thing') }
     })
     client.clearMetadata('widget')
-    const error = logger.error as jest.Mock<Function>
+    const error = client._logger.error as jest.Mock<Function>
     expect(error.mock.calls.length).toBe(1)
     expect(error.mock.calls[0][0].message).toContain('wrong thing')
   })
 
   it('logs errors thrown from updating user info', () => {
-    const [client, logger] = loggingClient({
+    const { client } = makeClient({
       updateUser: () => { throw new Error('wrong thing') }
     })
     client.setUser('404', 'tim@example.com', undefined)
-    const error = logger.error as jest.Mock<Function>
+    const error = client._logger.error as jest.Mock<Function>
     expect(error.mock.calls.length).toBe(1)
     expect(error.mock.calls[0][0].message).toContain('wrong thing')
   })
 
   it('logs errors thrown from updating feature flags', () => {
-    const [client, logger] = loggingClient({
+    const { client } = makeClient({
       updateFeatureFlags: () => { throw new Error('wrong thing') }
     })
 
     client.addFeatureFlag('a', 'b')
 
-    const error = logger.error as jest.Mock<Function>
+    const error = client._logger.error as jest.Mock<Function>
 
     expect(error.mock.calls.length).toBe(1)
     expect(error.mock.calls[0][0].message).toContain('wrong thing')
+  })
+
+  it('does not sync data to the NativeClient if enabledErrorTypes.nativeCrashes is disabled', () => {
+    const NativeClient = {
+      leaveBreadcrumb: jest.fn(),
+      updateUser: jest.fn(),
+      updateContext: jest.fn(),
+      updateMetadata: jest.fn(),
+      updateFeatureFlags: jest.fn()
+    }
+
+    const { client } = makeClient(NativeClient, { enabledErrorTypes: { nativeCrashes: false } })
+    client.leaveBreadcrumb('no sync')
+    client.setUser('1234', 'user@example.com', 'Ben')
+    client.setContext('no sync')
+    client.addMetadata('no sync', { id: '14', count: 340 })
+    client.addFeatureFlag('no', 'sync')
+
+    expect(NativeClient.leaveBreadcrumb).not.toHaveBeenCalled()
+    expect(NativeClient.updateUser).not.toHaveBeenCalled()
+    expect(NativeClient.updateContext).not.toHaveBeenCalled()
+    expect(NativeClient.updateMetadata).not.toHaveBeenCalled()
+    expect(NativeClient.updateFeatureFlags).not.toHaveBeenCalled()
+  })
+
+  it('does not sync data to the NativeClient if autoDetectErrors is disabled', () => {
+    const NativeClient = {
+      leaveBreadcrumb: jest.fn(),
+      updateUser: jest.fn(),
+      updateContext: jest.fn(),
+      updateMetadata: jest.fn(),
+      updateFeatureFlags: jest.fn()
+    }
+
+    const { client } = makeClient(NativeClient, { autoDetectErrors: false })
+    client.leaveBreadcrumb('no sync')
+    client.setUser('1234', 'user@example.com', 'Ben')
+    client.setContext('no sync')
+    client.addMetadata('no sync', { id: '14', count: 340 })
+    client.addFeatureFlag('no', 'sync')
+
+    expect(NativeClient.leaveBreadcrumb).not.toHaveBeenCalled()
+    expect(NativeClient.updateUser).not.toHaveBeenCalled()
+    expect(NativeClient.updateContext).not.toHaveBeenCalled()
+    expect(NativeClient.updateMetadata).not.toHaveBeenCalled()
+    expect(NativeClient.updateFeatureFlags).not.toHaveBeenCalled()
   })
 })

--- a/packages/plugin-electron-device/device.js
+++ b/packages/plugin-electron-device/device.js
@@ -7,13 +7,21 @@ const platformToOs = new Map([
 // electron memory APIs are documented as KB but are actually KiB
 const kibibytesToBytes = kibibytes => kibibytes * 1024
 
-const createDeviceUpdater = (client, NativeClient, device) => newProperties => {
-  Object.assign(device, newProperties)
+const isNativeClientEnabled = client => client._config.autoDetectErrors && client._config.enabledErrorTypes.nativeCrashes
 
-  try {
-    NativeClient.setDevice(device)
-  } catch (err) {
-    client._logger.error(err)
+const createDeviceUpdater = (client, NativeClient, device) => {
+  if (!isNativeClientEnabled(client)) {
+    return newProperties => Object.assign(device, newProperties)
+  }
+
+  return newProperties => {
+    Object.assign(device, newProperties)
+
+    try {
+      NativeClient.setDevice(device)
+    } catch (err) {
+      client._logger.error(err)
+    }
   }
 }
 

--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -283,7 +283,7 @@ describe.skip('plugin: electron net breadcrumbs', () => {
 })
 
 function makeClient ({ config = {}, schema = {} } = {}) {
-  return makeClientForPlugin({ config, schema, plugin: plugin(net) }).client
+  return makeClientForPlugin({ config, schema, plugins: [plugin(net)] }).client
 }
 
 const defaultRequestHandler = (statusCode: number) => (req: IncomingMessage, res: ServerResponse) => {

--- a/packages/plugin-electron-power-monitor-breadcrumbs/test/power-monitor-breadcrumbs.test.ts
+++ b/packages/plugin-electron-power-monitor-breadcrumbs/test/power-monitor-breadcrumbs.test.ts
@@ -16,7 +16,7 @@ describe('plugin: electron power monitor breadcrumbs', () => {
 
   it.each(events)('leaves a breadcrumb for the "%s" event', (event, expectedMessage) => {
     const powerMonitor = makePowerMonitor()
-    const { client } = makeClientForPlugin({ plugin: plugin(powerMonitor) })
+    const { client } = makeClientForPlugin({ plugins: [plugin(powerMonitor)] })
 
     powerMonitor._emit(event)
 
@@ -28,7 +28,7 @@ describe('plugin: electron power monitor breadcrumbs', () => {
   it.each(events)('honours enabledBreadcrumbTypes for "%s"', (event, expectedMessage) => {
     const powerMonitor = makePowerMonitor()
     const { client } = makeClientForPlugin({
-      plugin: plugin(powerMonitor),
+      plugins: [plugin(powerMonitor)],
       config: { enabledBreadcrumbTypes: [] }
     })
 
@@ -40,7 +40,7 @@ describe('plugin: electron power monitor breadcrumbs', () => {
   it.each(events)('works when enabledBreadcrumbTypes=null for "%s"', (event, expectedMessage) => {
     const powerMonitor = makePowerMonitor()
     const { client } = makeClientForPlugin({
-      plugin: plugin(powerMonitor),
+      plugins: [plugin(powerMonitor)],
       config: { enabledBreadcrumbTypes: null }
     })
 

--- a/packages/plugin-electron-preload-error/test/preload-error.test-main.ts
+++ b/packages/plugin-electron-preload-error/test/preload-error.test-main.ts
@@ -117,7 +117,7 @@ describe('plugin: preload-error', () => {
 })
 
 function makeClient ({ config = {}, schema = {}, _app = app } = {}) {
-  const { client } = makeClientForPlugin({ config, schema, plugin: plugin(_app) })
+  const { client } = makeClientForPlugin({ config, schema, plugins: [plugin(_app)] })
   client._setDelivery(() => ({ sendEvent: jest.fn(), sendSession: () => {} }))
 
   return client

--- a/packages/plugin-electron-renderer-event-data/test/renderer-event-data.test.ts
+++ b/packages/plugin-electron-renderer-event-data/test/renderer-event-data.test.ts
@@ -56,5 +56,5 @@ describe('plugin: electron renderer event data', () => {
   })
 })
 
-const makeClient = payloadInfo => makeClientForPlugin({ plugin: plugin(makeIpcRenderer(payloadInfo)) })
+const makeClient = payloadInfo => makeClientForPlugin({ plugins: [plugin(makeIpcRenderer(payloadInfo))] })
 const makeIpcRenderer = payloadInfo => ({ getPayloadInfo: async () => payloadInfo })

--- a/packages/plugin-electron-renderer-strip-project-root/test/strip-project-root.test.ts
+++ b/packages/plugin-electron-renderer-strip-project-root/test/strip-project-root.test.ts
@@ -55,7 +55,7 @@ describe('plugin: stack frame file trimmer', () => {
 async function sendEvent (initialStackframe: any, projectRoot: string|null = null) {
   const config = { projectRoot }
   const schema = { projectRoot: { defaultValue: () => null, validate: () => true } }
-  const { client, sendEvent } = makeClientForPlugin({ config, schema, plugin })
+  const { client, sendEvent } = makeClientForPlugin({ config, schema, plugins: [plugin] })
   client.addOnError((event: Event) => {
     event.errors[0].stacktrace = [initialStackframe]
   }, true)

--- a/packages/plugin-electron-screen-breadcrumbs/test/screen-breadcrumbs.test.ts
+++ b/packages/plugin-electron-screen-breadcrumbs/test/screen-breadcrumbs.test.ts
@@ -5,7 +5,7 @@ import plugin from '../'
 describe('plugin: electron screen breadcrumbs', () => {
   it('leaves a breadcrumb for the "display-added" event', () => {
     const screen = makeScreen()
-    const { client } = makeClientForPlugin({ plugin: plugin(screen) })
+    const { client } = makeClientForPlugin({ plugins: [plugin(screen)] })
 
     const display = makeDisplay({ id: 1234 })
 
@@ -21,7 +21,7 @@ describe('plugin: electron screen breadcrumbs', () => {
 
   it('leaves a breadcrumb for the "display-removed" event', () => {
     const screen = makeScreen()
-    const { client } = makeClientForPlugin({ plugin: plugin(screen) })
+    const { client } = makeClientForPlugin({ plugins: [plugin(screen)] })
 
     const display = makeDisplay({ id: 1234 })
 
@@ -46,7 +46,7 @@ describe('plugin: electron screen breadcrumbs', () => {
     ]
   ])('leaves a breadcrumb for the "display-metrics-changed" event with changedMetrics = %p', (changedMetrics, message) => {
     const screen = makeScreen()
-    const { client } = makeClientForPlugin({ plugin: plugin(screen) })
+    const { client } = makeClientForPlugin({ plugins: [plugin(screen)] })
 
     const display = makeDisplay({ id: 23456 })
 
@@ -61,7 +61,7 @@ describe('plugin: electron screen breadcrumbs', () => {
   it('honours enabledBreadcrumbTypes', () => {
     const screen = makeScreen()
     const { client } = makeClientForPlugin({
-      plugin: plugin(screen),
+      plugins: [plugin(screen)],
       config: { enabledBreadcrumbTypes: [] }
     })
 
@@ -77,7 +77,7 @@ describe('plugin: electron screen breadcrumbs', () => {
   it('works when enabledBreadcrumbTypes=null', () => {
     const screen = makeScreen()
     const { client } = makeClientForPlugin({
-      plugin: plugin(screen),
+      plugins: [plugin(screen)],
       config: { enabledBreadcrumbTypes: null }
     })
 
@@ -92,7 +92,7 @@ describe('plugin: electron screen breadcrumbs', () => {
 
   it('anonymises IDs correctly', () => {
     const screen = makeScreen()
-    const { client } = makeClientForPlugin({ plugin: plugin(screen) })
+    const { client } = makeClientForPlugin({ plugins: [plugin(screen)] })
 
     const display = makeDisplay({ id: 1234 })
 

--- a/packages/plugin-electron-session/session.js
+++ b/packages/plugin-electron-session/session.js
@@ -3,36 +3,40 @@ const Session = require('@bugsnag/core/session')
 
 const SESSION_TIMEOUT_MS = 60 * 1000
 
+const isNativeClientEnabled = client => client._config.autoDetectErrors && client._config.enabledErrorTypes.nativeCrashes
+
 module.exports = (app, BrowserWindow, NativeClient) => ({
   load (client) {
-    // Ensure native session kept in sync with session changes
-    const oldTrack = Session.prototype._track
-    Session.prototype._track = function (...args) {
-      const result = oldTrack.apply(this, args)
-      NativeClient.setSession(serializeForNativeEvent(this))
-      return result
-    }
-
     // load the actual session delegate from plugin-browser-session
     sessionDelegate.load(client)
 
-    // Override the delegate to perform electron-specific synchronization
-    const defaultDelegate = client._sessionDelegate
-    client._sessionDelegate = {
-      startSession: (client, session) => {
-        const result = defaultDelegate.startSession(client, session)
-        NativeClient.setSession(serializeForNativeEvent(client._session))
+    if (isNativeClientEnabled(client)) {
+    // Ensure native session kept in sync with session changes
+      const oldTrack = Session.prototype._track
+      Session.prototype._track = function (...args) {
+        const result = oldTrack.apply(this, args)
+        NativeClient.setSession(serializeForNativeEvent(this))
         return result
-      },
-      resumeSession: (client) => {
-        const result = defaultDelegate.resumeSession(client)
-        NativeClient.setSession(serializeForNativeEvent(client._session))
-        return result
-      },
-      pauseSession: (client) => {
-        const result = defaultDelegate.pauseSession(client)
-        NativeClient.setSession(serializeForNativeEvent(client._session))
-        return result
+      }
+
+      // Override the delegate to perform electron-specific synchronization
+      const defaultDelegate = client._sessionDelegate
+      client._sessionDelegate = {
+        startSession: (client, session) => {
+          const result = defaultDelegate.startSession(client, session)
+          NativeClient.setSession(serializeForNativeEvent(client._session))
+          return result
+        },
+        resumeSession: (client) => {
+          const result = defaultDelegate.resumeSession(client)
+          NativeClient.setSession(serializeForNativeEvent(client._session))
+          return result
+        },
+        pauseSession: (client) => {
+          const result = defaultDelegate.pauseSession(client)
+          NativeClient.setSession(serializeForNativeEvent(client._session))
+          return result
+        }
       }
     }
 


### PR DESCRIPTION
## Goal

If either of `enabledErrorTypes.nativeCrashes` or `autoDetectErrors` are disabled, we don't install the sync layer (`NativeClient.install`) but still call all the methods to sync state to the native client. 

Currently this logs an error message: `Sync layer is not installed, first call install()`, which isn't very useful as users can't call `NativeClient.install`

This PR updates each of the plugins that sync to the native layer to ensure that they do not sync to the native layer if those config options are disabled. This affects:
- `plugin-electron-client-state-persistence`
- `plugin-electron-app`
- `plugin-electron-device`
- `plugin-electron-session`

## Testing

Added unit tests to assert that the native sync methods are not called when the relevant config options are disabled.

Also updated the `makeClientForPlugin` function in `electron-test-helpers` to support creating a client with an array of plugins - this allows the `client-state-persistence` unit tests to make use of the test helper since the plugin depends on the `client-state-manager` plugin being loaded.