### PR TITLE
Build test fixtures with NDK for all architectures

### DIFF
--- a/test/react-native-cli/features/fixtures/rn0_60/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_60/android/app/build.gradle
@@ -135,7 +135,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native-cli/features/fixtures/rn0_61/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_61/android/app/build.gradle
@@ -135,7 +135,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native-cli/features/fixtures/rn0_62/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_62/android/app/build.gradle
@@ -136,7 +136,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native-cli/features/fixtures/rn0_63/android/app/build.gradle
+++ b/test/react-native-cli/features/fixtures/rn0_63/android/app/build.gradle
@@ -136,7 +136,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native/TESTING.md
+++ b/test/react-native/TESTING.md
@@ -127,7 +127,7 @@ Remove
     1. In app/build.gradle:
         - add Kotlin
         - add Bugsnag
-        - add NDK `abiFilters "arm64-v8a", "x86"`
+        - add NDK `abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"`
     1. In gradle.properties, set org.gradle.jvmargs=-Xmx4096m  
     1. In app/proguard-rules.pro, add:
         ```

--- a/test/react-native/features/fixtures/rn0.60/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.60/android/app/build.gradle
@@ -136,7 +136,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native/features/fixtures/rn0.66/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.66/android/app/build.gradle
@@ -139,7 +139,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native/features/fixtures/rn0.67/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.67/android/app/build.gradle
@@ -139,7 +139,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     splits {

--- a/test/react-native/features/fixtures/rn0.68-hermes/android/app/build.gradle
+++ b/test/react-native/features/fixtures/rn0.68-hermes/android/app/build.gradle
@@ -144,7 +144,7 @@ android {
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         ndk {
-            abiFilters "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
 
         if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
## Goal

Ensure that the e2e test fixtures can run on any of the phone in our device groups.

## Changeset

Gradle scripts updated to specify all ABIs for the NDK.

## Testing

Covered by a full CI run and I've also verified that the build test fixtures run on the phone that first identified the issue (Samsung Galaxy A6 SM-A600FN).