### PR TITLE
Use Xcode 14 to build RN test fixtures

### DIFF
--- a/.buildkite/full/pipeline.full.yml
+++ b/.buildkite/full/pipeline.full.yml
@@ -25,8 +25,10 @@ steps:
 
   #
   # Trigger Expo pipelines
+  # TODO: Skip pending PLAT-11676 and PLAT-11745
   #
   - label: "@bugsnag/expo latest"
+    skip: PLAT-11676 and PLAT-11745
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:

--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -157,7 +157,7 @@ steps:
         env:
           DEBUG: true
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0_66.ipa
         commands:
           - test/react-native-cli/scripts/init-and-build-test.sh rn0_66
@@ -174,7 +174,7 @@ steps:
         env:
           DEBUG: true
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0_67.ipa
         commands:
           - test/react-native-cli/scripts/init-and-build-test.sh rn0_67
@@ -191,7 +191,7 @@ steps:
         env:
           DEBUG: true
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0_69.ipa
         commands:
           - test/react-native-cli/scripts/init-and-build-test.sh rn0_69

--- a/.buildkite/full/react-native-ios-pipeline.full.yml
+++ b/.buildkite/full/react-native-ios-pipeline.full.yml
@@ -14,7 +14,7 @@ steps:
         env:
           REACT_NATIVE_VERSION: rn0.66
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0.66.ipa
         commands:
           - npm run test:build-react-native-ios
@@ -31,7 +31,7 @@ steps:
         env:
           REACT_NATIVE_VERSION: rn0.67
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0.67.ipa
         commands:
           - npm run test:build-react-native-ios
@@ -48,7 +48,7 @@ steps:
         env:
           REACT_NATIVE_VERSION: rn0.68-hermes
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0.68-hermes.ipa
         commands:
           - npm run test:build-react-native-ios
@@ -65,7 +65,7 @@ steps:
         env:
           REACT_NATIVE_VERSION: rn0.69
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/rn0.69.ipa
         commands:
           - npm run test:build-react-native-ios
@@ -122,7 +122,7 @@ steps:
           JS_SOURCE_DIR: "react_navigation_js"
           ARTEFACT_NAME: "r_navigation_0.69"
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/r_navigation_0.69.ipa
         commands:
           - npm run test:build-react-native-ios
@@ -143,7 +143,7 @@ steps:
           JS_SOURCE_DIR: "react_native_navigation_js"
           ARTEFACT_NAME: "r_native_navigation_0.66"
           LANG: "en_US.UTF-8"
-          DEVELOPER_DIR: "/Applications/Xcode13.app"
+          DEVELOPER_DIR: "/Applications/Xcode14.app"
         artifact_paths: build/r_native_navigation_0.66.ipa
         commands:
           - npm run test:build-react-native-ios

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,8 +7,6 @@ steps:
     timeout_in_minutes: 20
     agents:
       queue: macos-12-arm
-    env:
-      DEVELOPER_DIR: /Applications/Xcode13.4.app
     command: scripts/license_finder.sh
 
   #

--- a/test/react-native-cli/features/fixtures/rn0_66/ios/Podfile
+++ b/test/react-native-cli/features/fixtures/rn0_66/ios/Podfile
@@ -20,5 +20,13 @@ target 'rn0_66' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native-cli/features/fixtures/rn0_67/ios/Podfile
+++ b/test/react-native-cli/features/fixtures/rn0_67/ios/Podfile
@@ -20,5 +20,13 @@ target 'rn0_67' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native-cli/features/fixtures/rn0_67_hermes/ios/Podfile
+++ b/test/react-native-cli/features/fixtures/rn0_67_hermes/ios/Podfile
@@ -20,5 +20,13 @@ target 'rn0_67_hermes' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native-cli/features/fixtures/rn0_69/ios/Podfile
+++ b/test/react-native-cli/features/fixtures/rn0_69/ios/Podfile
@@ -27,5 +27,13 @@ target 'rn0_69' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native/features/fixtures/rn0.66/ios/Podfile
+++ b/test/react-native/features/fixtures/rn0.66/ios/Podfile
@@ -20,5 +20,13 @@ target 'reactnative' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native/features/fixtures/rn0.67/ios/Podfile
+++ b/test/react-native/features/fixtures/rn0.67/ios/Podfile
@@ -20,5 +20,13 @@ target 'reactnative' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native/features/fixtures/rn0.68-hermes/ios/Podfile
+++ b/test/react-native/features/fixtures/rn0.68-hermes/ios/Podfile
@@ -27,5 +27,13 @@ target 'reactnative' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end

--- a/test/react-native/features/fixtures/rn0.69/ios/Podfile
+++ b/test/react-native/features/fixtures/rn0.69/ios/Podfile
@@ -27,5 +27,13 @@ target 'reactnative' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    installer.generated_projects.each do |project|
+      project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['DEVELOPMENT_TEAM'] = '7W9PZ27Y5F'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Goal

Build the React Native test fixtures for iOS using Xcode 14, the current earliest version of Xcode that can be used to release apps in the App Store.

## Testing

Covered by a full CI run.