### PR TITLE
Add automatic dependency updating workflow to github actions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -22,6 +22,7 @@ jobs:
       VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_version || inputs.target_version }}
       BUNDLE_GITHUB__COM: ${{ secrets.BUNDLE_ACCESS_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REVIEWER: gingerbenw
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,4 +59,4 @@ jobs:
          -H bumpsnag-$TARGET_SUBMODULE-$TARGET_VERSION
          --title "Update $TARGET_SUBMODULE to version $TARGET_VERSION"
          --body 'Created by bumpsnag'
-         --reviewer gingerbenw
+         --reviewer $REVIEWER

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,61 @@
+name: update-dependencies
+
+on:
+  repository_dispatch:
+    types: [update-dependency]
+  workflow_dispatch:
+    inputs:
+      target_submodule:
+        description: 'Submodule to update'
+        required: true
+        type: string
+      target_version:
+        description: 'Version of the submodule to update to'
+        required: true
+        type: string
+
+jobs:
+  update-dependencies:
+    runs-on: macos-latest
+    env:
+      SUBMODULE: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_submodule || inputs.target_submodule }}
+      VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_version || inputs.target_version }}
+      BUNDLE_GITHUB__COM: ${{ secrets.BUNDLE_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: next
+
+      - run: |
+          git config --global user.name 'Bumpsnag bot'
+          git config --global user.email ''
+
+      - run: git fetch --prune --unshallow
+
+      - name: Install ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Update references locally
+        run: TARGET_SUBMODULE=$SUBMODULE TARGET_VERSION=$VERSION bundle exec scripts/update-dependencies.rb
+
+      - name: Commit and push changes
+        run: bundle exec bumpsnag commit_update $SUBMODULE $VERSION
+
+      - name: List current branch name
+        id: current-branch
+        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create pull request
+        if: ${{ steps.current-branch.outputs.branch != 'next'}}
+        run: >
+         gh pr create -B next
+         -H bumpsnag-$TARGET_SUBMODULE-$TARGET_VERSION
+         --title "Update $TARGET_SUBMODULE to version $TARGET_VERSION"
+         --body 'Created by bumpsnag'
+         --reviewer gingerbenw

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.14.3'
+
+# Only install bumpsnag if we're using Github actions
+unless ENV['GITHUB_ACTIONS'].nil?
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
+end

--- a/packages/react-native/CONTRIBUTING.md
+++ b/packages/react-native/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 ## Upgrading native notifier dependencies
 
-Both [`bugsnag-android`](https://github.com/bugnsag/bugsnag-android) and [`bugsnag-cocoa`](https://github.com/bugnsag/bugsnag-cocoa) are vendored into this repository as part of the `@bugsnag/react-native` package. When updates to those notifiers are released, a PR should be make to this repository to vendor the new version.
+Both [`bugsnag-android`](https://github.com/bugsnag/bugsnag-android) and [`bugsnag-cocoa`](https://github.com/bugsnag/bugsnag-cocoa) are vendored into this repository as part of the `@bugsnag/react-native` package. When updates to those notifiers are released, a PR should be make to this repository to vendor the new version.
 
 ### Android
 
-[bugsnag-android](https://github.com/bugnsag/bugsnag-android) AAR artefacts are located in `packages/react-native/android/com/bugsnag`
+[bugsnag-android](https://github.com/bugsnag/bugsnag-android) AAR artefacts are located in `packages/react-native/android/com/bugsnag`
 
 To update the version of the bundled artefacts:
 
@@ -16,7 +16,7 @@ To update the version of the bundled artefacts:
 
 #### iOS
 
-[bugsnag-cocoa](https://github.com/bugnsag/bugsnag-cocoa) source is vendored in `packages/react-native/ios/vendor/bugsnag-cocoa`.
+[bugsnag-cocoa](https://github.com/bugsnag/bugsnag-cocoa) source is vendored in `packages/react-native/ios/vendor/bugsnag-cocoa`.
 
 To update the version of the bundled notifier source:
 

--- a/scripts/update-dependencies.rb
+++ b/scripts/update-dependencies.rb
@@ -1,0 +1,19 @@
+require 'bumpsnag'
+
+target_submodule = ENV['TARGET_SUBMODULE']
+target_version = ENV['TARGET_VERSION']
+
+if target_submodule.nil? || target_version.nil?
+  raise 'Submodule or version targets not provided, exiting'
+  exit(1)
+end
+
+pp "Attempting upgrade of #{target_submodule} to #{target_version}"
+
+if target_submodule.eql?('bugsnag-android')
+  `packages/react-native/update-android.sh --version #{target_version}`
+elsif target_submodule.eql?('bugsnag-cocoa')
+  `packages/react-native/update-ios.sh --version #{target_version}`
+else
+  raise "Submodule #{target_submodule} not supported, exiting"
+end


### PR DESCRIPTION
Adds a workflow triggered by remote branches that will:
- Run an appropriate update script
- Push and create a PR into next
- Use an appropriate commit message to trigger the full CI run
- 
This will require some upstream changes before it starts triggering, but has been extensively tested in the forked repo.

Note - This is an internal copy of https://github.com/bugsnag/bugsnag-js/pull/2168 as I wanted CI to run against it