### PR TITLE
Preventing prototype pollution vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changed
 
 - (metadata-delegate) Preventing prototype pollution vulnerabilities [#2115](https://github.com/bugsnag/bugsnag-js/pull/2115)
-
 - (plugin-interaction-breadcrumbs) Improved performance of click event breadcrumbs [#2094](https://github.com/bugsnag/bugsnag-js/pull/2094)
 
 ## v7.22.6 (2024-03-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- (metadata-delegate) Preventing prototype pollution vulnerabilities
+
+## TBD
+
+### Changed
+
 - (plugin-interaction-breadcrumbs) Improved performance of click event breadcrumbs [#2094](https://github.com/bugsnag/bugsnag-js/pull/2094)
 
 ## v7.22.6 (2024-03-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - (metadata-delegate) Preventing prototype pollution vulnerabilities [#2115](https://github.com/bugsnag/bugsnag-js/pull/2115)
 
-## TBD
-
-### Changed
-
 - (plugin-interaction-breadcrumbs) Improved performance of click event breadcrumbs [#2094](https://github.com/bugsnag/bugsnag-js/pull/2094)
 
 ## v7.22.6 (2024-03-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- (metadata-delegate) Preventing prototype pollution vulnerabilities
+- (metadata-delegate) Preventing prototype pollution vulnerabilities [#2115](https://github.com/bugsnag/bugsnag-js/pull/2115)
 
 ## TBD
 

--- a/packages/core/lib/metadata-delegate.js
+++ b/packages/core/lib/metadata-delegate.js
@@ -14,6 +14,11 @@ const add = (state, section, keyOrObj, maybeVal) => {
   // exit if we don't have an updates object at this point
   if (!updates) return
 
+  // preventing the __proto__ property from being used as a key
+  if (section === '__proto__' || section === 'constructor' || section === 'prototype') {
+    return
+  }
+
   // ensure a section with this name exists
   if (!state[section]) state[section] = {}
 

--- a/packages/core/lib/metadata-delegate.js
+++ b/packages/core/lib/metadata-delegate.js
@@ -41,6 +41,11 @@ const clear = (state, section, key) => {
     return
   }
 
+  // preventing the __proto__ property from being used as a key
+  if (section === '__proto__' || section === 'constructor' || section === 'prototype') {
+    return
+  }
+
   // clear a single value from a section
   if (state[section]) {
     delete state[section][key]

--- a/packages/core/test/metadata-delegate.test.js
+++ b/packages/core/test/metadata-delegate.test.js
@@ -1,0 +1,37 @@
+import { add, clear } from '../lib/metadata-delegate'
+
+// it doesn't seem easy or even impossible to check whether __proto__ keys can be overwritten
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
+// so tests are only for prototype and constructor
+
+describe('metadata delegate', () => {
+  describe('clear', () => {
+    it('should not overwrite prototype keys', () => {
+      const state = {}
+
+      add(state, 'prototype', 'foo', 'bar')
+
+      clear(state, 'prototype', 'foo')
+
+      expect(state).toStrictEqual({
+        prototype: {
+          foo: 'bar'
+        }
+      })
+    })
+
+    it('should not overwrite constructor keys', () => {
+      const state = {}
+
+      add(state, 'constructor', 'foo', 'bar')
+
+      clear(state, 'constructor', 'foo')
+
+      expect(state).toEqual({
+        constructor: {
+          foo: 'bar'
+        }
+      })
+    })
+  })
+})

--- a/packages/core/test/metadata-delegate.test.js
+++ b/packages/core/test/metadata-delegate.test.js
@@ -15,7 +15,7 @@ describe('metadata delegate', () => {
         key: 'prototype',
         expected: {}
       }
-    ])('should not add constructor or prototype keys', ({ key, expected }) => {
+    ])('should not add $key keys', ({ key, expected }) => {
       const state = {}
       add(state, key, 'foo', 'bar')
       expect(state).toEqual(expected)
@@ -50,7 +50,7 @@ describe('metadata delegate', () => {
           }
         }
       }
-    ])('should not overwrite constructor or prototype keys', ({ key, state, expected }) => {
+    ])('should not overwrite $key keys', ({ key, state, expected }) => {
       clear(state, key, 'foo')
       expect(state).toEqual(expected)
     })

--- a/packages/core/test/metadata-delegate.test.js
+++ b/packages/core/test/metadata-delegate.test.js
@@ -23,7 +23,7 @@ describe('metadata delegate', () => {
           }
         }
       }
-    ])('should not overwrite constructor keys', ({ key, expected }) => {
+    ])('should not overwrite constructor or prototype keys', ({ key, expected }) => {
       const state = {}
 
       add(state, key, 'foo', 'bar')

--- a/packages/core/test/metadata-delegate.test.js
+++ b/packages/core/test/metadata-delegate.test.js
@@ -5,10 +5,32 @@ import { add, clear } from '../lib/metadata-delegate'
 // so tests are only for prototype and constructor
 
 describe('metadata delegate', () => {
+  describe('add', () => {
+    it.each([
+      {
+        key: 'constructor',
+        expected: {}
+      },
+      {
+        key: 'prototype',
+        expected: {}
+      }
+    ])('should not add constructor or prototype keys', ({ key, expected }) => {
+      const state = {}
+      add(state, key, 'foo', 'bar')
+      expect(state).toEqual(expected)
+    })
+  })
+
   describe('clear', () => {
     it.each([
       {
         key: 'constructor',
+        state: {
+          constructor: {
+            foo: 'bar'
+          }
+        },
         expected: {
           constructor: {
             foo: 'bar'
@@ -17,19 +39,19 @@ describe('metadata delegate', () => {
       },
       {
         key: 'prototype',
+        state: {
+          prototype: {
+            foo: 'bar'
+          }
+        },
         expected: {
           prototype: {
             foo: 'bar'
           }
         }
       }
-    ])('should not overwrite constructor or prototype keys', ({ key, expected }) => {
-      const state = {}
-
-      add(state, key, 'foo', 'bar')
-
+    ])('should not overwrite constructor or prototype keys', ({ key, state, expected }) => {
       clear(state, key, 'foo')
-
       expect(state).toEqual(expected)
     })
   })

--- a/packages/core/test/metadata-delegate.test.js
+++ b/packages/core/test/metadata-delegate.test.js
@@ -6,32 +6,31 @@ import { add, clear } from '../lib/metadata-delegate'
 
 describe('metadata delegate', () => {
   describe('clear', () => {
-    it('should not overwrite prototype keys', () => {
+    it.each([
+      {
+        key: 'constructor',
+        expected: {
+          constructor: {
+            foo: 'bar'
+          }
+        }
+      },
+      {
+        key: 'prototype',
+        expected: {
+          prototype: {
+            foo: 'bar'
+          }
+        }
+      }
+    ])('should not overwrite constructor keys', ({ key, expected }) => {
       const state = {}
 
-      add(state, 'prototype', 'foo', 'bar')
+      add(state, key, 'foo', 'bar')
 
-      clear(state, 'prototype', 'foo')
+      clear(state, key, 'foo')
 
-      expect(state).toStrictEqual({
-        prototype: {
-          foo: 'bar'
-        }
-      })
-    })
-
-    it('should not overwrite constructor keys', () => {
-      const state = {}
-
-      add(state, 'constructor', 'foo', 'bar')
-
-      clear(state, 'constructor', 'foo')
-
-      expect(state).toEqual({
-        constructor: {
-          foo: 'bar'
-        }
-      })
+      expect(state).toEqual(expected)
     })
   })
 })


### PR DESCRIPTION
## Goal

Preventing the `__proto__` , `constructor` or `prototype` property from being used as a section in `clear` and `add` methods of metadata-delegate.js

## Changeset

Added condition if `__proto__ || constructor || prototype` tries to pass as a section in the `clear` or `add` method, it will not be executed. 

## Testing

Created unit tests for checking 'constructor' and 'prototype'. 
it doesn't seem easy to check whether __proto__ keys can be overwritten
