### PR TITLE
Use synchronous native module calls when New Architecture is enabled

### DIFF
--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -76,6 +76,7 @@ steps:
             permit_on_passed: true
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
+          RN_VERSION: "{{matrix}}"
         concurrency: 25
         concurrency_group: "bitbar"
         concurrency_method: eager
@@ -108,6 +109,7 @@ steps:
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           RCT_NEW_ARCH_ENABLED: "true"
+          RN_VERSION: "{{matrix}}"
         concurrency: 25
         concurrency_group: "bitbar"
         concurrency_method: eager

--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -19,6 +19,7 @@ steps:
           - "node scripts/generate-react-native-fixture.js"
         matrix:
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -46,6 +47,7 @@ steps:
               limit: 1
         matrix:
           - "0.73"
+          - "0.74"
 
       #
       # End-to-end tests
@@ -79,6 +81,7 @@ steps:
         concurrency_method: eager
         matrix:
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
@@ -110,4 +113,5 @@ steps:
         concurrency_method: eager
         matrix:
           - "0.73"
+          - "0.74"
 

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -23,6 +23,7 @@ steps:
           - "node scripts/generate-react-native-fixture.js"
         matrix:
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -46,6 +47,7 @@ steps:
           - "node scripts/generate-react-native-fixture.js"
         matrix:
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -82,6 +84,7 @@ steps:
         concurrency_method: eager
         matrix:
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 16 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
@@ -113,4 +116,5 @@ steps:
         concurrency_method: eager
         matrix:
           - "0.73"
+          - "0.74"
 

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -79,6 +79,7 @@ steps:
             permit_on_passed: true
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
+          RN_VERSION: "{{matrix}}"
         concurrency: 25
         concurrency_group: "bitbar"
         concurrency_method: eager
@@ -108,6 +109,7 @@ steps:
         env:
           RCT_NEW_ARCH_ENABLED: "true"
           SKIP_NAVIGATION_SCENARIOS: "true"
+          RN_VERSION: "{{matrix}}"
         retry:
           manual:
             permit_on_passed: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (react-native) Use synchronous native module calls when New Architecture is enabled [#2152](https://github.com/bugsnag/bugsnag-js/pull/2152)
+
 ## [7.24.0] - 2024-06-10
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,7 @@ services:
       BITBAR_USERNAME:
       BITBAR_ACCESS_KEY:
       HERMES:
+      RN_VERSION:
     ports:
       - "9000-9499:9339"
     networks:

--- a/packages/plugin-react-native-event-sync/event-sync.js
+++ b/packages/plugin-react-native-event-sync/event-sync.js
@@ -1,21 +1,35 @@
 module.exports = (NativeClient) => ({
   load: (client) => {
-    client.addOnError(async event => {
-      const {
-        threads,
-        breadcrumbs,
-        app,
-        device,
-        deviceMetadata,
-        appMetadata
-      } = await NativeClient.getPayloadInfo({ unhandled: event.unhandled })
+    const isTurboModuleEnabled = global.__turboModuleProxy != null
 
-      event.breadcrumbs = breadcrumbs
-      event.app = { ...event.app, ...app }
-      event.device = { ...event.device, ...device }
-      event.threads = threads
-      event.addMetadata('device', deviceMetadata)
-      event.addMetadata('app', appMetadata)
-    }, true)
+    if (isTurboModuleEnabled) {
+      client.addOnError(event => {
+        const payloadInfo = NativeClient.getPayloadInfo({ unhandled: event.unhandled })
+        syncEvent(payloadInfo, event)
+      }, true)
+    } else {
+      client.addOnError(async event => {
+        const payloadInfo = await NativeClient.getPayloadInfoAsync({ unhandled: event.unhandled })
+        syncEvent(payloadInfo, event)
+      }, true)
+    }
   }
 })
+
+const syncEvent = (payloadInfo, event) => {
+  const {
+    threads,
+    breadcrumbs,
+    app,
+    device,
+    deviceMetadata,
+    appMetadata
+  } = payloadInfo
+
+  event.breadcrumbs = breadcrumbs
+  event.app = { ...event.app, ...app }
+  event.device = { ...event.device, ...device }
+  event.threads = threads
+  event.addMetadata('device', deviceMetadata)
+  event.addMetadata('app', appMetadata)
+}

--- a/packages/plugin-react-native-event-sync/test/event-sync.test.ts
+++ b/packages/plugin-react-native-event-sync/test/event-sync.test.ts
@@ -8,7 +8,54 @@ describe('plugin: react native event sync', () => {
       apiKey: 'api_key',
       plugins: [
         plugin({
-          getPayloadInfo: async () => {
+          getPayloadInfoAsync: async () => {
+            return {
+              device: { osName: 'android', manufacturer: 'google' },
+              app: { versionCode: '1.0' },
+              breadcrumbs: [
+                {
+                  message: 'Test',
+                  type: 'manual',
+                  metadata: { meta: 'data' },
+                  timestamp: ts.toISOString()
+                }
+              ],
+              threads: [
+                {
+                  id: '123',
+                  name: 'main',
+                  errorReportingThread: false,
+                  type: 'android',
+                  stacktrace: []
+                }
+              ]
+            }
+          }
+        })
+      ]
+    })
+
+    c.notify(new Error('blah'), (event) => {
+      expect(event.device.osName).toBe('android')
+      expect(event.device.manufacturer).toBe('google')
+      expect(event.app.versionCode).toBe('1.0')
+      expect(event.threads.length).toBe(1)
+      expect(event.threads[0].name).toBe('main')
+      expect(event.breadcrumbs.length).toBe(1)
+      expect(event.breadcrumbs[0].timestamp).toBe(ts.toISOString())
+      done()
+    })
+  })
+
+  it('uses the synchronous getPayloadInfo method when Turbo Modules are enabled', done => {
+    // @ts-expect-error __turboModuleProxy does not exist on type 'Global'
+    global.__turboModuleProxy = {}
+    const ts = new Date()
+    const c = new Client({
+      apiKey: 'api_key',
+      plugins: [
+        plugin({
+          getPayloadInfo: () => {
             return {
               device: { osName: 'android', manufacturer: 'google' },
               app: { versionCode: '1.0' },

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNativeImpl.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNativeImpl.java
@@ -185,25 +185,33 @@ class BugsnagReactNativeImpl {
     }
   }
 
-  void dispatch(@NonNull ReadableMap payload, @NonNull Promise promise) {
+  boolean dispatch(@NonNull ReadableMap payload) {
     try {
       plugin.dispatch(payload.toHashMap());
-      promise.resolve(true);
+      return true;
     } catch (Throwable exc) {
       logFailure("dispatch", exc);
-      promise.resolve(false);
+      return false;
     }
   }
 
-  void getPayloadInfo(@NonNull ReadableMap payload, @NonNull Promise promise) {
+  void dispatchAsync(@NonNull ReadableMap payload, @NonNull Promise promise) {
+    promise.resolve(dispatch(payload));
+  }
+
+  WritableMap getPayloadInfo(@NonNull ReadableMap payload) {
     try {
       boolean unhandled = payload.getBoolean("unhandled");
       Map<String, Object> info = plugin.getPayloadInfo(unhandled);
-      promise.resolve(ReactNativeCompat.toWritableMap(info));
+      return ReactNativeCompat.toWritableMap(info);
     } catch (Throwable exc) {
       logFailure("dispatch", exc);
-      promise.resolve(null);
+      return new WritableNativeMap();
     }
+  }
+
+  void getPayloadInfoAsync(@NonNull ReadableMap payload, @NonNull Promise promise) {
+    promise.resolve(getPayloadInfo(payload));
   }
 
   void addFeatureFlag(@NonNull String name, @Nullable String variant) {

--- a/packages/react-native/android/src/newarch/java/com/bugsnag/android/NativeBugsnagImpl.java
+++ b/packages/react-native/android/src/newarch/java/com/bugsnag/android/NativeBugsnagImpl.java
@@ -87,13 +87,23 @@ public class NativeBugsnagImpl extends NativeBugsnagSpec {
   }
 
   @Override
-  public void dispatch(ReadableMap payload, Promise promise) {
-    impl.dispatch(payload, promise);
+  public boolean dispatch(ReadableMap payload) {
+    return impl.dispatch(payload);
   }
 
   @Override
-  public void getPayloadInfo(ReadableMap payload, Promise promise) {
-    impl.getPayloadInfo(payload, promise);
+  public void dispatchAsync(ReadableMap payload, Promise promise) {
+    impl.dispatchAsync(payload, promise);
+  }
+
+  @Override
+  public WritableMap getPayloadInfo(ReadableMap payload) {
+    return impl.getPayloadInfo(payload);
+  }
+
+  @Override
+  public void getPayloadInfoAsync(ReadableMap payload, Promise promise) {
+    impl.getPayloadInfoAsync(payload, promise);
   }
 
   @Override

--- a/packages/react-native/android/src/oldarch/java/com/bugsnag/android/BugsnagReactNative.java
+++ b/packages/react-native/android/src/oldarch/java/com/bugsnag/android/BugsnagReactNative.java
@@ -93,13 +93,23 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  void dispatch(@NonNull ReadableMap payload, @NonNull Promise promise) {
-    impl.dispatch(payload, promise);
+  boolean dispatch(@NonNull ReadableMap payload) {
+    return impl.dispatch(payload);
   }
 
   @ReactMethod
-  void getPayloadInfo(@NonNull ReadableMap payload, @NonNull Promise promise) {
-    impl.getPayloadInfo(payload, promise);
+  void dispatchAsync(@NonNull ReadableMap payload, @NonNull Promise promise) {
+    impl.dispatchAsync(payload, promise);
+  }
+
+  @ReactMethod
+  WritableMap getPayloadInfo(@NonNull ReadableMap payload) {
+    return impl.getPayloadInfo(payload);
+  }
+
+  @ReactMethod
+  void getPayloadInfoAsync(@NonNull ReadableMap payload, @NonNull Promise promise) {
+    impl.getPayloadInfoAsync(payload, promise);
   }
 
   @ReactMethod

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
@@ -9,6 +9,14 @@
 #import "BugsnagReactNativeEmitter.h"
 #endif
 
+// BSG_VOID_LIKE sets the correct return type for 'void-like' methods that are
+// synchronous in the new architecture (return id) and asynchronous in the old architecture (void)
+#ifdef RCT_NEW_ARCH_ENABLED
+#define BSG_VOID_LIKE id
+#else
+#define BSG_VOID_LIKE void
+#endif
+
 @class BugsnagConfiguration;
 
 @interface BugsnagReactNative: NSObject<RCTBridgeModule>
@@ -19,30 +27,30 @@
 
 - (NSDictionary *)configure:(NSDictionary *)readableMap;
 
-- (void)updateCodeBundleId:(NSString *)codeBundleId;
+- (BSG_VOID_LIKE)updateCodeBundleId:(NSString *)codeBundleId;
 
-- (void)addMetadata:(NSString *)section
+- (BSG_VOID_LIKE)addMetadata:(NSString *)section
            withData:(NSDictionary *)data;
 
-- (void)clearMetadata:(NSString *)section
+- (BSG_VOID_LIKE)clearMetadata:(NSString *)section
               withKey:(NSDictionary *)key;
 
-- (void)updateContext:(NSString *)context;
+- (BSG_VOID_LIKE)updateContext:(NSString *)context;
 
-- (void)updateUser:(NSString *)userId
+- (BSG_VOID_LIKE)updateUser:(NSString *)userId
          withEmail:(NSString *)email
           withName:(NSString *)name;
 
-- (void)startSession;
-- (void)pauseSession;
-- (void)resumeSession;
-- (void)resumeSessionOnStartup;
+- (BSG_VOID_LIKE)startSession;
+- (BSG_VOID_LIKE)pauseSession;
+- (BSG_VOID_LIKE)resumeSession;
+- (BSG_VOID_LIKE)resumeSessionOnStartup;
 
-- (void)addFeatureFlags:(NSArray *)readableArray;
-- (void)addFeatureFlag:(NSString *)name
+- (BSG_VOID_LIKE)addFeatureFlags:(NSArray *)readableArray;
+- (BSG_VOID_LIKE)addFeatureFlag:(NSString *)name
            withVariant:(NSString *)variant;
-- (void)clearFeatureFlag:(NSString *)name;
-- (void)clearFeatureFlags;
+- (BSG_VOID_LIKE)clearFeatureFlag:(NSString *)name;
+- (BSG_VOID_LIKE)clearFeatureFlags;
 
 - (NSNumber *)dispatch:(NSDictionary *)payload;
 
@@ -56,7 +64,7 @@
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject;
 
-- (void)leaveBreadcrumb:(NSDictionary *)options;
+- (BSG_VOID_LIKE)leaveBreadcrumb:(NSDictionary *)options;
 
 @end
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
@@ -44,11 +44,15 @@
 - (void)clearFeatureFlag:(NSString *)name;
 - (void)clearFeatureFlags;
 
-- (void)dispatch:(NSDictionary *)payload
+- (NSNumber *)dispatch:(NSDictionary *)payload;
+
+- (void)dispatchAsync:(NSDictionary *)payload
          resolve:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject;
 
-- (void)getPayloadInfo:(NSDictionary *)payloadInfo
+- (NSDictionary *)getPayloadInfo:(NSDictionary *)payloadInfo;
+
+- (void)getPayloadInfoAsync:(NSDictionary *)payloadInfo
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject;
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.mm
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.mm
@@ -12,17 +12,17 @@
 // BSG_EXPORT_METHOD exposes methods as blocking synchronous methods in the new architecture and
 // as asynchronous methods in the old architecture.
 //
-// Methods written in BSG_EXPORT_METHOD must be ended using BSG_END_EXPORT_METHOD so that the correct
+// Methods written in BSG_EXPORT_METHOD must be ended using BSG_EXPORT_RETURN so that the correct
 // return type is used. (void for asynchronous and id for synchronous methods)
 //
 // Note that this should only be used for methods that are marked as void in JS. Methods that return
 // a value or a promise should be exposed as synchronous or asynchronous explicitly in both architectures.
 #ifdef RCT_NEW_ARCH_ENABLED
 #define BSG_EXPORT_METHOD RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD
-#define BSG_END_EXPORT_METHOD return nil;
+#define BSG_EXPORT_RETURN return nil;
 #else
 #define BSG_EXPORT_METHOD RCT_EXPORT_METHOD
-#define BSG_END_EXPORT_METHOD
+#define BSG_EXPORT_RETURN return;
 #endif
 
 @interface BugsnagReactNative ()
@@ -55,7 +55,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure:(NSDictionary *)readableMap) {
 BSG_EXPORT_METHOD(addMetadata:(NSString *)section
                      withData:(NSDictionary *)data) {
     [Bugsnag addMetadata:data toSection:section];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(clearMetadata:(NSString *)section
@@ -65,24 +65,24 @@ BSG_EXPORT_METHOD(clearMetadata:(NSString *)section
     } else {
         [Bugsnag clearMetadataFromSection:section withKey:key];
     }
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(updateContext:(NSString *)context) {
     [Bugsnag setContext:context];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(updateCodeBundleId:(NSString *)codeBundleId) {
     Bugsnag.client.codeBundleId = codeBundleId; 
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(updateUser:(NSString *)userId
                    withEmail:(NSString *)email
                     withName:(NSString *)name) {
     [Bugsnag setUser:userId withEmail:email andName:name];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(dispatch:(NSDictionary *)payload) {
@@ -111,27 +111,27 @@ BSG_EXPORT_METHOD(leaveBreadcrumb:(NSDictionary *)options) {
                                    metadata:metadata
                                     andType:type];
     }
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(startSession) {
     [Bugsnag startSession];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(pauseSession) {
     [Bugsnag pauseSession];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(resumeSession) {
     [Bugsnag resumeSession];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(resumeSessionOnStartup) {
     [Bugsnag resumeSession];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(addFeatureFlags:(NSArray *)readableArray) {
@@ -149,7 +149,7 @@ BSG_EXPORT_METHOD(addFeatureFlags:(NSArray *)readableArray) {
     }
 
     [Bugsnag addFeatureFlags:array];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(addFeatureFlag:(NSString *)name
@@ -157,19 +157,19 @@ BSG_EXPORT_METHOD(addFeatureFlag:(NSString *)name
     if(name != nil) {
         [Bugsnag addFeatureFlagWithName:name variant:variant];
     }
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(clearFeatureFlag:(NSString *)name) {
     if(name != nil) {
         [Bugsnag clearFeatureFlagWithName:name];
     }
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 BSG_EXPORT_METHOD(clearFeatureFlags) {
     [Bugsnag clearFeatureFlags];
-    BSG_END_EXPORT_METHOD
+    BSG_EXPORT_RETURN
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getPayloadInfo:(NSDictionary *)options) {

--- a/packages/react-native/src/NativeBugsnag.ts
+++ b/packages/react-native/src/NativeBugsnag.ts
@@ -27,9 +27,13 @@ export interface Spec extends TurboModule {
 
   updateUser(id: string | undefined | null, email: string | undefined | null, name: string | undefined | null): void
 
-  dispatch(payload: UnsafeObject): Promise<boolean>
+  dispatch(payload: UnsafeObject): boolean
 
-  getPayloadInfo(payload: UnsafeObject): Promise<unknown>
+  dispatchAsync(payload: UnsafeObject): Promise<boolean>
+
+  getPayloadInfo(payload: UnsafeObject): Object
+
+  getPayloadInfoAsync(payload: UnsafeObject): Promise<unknown>
 
   addFeatureFlag(name: string, variant: string | undefined | null): void
 

--- a/packages/react-native/src/test/integration/handled-unhandled.test.ts
+++ b/packages/react-native/src/test/integration/handled-unhandled.test.ts
@@ -11,10 +11,10 @@ jest.mock('react-native', () => {
           enabledBreadcrumbTypes: []
         }),
         leaveBreadcrumb: () => {},
-        dispatch: async (event: any) => {
+        dispatchAsync: async (event: any) => {
           events.push(event)
         },
-        getPayloadInfo: async () => ({
+        getPayloadInfoAsync: async () => ({
           threads: [],
           breadcrumbs: [],
           app: {},

--- a/packages/react-native/test/index.test.ts
+++ b/packages/react-native/test/index.test.ts
@@ -22,8 +22,8 @@ jest.mock('react-native', () => ({
       resumeSessionOnStartup: jest.fn(),
       addFeatureFlags: jest.fn(),
       leaveBreadcrumb: jest.fn(),
-      getPayloadInfo: jest.fn().mockReturnValue({}),
-      dispatch: jest.fn().mockResolvedValue(true)
+      getPayloadInfoAsync: jest.fn().mockResolvedValue({}),
+      dispatchAsync: jest.fn().mockResolvedValue(true)
     }
   },
   Platform: {
@@ -79,7 +79,7 @@ describe('react native notifier', () => {
       if (err) {
         done(err)
       }
-      expect(NativeClient.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      expect(NativeClient.dispatchAsync).toHaveBeenCalledWith(expect.objectContaining({
         errors: expect.arrayContaining([
           expect.objectContaining({
             errorClass: 'Error',

--- a/test/react-native/features/app.feature
+++ b/test/react-native/features/app.feature
@@ -72,16 +72,11 @@ Scenario: App data in Handled native error
   | android | android |
   | ios     | iOS     |
 
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_ios_new_arch
 Scenario: App data in Unhandled native error
   When I run "AppNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "AppNativeUnhandledScenario"
   Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals the platform-dependent string:
-  | android | java.lang.RuntimeException |
-  | ios     | NSException                |
-  And the exception "message" equals "AppNativeUnhandledScenario"
+  And the exception "message" matches "AppNativeUnhandledScenario"
   And the event "unhandled" is true
   And the event "app.version" equals "1.2.3"
   # Parameter not present on iOS devices
@@ -99,24 +94,6 @@ Scenario: App data in Unhandled native error
   And the event "app.type" equals the platform-dependent string:
   | android | android |
   | ios     | iOS     |
-
-# TODO: remove this scenario when PLAT-12184 is resolved
-@ios_only @skip_old_arch
-Scenario: App data in Unhandled native error
-  When I run "AppNativeUnhandledScenario" and relaunch the crashed app
-  And I configure Bugsnag for "AppNativeUnhandledScenario"
-  Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
-  And the exception "message" starts with "Exception in HostFunction: AppNativeUnhandledScenario"
-  And the event "unhandled" is true
-  And the event "app.version" equals "1.2.3"
-  And the event "app.releaseStage" equals "production"
-  And the event "app.inForeground" is true
-  And the event "app.duration" is not null
-  And the event "app.durationInForeground" is not null
-  And the event "app.codeBundleId" equals "1.2.3-r00110011"
-  And the event "app.id" equals "com.bugsnag.fixtures.reactnative"
-  And the event "app.type" equals "iOS"
 
 Scenario: Setting appType in configuration
   When I run "AppConfigAppTypeScenario"

--- a/test/react-native/features/device-android.feature
+++ b/test/react-native/features/device-android.feature
@@ -75,10 +75,8 @@ Scenario: Device data in Unhandled native error
   When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceNativeUnhandledScenario"
   Then I wait to receive an error
-  And the exception "errorClass" equals "java.lang.RuntimeException"
-  And the exception "message" equals "DeviceNativeUnhandledScenario"
   And the event "unhandled" is true
-
+  And the exception "message" matches "DeviceNativeUnhandledScenario"
   And the event "device.id" is not null
   And the event "device.jailbroken" is false
   And the event "device.locale" matches "^[a-z]{2}_[A-Z]{2}$"

--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -80,44 +80,12 @@ Scenario: Device data in Handled native error
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_new_arch
 Scenario: Device data in Unhandled native error
   When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceNativeUnhandledScenario"
   Then I wait to receive an error
-  And the exception "errorClass" equals "NSException"
-  And the exception "message" equals "DeviceNativeUnhandledScenario"
   And the event "unhandled" is true
-
-  And the event "device.id" matches "^(\d|[abcdef]){40}$"
-  And the event "device.osName" equals "iOS"
-  And the event "device.jailbroken" is false
-  And the event "device.osVersion" matches "^\d+\.\d+(.\d+)?$"
-  And the event "device.time" is a timestamp
-  And the event "device.locale" is not null
-  And the event "device.runtimeVersions.reactNative" matches "^\d+\.\d+\.\d+$"
-  And the event "device.runtimeVersions.reactNativeJsEngine" matches "^jsc|hermes$"
-  And the event "device.runtimeVersions.osBuild" is not null
-  And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
-  And the error payload field "events.0.device.freeMemory" is greater than 0
-  And the event "device.manufacturer" equals "Apple"
-  # Skipped - PLAT-11345
-  # And the error payload field "events.0.device.freeDisk" is greater than 0
-  And the event "device.modelNumber" is not null
-  And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
-  And the error payload field "events.0.device.totalMemory" is greater than 0
-
-# TODO: remove this scenario when PLAT-12184 is resolved
-@skip_old_arch
-Scenario: Device data in Unhandled native error
-  When I run "DeviceNativeUnhandledScenario" and relaunch the crashed app
-  And I configure Bugsnag for "DeviceNativeUnhandledScenario"
-  Then I wait to receive an error
-  And the exception "errorClass" equals "N8facebook3jsi7JSErrorE"
-  And the exception "message" starts with "Exception in HostFunction: DeviceNativeUnhandledScenario"
-  And the event "unhandled" is true
-
+  And the exception "message" matches "DeviceNativeUnhandledScenario"
   And the event "device.id" matches "^(\d|[abcdef]){40}$"
   And the event "device.osName" equals "iOS"
   And the event "device.jailbroken" is false

--- a/test/react-native/features/feature_flags.feature
+++ b/test/react-native/features/feature_flags.feature
@@ -40,34 +40,12 @@ Scenario: Sends no feature flags after clearFeatureFlags()
   And the event "unhandled" is false
   And event 0 has no feature flags
 
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_ios_new_arch
 Scenario: Sends JS feature flags in a native crash
   When I run "FeatureFlagsNativeCrashScenario" and relaunch the crashed app
   And I configure Bugsnag for "FeatureFlagsNativeCrashScenario"
   Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals the platform-dependent string:
-    | android | java.lang.RuntimeException |
-    | ios     | NSException                |
-  And the event "exceptions.0.type" equals the platform-dependent string:
-    | android | android |
-    | ios     | cocoa   |
   And the event "unhandled" is true
-  And event 0 contains the feature flag "demo_mode" with no variant
-  And event 0 contains the feature flag "sample_group" with variant "a"
-  And event 0 does not contain the feature flag "should_not_be_reported_1"
-  And event 0 does not contain the feature flag "should_not_be_reported_2"
-  And event 0 does not contain the feature flag "should_not_be_reported_3"
-
-# TODO: remove this scenario when PLAT-12184 is resolved
-@ios_only @skip_old_arch
-Scenario: Sends JS feature flags in a native crash
-  When I run "FeatureFlagsNativeCrashScenario" and relaunch the crashed app
-  And I configure Bugsnag for "FeatureFlagsNativeCrashScenario"
-  Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
-  And the event "exceptions.0.type" equals "cocoa"
-  And the event "unhandled" is true
+  And the exception "message" matches "FeatureFlagsNativeCrashScenario"
   And event 0 contains the feature flag "demo_mode" with no variant
   And event 0 contains the feature flag "sample_group" with variant "a"
   And event 0 does not contain the feature flag "should_not_be_reported_1"

--- a/test/react-native/features/metadata.feature
+++ b/test/react-native/features/metadata.feature
@@ -25,8 +25,6 @@ Scenario: Setting metadata (native handled)
   And the event "metaData.nativedata.even_more_data" equals "set via event"
   And the event "metaData.nativedata.cleared_data" is null
 
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_ios_new_arch
 Scenario: Setting metadata (native unhandled)
   When I run "MetadataNativeUnhandledScenario"
   And I wait for 2 seconds
@@ -34,29 +32,12 @@ Scenario: Setting metadata (native unhandled)
   And I relaunch the app after a crash
   And I configure Bugsnag for "MetadataNativeUnhandledScenario"
   Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals the platform-dependent string:
-  | android | java.lang.RuntimeException |
-  | ios     | NSException                |
-  And the exception "message" equals "MetadataNativeUnhandledScenario"
+  And the exception "message" matches "MetadataNativeUnhandledScenario"
+  And the event "unhandled" is true
   And the event "metaData.nativedata.some_data" equals "set via config"
   And the event "metaData.nativedata.some_more_data" equals "set via client"
   # Skipped on iOS as callbacks cannot be added outside of config
   And the event "metaData.nativedata.even_more_data" equals the platform-dependent string:
   | android | set via event |
   | ios     | @skip         |
-  And the event "metaData.nativedata.cleared_data" is null
-
-# TODO: remove this scenario when PLAT-12184 is resolved
-@ios_only @skip_old_arch
-Scenario: Setting metadata (native unhandled)
-  When I run "MetadataNativeUnhandledScenario"
-  And I wait for 2 seconds
-  And I clear any error dialogue
-  And I relaunch the app after a crash
-  And I configure Bugsnag for "MetadataNativeUnhandledScenario"
-  Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
-  And the exception "message" starts with "Exception in HostFunction: MetadataNativeUnhandledScenario"
-  And the event "metaData.nativedata.some_data" equals "set via config"
-  And the event "metaData.nativedata.some_more_data" equals "set via client"
   And the event "metaData.nativedata.cleared_data" is null

--- a/test/react-native/features/unhandled-android.feature
+++ b/test/react-native/features/unhandled-android.feature
@@ -1,0 +1,49 @@
+@android_only
+Feature: Reporting unhandled errors
+
+Scenario: Reporting an Unhandled error
+  When I run "UnhandledJsErrorScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledJsErrorScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the exception "type" equals "reactnativejs"
+  And the event "unhandled" is true
+  And the exception "message" equals "UnhandledJsErrorScenario"
+
+Scenario: Reporting an Unhandled promise rejection
+  When I run "UnhandledJsPromiseRejectionScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the exception "type" equals "reactnativejs"
+  And the event "unhandled" is true
+  And the exception "message" equals "UnhandledJsPromiseRejectionScenario"
+
+Scenario: Reporting an Unhandled Native error
+  When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledNativeErrorScenario"
+  Then I wait to receive an error
+  And the event "unhandled" is true
+  And the event "exceptions.0.errorClass" equals the version-dependent string:
+  | arch | version | value                      |
+  | new  | 0.74    | Error                      |
+  | new  | default | java.lang.RuntimeException |
+  | old  | default | java.lang.RuntimeException |
+  And the event "exceptions.0.type" equals the version-dependent string:
+  | arch | version | value                      |
+  | new  | 0.74    | reactnativejs              |
+  | new  | default | android                    |
+  | old  | default | android                    |
+  And the event "exceptions.0.message" equals the version-dependent string:
+  | arch | version | value                                                   |
+  | new  | 0.74    | Exception in HostFunction: UnhandledNativeErrorScenario |
+  | new  | default | UnhandledNativeErrorScenario                            |
+  | old  | default | UnhandledNativeErrorScenario                            |
+
+Scenario: Updating severity on an unhandled JS error
+  When I run "UnhandledJsErrorSeverityScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledJsErrorSeverityScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "UnhandledJsErrorSeverityScenario"
+  And the event "unhandled" is true
+  And the event "severity" equals "info"

--- a/test/react-native/features/unhandled-ios.feature
+++ b/test/react-native/features/unhandled-ios.feature
@@ -1,3 +1,4 @@
+@ios_only
 Feature: Reporting unhandled errors
 
 Scenario: Reporting an Unhandled error
@@ -17,31 +18,25 @@ Scenario: Reporting an Unhandled promise rejection
   And the event "unhandled" is true
   And the exception "message" equals "UnhandledJsPromiseRejectionScenario"
 
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_ios_new_arch
 Scenario: Reporting an Unhandled Native error
   When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledNativeErrorScenario"
   Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals the platform-dependent string:
-  | android | java.lang.RuntimeException |
-  | ios     | NSException                |
-  And the event "exceptions.0.type" equals the platform-dependent string:
-  | android | android |
-  | ios     | cocoa   |
-  And the event "unhandled" is true
-  And the exception "message" equals "UnhandledNativeErrorScenario"
+  And the event "exceptions.0.errorClass" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | N8facebook3jsi7JSErrorE |
+  | new  | 0.73    | N8facebook3jsi7JSErrorE |
+  | new  | default | NSException             |
+  | old  | default | NSException             |
 
-# TODO: remove this scenario when PLAT-12184 is resolved
-@ios_only @skip_old_arch
-Scenario: Reporting an Unhandled Native error
-  When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
-  And I configure Bugsnag for "UnhandledNativeErrorScenario"
-  Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
   And the event "exceptions.0.type" equals "cocoa"
   And the event "unhandled" is true
-  And the exception "message" starts with "Exception in HostFunction: UnhandledNativeErrorScenario"
+  And the event "exceptions.0.message" equals the version-dependent string:
+  | arch | version | value                                                                                                                     |
+  | new  | 0.74    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
+  | new  | 0.73    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
+  | new  | default | UnhandledNativeErrorScenario                                                                                              |
+  | old  | default | UnhandledNativeErrorScenario                                                                                              |
 
 Scenario: Updating severity on an unhandled JS error
   When I run "UnhandledJsErrorSeverityScenario" and relaunch the crashed app
@@ -52,7 +47,7 @@ Scenario: Updating severity on an unhandled JS error
   And the event "unhandled" is true
   And the event "severity" equals "info"
 
-@ios_only @skip_new_arch
+@skip_new_arch
 Scenario: Reporting an unhandled Objective-C exception raise by RCTFatal
   When I run "RCTFatalScenario" and relaunch the crashed app
   And I configure Bugsnag for "RCTFatalScenario"

--- a/test/react-native/features/user.feature
+++ b/test/react-native/features/user.feature
@@ -27,60 +27,23 @@ Scenario: Setting user in JS via event
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"
 
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_ios_new_arch
 Scenario: Setting user in native via client
   When I run "UserNativeClientScenario" and relaunch the crashed app
   And I configure Bugsnag for "UserNativeClientScenario"
   Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals the platform-dependent string:
-  | android | java.lang.RuntimeException |
-  | ios     | NSException                |
-  And the exception "message" equals "UserNativeClientScenario"
+  And the exception "message" matches "UserNativeClientScenario"
+  And the event "unhandled" is true
   And the event "user.email" equals "bug@sn.ag"
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"
 
-# TODO: remove this scenario when PLAT-12184 is resolved
-@ios_only @skip_old_arch
-Scenario: Setting user in native via client
-  When I run "UserNativeClientScenario" and relaunch the crashed app
-  And I configure Bugsnag for "UserNativeClientScenario"
-  Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
-  And the exception "message" starts with "Exception in HostFunction: UserNativeClientScenario"
-  And the event "user.email" equals "bug@sn.ag"
-  And the event "user.name" equals "Bug Snag"
-  And the event "user.id" equals "123"
-
-# Skipped on iOS New Arch pending PLAT-12184
-@skip_ios_new_arch
 Scenario: Setting user in JS via client and sending Native error
   When I run "UserJsNativeScenario" and relaunch the crashed app
   And I configure Bugsnag for "UserJsNativeScenario"
   Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals the platform-dependent string:
-  | android | java.lang.RuntimeException |
-  | ios     | NSException                |
-  And the event "exceptions.0.type" equals the platform-dependent string:
-  | android | android |
-  | ios     | cocoa   |
+  And the exception "message" matches "UnhandledNativeErrorScenario"
   And the event "unhandled" is true
-  And the exception "message" equals "UnhandledNativeErrorScenario"
   And the event "user.email" equals "bug@sn.ag"
   And the event "user.name" equals "Bug Snag"
   And the event "user.id" equals "123"
 
-# TODO: remove this scenario when PLAT-12184 is resolved
-@ios_only @skip_old_arch
-Scenario: Setting user in JS via client and sending Native error
-  When I run "UserJsNativeScenario" and relaunch the crashed app
-  And I configure Bugsnag for "UserJsNativeScenario"
-  Then I wait to receive an error
-  And the event "exceptions.0.errorClass" equals "N8facebook3jsi7JSErrorE"
-  And the event "exceptions.0.type" equals "cocoa"
-  And the event "unhandled" is true
-  And the exception "message" starts with "Exception in HostFunction: UnhandledNativeErrorScenario"
-  And the event "user.email" equals "bug@sn.ag"
-  And the event "user.name" equals "Bug Snag"
-  And the event "user.id" equals "123"


### PR DESCRIPTION
## Goal

In RN 0.74 New Architecture (bridgeless mode), once an exception is thrown, async promises are no longer being resolved. This means JS exceptions are not being reported, because post-error communication with the native layer to capture native state and send an exception for delivery is not able to run.

This PR fixes the issue by making calls to the native layer synchronous when the New Architecture is enabled.

As part of this, RN 0.74 has been added to the test matrix and the e2e tests have been updated accordingly.

## Design

#### Synchronous native methods

There are 2 explicitly async (i.e. promise-returning) methods involved in post-error communication: 
- `getPayloadInfo` (used in `plugin-react-native-event-sync`)
- `dispatch` (used in `delivery-react-native`)

These have been converted to synchronous methods and separate async versions `getPayloadInfoAsync` and `dispatchAsync` added. Both packages have been updated to use the synchronous methods when the New Arch is enabled.

For the remaining native module methods, a preprocessor directive is used on iOS to export those methods as synchronous when the new architecture is enabled (on iOS, `void` native methods that don't return a value in JS are also asynchronous unless exported on the native side with `RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD`)

## Testing

React Native 0.74 has now been added to the test matrix. A new step definition has been added to support testing payload values for a given architecture (old vs new) and RN version combination.