### PR TITLE
Fix NoSuchMethodError in ReactNative tests

### DIFF
--- a/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
+++ b/test/react-native/features/fixtures/scenario-launcher/android/build.gradle
@@ -48,7 +48,7 @@ android {
 }
 
 dependencies {
-    api "com.bugsnag:bugsnag-android:6.+"
+    compileOnly "com.bugsnag:bugsnag-android:6.+"
     implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
## Goal
Fix NoSuchMethodError in ReactNative tests

## Changeset
Replaced `api` with `compileOnly` for `bugsnag-android` dependency in the scenario loader to avoid accidentally upgrading the version of `bugsnag-android` included in the test fixture beyond the expected version.

## Testing
Existing tests should pass again.