### PR TITLE
make types for Bugsnag.start metadata consistent with addMetadata types

### DIFF
--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -162,7 +162,9 @@ describe('browser notifier', () => {
       maxBreadcrumbs: 20,
       enabledBreadcrumbTypes: ['manual', 'log', 'request'],
       user: null,
-      metadata: {},
+      metadata: {
+        debug: { foo: 'bar' }
+      },
       logger: undefined,
       redactedKeys: ['foo', /bar/],
       collectUserIp: true,
@@ -179,6 +181,7 @@ describe('browser notifier', () => {
       }
       expect(event.breadcrumbs.length).toBe(0)
       expect(event.originalError.message).toBe('123')
+      expect(event.getMetadata('debug')).toEqual({ foo: 'bar' })
       done()
     })
   })

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -23,7 +23,7 @@ export interface Config {
   onSession?: OnSessionCallback | OnSessionCallback[]
   logger?: Logger | null
   maxBreadcrumbs?: number
-  metadata?: { [key: string]: any }
+  metadata?: { [section: string]: { [key: string]: any } }
   featureFlags?: FeatureFlag[]
   releaseStage?: string
   plugins?: Plugin[]


### PR DESCRIPTION
## Goal

- Make the types for when setting metadata using `Bugsnag.start({ metadata })` consistent with `Event.addMetadata`

## Testing

- unit test