### PR TITLE
Fix dependency updater workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ steps.current-branch.outputs.branch != 'next'}}
         run: >
          gh pr create -B next
-         -H bumpsnag-$TARGET_SUBMODULE-$TARGET_VERSION
-         --title "Update $TARGET_SUBMODULE to version $TARGET_VERSION"
+         -H bumpsnag-$SUBMODULE-$VERSION
+         --title "Update $SUBMODULE to version $VERSION"
          --body 'Created by bumpsnag'
          --reviewer $REVIEWER

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: dep-updater-fixes
+          ref: next
 
       - run: |
           git config --global user.name 'Bumpsnag bot'

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -46,7 +46,7 @@ jobs:
         run: TARGET_SUBMODULE=$SUBMODULE TARGET_VERSION=$VERSION bundle exec scripts/update-dependencies.rb
 
       - name: Commit and push changes
-        run: bundle exec bumpsnag commit_update $SUBMODULE $VERSION
+        run: bundle exec bumpsnag commit-update $SUBMODULE $VERSION
 
       - name: List current branch name
         id: current-branch

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: next
+          ref: dep-updater-fixes
 
       - run: |
           git config --global user.name 'Bumpsnag bot'

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'xcodeproj', '< 1.26.0'
 
 # Only install bumpsnag if we're using Github actions
 unless ENV['GITHUB_ACTIONS'].nil?
-  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'better-commit-check'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'xcodeproj', '< 1.26.0'
 
 # Only install bumpsnag if we're using Github actions
 unless ENV['GITHUB_ACTIONS'].nil?
-  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'better-commit-check'
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
 end

--- a/scripts/update-dependencies.rb
+++ b/scripts/update-dependencies.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require 'bumpsnag'
 
 target_submodule = ENV['TARGET_SUBMODULE']


### PR DESCRIPTION
## Goal

Despite requiring a small update in bumpsnag, this should allow the dependency updater to run and create PRs again.

## Tests

The last test run on this worked successfully (up to actually creating the PR) - pushing a valid updated branch as can be seen [here](https://github.com/bugsnag/bugsnag-js/actions/runs/12027829501/job/33529646710#step:8:21).  I've since deleted the branch.