### PR TITLE
Ensure client is initialised synchronously in bridgeless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - (react-native) Use synchronous native module calls when New Architecture is enabled [#2152](https://github.com/bugsnag/bugsnag-js/pull/2152)
+- (react-native) Ensure client is initialised synchronously in bridgeless mode [#2165](https://github.com/bugsnag/bugsnag-js/pull/2165)
 
 ## [7.24.0] - 2024-06-10
 

--- a/packages/react-native/src/notifier.js
+++ b/packages/react-native/src/notifier.js
@@ -9,9 +9,9 @@ This only affects the remote debugger. Execution of JS in the normal way (on the
 
 // this is how some internal react native code detects whether the app is running
 // in the remote debugger:
-//   https://github.com/facebook/react-native/blob/1f4535c17572df78e2a033890220337e5703b614/Libraries/ReactNative/PaperUIManager.js#L62-L66
+//   https://github.com/facebook/react-native/blob/e320ab47cf855f2e5de74ea448ec292cf0bbb29a/packages/react-native/Libraries/Utilities/DebugEnvironment.js#L15
 // there's no public api for this so we use the same approach
-const isDebuggingRemotely = !global.nativeCallSyncHook
+const isDebuggingRemotely = !global.nativeCallSyncHook && !global.RN$Bridgeless
 
 const name = 'Bugsnag React Native'
 const { version } = require('../package.json')


### PR DESCRIPTION
## Goal

The current code for detecting if the app is running in the remote debugger gives a false positive when running in Bridgeless New Architecture mode because `global.nativeCallSyncHook` is always undefined, meaning that the client is initialised asynchronously unnecessarily.

This PR updates the check  to also check for `global.RN$Bridgeless` avoid a false positive on Bridgeless (based on React Native's internal code)

## Testing

Tested manually in a 0.74 app