### PR TITLE
Pin concurrent-ruby to 1.3.4 in react-native fixtures

### DIFF
--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -203,6 +203,7 @@ function configureIOSProject () {
   if (fs.existsSync(gemfilePath)) {
     let gemfileContents = fs.readFileSync(gemfilePath, 'utf8')
     gemfileContents += '\ngem \'xcodeproj\', \'< 1.26.0\''
+    gemfileContents += '\ngem \'concurrent-ruby\', \'1.3.4\''
     fs.writeFileSync(gemfilePath, gemfileContents)
   }
 


### PR DESCRIPTION
## Goal

Fix failing iOS build due to latest concurrent-ruby release dropping requirement for logger