### PR TITLE
[PLAT-12487] Handle correlation property in iOS events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- (delivery-react-native) Support error correlation properties in event payloads [#2174](https://github.com/bugsnag/bugsnag-js/pull/2174) 
+Support error correlation properties in event payloads [#2181](https://github.com/bugsnag/bugsnag-js/pull/2181) [#2174](https://github.com/bugsnag/bugsnag-js/pull/2174) 
 
 ### Fixed
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -17,6 +17,7 @@
 
     BugsnagHandledState *handledState = [self deserializeHandledState:payload];
     NSDictionary *user = payload[@"user"];
+    NSDictionary *correlation = payload[@"correlation"];
 
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithApp:[BugsnagAppWithState appFromJson:payload[@"app"]]
                                                      device:[BugsnagDeviceWithState deviceFromJson:payload[@"device"]]
@@ -29,6 +30,8 @@
                                                     session:nil /* set by -[BugsnagClient notifyInternal:block:] */];
     event.context = payload[@"context"];
     event.groupingHash = payload[@"groupingHash"];
+
+    [event setCorrelationTraceId:correlation[@"traceId"] spanId:correlation[@"spanId"]];
 
     if (payload[@"apiKey"]) {
         event.apiKey = payload[@"apiKey"];


### PR DESCRIPTION
## Goal

Handle error correlation properties in event delivery for iOS 