### PR TITLE
Restrict access for built-in github token

### DIFF
--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,5 +1,7 @@
 name: Sign release assets
 
+permissions: read-all
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
## Goal

Prevents the workflow token having default access.