### PR TITLE
Update AWS Lambda tests to use Maze Runner v9

### DIFF
--- a/test/aws-lambda/Gemfile
+++ b/test/aws-lambda/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
+gem 'bugsnag-maze-runner', '~>9.0'
 
 # Use a branch of Maze Runner
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/use-maze-check'


### PR DESCRIPTION
## Goal

Update AWS Lambda tests to use Maze Runner v9.

## Testing

Covered by a basic CI run.