### PR TITLE
test(react-native): reinstate native stack tests

### DIFF
--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -71,6 +71,7 @@ steps:
               - --farm=bb
               - --device=IOS_16
               - --a11y-locator
+              - --fail-fast
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -102,6 +103,7 @@ steps:
               - --farm=bb
               - --device=IOS_16
               - --a11y-locator
+              - --fail-fast
               - --no-tunnel
               - --aws-public-ip
         env:

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -71,7 +71,6 @@ steps:
               - --farm=bb
               - --device=IOS_16
               - --a11y-locator
-              - --fail-fast
               - --no-tunnel
               - --aws-public-ip
         retry:
@@ -103,7 +102,6 @@ steps:
               - --farm=bb
               - --device=IOS_16
               - --a11y-locator
-              - --fail-fast
               - --no-tunnel
               - --aws-public-ip
         env:

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -1,7 +1,7 @@
 Feature: Native stacktrace is parsed for promise rejections
 
 # Skipped pending PLAT-12063
-@android_only @skip_new_arch
+@android_only
 Scenario: Handled JS error with native stacktrace
   When I run "NativeStackHandledScenario"
   Then I wait to receive an error
@@ -32,7 +32,7 @@ Scenario: Handled JS error with native stacktrace
   And the stacktrace contains "file" equal to "index.android.bundle"
 
 # Skipped pending PLAT-12063
-@android_only @skip_new_arch
+@android_only
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error
@@ -74,7 +74,7 @@ Scenario: Unhandled JS error with native stacktrace
 #   And the error payload field "events.0.exceptions.1.stacktrace.2.lineNumber" equals 2
 
 # Skipped pending PLAT-12063
-@ios_only @skip_new_arch
+@ios_only
 Scenario: Handled JS error with native stacktrace
   When I run "NativeStackHandledScenario"
   Then I wait to receive an error
@@ -102,7 +102,7 @@ Scenario: Handled JS error with native stacktrace
   And the error payload field "events.0.exceptions.0.stacktrace.20.type" is null
 
 # Skipped pending PLAT-12063
-@ios_only @skip_new_arch
+@ios_only
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -1,7 +1,7 @@
 Feature: Native stacktrace is parsed for promise rejections
 
-# Skipped pending PLAT-12063
-@android_only
+# Skipped pending PLAT-12193
+@android_only @skip_new_arch
 Scenario: Handled JS error with native stacktrace
   When I run "NativeStackHandledScenario"
   Then I wait to receive an error
@@ -31,8 +31,8 @@ Scenario: Handled JS error with native stacktrace
   # the javascript part follows
   And the stacktrace contains "file" equal to "index.android.bundle"
 
-# Skipped pending PLAT-12063
-@android_only
+# Skipped pending PLAT-12193
+@android_only @skip_new_arch
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error
@@ -73,8 +73,8 @@ Scenario: Unhandled JS error with native stacktrace
 #   And the error payload field "events.0.exceptions.1.stacktrace.1.lineNumber" equals 1
 #   And the error payload field "events.0.exceptions.1.stacktrace.2.lineNumber" equals 2
 
-# Skipped pending PLAT-12063
-@ios_only
+# Skipped on New Arch below 0.74 - see PLAT-12193
+@ios_only @skip_new_arch_below_074
 Scenario: Handled JS error with native stacktrace
   When I run "NativeStackHandledScenario"
   Then I wait to receive an error
@@ -96,13 +96,30 @@ Scenario: Handled JS error with native stacktrace
   And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "cocoa"
 
   # the javascript part follows
-  And the error payload field "events.0.exceptions.0.stacktrace.20.columnNumber" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.20.file" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.20.lineNumber" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.20.type" is null
+  # On 0.74 New Arch there is no JS stacktrace - see PLAT-12193
+  And the event "exceptions.0.stacktrace.20.columnNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @not_null               |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.20.file" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @not_null               |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.20.lineNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @not_null               |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.20.type" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @null                   |
+  | old  | default | @null                   |
 
-# Skipped pending PLAT-12063
-@ios_only
+# Skipped on New Arch below 0.74 - see PLAT-12193
+@ios_only @skip_new_arch_below_074
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error
@@ -123,7 +140,24 @@ Scenario: Unhandled JS error with native stacktrace
   And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "cocoa"
 
   # the javascript part follows
-  And the error payload field "events.0.exceptions.0.stacktrace.20.columnNumber" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.20.file" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.20.lineNumber" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.20.type" is null
+  # On 0.74 New Arch there is no JS stacktrace - see PLAT-12193
+  And the event "exceptions.0.stacktrace.20.columnNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @not_null               |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.20.file" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @not_null               |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.20.lineNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @not_null               |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.20.type" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @null                   |
+  | old  | default | @null                   |

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -191,5 +191,8 @@ Then('the event {string} equals the version-dependent string:') do |field_path, 
   raise("Multiple expected values found for arch \"#{arch}\" and version \"#{current_version}\"") if version_values.length() > 1
 
   expected_value = version_values[0]['value']
-  assert_equal_with_nullability(expected_value, payload_value)
+  
+  unless expected_value.eql?('@skip')
+    assert_equal_with_nullability(expected_value, payload_value)
+  end
 end

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -38,6 +38,7 @@ Before('@skip_old_arch') do |scenario|
   skip_this_scenario("Skipping scenario") unless ENV['RCT_NEW_ARCH_ENABLED'].eql?('true')
 end
 
-Before('@skip_ios_new_arch') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == 'ios' && ENV['RCT_NEW_ARCH_ENABLED'].eql?('true')
+Before('@skip_new_arch_below_074') do |scenario|
+  current_version = ENV['RN_VERSION'].nil? ? 0 : ENV['RN_VERSION'].to_f
+  skip_this_scenario("Skipping scenario") if ENV['RCT_NEW_ARCH_ENABLED'].eql?('true') && current_version < 0.74
 end


### PR DESCRIPTION
## Goal

reinstated the native stack trace tests for React Native iOS New Arch on 0.74 and updated the linked PLAT ticket - android new arch tests are still skipped pending a fix in React Native

## Testing

covered by CI