### PR TITLE
[PLAT-12116] React native privacy manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- (react-native) Add privacy manifest resource bundle to podspec [#2149](https://github.com/bugsnag/bugsnag-js/pull/2149)
+
 ### Changed
 
 - (plugin-react) Modified the polynomial regular expression to remove the ambiguity [#2135](https://github.com/bugsnag/bugsnag-js/pull/2135)

--- a/packages/react-native/BugsnagReactNative.podspec
+++ b/packages/react-native/BugsnagReactNative.podspec
@@ -16,10 +16,13 @@ Pod::Spec.new do |s|
   s.source_files = "ios/BugsnagReactNative/**/*.{h,mm,m}",
                    "ios/vendor/bugsnag-cocoa/**/*.{h,mm,m,cpp,c}",
   s.public_header_files = "ios/vendor/bugsnag-cocoa/{#{bugsnag_cocoa_public_header_files.join(',')}}"
-  s.header_dir = 'Bugsnag'
+  s.header_dir = "Bugsnag"
   s.requires_arc = true
+  s.resource_bundles = {
+    "Bugsnag" => ["ios/vendor/bugsnag-cocoa/Bugsnag/resources/PrivacyInfo.xcprivacy"],
+  }
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == "1"
+  if ENV["RCT_NEW_ARCH_ENABLED"] == "1"
     install_modules_dependencies(s)
   else
     s.dependency "React-Core"


### PR DESCRIPTION
## Goal

Bring podspec inline with [bugsnag-cocoa](https://github.com/bugsnag/bugsnag-cocoa/blob/16b9145fc66e5296f16e733f6feb5d0e450574e8/Bugsnag.podspec.json#L56) by adding the resource_bundles entry to include the privacy manifest resource

## Changeset

Add resource_bundles entry to podspec as per request by user @sparga in issue #2132