### PR TITLE
ci(react-native): fix react-navigation 0.69 test fixture builds

### DIFF
--- a/test/react-native/features/fixtures/app/react_navigation_js/install.sh
+++ b/test/react-native/features/fixtures/app/react_navigation_js/install.sh
@@ -22,7 +22,7 @@ else
   npm install @react-native-community/masked-view@^0.1 --legacy-peer-deps --registry=$REGISTRY_URL
       npm install @react-navigation/native@^6.0 --legacy-peer-deps --registry=$REGISTRY_URL
       npm install @react-navigation/stack@^6.0 --legacy-peer-deps --registry=$REGISTRY_URL
-      npm install react-native-gesture-handler@^2.2 --legacy-peer-deps --registry=$REGISTRY_URL
+      npm install react-native-gesture-handler@2.18.1 --legacy-peer-deps --registry=$REGISTRY_URL
       npm install react-native-reanimated@^1.13 --legacy-peer-deps --registry=$REGISTRY_URL
       npm install react-native-safe-area-context@3.3 --legacy-peer-deps --registry=$REGISTRY_URL
       npm install react-native-screens@3.10 --legacy-peer-deps --registry=$REGISTRY_URL


### PR DESCRIPTION
## Goal

Fixes the react-navigation 0.69 test fixture builds in CI

The test fixture was configured to install the latest v2 version of react-native-gesture-handler, and it looks like something in the latest release (which coincides with when these builds began failing) has broken compatibility with RN 0.69.

Updated the build script to pin the dependency to the last known working version.

## Testing

Covered by a full CI run