### PR TITLE
[PLAT-11476] Publish xcprivacy file from vendored bugsnag-cocoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - (plugin-vue) Handle updated Vue error info URL [#2068](https://github.com/bugsnag/bugsnag-js/pull/2068)
+- (react-native) Publish xcprivacy file from vendored bugsnag-cocoa [#2072](https://github.com/bugsnag/bugsnag-js/pull/2072)
 
 ## v7.22.3 (2024-01-03)
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,6 +38,7 @@
     "ios/vendor/bugsnag-cocoa/Bugsnag.xcodeproj",
     "ios/vendor/bugsnag-cocoa/Framework/{Info.plist,module.modulemap}",
     "ios/vendor/bugsnag-cocoa/Bugsnag.podspec.json",
+    "ios/vendor/bugsnag-cocoa/Bugsnag/resources/PrivacyInfo.xcprivacy",
     "BugsnagReactNative.podspec",
     "react-native.config.js",
     "bugsnag-react-native.gradle",


### PR DESCRIPTION
## Goal

Ensure the `bugsnag-cocoa` privacy manifest is shipped as part of the vendored SDK in `@bugsnag/react-native`