### PR TITLE
Don't start sessions when ReactNative apps are loaded in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - (plugin-react) Modified the polynomial regular expression to remove the ambiguity [#2135](https://github.com/bugsnag/bugsnag-js/pull/2135)
+- (react-native) ReactNative apps loaded in the background will no longer start a new session [#2154](https://github.com/bugsnag/bugsnag-js/pull/2154)
 
 ## [7.23.0] - 2024-05-09
 

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNativeImpl.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNativeImpl.java
@@ -142,6 +142,17 @@ class BugsnagReactNativeImpl {
     }
   }
 
+  void resumeSessionOnStartup() {
+    try {
+      Client client = Bugsnag.getClient();
+      if (Boolean.TRUE.equals(client.sessionTracker.isInForeground())) {
+        plugin.resumeSession();
+      }
+    } catch (Throwable exc) {
+      logFailure("resumeSessionOnStartup", exc);
+    }
+  }
+
   void updateContext(@Nullable String context) {
     try {
       plugin.updateContext(context);

--- a/packages/react-native/android/src/newarch/java/com/bugsnag/android/NativeBugsnagImpl.java
+++ b/packages/react-native/android/src/newarch/java/com/bugsnag/android/NativeBugsnagImpl.java
@@ -62,6 +62,11 @@ public class NativeBugsnagImpl extends NativeBugsnagSpec {
   }
 
   @Override
+  public void resumeSessionOnStartup() {
+    impl.resumeSessionOnStartup();
+  }
+
+  @Override
   public void updateContext(@Nullable String context) {
     impl.updateContext(context);
   }

--- a/packages/react-native/android/src/oldarch/java/com/bugsnag/android/BugsnagReactNative.java
+++ b/packages/react-native/android/src/oldarch/java/com/bugsnag/android/BugsnagReactNative.java
@@ -68,6 +68,11 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void resumeSessionOnStartup() {
+    impl.resumeSessionOnStartup();
+  }
+
+  @ReactMethod
   void updateContext(@Nullable String context) {
     impl.updateContext(context);
   }

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.h
@@ -36,6 +36,7 @@
 - (void)startSession;
 - (void)pauseSession;
 - (void)resumeSession;
+- (void)resumeSessionOnStartup;
 
 - (void)addFeatureFlags:(NSArray *)readableArray;
 - (void)addFeatureFlag:(NSString *)name

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.mm
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.mm
@@ -100,6 +100,10 @@ RCT_EXPORT_METHOD(resumeSession) {
     [Bugsnag resumeSession];
 }
 
+RCT_EXPORT_METHOD(resumeSessionOnStartup) {
+    [Bugsnag resumeSession];
+}
+
 RCT_EXPORT_METHOD(addFeatureFlags:(NSArray *)readableArray) {
     NSMutableArray *array = [NSMutableArray new];
     if(readableArray == nil) {

--- a/packages/react-native/src/NativeBugsnag.ts
+++ b/packages/react-native/src/NativeBugsnag.ts
@@ -17,6 +17,8 @@ export interface Spec extends TurboModule {
 
   resumeSession(): void
 
+  resumeSessionOnStartup(): void
+
   updateContext(context: string | undefined | null): void
 
   addMetadata(section: string, metadata?: UnsafeObject): void

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -91,7 +91,7 @@ const _createClient = (opts, jsOpts) => {
     NativeClient.updateCodeBundleId(opts.codeBundleId)
   }
 
-  if (bugsnag._config.autoTrackSessions) bugsnag.resumeSession()
+  if (bugsnag._config.autoTrackSessions) NativeClient.resumeSessionOnStartup()
 
   bugsnag._logger.debug('Loaded!')
 

--- a/packages/react-native/src/test/integration/handled-unhandled.test.ts
+++ b/packages/react-native/src/test/integration/handled-unhandled.test.ts
@@ -23,6 +23,7 @@ jest.mock('react-native', () => {
         _events: events,
         _clear: () => { while (events.length) events.pop() },
         resumeSession: () => {},
+        resumeSessionOnStartup: () => {},
         pauseSession: () => {},
         startSession: () => {}
       }

--- a/packages/react-native/test/index.test.ts
+++ b/packages/react-native/test/index.test.ts
@@ -19,6 +19,7 @@ jest.mock('react-native', () => ({
       })),
       updateCodeBundleId: jest.fn(),
       resumeSession: jest.fn(),
+      resumeSessionOnStartup: jest.fn(),
       addFeatureFlags: jest.fn(),
       leaveBreadcrumb: jest.fn(),
       getPayloadInfo: jest.fn().mockReturnValue({}),


### PR DESCRIPTION
## Goal
Don't start/resume sessions in ReactNative apps when the bundle is pre-loaded in the background (leaving it to the native layer to start the session when appropriate).

## Changeset
Replace the `resumeSession` call in the ReactNative `Bugsnag.start` implementation with a new `NativeClient.resumeSessionOnStartup` call. The Android native layer first checks that the app is in the foreground before calling `resumeSession` as normal.

## Testing
Manually tested using system broadcasts.