### PR TITLE
test(react-native): bump react-native-file-access version and remove workaround

### DIFF
--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -37,7 +37,7 @@ const fixtureDir = resolve(ROOT_DIR, fixturePath, reactNativeVersion)
 const replacementFilesDir = resolve(ROOT_DIR, 'test/react-native/features/fixtures/app/dynamic/')
 
 const DEPENDENCIES = [
-  'react-native-file-access@3.0.4',
+  'react-native-file-access@3.1.1',
   `@bugsnag/react-native@${notifierVersion}`,
   `@bugsnag/plugin-react-navigation@${notifierVersion}`,
   `@bugsnag/plugin-react-native-navigation@${notifierVersion}`
@@ -192,11 +192,6 @@ function replaceGeneratedFixtureFiles () {
 
   // update Podfile
   let podfileContents = fs.readFileSync(`${fixtureDir}/ios/Podfile`, 'utf8')
-
-  // use static frameworks (this fixes an issue with react-native-file-access on 0.75)
-  if (parseFloat(reactNativeVersion) >= 0.75) {
-    podfileContents = podfileContents.replace(/target 'reactnative' do/, 'use_frameworks! :linkage => :static\ntarget \'reactnative\' do')
-  }
 
   // disable Flipper
   if (podfileContents.includes('use_flipper!')) {


### PR DESCRIPTION
## Goal
Updates the test fixture script to use the latest version of react-native-file-access and removes the static frameworks workaround for RN 0.75 tests.

## Design
Previously static frameworks were required for iOS in React Native 0.75 in order to work around an issue in react-native-file-access - this issue has now been fixed in v3.1.1 of react-native-file-access, so the workaround is no longer required.

## Testing
Relied on CI