### PR TITLE
Disable the network plugin if the 'window' object does not exist

### DIFF
--- a/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
+++ b/packages/plugin-network-breadcrumbs/network-breadcrumbs.js
@@ -5,11 +5,11 @@ const includes = require('@bugsnag/core/lib/es-utils/includes')
 /*
  * Leaves breadcrumbs when network requests occur
  */
-module.exports = (_ignoredUrls = [], win = window) => {
+module.exports = (_ignoredUrls = [], win = typeof window !== 'undefined' ? window : null) => {
   let restoreFunctions = []
   const plugin = {
     load: client => {
-      if (!client._isBreadcrumbTypeEnabled('request')) return
+      if (!client._isBreadcrumbTypeEnabled('request') || window === null) return
 
       const ignoredUrls = [
         client._config.endpoints.notify,


### PR DESCRIPTION
## Goal

The unchecked access to the `window` object was breaking the Expo notifier in browser. This change aims to fix that issue by disabling the plugin when the `window` object is not accessible. 

## Design

This way the plugin exits gracefully when the  `window` object is not accessible instead of throwing an error.

## Changeset

Added handling for environments where the `window` object is not available.

## Testing

I've run the automated unit tests which all have passed. I've also built the package and used it in my React Native project without any issues. 