### PR TITLE
Corrected setUser TS interface to allow for null arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (plugin-angular) Generate type definition using Angular 17 [#2275](https://github.com/bugsnag/bugsnag-js/pull/2275)
 
+### Fixed
+
+- Corrected setUser TS interface to allow for null arguments [#2262](https://github.com/bugsnag/bugsnag-js/pull/2262)
+
 ## [8.1.3] - 2024-11-28
 
 ### Changed

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -871,6 +871,10 @@ describe('@bugsnag/core/client', () => {
       expect(c.getUser()).toEqual({ id: '123', email: 'bug@sn.ag', name: 'Bug S. Nag' })
       c.setUser()
       expect(c.getUser()).toEqual({ id: undefined, email: undefined, name: undefined })
+      c.setUser(null, null, null)
+      expect(c.getUser()).toEqual({ id: null, email: null, name: null })
+      c.setUser('123', null, 'Bug S. Nag')
+      expect(c.getUser()).toEqual({ id: '123', email: null, name: 'Bug S. Nag' })
     })
 
     it('can be set via config', () => {

--- a/packages/core/types/client.d.ts
+++ b/packages/core/types/client.d.ts
@@ -52,7 +52,7 @@ declare class Client {
 
   // user
   public getUser(): User;
-  public setUser(id?: string, email?: string, name?: string): void;
+  public setUser(id?: string | null, email?: string | null, name?: string | null): void;
 
   // sessions
   public startSession(): Client;


### PR DESCRIPTION
## Goal

The `setUser` method in the notifier can take null as a parameter to clear the value from the user object. The current TypeScript interface only allows for `string | undefined`, which causes type errors when trying to pass null as a parameter.

[BugSnag documentation](https://docs.bugsnag.com/platforms/javascript/customizing-error-reports/#setuser) mentions passing null to `setUser` as a possibility.

## Design

The type definition has been updated to accurately reflect the capabilities od the notifier. 

## Changeset

The type definition for `setUser`'s arguments has been extended from `id?: string` to `id?: string | null`.

## Testing

The change was tested manually.