### PR TITLE
Reinstate and refresh Electon tests on macOS

### DIFF
--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -6,9 +6,8 @@ steps:
   - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
     timeout_in_minutes: 40
     agents:
-      queue: macos-11
+      queue: macos-14
     env:
-      DEVELOPER_DIR: "/Applications/Xcode12.app"
       NODE_VERSION: "{{matrix.node_version}}"
       ELECTRON_VERSION: "{{matrix.electron_version}}"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
@@ -17,11 +16,13 @@ steps:
     matrix:
       setup:
         electron_version:
-          - "^12.0.0"
           - "^20.0.0"
+          - "^24.0.0"
+          - "^26.0.0"
+          - "^28.0.0"
+          - "^30.0.0"
         node_version:
-          - "12"
-          - "14"
+          - "18"
     commands:
       - echo "Running on Node `node -v`"
       - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -121,7 +121,6 @@ steps:
       - buildkite-agent pipeline upload .buildkite/basic/browser-pipeline.yml
 
   - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: ELECTRON STEPS :large_blue_circle: :large_blue_circle: :large_blue_circle:"
-    skip: Skipped pending PLAT-10345
     commands:
       - buildkite-agent pipeline upload .buildkite/basic/electron-pipeline.yml
 

--- a/test/electron/features/last-run-info.feature
+++ b/test/electron/features/last-run-info.feature
@@ -1,5 +1,7 @@
 Feature: lastRunInfo
 
+   # Skipped on macOS pending PLAT-12276
+  @not_macos
   Scenario: Last run info consecutive crashes on-launch
       # Crash the app during launch - twice
     Given I launch an app with configuration:
@@ -22,6 +24,8 @@ Feature: lastRunInfo
       | Content-Type      | application/json                 |
     Then the contents of an event request matches "launch-info/consecutive-launch-crashes.json"
 
+   # Skipped on macOS pending PLAT-12276
+  @not_macos
   Scenario: Last run info after crash
     Given I launch an app with configuration:
       | bugsnag | zero-launch-duration |

--- a/test/electron/features/support/world.js
+++ b/test/electron/features/support/world.js
@@ -70,6 +70,10 @@ Before('@not_windows', () => {
   if (process.platform === 'win32') return 'skipped'
 })
 
+Before('@not_macos', () => {
+  if (process.platform === 'darwin') return 'skipped'
+})
+
 Before(async () => {
   await global.server.start()
 })


### PR DESCRIPTION
## Goal

Reinstate and refresh Electon tests on macOS.

## Design

The version test matrix has been bumped and a couple of scenarios skipped on macOS as there were flaking a lot.

## Testing

Covered by a basic CI run.