### PR TITLE
Add buildkite analytics test collection to react and react-native e2e tests

### DIFF
--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -69,7 +69,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -104,7 +107,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -69,10 +69,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -102,10 +104,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -71,7 +71,10 @@ steps:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -105,7 +108,10 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -71,10 +71,12 @@ steps:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -103,10 +105,12 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           RCT_NEW_ARCH_ENABLED: "1"
           RN_VERSION: "{{matrix}}"

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -216,10 +216,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
         concurrency: 25
@@ -244,10 +246,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
@@ -273,10 +277,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
@@ -302,10 +308,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
@@ -329,10 +337,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -366,10 +376,12 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -400,11 +412,13 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
               - features/react-native-navigation.feature
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -435,11 +449,13 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
               - features/react-native-navigation.feature
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -216,7 +216,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -246,7 +249,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -277,7 +283,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -308,7 +317,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -337,7 +349,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -376,7 +391,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -412,7 +430,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
               - features/react-native-navigation.feature
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
@@ -449,7 +470,10 @@ steps:
               - --farm=bb
               - --device=ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
               - features/react-native-navigation.feature
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"

--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -157,6 +157,7 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
               - features/run-app-tests
@@ -187,6 +188,7 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
               - features/run-app-tests
@@ -217,6 +219,7 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
+              - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
               - features/run-app-tests
@@ -247,6 +250,7 @@ steps:
               - --app=build/rn0_66.ipa
               - --farm=bs
               - --device=IOS_14
+              - --a11y-locator
               - features/run-app-tests
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
@@ -272,6 +276,7 @@ steps:
               - --app=build/rn0_67.ipa
               - --farm=bs
               - --device=IOS_14
+              - --a11y-locator
               - features/run-app-tests
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
@@ -297,6 +302,7 @@ steps:
               - --app=build/rn0_69.ipa
               - --farm=bs
               - --device=IOS_14
+              - --a11y-locator
               - features/run-app-tests
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"

--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -157,10 +157,14 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
               - features/run-app-tests
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_CLI_BUILDKITE_ANALYTICS_TOKEN"
         concurrency: 25
         concurrency_group: 'bitbar'
         concurrency_method: eager
@@ -183,10 +187,14 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
               - features/run-app-tests
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_CLI_BUILDKITE_ANALYTICS_TOKEN"
         concurrency: 25
         concurrency_group: 'bitbar'
         concurrency_method: eager
@@ -209,10 +217,14 @@ steps:
               - --farm=bb
               - --device=ANDROID_10|ANDROID_11|ANDROID_12
               - --appium-version=1.22
-              - --a11y-locator
               - --no-tunnel
               - --aws-public-ip
               - features/run-app-tests
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_CLI_BUILDKITE_ANALYTICS_TOKEN"
         concurrency: 25
         concurrency_group: 'bitbar'
         concurrency_method: eager
@@ -235,8 +247,12 @@ steps:
               - --app=build/rn0_66.ipa
               - --farm=bs
               - --device=IOS_14
-              - --a11y-locator
               - features/run-app-tests
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_CLI_BUILDKITE_ANALYTICS_TOKEN"
         concurrency: 5
         concurrency_group: "browserstack-app"
         concurrency_method: eager
@@ -256,8 +272,12 @@ steps:
               - --app=build/rn0_67.ipa
               - --farm=bs
               - --device=IOS_14
-              - --a11y-locator
               - features/run-app-tests
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_CLI_BUILDKITE_ANALYTICS_TOKEN"
         concurrency: 5
         concurrency_group: "browserstack-app"
         concurrency_method: eager
@@ -277,8 +297,12 @@ steps:
               - --app=build/rn0_69.ipa
               - --farm=bs
               - --device=IOS_14
-              - --a11y-locator
               - features/run-app-tests
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_CLI_BUILDKITE_ANALYTICS_TOKEN"
         concurrency: 5
         concurrency_group: "browserstack-app"
         concurrency_method: eager

--- a/.buildkite/full/react-native-ios-pipeline.full.yml
+++ b/.buildkite/full/react-native-ios-pipeline.full.yml
@@ -195,7 +195,10 @@ steps:
               - --app=build/rn0.66.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -223,7 +226,10 @@ steps:
               - --app=build/rn0.67.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -252,7 +258,10 @@ steps:
               - --app=build/rn0.69.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -281,7 +290,10 @@ steps:
               - --app=build/rn0.68-hermes.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -309,7 +321,10 @@ steps:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -344,7 +359,10 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
@@ -382,7 +400,10 @@ steps:
               - --app=/app/features/fixtures/generated/react-native-navigation/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
+              - --a11y-locator
               - --fail-fast
+              - --no-tunnel
+              - --aws-public-ip
               - features/react-native-navigation.feature
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
@@ -420,7 +441,10 @@ steps:
       #         - --app=/app/features/fixtures/generated/react-native-navigation/new-arch/{{matrix}}/output/reactnative.ipa
       #         - --farm=bb
       #         - --device=IOS_16
+      #         - --a11y-locator
       #         - --fail-fast
+      #         - --no-tunnel
+      #         - --aws-public-ip
       #         - features/react-native-navigation.feature
       #     test-collector#v1.10.2:
       #       files: "reports/TEST-*.xml"

--- a/.buildkite/full/react-native-ios-pipeline.full.yml
+++ b/.buildkite/full/react-native-ios-pipeline.full.yml
@@ -195,10 +195,12 @@ steps:
               - --app=build/rn0.66.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
         concurrency: 25
@@ -221,10 +223,12 @@ steps:
               - --app=build/rn0.67.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
@@ -248,10 +252,12 @@ steps:
               - --app=build/rn0.69.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
@@ -275,10 +281,12 @@ steps:
               - --app=build/rn0.68-hermes.ipa
               - --farm=bb
               - --device=IOS_15|IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           SKIP_NAVIGATION_SCENARIOS: "true"
           HERMES: "true"
@@ -301,10 +309,12 @@ steps:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -334,10 +344,12 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         env:
           RCT_NEW_ARCH_ENABLED: "1"
           RN_VERSION: "{{matrix}}"
@@ -370,11 +382,13 @@ steps:
               - --app=/app/features/fixtures/generated/react-native-navigation/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
               - --device=IOS_16
-              - --a11y-locator
               - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
               - features/react-native-navigation.feature
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
         retry:
           manual:
             permit_on_passed: true
@@ -406,11 +420,13 @@ steps:
       #         - --app=/app/features/fixtures/generated/react-native-navigation/new-arch/{{matrix}}/output/reactnative.ipa
       #         - --farm=bb
       #         - --device=IOS_16
-      #         - --a11y-locator
       #         - --fail-fast
-      #         - --no-tunnel
-      #         - --aws-public-ip
       #         - features/react-native-navigation.feature
+      #     test-collector#v1.10.2:
+      #       files: "reports/TEST-*.xml"
+      #       format: "junit"
+      #       branch: "^main|next$$"
+      #       api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
       #   env:
       #     RCT_NEW_ARCH_ENABLED: "1"
       #     RN_VERSION: "{{matrix}}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
       - ./test/react-native/features/:/app/features
       - ./test/react-native/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./reports/:/app
+      - ./reports/:/app/reports
 
   react-native-cli-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
@@ -208,7 +208,7 @@ services:
       - ./test/react-native-cli/features/:/app/features/
       - ./test/react-native-cli/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./reports/:/app
+      - ./reports/:/app/reports
 
   release:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
       - ./test/react-native/features/:/app/features
       - ./test/react-native/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./reports/:/app/features/
+      - ./reports/:/app
 
   react-native-cli-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
@@ -208,7 +208,7 @@ services:
       - ./test/react-native-cli/features/:/app/features/
       - ./test/react-native-cli/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./reports/:/app/features/
+      - ./reports/:/app
 
   release:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,7 @@ services:
       - ./test/react-native/features/:/app/features
       - ./test/react-native/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./reports/:/app/features/
 
   react-native-cli-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v9-cli
@@ -207,6 +208,7 @@ services:
       - ./test/react-native-cli/features/:/app/features/
       - ./test/react-native-cli/maze_output:/app/maze_output
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./reports/:/app/features/
 
   release:
     build:

--- a/test/react-native-cli/features/support/maze.all.cfg
+++ b/test/react-native-cli/features/support/maze.all.cfg
@@ -1,0 +1,1 @@
+--a11y-locator

--- a/test/react-native-cli/features/support/maze.buildkite.cfg
+++ b/test/react-native-cli/features/support/maze.buildkite.cfg
@@ -1,0 +1,3 @@
+--format=junit
+--out=reports
+--format=pretty

--- a/test/react-native/features/support/maze.all.cfg
+++ b/test/react-native/features/support/maze.all.cfg
@@ -1,3 +1,1 @@
---no-tunnel
---aws-public-ip
 --a11y-locator

--- a/test/react-native/features/support/maze.all.cfg
+++ b/test/react-native/features/support/maze.all.cfg
@@ -1,0 +1,3 @@
+--no-tunnel
+--aws-public-ip
+--a11y-locator

--- a/test/react-native/features/support/maze.buildkite.cfg
+++ b/test/react-native/features/support/maze.buildkite.cfg
@@ -1,0 +1,3 @@
+--format=junit
+--out=reports
+--format=pretty


### PR DESCRIPTION
There's some overlap with maze-runner options between config files and options in the pipeline, once the maze-runner mechanism for reading the config files is fixed we should be able to remove the pipeline options.