### PR TITLE
Modified the polynomial regular expression to remove the ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- (plugin-react) Modified the polynomial regular expression to remove the ambiguity
+- (plugin-react) Modified the polynomial regular expression to remove the ambiguity [#2135](https://github.com/bugsnag/bugsnag-js/pull/2135)
 
 ## [7.23.0] - 2024-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## [Unreleased]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changed
+
+- (plugin-react) Modified the polynomial regular expression to remove the ambiguity
+
 ## [7.23.0] - 2024-05-09
 
 ### Added

--- a/packages/plugin-react/src/index.js
+++ b/packages/plugin-react/src/index.js
@@ -41,10 +41,10 @@ then pass in React when available to construct your error boundary
 }
 
 const formatComponentStack = str => {
-  const lines = str.split(/\s*\n\s*/g)
+  const lines = str.split(/\n/g)
   let ret = ''
   for (let line = 0, len = lines.length; line < len; line++) {
-    if (lines[line].length) ret += `${ret.length ? '\n' : ''}${lines[line]}`
+    if (lines[line].length) ret += `${ret.length ? '\n' : ''}${lines[line].trim()}`
   }
   return ret
 }


### PR DESCRIPTION
## Goal

Modify the regular expression to remove the ambiguity, or ensure that the strings matched with the regular expression are short enough that the time-complexity does not matter.

## Changeset

Updated RegExp and added .trim() for trimming whitespaces in `ret` 

## Testing

Covered by existing unit test