### PR TITLE
Specify branch when triggering latest Expo pipeline

### DIFF
--- a/.buildkite/full/pipeline.full.yml
+++ b/.buildkite/full/pipeline.full.yml
@@ -48,8 +48,7 @@ steps:
     depends_on: "publish-js"
     trigger: "bugsnag-expo"
     build:
-      # don't specify 'branch' here so we build the default branch in the expo
-      # repo, which should be the most up-to-date @bugsnag/expo version
+      branch: "v51/next"
       env:
         BUGSNAG_JS_BRANCH: "${BUILDKITE_BRANCH}"
         BUGSNAG_JS_COMMIT: "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
## Goal

Allow triggered Expo pipeline build to be cleanly integrated with TestAnalytics.

## Design

To date we've always omitted the branch when triggering the latest Expo pipeline, to be sure that we run test for the latest Expo version each night, even if we forget to update the triggers when a new version of Expo is released.  

However, this is problematic when integrating the Expo pipelines with Buildkite TestAnalytics.  TestAnalytics is set up to included results from select branches only and in this scenario the branch given is `HEAD`, as opposed to `v51/next` (for example).  Although we could set up TestAnalytics to include results for `HEAD` on our latest Expo branch, it would mean having to raise an extra PR each time (to move `HEAD` to and explicit branch).  

Overall I feel it's going to be easier to maintain and less likely to go wrong if we now just give explicit branch names for all 3 Expo pipeline triggers.

## Testing

Covered by CI.