### PR TITLE
Add React Native 0.76 tests to CI

### DIFF
--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -19,8 +19,8 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
         retry:
           automatic:
             - exit_status: "*"
@@ -47,8 +47,8 @@ steps:
             - exit_status: "*"
               limit: 1
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
 
       #
       # End-to-end tests
@@ -87,8 +87,8 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
 
       - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
@@ -124,6 +124,6 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
 

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -23,8 +23,8 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
         retry:
           automatic:
             - exit_status: "*"
@@ -47,8 +47,8 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
         retry:
           automatic:
             - exit_status: "*"
@@ -89,8 +89,8 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 16 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
@@ -125,6 +125,6 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.74"
           - "0.75"
+          - "0.76"
 

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -115,6 +115,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -144,6 +145,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       - label: ':android: Build react-native-navigation {{matrix}} test fixture APK (Old Arch)'
         key: "build-react-native-navigation-android-fixture-old-arch"
@@ -366,6 +368,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       # current latest version (v7.40.1) of react-native-navigation's autolinking tool doesn't support RN 0.73+,
       # causing a build failure - see https://github.com/wix/react-native-navigation/issues/7821
@@ -407,6 +410,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :android: react-native-navigation {{matrix}} Android 12 (Old Arch) end-to-end tests"
         depends_on: "build-react-native-navigation-android-fixture-old-arch"

--- a/.buildkite/full/react-native-ios-pipeline.full.yml
+++ b/.buildkite/full/react-native-ios-pipeline.full.yml
@@ -94,6 +94,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -119,6 +120,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
         retry:
           automatic:
             - exit_status: "*"
@@ -338,6 +340,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS 16 (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"
@@ -375,6 +378,7 @@ steps:
           - "0.71"
           - "0.72"
           - "0.73"
+          - "0.74"
 
       # current latest version (v7.40.1) of react-native-navigation's autolinking tool doesn't currently support RN 0.73+,
       # causing a build failure - see https://github.com/wix/react-native-navigation/issues/7821

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -93,7 +93,7 @@ if (process.env.BUILD_IOS === 'true' || process.env.BUILD_IOS === '1') {
   fs.rmSync(`${fixtureDir}/reactnative.xcarchive`, { recursive: true, force: true })
 
   // install pods
-  execFileSync('pod', ['install'], { cwd: `${fixtureDir}/ios`, stdio: 'inherit' })
+  execFileSync('pod', ['install', '--repo-update'], { cwd: `${fixtureDir}/ios`, stdio: 'inherit' })
 
   // build the ios app
   const archiveArgs = [

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -13,12 +13,17 @@ if (!process.env.REGISTRY_URL) {
   process.exit(1)
 }
 
+if (!process.env.RCT_NEW_ARCH_ENABLED || (process.env.RCT_NEW_ARCH_ENABLED !== '1' && process.env.RCT_NEW_ARCH_ENABLED !== '0')) {
+  console.error('RCT_NEW_ARCH_ENABLED must be set to 1 or 0')
+  process.exit(1)
+}
+
 const notifierVersion = process.env.NOTIFIER_VERSION || common.determineVersion()
 
 const reactNativeVersion = process.env.RN_VERSION
 const ROOT_DIR = resolve(__dirname, '../')
 
-const isNewArchEnabled = process.env.RCT_NEW_ARCH_ENABLED === 'true' || process.env.RCT_NEW_ARCH_ENABLED === '1'
+const isNewArchEnabled = process.env.RCT_NEW_ARCH_ENABLED === '1'
 
 let fixturePath = 'test/react-native/features/fixtures/generated/'
 
@@ -212,13 +217,13 @@ function configureAndroidProject () {
   androidManifestContents = androidManifestContents.replace('<application', '<application android:usesCleartextTraffic="true"')
   fs.writeFileSync(androidManifestPath, androidManifestContents)
 
-  if (isNewArchEnabled) {
-    // enable the new architecture in gradle properties
-    const gradlePropertiesPath = `${fixtureDir}/android/gradle.properties`
-    let gradlePropertiesContents = fs.readFileSync(gradlePropertiesPath, 'utf8')
-    gradlePropertiesContents = gradlePropertiesContents.replace('newArchEnabled=false', 'newArchEnabled=true')
-    fs.writeFileSync(gradlePropertiesPath, gradlePropertiesContents)
-  } else {
+  // enable/disable the new architecture in gradle.properties
+  const gradlePropertiesPath = `${fixtureDir}/android/gradle.properties`
+  let gradlePropertiesContents = fs.readFileSync(gradlePropertiesPath, 'utf8')
+  gradlePropertiesContents = gradlePropertiesContents.replace(/newArchEnabled\s*=\s*(true|false)/, `newArchEnabled=${isNewArchEnabled}`)
+  fs.writeFileSync(gradlePropertiesPath, gradlePropertiesContents)
+
+  if (!isNewArchEnabled) {
     // react navigation setup
     configureReactNavigationAndroid()
   }

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -11,8 +11,10 @@ Scenario: Handled JS error with native stacktrace
   # On 0.75+ the Error name is set to the native exception class
   And the event "exceptions.0.errorClass" equals the version-dependent string:
     | arch | version | value                      |
+    | new  | 0.76    | java.lang.RuntimeException |
     | new  | 0.75    | java.lang.RuntimeException |
     | new  | default | Error                      |
+    | old  | 0.76    | java.lang.RuntimeException |
     | old  | 0.75    | java.lang.RuntimeException |
     | old  | default | Error                      |
 
@@ -53,8 +55,10 @@ Scenario: Unhandled JS error with native stacktrace
   # On 0.75+ the Error name is set to the native exception class
   And the event "exceptions.0.errorClass" equals the version-dependent string:
     | arch | version | value                      |
+    | new  | 0.76    | java.lang.RuntimeException |
     | new  | 0.75    | java.lang.RuntimeException |
     | new  | default | Error                      |
+    | old  | 0.76    | java.lang.RuntimeException |
     | old  | 0.75    | java.lang.RuntimeException |
     | old  | default | Error                      |
 
@@ -123,24 +127,28 @@ Scenario: Handled JS error with native stacktrace
   # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
   And the event "exceptions.0.stacktrace.20.columnNumber" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @not_null               |
   | old  | default | @not_null               |
   And the event "exceptions.0.stacktrace.20.file" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @not_null               |
   | old  | default | @not_null               |
   And the event "exceptions.0.stacktrace.20.lineNumber" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @not_null               |
   | old  | default | @not_null               |
   And the event "exceptions.0.stacktrace.20.type" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @null                   |
@@ -171,24 +179,28 @@ Scenario: Unhandled JS error with native stacktrace
   # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
   And the event "exceptions.0.stacktrace.20.columnNumber" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @not_null               |
   | old  | default | @not_null               |
   And the event "exceptions.0.stacktrace.20.file" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @not_null               |
   | old  | default | @not_null               |
   And the event "exceptions.0.stacktrace.20.lineNumber" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @not_null               |
   | old  | default | @not_null               |
   And the event "exceptions.0.stacktrace.20.type" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | @skip                   |
   | new  | 0.75    | @skip                   |
   | new  | 0.74    | @skip                   |
   | new  | default | @null                   |

--- a/test/react-native/features/unhandled-android.feature
+++ b/test/react-native/features/unhandled-android.feature
@@ -33,18 +33,21 @@ Scenario: Reporting an Unhandled Native error
   And the event "unhandled" is true
   And the event "exceptions.0.errorClass" equals the version-dependent string:
   | arch | version | value                      |
+  | new  | 0.76    | Error                      |
   | new  | 0.75    | Error                      |
   | new  | 0.74    | Error                      |
   | new  | default | java.lang.RuntimeException |
   | old  | default | java.lang.RuntimeException |
   And the event "exceptions.0.type" equals the version-dependent string:
   | arch | version | value                      |
+  | new  | 0.76    | reactnativejs              |
   | new  | 0.75    | reactnativejs              |
   | new  | 0.74    | reactnativejs              |
   | new  | default | android                    |
   | old  | default | android                    |
   And the event "exceptions.0.message" equals the version-dependent string:
   | arch | version | value                                                   |
+  | new  | 0.76    | Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.75    | Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.74    | Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | default | UnhandledNativeErrorScenario                            |

--- a/test/react-native/features/unhandled-ios.feature
+++ b/test/react-native/features/unhandled-ios.feature
@@ -32,6 +32,7 @@ Scenario: Reporting an Unhandled Native error
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the version-dependent string:
   | arch | version | value                   |
+  | new  | 0.76    | N8facebook3jsi7JSErrorE |
   | new  | 0.75    | N8facebook3jsi7JSErrorE |
   | new  | 0.74    | N8facebook3jsi7JSErrorE |
   | new  | 0.73    | N8facebook3jsi7JSErrorE |
@@ -42,6 +43,7 @@ Scenario: Reporting an Unhandled Native error
   And the event "unhandled" is true
   And the event "exceptions.0.message" equals the version-dependent string:
   | arch | version | value                                                                                                                     |
+  | new  | 0.76    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.75    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.74    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.73    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |


### PR DESCRIPTION
## Goal

Adds React Native 0.76 tests to CI.

## Design

This required a small tweak to the test fixture generation script as New Architecture is enabled by default in 0.76

## Testing

Relied on CI