### PR TITLE
Add server reset to skipping scenario

### DIFF
--- a/test/browser/features/steps/browser_steps.rb
+++ b/test/browser/features/steps/browser_steps.rb
@@ -26,7 +26,10 @@ When('the test should run in this browser') do
     Maze.driver.find_element(id: 'bugsnag-test-should-run') &&
         Maze.driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
   }
-  skip_this_scenario if Maze.driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
+  if Maze.driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
+    Maze::Server.reset!
+    skip_this_scenario
+  end
 end
 
 When('I let the test page run for up to {int} seconds') do |n|


### PR DESCRIPTION
## Goal

Implementing a quick suggested fix by @twometresteve that ensures the maze server is properly reset when skipping a test scenario due to feature being unsupported by the browser. I've run it several times on CI and it's passed with no issues.