### PR TITLE
[PLAT-12474] Support error correlation property in events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [8.0.0] - Unreleased
 
+### Added
+
+- (delivery-react-native) Support error correlation properties in event payloads [#2174](https://github.com/bugsnag/bugsnag-js/pull/2174) 
+
 ### Fixed
 
 - (plugin-angular) Prevent excess change detection cycles when calling `Bugsnag.notify` [#1861](https://github.com/bugsnag/bugsnag-js/pull/1861)

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -29,7 +29,8 @@ module.exports = (client, NativeClient) => ({
       groupingHash: event.groupingHash,
       apiKey: event.apiKey,
       featureFlags: event.toJSON().featureFlags,
-      nativeStack: nativeStack
+      nativeStack: nativeStack,
+      correlation: event.toJSON().correlation
     }
 
     if (isTurboModuleEnabled) {

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -30,7 +30,7 @@ module.exports = (client, NativeClient) => ({
       apiKey: event.apiKey,
       featureFlags: event.toJSON().featureFlags,
       nativeStack: nativeStack,
-      correlation: event.toJSON().correlation
+      correlation: event._correlation
     }
 
     if (isTurboModuleEnabled) {

--- a/packages/delivery-react-native/test/delivery.test.ts
+++ b/packages/delivery-react-native/test/delivery.test.ts
@@ -26,6 +26,7 @@ type NativeClientEvent = Pick<EventWithInternals,
   severityReason: EventWithInternals['_handledState']['severityReason']
   user: EventWithInternals['_user']
   metadata: EventWithInternals['_metadata']
+  correlation: EventWithInternals['_correlation']
   nativeStack: NativeStackIOS | NativeStackAndroid
 }
 
@@ -57,6 +58,7 @@ describe('delivery: react native', () => {
     c.setContext('test screen')
     c.setUser('123')
     c.notify(new Error('oh no'), (e) => {
+      e.setTraceCorrelation('trace-id', 'span-id')
       e.groupingHash = 'ER_GRP_098'
       e.apiKey = 'abcdef123456abcdef123456abcdef123456'
     }, (err, event) => {
@@ -80,6 +82,7 @@ describe('delivery: react native', () => {
       expect(sent[0].metadata).toEqual({})
       expect(sent[0].groupingHash).toEqual('ER_GRP_098')
       expect(sent[0].apiKey).toBe('abcdef123456abcdef123456abcdef123456')
+      expect(sent[0].correlation).toEqual({ traceId: 'trace-id', spanId: 'span-id' })
       done()
     })
   })


### PR DESCRIPTION
## Goal

Support error correlation when using React Native

## Changeset

Add `correlation` property to event payload

## Testing

Update unit tests to assert on correlation property