### PR TITLE
Ensure that electron test failure files are still uploaded

### DIFF
--- a/.github/workflows/test-electron.yml
+++ b/.github/workflows/test-electron.yml
@@ -71,3 +71,4 @@ jobs:
       with:
         name: cucumber-failures
         path: test/.cucumber-failures/
+        include-hidden-files: true


### PR DESCRIPTION
## Goal

Relating to [this change](https://github.com/actions/upload-artifact/issues/602) in the github upload action, this will ensure that the secret `.` directory, `.cucumber-failures` is still uploaded.