### PR TITLE
Check global vue config exists before installing vue 2 handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (plugin-vue) Check global vue config exists before installing vue 2 handler [#2171](https://github.com/bugsnag/bugsnag-js/pull/2171)
+
 ## [7.25.0] - 2024-07-03
 
 ### Added

--- a/packages/plugin-vue/src/index.js
+++ b/packages/plugin-vue/src/index.js
@@ -16,7 +16,7 @@ module.exports = class BugsnagPluginVue {
   }
 
   load (client) {
-    if (this.Vue) {
+    if (this.Vue && this.Vue.config) {
       installVue2(this.Vue, client)
       return {
         installVueErrorHandler: () => client._logger.warn('installVueErrorHandler() was called unnecessarily')


### PR DESCRIPTION
## Goal

Fixes an error in the Vue plugin initialisation when using Vue 3+ via CDN (reported in #2150)

## Design

Currently the plugin attempts to install the Vue 2 handler (via the global Vue.config) if a global Vue object exists, but CDN builds of Vue 3+ will also expose a global Vue object.

This PR updates the check in plugin load to ensure that Vue.config exists before installing the Vue 2 handler.

## Testing

Added a new unit test and tested manually with a Vue 3 CDN build.