### PR TITLE
Track patched XHR requests for network breadcrumbs

### DIFF
--- a/test/browser/features/fixtures/network_breadcrumbs/script/xhr_failure.html
+++ b/test/browser/features/fixtures/network_breadcrumbs/script/xhr_failure.html
@@ -32,7 +32,7 @@
     <pre id="bugsnag-test-should-run">PENDING</pre>
     <script>
         var el = document.getElementById('bugsnag-test-should-run')
-        el.textContent = el.innerText = 'XMLHttpRequest' in window
+        el.textContent = el.innerText = 'XMLHttpRequest' in window && 'WeakMap' in window
             ? 'YES'
             : 'NO'
     </script>

--- a/test/browser/features/fixtures/network_breadcrumbs/script/xhr_success.html
+++ b/test/browser/features/fixtures/network_breadcrumbs/script/xhr_success.html
@@ -31,7 +31,7 @@
     <pre id="bugsnag-test-should-run">PENDING</pre>
     <script>
         var el = document.getElementById('bugsnag-test-should-run')
-        el.textContent = el.innerText = 'XMLHttpRequest' in window
+        el.textContent = el.innerText = 'XMLHttpRequest' in window && 'WeakMap' in window
             ? 'YES'
             : 'NO'
     </script>


### PR DESCRIPTION
## Goal

Fixes two issues with the current xhr monkey patch for network breadcrumbs:

- previously `XMLHttpRequest.send` was overridden on the instance in order to record the duration of the request. However this causes a potential incompatibility issue with other libraries that may be monkey patching XHR and calling `this.send` - as observed with [msw](https://github.com/mswjs/msw/blob/ea28bd9ad2efe0918660cd37054f21883caa3d30/src/browser/utils/deferNetworkRequestsUntil.ts#L8-L20), where both libraries call into each other causing an infinite loop.
- If an XHR instance is re-used (i.e. `open` is called more than once) event listeners from previous uses were not removed, resulting in duplicate breadcrumbs being logged.

## Design

`send` is now overridden on the prototype rather than the instance, and WeakMaps are used to store metadata and event listeners associated with tracked XHR instances. 

The `open` override now just adds the request instance to a weak map along with it's method and url. When `send` is called, the request metadata and any existing event listeners are retrieved - if there are previous event listeners for the request these are removed before new ones are added.

XHR is not monkey-patched (and XHR breadcrumbs are disabled) if WeakMap is not available - this affects IE<=10.

## Testing

Updated unit tests and relied on existing e2e tests.