### PR TITLE
Revert Access-Control-Max-Age Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,6 @@ As well as some bug fixes and **breaking changes** described in the [Upgrade Gui
 
 ## [7.25.1] - 2024-08-27
 
-### Added
-
-- (delivery-xml-http-request) Add Access-Control-Max-Age header to CORS preflight responses [#2160](https://github.com/bugsnag/bugsnag-js/pull/2160)
-
 ### Changed
 
 - (react-native) Update bugsnag-cocoa from v6.29.0 to [v6.30.1](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6301-2024-07-25)

--- a/packages/delivery-xml-http-request/delivery.js
+++ b/packages/delivery-xml-http-request/delivery.js
@@ -32,9 +32,6 @@ module.exports = (client, win = window) => ({
       req.setRequestHeader('Bugsnag-Api-Key', event.apiKey || client._config.apiKey)
       req.setRequestHeader('Bugsnag-Payload-Version', '4')
       req.setRequestHeader('Bugsnag-Sent-At', (new Date()).toISOString())
-      if (url.substring(0, 5) === 'https') {
-        req.setRequestHeader('Access-Control-Max-Age', 86400)
-      }
       req.send(body)
     } catch (e) {
       client._logger.error(e)

--- a/packages/delivery-xml-http-request/test/delivery.test.ts
+++ b/packages/delivery-xml-http-request/test/delivery.test.ts
@@ -53,7 +53,7 @@ describe('delivery:XMLHttpRequest', () => {
     const payload = { sample: 'payload' } as unknown as EventDeliveryPayload
     const config = {
       apiKey: 'aaaaaaaa',
-      endpoints: { notify: 'https/echo/' },
+      endpoints: { notify: 'echo/' },
       redactedKeys: []
     }
 
@@ -61,12 +61,11 @@ describe('delivery:XMLHttpRequest', () => {
       expect(err).toBe(null)
       expect(requests.length).toBe(1)
       expect(requests[0].method).toBe('POST')
-      expect(requests[0].url).toMatch('https/echo/')
+      expect(requests[0].url).toMatch('echo/')
       expect(requests[0].headers['Content-Type']).toEqual('application/json')
       expect(requests[0].headers['Bugsnag-Api-Key']).toEqual('aaaaaaaa')
       expect(requests[0].headers['Bugsnag-Payload-Version']).toEqual('4')
       expect(requests[0].headers['Bugsnag-Sent-At']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
-      expect(requests[0].headers['Access-Control-Max-Age']).toEqual(86400)
       expect(requests[0].data).toBe(JSON.stringify(payload))
       done()
     })


### PR DESCRIPTION
## Goal

Revert a change to add Access-Control-Max-Age headers to XHR requests which is currently not supported by the notifier pipeline