### PR TITLE
Ignore dependabot in the examples directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # Disable all checks for the examples directory
+  - package-ecosystem: github-actions
+    directory: /examples
+    schedule:
+      interval: monthly
+    labels: [ ]
+    ignore:
+      - dependency-name: '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
 
   # Disable all checks for the examples directory
-  - package-ecosystem: github-actions
-    directory: /examples
+  - package-ecosystem: "github-actions"
+    directory: "/examples"
     schedule:
-      interval: monthly
-    labels: [ ]
+      interval: "monthly"
     ignore:
-      - dependency-name: '*'
+      - dependency-name: "*"


### PR DESCRIPTION
## Goal

Disable dependabot checks for example apps using configuration documented [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-disabling-version-updates-for-some-dependencies)