### PR TITLE
Bump hermes-engine to v0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19970,9 +19970,9 @@
       }
     },
     "node_modules/hermes-engine": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.7.2.tgz",
-      "integrity": "sha512-E2DkRaO97gwL98LPhgfkMqhHiNsrAjIfEk3wWYn2Y31xdkdWn0572H7RnVcGujMJVqZNJvtknxlpsUb8Wzc3KA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.10.0.tgz",
+      "integrity": "sha512-SiBo9rvuWetTIQGPPYwRHP0Omo/Iw/yd0sujWR0bW08+syIO0qDpo/fgx7GrY5PEy8wLcVz8v7adET2i5DOmJg==",
       "dev": true
     },
     "node_modules/hermes-profile-transformer": {
@@ -56956,9 +56956,9 @@
       }
     },
     "hermes-engine": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.7.2.tgz",
-      "integrity": "sha512-E2DkRaO97gwL98LPhgfkMqhHiNsrAjIfEk3wWYn2Y31xdkdWn0572H7RnVcGujMJVqZNJvtknxlpsUb8Wzc3KA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.10.0.tgz",
+      "integrity": "sha512-SiBo9rvuWetTIQGPPYwRHP0Omo/Iw/yd0sujWR0bW08+syIO0qDpo/fgx7GrY5PEy8wLcVz8v7adET2i5DOmJg==",
       "dev": true
     },
     "hermes-profile-transformer": {
@@ -67003,7 +67003,7 @@
         "event-target-shim": "^5.0.1",
         "fbjs": "^1.0.0",
         "fbjs-scripts": "^1.1.0",
-        "hermes-engine": "^0.7.2",
+        "hermes-engine": "^0.10.0",
         "invariant": "^2.2.4",
         "jsc-android": "^245459.0.0",
         "metro-babel-register": "0.59.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@types/express-serve-static-core": "4.17.28",
     "@types/prettier": "2.6.0",
     "@types/yargs": "17.0.10",
-    "hermes-engine": "^0.7.2",
+    "hermes-engine": "^0.10.0",
     "json-schema": "^0.4.0",
     "shell-quote": "^1.7.3",
     "thenify": "^3.3.1"


### PR DESCRIPTION
## Goal

Resolve CVE-2021-24037 and CVE-2021-24044

## Changeset

Override `hermes-engine` dev dependency to `^0.10.0` 

## Testing

Covered by CI