### PR TITLE
Discard duplicate JS exceptions in iOS New Architecture

### DIFF
--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -28,29 +28,28 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      # Skipped pending PLAT-12064
-      # - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
-      #   key: "build-react-native-ios-fixture-new-arch"
-      #   timeout_in_minutes: 30
-      #   agents:
-      #     queue: "macos-12-arm"
-      #   env:
-      #     NODE_VERSION: "18"
-      #     RN_VERSION: "{{matrix}}"
-      #     RCT_NEW_ARCH_ENABLED: "1"
-      #     BUILD_IOS: "true"
-      #     DEVELOPER_DIR: "/Applications/Xcode14.app"
-      #   artifact_paths:
-      #     - "test/react-native/features/fixtures/generated/new-arch/**/output/reactnative.ipa"
-      #   commands:
-      #     - "bundle install"
-      #     - "node scripts/generate-react-native-fixture.js"
-      #   matrix:
-      #     - "0.73"
-      #   retry:
-      #     automatic:
-      #       - exit_status: "*"
-      #         limit: 1
+      - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
+        key: "build-react-native-ios-fixture-new-arch"
+        timeout_in_minutes: 30
+        agents:
+          queue: "macos-14"
+        env:
+          NODE_VERSION: "18"
+          RN_VERSION: "{{matrix}}"
+          RCT_NEW_ARCH_ENABLED: "1"
+          BUILD_IOS: "true"
+          XCODE_VERSION: "15.3.0"
+        artifact_paths:
+          - "test/react-native/features/fixtures/generated/new-arch/**/output/reactnative.ipa"
+        commands:
+          - "bundle install"
+          - "node scripts/generate-react-native-fixture.js"
+        matrix:
+          - "0.73"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
       #
       # End-to-end tests
       #
@@ -84,35 +83,34 @@ steps:
         matrix:
           - "0.73"
 
-      # Skipped pending PLAT-12064
-      # - label: ":bitbar: :mac: RN {{matrix}} iOS 16 (New Arch) end-to-end tests"
-      #   depends_on: "build-react-native-ios-fixture-new-arch"
-      #   timeout_in_minutes: 60
-      #   plugins:
-      #     artifacts#v1.9.0:
-      #       download: "test/react-native/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa"
-      #       upload: ./test/react-native/maze_output/**/*
-      #     docker-compose#v4.12.0:
-      #       pull: react-native-maze-runner
-      #       run: react-native-maze-runner
-      #       service-ports: true
-      #       command:
-      #         - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
-      #         - --farm=bb
-      #         - --device=IOS_16
-      #         - --a11y-locator
-      #         - --fail-fast
-      #         - --no-tunnel
-      #         - --aws-public-ip
-      #   env:
-      #     RCT_NEW_ARCH_ENABLED: "true"
-      #     SKIP_NAVIGATION_SCENARIOS: "true"
-      #   retry:
-      #     manual:
-      #       permit_on_passed: true
-      #   concurrency: 25
-      #   concurrency_group: "bitbar"
-      #   concurrency_method: eager
-      #   matrix:
-      #     - "0.73"
+      - label: ":bitbar: :mac: RN {{matrix}} iOS 16 (New Arch) end-to-end tests"
+        depends_on: "build-react-native-ios-fixture-new-arch"
+        timeout_in_minutes: 60
+        plugins:
+          artifacts#v1.9.0:
+            download: "test/react-native/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa"
+            upload: ./test/react-native/maze_output/**/*
+          docker-compose#v4.12.0:
+            pull: react-native-maze-runner
+            run: react-native-maze-runner
+            service-ports: true
+            command:
+              - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
+              - --farm=bb
+              - --device=IOS_16
+              - --a11y-locator
+              - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
+        env:
+          RCT_NEW_ARCH_ENABLED: "true"
+          SKIP_NAVIGATION_SCENARIOS: "true"
+        retry:
+          manual:
+            permit_on_passed: true
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: eager
+        matrix:
+          - "0.73"
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
@@ -12,7 +12,7 @@
 
 - (void)load:(BugsnagClient *)client {
     //
-    // React Native catches JS exceptions and calls RCTFatal() to raise an Objective-C exception in response.
+    // When using the old architecture, React Native catches JS exceptions and calls RCTFatal() to raise an Objective-C exception in response.
     // These need to be ignored because Bugsnag's JS layer also catches JS exceptions, via a different mechanism.
     //
     // RCTFatal() sets the exception name to "RCTFatalException: ${error.localizedDescription}"
@@ -29,6 +29,19 @@
     NSMutableSet *discardClasses = [client.configuration.discardClasses mutableCopy] ?: [NSMutableSet set];
     [discardClasses addObject:[NSRegularExpression regularExpressionWithPattern:discardPattern options:0 error:nil]];
     client.configuration.discardClasses = discardClasses;
+
+    // When using the new architecture on 0.73+, these exceptions are caught and rethrown as facebook::jsi::JSError exceptions,
+    // with the error message set to "Exception in HostFunction: Unhandled JS Exception: ${message}"
+    // https://github.com/facebook/react-native/blob/v0.73.0/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm#L406
+    // https://github.com/facebook/react-native/blob/v0.73.0/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm#L235
+    
+    // We can't use discardClasses here because the errorClass facebook::jsi::JSError is not specific to JS exceptions, 
+    // so we need to use an onSendError block and discard based on the error message instead.
+    #ifdef RCT_NEW_ARCH_ENABLED
+    [client.configuration addOnSendErrorBlock:^BOOL (BugsnagEvent *event) {
+        return ![event.errors[0].errorMessage hasPrefix:@"Exception in HostFunction: Unhandled JS Exception"];
+    }];
+    #endif
 }
 
 - (void)unload {

--- a/test/react-native/features/app.feature
+++ b/test/react-native/features/app.feature
@@ -1,6 +1,6 @@
 Feature: App data
 
-Scenario: Handled JS error
+Scenario: App data in Handled JS error
   When I run "AppJsHandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -23,7 +23,7 @@ Scenario: Handled JS error
   | android | android |
   | ios     | iOS     |
 
-Scenario: Unhandled JS error
+Scenario: App data in Unhandled JS error
   When I run "AppJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "AppJsUnhandledScenario"
   Then I wait to receive an error
@@ -47,7 +47,7 @@ Scenario: Unhandled JS error
   | android | android |
   | ios     | iOS   |
 
-Scenario: Handled native error
+Scenario: App data in Handled native error
   When I run "AppNativeHandledScenario"
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the platform-dependent string:
@@ -72,7 +72,9 @@ Scenario: Handled native error
   | android | android |
   | ios     | iOS     |
 
-Scenario: Unhandled native error
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_ios_new_arch
+Scenario: App data in Unhandled native error
   When I run "AppNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "AppNativeUnhandledScenario"
   Then I wait to receive an error
@@ -97,6 +99,24 @@ Scenario: Unhandled native error
   And the event "app.type" equals the platform-dependent string:
   | android | android |
   | ios     | iOS     |
+
+# TODO: remove this scenario when PLAT-12184 is resolved
+@ios_only @skip_old_arch
+Scenario: App data in Unhandled native error
+  When I run "AppNativeUnhandledScenario" and relaunch the crashed app
+  And I configure Bugsnag for "AppNativeUnhandledScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the exception "message" starts with "Exception in HostFunction: AppNativeUnhandledScenario"
+  And the event "unhandled" is true
+  And the event "app.version" equals "1.2.3"
+  And the event "app.releaseStage" equals "production"
+  And the event "app.inForeground" is true
+  And the event "app.duration" is not null
+  And the event "app.durationInForeground" is not null
+  And the event "app.codeBundleId" equals "1.2.3-r00110011"
+  And the event "app.id" equals "com.bugsnag.fixtures.reactnative"
+  And the event "app.type" equals "iOS"
 
 Scenario: Setting appType in configuration
   When I run "AppConfigAppTypeScenario"

--- a/test/react-native/features/device-android.feature
+++ b/test/react-native/features/device-android.feature
@@ -1,7 +1,7 @@
 @android_only
 Feature: Android Device data
 
-Scenario: Handled JS error
+Scenario: Device data in Handled JS error
   When I run "DeviceJsHandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -24,7 +24,7 @@ Scenario: Handled JS error
   And the event "device.orientation" equals "portrait"
   And the event "device.time" is a timestamp
 
-Scenario: Unhandled JS error
+Scenario: Device data in Unhandled JS error
   When I run "DeviceJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceJsUnhandledScenario"
   Then I wait to receive an error
@@ -48,7 +48,7 @@ Scenario: Unhandled JS error
   And the event "device.orientation" equals "portrait"
   And the event "device.time" is a timestamp
 
-Scenario: Handled native error
+Scenario: Device data in Handled native error
   When I run "DeviceNativeHandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "java.lang.RuntimeException"
@@ -71,7 +71,7 @@ Scenario: Handled native error
   And the event "device.orientation" equals "portrait"
   And the event "device.time" is a timestamp
 
-Scenario: Unhandled native error
+Scenario: Device data in Unhandled native error
   When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceNativeUnhandledScenario"
   Then I wait to receive an error

--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -1,7 +1,7 @@
 @ios_only
 Feature: iOS Device data
 
-Scenario: Handled JS error
+Scenario: Device data in Handled JS error
   When I run "DeviceJsHandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -27,7 +27,7 @@ Scenario: Handled JS error
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
-Scenario: Unhandled JS error
+Scenario: Device data in Unhandled JS error
   When I run "DeviceJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceJsUnhandledScenario"
   Then I wait to receive an error
@@ -54,7 +54,7 @@ Scenario: Unhandled JS error
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
-Scenario: Handled native error
+Scenario: Device data in Handled native error
   When I run "DeviceNativeHandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "NSException"
@@ -80,12 +80,42 @@ Scenario: Handled native error
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
-Scenario: Unhandled native error
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_new_arch
+Scenario: Device data in Unhandled native error
   When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceNativeUnhandledScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "NSException"
   And the exception "message" equals "DeviceNativeUnhandledScenario"
+  And the event "unhandled" is true
+
+  And the event "device.id" matches "^(\d|[abcdef]){40}$"
+  And the event "device.osName" equals "iOS"
+  And the event "device.jailbroken" is false
+  And the event "device.osVersion" matches "^\d+\.\d+(.\d+)?$"
+  And the event "device.time" is a timestamp
+  And the event "device.locale" is not null
+  And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
+  And the event "device.runtimeVersions.reactNativeJsEngine" matches "^jsc|hermes$"
+  And the event "device.runtimeVersions.osBuild" is not null
+  And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
+  And the error payload field "events.0.device.freeMemory" is greater than 0
+  And the event "device.manufacturer" equals "Apple"
+  # Skipped - PLAT-11345
+  # And the error payload field "events.0.device.freeDisk" is greater than 0
+  And the event "device.modelNumber" is not null
+  And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
+  And the error payload field "events.0.device.totalMemory" is greater than 0
+
+# TODO: remove this scenario when PLAT-12184 is resolved
+@skip_old_arch
+Scenario: Device data in Unhandled native error
+  When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
+  And I configure Bugsnag for "DeviceNativeUnhandledScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the exception "message" starts with "Exception in HostFunction: DeviceNativeUnhandledScenario"
   And the event "unhandled" is true
 
   And the event "device.id" matches "^(\d|[abcdef]){40}$"

--- a/test/react-native/features/feature_flags.feature
+++ b/test/react-native/features/feature_flags.feature
@@ -40,6 +40,8 @@ Scenario: Sends no feature flags after clearFeatureFlags()
   And the event "unhandled" is false
   And event 0 has no feature flags
 
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_ios_new_arch
 Scenario: Sends JS feature flags in a native crash
   When I run "FeatureFlagsNativeCrashScenario" and relaunch the crashed app
   And I configure Bugsnag for "FeatureFlagsNativeCrashScenario"
@@ -50,6 +52,21 @@ Scenario: Sends JS feature flags in a native crash
   And the event "exceptions.0.type" equals the platform-dependent string:
     | android | android |
     | ios     | cocoa   |
+  And the event "unhandled" is true
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+# TODO: remove this scenario when PLAT-12184 is resolved
+@ios_only @skip_old_arch
+Scenario: Sends JS feature flags in a native crash
+  When I run "FeatureFlagsNativeCrashScenario" and relaunch the crashed app
+  And I configure Bugsnag for "FeatureFlagsNativeCrashScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the event "exceptions.0.type" equals "cocoa"
   And the event "unhandled" is true
   And event 0 contains the feature flag "demo_mode" with no variant
   And event 0 contains the feature flag "sample_group" with variant "a"

--- a/test/react-native/features/metadata.feature
+++ b/test/react-native/features/metadata.feature
@@ -25,6 +25,8 @@ Scenario: Setting metadata (native handled)
   And the event "metaData.nativedata.even_more_data" equals "set via event"
   And the event "metaData.nativedata.cleared_data" is null
 
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_ios_new_arch
 Scenario: Setting metadata (native unhandled)
   When I run "MetadataNativeUnhandledScenario"
   And I wait for 2 seconds
@@ -42,4 +44,19 @@ Scenario: Setting metadata (native unhandled)
   And the event "metaData.nativedata.even_more_data" equals the platform-dependent string:
   | android | set via event |
   | ios     | @skip         |
+  And the event "metaData.nativedata.cleared_data" is null
+
+# TODO: remove this scenario when PLAT-12184 is resolved
+@ios_only @skip_old_arch
+Scenario: Setting metadata (native unhandled)
+  When I run "MetadataNativeUnhandledScenario"
+  And I wait for 2 seconds
+  And I clear any error dialogue
+  And I relaunch the app after a crash
+  And I configure Bugsnag for "MetadataNativeUnhandledScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the exception "message" starts with "Exception in HostFunction: MetadataNativeUnhandledScenario"
+  And the event "metaData.nativedata.some_data" equals "set via config"
+  And the event "metaData.nativedata.some_more_data" equals "set via client"
   And the event "metaData.nativedata.cleared_data" is null

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -73,7 +73,8 @@ Scenario: Unhandled JS error with native stacktrace
 #   And the error payload field "events.0.exceptions.1.stacktrace.1.lineNumber" equals 1
 #   And the error payload field "events.0.exceptions.1.stacktrace.2.lineNumber" equals 2
 
-@ios_only
+# Skipped pending PLAT-12063
+@ios_only @skip_new_arch
 Scenario: Handled JS error with native stacktrace
   When I run "NativeStackHandledScenario"
   Then I wait to receive an error
@@ -100,7 +101,8 @@ Scenario: Handled JS error with native stacktrace
   And the error payload field "events.0.exceptions.0.stacktrace.20.lineNumber" is not null
   And the error payload field "events.0.exceptions.0.stacktrace.20.type" is null
 
-@ios_only
+# Skipped pending PLAT-12063
+@ios_only @skip_new_arch
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -33,3 +33,11 @@ end
 Before('@skip_new_arch') do |scenario|
   skip_this_scenario("Skipping scenario") if ENV['RCT_NEW_ARCH_ENABLED'].eql?('true')
 end
+
+Before('@skip_old_arch') do |scenario|
+  skip_this_scenario("Skipping scenario") unless ENV['RCT_NEW_ARCH_ENABLED'].eql?('true')
+end
+
+Before('@skip_ios_new_arch') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == 'ios' && ENV['RCT_NEW_ARCH_ENABLED'].eql?('true')
+end

--- a/test/react-native/features/unhandled.feature
+++ b/test/react-native/features/unhandled.feature
@@ -1,6 +1,6 @@
 Feature: Reporting unhandled errors
 
-Scenario: Catching an Unhandled error
+Scenario: Reporting an Unhandled error
   When I run "UnhandledJsErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsErrorScenario"
   Then I wait to receive an error
@@ -9,7 +9,7 @@ Scenario: Catching an Unhandled error
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledJsErrorScenario"
 
-Scenario: Catching an Unhandled promise rejection
+Scenario: Reporting an Unhandled promise rejection
   When I run "UnhandledJsPromiseRejectionScenario"
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
@@ -17,7 +17,9 @@ Scenario: Catching an Unhandled promise rejection
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledJsPromiseRejectionScenario"
 
-Scenario: Catching an Unhandled Native error
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_ios_new_arch
+Scenario: Reporting an Unhandled Native error
   When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledNativeErrorScenario"
   Then I wait to receive an error
@@ -30,6 +32,17 @@ Scenario: Catching an Unhandled Native error
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledNativeErrorScenario"
 
+# TODO: remove this scenario when PLAT-12184 is resolved
+@ios_only @skip_old_arch
+Scenario: Reporting an Unhandled Native error
+  When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledNativeErrorScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the event "exceptions.0.type" equals "cocoa"
+  And the event "unhandled" is true
+  And the exception "message" starts with "Exception in HostFunction: UnhandledNativeErrorScenario"
+
 Scenario: Updating severity on an unhandled JS error
   When I run "UnhandledJsErrorSeverityScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsErrorSeverityScenario"
@@ -39,7 +52,7 @@ Scenario: Updating severity on an unhandled JS error
   And the event "unhandled" is true
   And the event "severity" equals "info"
 
-@ios_only
+@ios_only @skip_new_arch
 Scenario: Reporting an unhandled Objective-C exception raise by RCTFatal
   When I run "RCTFatalScenario" and relaunch the crashed app
   And I configure Bugsnag for "RCTFatalScenario"

--- a/test/react-native/features/user.feature
+++ b/test/react-native/features/user.feature
@@ -27,6 +27,8 @@ Scenario: Setting user in JS via event
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"
 
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_ios_new_arch
 Scenario: Setting user in native via client
   When I run "UserNativeClientScenario" and relaunch the crashed app
   And I configure Bugsnag for "UserNativeClientScenario"
@@ -39,6 +41,20 @@ Scenario: Setting user in native via client
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"
 
+# TODO: remove this scenario when PLAT-12184 is resolved
+@ios_only @skip_old_arch
+Scenario: Setting user in native via client
+  When I run "UserNativeClientScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UserNativeClientScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the exception "message" starts with "Exception in HostFunction: UserNativeClientScenario"
+  And the event "user.email" equals "bug@sn.ag"
+  And the event "user.name" equals "Bug Snag"
+  And the event "user.id" equals "123"
+
+# Skipped on iOS New Arch pending PLAT-12184
+@skip_ios_new_arch
 Scenario: Setting user in JS via client and sending Native error
   When I run "UserJsNativeScenario" and relaunch the crashed app
   And I configure Bugsnag for "UserJsNativeScenario"
@@ -51,6 +67,20 @@ Scenario: Setting user in JS via client and sending Native error
   | ios     | cocoa   |
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledNativeErrorScenario"
+  And the event "user.email" equals "bug@sn.ag"
+  And the event "user.name" equals "Bug Snag"
+  And the event "user.id" equals "123"
+
+# TODO: remove this scenario when PLAT-12184 is resolved
+@ios_only @skip_old_arch
+Scenario: Setting user in JS via client and sending Native error
+  When I run "UserJsNativeScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UserJsNativeScenario"
+  Then I wait to receive an error
+  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
+  And the event "exceptions.0.type" equals "cocoa"
+  And the event "unhandled" is true
+  And the exception "message" starts with "Exception in HostFunction: UnhandledNativeErrorScenario"
   And the event "user.email" equals "bug@sn.ag"
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"


### PR DESCRIPTION
## Goal

In the Old Architecture React Native raises an Objective-C `RCTFatalException` when an unhandled JS exception occurs. These are discarded in the native notifier because BugSnag's JS layer also catches these JS exceptions.

However in 0.73+, with New Architecture enabled, these exceptions are caught and rethrown as a cpp exception, so the discard pattern no longer applies and a duplicate native event is reported.

This PR adds an additional `onSendError` block (when the New Architecture is enabled) to also discard these new exception types 

## Design

Because this new exception type `facebook::jsi::JSError` is also thrown for any exceptions that occur in Turbo Module methods, we're not able to discard unhandled JS exceptions using a `discardClasses` pattern.

Instead an onSendError callback is used to discard based on the error message. For unhandled JS exceptions the error message is always prepended with `Exception in HostFunction: Unhandled JS Exception`

## Changeset

Added a new `onSendError` block to the native config in `BugsnagReactNativePlugin.m` if the New Architecture is enabled.

The iOS New Architecture tests for 0.73 have been reinstated - as part of this all scenarios that throw native exceptions have been split into separate tests for old arch and new arch to account for the new exception handling behaviour in iOS Turbo Modules

## Testing

Covered by a full CI run