### PR TITLE
fix(deps): Command injection in cocoapods-downloader

### DIFF
--- a/test/react-native-cli/features/fixtures/rn0_67/Gemfile.lock
+++ b/test/react-native-cli/features/fixtures/rn0_67/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -92,6 +92,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.11, >= 1.11.2)
+  xcodeproj (< 1.26.0)
 
 RUBY VERSION
    ruby 2.7.4p191


### PR DESCRIPTION
cocoapods-downloader before 1.6.0, from 1.6.2 and before 1.6.3 are vulnerable to Command Injection via git argument injection. When calling the `Pod::Downloader.preprocess_options` function and using git, both the git and branch parameters are passed to the git ls-remote subcommand in a way that additional flags can be set. The additional flags can be used to perform a command injection.

