### PR TITLE
Reinstate skipped native stack tests for android

### DIFF
--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -29,7 +29,11 @@ Scenario: Handled JS error with native stacktrace
     | runScenario |
 
   # the javascript part follows
-  And the stacktrace contains "file" equal to "index.android.bundle"
+  And the stacktrace contains "file" equal to the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @skip                   |
+  | old  | default | index.android.bundle    |
 
 # Skipped pending PLAT-12193
 @android_only @skip_new_arch_below_074
@@ -66,7 +70,11 @@ Scenario: Unhandled JS error with native stacktrace
     | runScenario |
 
   # the javascript part follows
-  And the stacktrace contains "file" equal to "index.android.bundle"
+  And the stacktrace contains "file" equal to the version-dependent string:
+  | arch | version | value                   |
+  | new  | 0.74    | @skip                   |
+  | new  | default | @skip                   |
+  | old  | default | index.android.bundle    |
 
 #   # PLAT-5117 addresses float serialization
 #   And the error payload field "events.0.exceptions.1.stacktrace.0.lineNumber" equals 1

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -1,7 +1,7 @@
 Feature: Native stacktrace is parsed for promise rejections
 
 # Skipped pending PLAT-12193
-@android_only @skip_new_arch
+@android_only @skip_new_arch_below_074
 Scenario: Handled JS error with native stacktrace
   When I run "NativeStackHandledScenario"
   Then I wait to receive an error
@@ -32,7 +32,7 @@ Scenario: Handled JS error with native stacktrace
   And the stacktrace contains "file" equal to "index.android.bundle"
 
 # Skipped pending PLAT-12193
-@android_only @skip_new_arch
+@android_only @skip_new_arch_below_074
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error


### PR DESCRIPTION
## Goal

Reinstates skipped native stacktrace tests for Android on New Architecture - these were previously being skipped due to an issue in React Native, where native promise rejections from Turbo Modules were not an instance of `Error` in JS. This has now been fixed: https://github.com/facebook/react-native/commit/f4b0fcb92263667754348f82030f85cc941846ba

## Design

Although the issue has been fixed in React Native (promise rejections from Turbo Modules are now `Error`s in JS), the behaviour in Turbo Modules is still different vs legacy Native Modules - in the Old Architecture native promise rejections preserved the JS stack frames from before the call to the native module. This is no longer the case in Turbo Modules, which means events only contain native stack frames.

The test therefore skips the JS stack frame assertion on New Architecture.