### PR TITLE
Fix TS definition for reportUnhandledPromiseRejectionsAsHandled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [8.1.1] - 2024-10-23
+
+### Fixed
+
+- Add `reportUnhandledPromiseRejectionsAsHandled` config option to typescript definition [#2237](https://github.com/bugsnag/bugsnag-js/pull/2237)
+
 ## [8.1.0] - 2024-10-23
 
 ### Added

--- a/packages/core/types/common.d.ts
+++ b/packages/core/types/common.d.ts
@@ -28,6 +28,7 @@ export interface Config {
   releaseStage?: string
   plugins?: Plugin[]
   user?: User | null
+  reportUnhandledPromiseRejectionsAsHandled?: boolean
 }
 
 export type OnErrorCallback = (event: Event, cb: (err: null | Error, shouldSend?: boolean) => void) => void | boolean | Promise<void | boolean>


### PR DESCRIPTION
## Goal

Add `reportUnhandledPromiseRejectionsAsHandled` to TypeScript definition for core config