### PR TITLE
Skip broken electron network breadcrumb tests

### DIFF
--- a/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
+++ b/packages/plugin-electron-net-breadcrumbs/test/net-breadcrumbs.test-main.ts
@@ -13,7 +13,7 @@ let currentServer: ServerWithPort|null = null
 
 const originalRequest = net.request
 
-describe('plugin: electron net breadcrumbs', () => {
+describe.skip('plugin: electron net breadcrumbs', () => {
   afterEach(async () => {
     if (currentServer) {
       await new Promise(resolve => { currentServer.close(resolve) })


### PR DESCRIPTION
## Goal

Skip known failing electron tests reinstated as an experiment