### PR TITLE
[PLAT-13608] Enable source maps when generating a react native fixutre

### DIFF
--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -48,6 +48,10 @@ const PEER_DEPENDENCIES = [
   `@bugsnag/plugin-react-native-navigation@${notifierVersion}`
 ]
 
+const SOURCE_MAP_DEPENDENCIES = [
+  `@bugsnag/react-native-cli@${notifierVersion}`
+]
+
 const reactNavigationVersion = '6.1.18'
 const reactNavigationNativeStackVersion = '6.11.0'
 const reactNativeScreensVersion = '3.35.0'
@@ -82,6 +86,10 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   configureIOSProject()
 
   installFixtureDependencies()
+
+  if (process.env.ENABLE_SOURCE_MAPS === 'true' || process.env.ENABLE_SOURCE_MAPS === '1') {
+    enableSourceMaps()
+  }
 
   // link react-native-navigation using rnn-link tool
   if (process.env.REACT_NATIVE_NAVIGATION === 'true' || process.env.REACT_NATIVE_NAVIGATION === '1') {
@@ -144,6 +152,11 @@ function installFixtureDependencies () {
   } else if (!isNewArchEnabled) {
     // add dependencies for @react-navigation
     PEER_DEPENDENCIES.push(...REACT_NAVIGATION_PEER_DEPENDENCIES)
+  }
+
+  // add source map dependencies
+  if (process.env.ENABLE_SOURCE_MAPS === 'true' || process.env.ENABLE_SOURCE_MAPS === '1') {
+    PEER_DEPENDENCIES.push(...SOURCE_MAP_DEPENDENCIES)
   }
 
   const fixtureDependencyArgs = PEER_DEPENDENCIES.join(' ')
@@ -289,4 +302,10 @@ class MainActivity : ReactActivity() {
   let mainActivityContents = fs.readFileSync(mainActivityPath, 'utf8')
   mainActivityContents = mainActivityContents.replace(mainActivityPattern, mainActivityReplacement)
   fs.writeFileSync(mainActivityPath, mainActivityContents)
+}
+
+function enableSourceMaps () {
+  common.changeDir(`${ROOT_DIR}/scripts`)
+  const initCommand = `./init-rn-cli.sh ${notifierVersion} ${reactNativeVersion} ${fixtureDir}`
+  common.run(initCommand, true)
 }

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -221,7 +221,6 @@ function configureIOSProject () {
       gemfileContents += '\ngem \'concurrent-ruby\', \'<= 1.3.4\''
     }
     fs.writeFileSync(gemfilePath, gemfileContents)
-    fs.writeFileSync(gemfilePath, gemfileContents.replace(/concurrent-ruby/, 'concurrent-ruby', '<= 1.3.4'))
   }
 
   // set NSAllowsArbitraryLoads to allow http traffic for all domains (bitbar public IP + bs-local.com)

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -221,6 +221,7 @@ function configureIOSProject () {
       gemfileContents += '\ngem \'concurrent-ruby\', \'<= 1.3.4\''
     }
     fs.writeFileSync(gemfilePath, gemfileContents)
+    fs.writeFileSync(gemfilePath, gemfileContents.replace(/concurrent-ruby/, 'concurrent-ruby', '<= 1.3.4'))
   }
 
   // set NSAllowsArbitraryLoads to allow http traffic for all domains (bitbar public IP + bs-local.com)

--- a/scripts/init-rn-cli.sh
+++ b/scripts/init-rn-cli.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+set notifierVersion [lindex $argv 0];
+set rnVersion [lindex $argv 1];
+set fixturePath [lindex $argv 2];
+set rnVersionInt ""
+set substringToTrim ".expo.ejected"
+
+# Extract the substring starting from the third character
+set rnVersionInt [string range $rnVersion 2 end]
+
+# Replace underscore (_) with a period (.)
+set rnVersionInt2 [string map {_ .} $rnVersionInt]
+
+set rnVersionInt3 [string map [list $substringToTrim ""] $rnVersionInt2]
+
+# Convert float string to float value using bc
+regsub -all {^0+} $rnVersionInt3 "" $rnVersionInt3
+
+puts "Using notifier version: $notifierVersion"
+puts "Using React Native version: $rnVersion"
+
+cd $fixturePath
+spawn ./node_modules/.bin/bugsnag-react-native-cli init
+
+expect "Do you want to continue anyway?"
+send -- "Y\r"
+
+expect "Are you using Bugsnag on-premise?"
+send -- "Y\r"
+
+expect "What is your Bugsnag notify endpoint?"
+send -- http://bs-local.com:9339/notify\r
+
+expect "What is your Bugsnag sessions endpoint?"
+send -- http://bs-local.com:9339/sessions\r
+
+expect "What is your Bugsnag upload endpoint?"
+send -- http://localhost:9339\r
+
+expect "What is your Bugsnag build endpoint?"
+send -- http://localhost:9339/builds\r
+
+expect "Enter version of the Bugsnag Android Gradle plugin you want to use"
+send -- r
+
+expect "What is your Bugsnag project API key?"
+send -- "1234567890ABCDEF1234567890ABCDEF\r"
+
+expect "Do you want to install the BugSnag CLI to allow you to upload JavaScript source maps?"
+send -- y
+
+expect "If you want the latest version of @bugsnag/cli hit enter, otherwise type the version you want"
+send -- r
+
+expect "See https://docs.bugsnag.com/platforms/react-native/react-native/showing-full-stacktraces for details."
+send -- r
+
+expect "Do you want to update your Xcode build phase to output JavaScript source maps?"
+send -- y
+
+expect "This will enable you to see full native stacktraces. It can't be done automatically."
+send -- r
+
+expect eof


### PR DESCRIPTION
## Goal

Add an option to generate source maps for the react native fixtures generated by the NodeJS script.

## Testing

Tested locally.