### PR TITLE
Add appium version definitions on all android bitbar test runs

### DIFF
--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -67,6 +67,7 @@ steps:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -99,6 +100,7 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -235,6 +235,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -262,6 +263,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -290,6 +292,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -318,6 +321,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -346,6 +350,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -374,6 +379,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -402,6 +408,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -430,6 +437,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -458,6 +466,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel
@@ -484,6 +493,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --fail-fast
               - --no-tunnel

--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -220,6 +220,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
@@ -245,6 +246,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
@@ -270,6 +272,7 @@ steps:
               - --app-package=com.reactnative
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
+              - --appium-version=1.22
               - --a11y-locator
               - --no-tunnel
               - --aws-public-ip


### PR DESCRIPTION
## Goal

Helps prevent potential issues in appium 2.0 for our tests by setting appium to 1.22 on all of our android related test runs.