### PR TITLE
Export BrowserBugsnagStatic

### DIFF
--- a/packages/browser/types/bugsnag.d.ts
+++ b/packages/browser/types/bugsnag.d.ts
@@ -7,7 +7,7 @@ interface BrowserConfig extends Config {
   trackInlineScripts?: boolean
 }
 
-interface BrowserBugsnagStatic extends BugsnagStatic {
+export interface BrowserBugsnagStatic extends BugsnagStatic {
   start(apiKeyOrOpts: string | BrowserConfig): Client
   createClient(apiKeyOrOpts: string | BrowserConfig): Client
 }


### PR DESCRIPTION
- Allows the correct type to be imported in projects which use bugsnag

