### PR TITLE
concurrent-ruby override check

### DIFF
--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -59,8 +59,9 @@ const REACT_NAVIGATION_PEER_DEPENDENCIES = [
   `react-native-safe-area-context@${reactNativeSafeAreaContextVersion}`
 ]
 
+const reactNativeNavigationVersion = '7.41.0' // Issue with 7.42.0
 const REACT_NATIVE_NAVIGATION_PEER_DEPENDENCIES = [
-  'react-native-navigation'
+  `react-native-navigation@${reactNativeNavigationVersion}`
 ]
 
 // Generate the fixture

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -203,7 +203,9 @@ function configureIOSProject () {
   if (fs.existsSync(gemfilePath)) {
     let gemfileContents = fs.readFileSync(gemfilePath, 'utf8')
     gemfileContents += '\ngem \'xcodeproj\', \'< 1.26.0\''
-    gemfileContents += '\ngem \'concurrent-ruby\', \'<= 1.3.4\''
+    if (!gemfileContents.includes('concurrent-ruby')) {
+      gemfileContents += '\ngem \'concurrent-ruby\', \'<= 1.3.4\''
+    }
     fs.writeFileSync(gemfilePath, gemfileContents)
   }
 


### PR DESCRIPTION
## Goal

Ensure concurrent-ruby has not been overridden before adding override to gemfile

This PR also pins the react-native-navigation dependency as the latest release was causing a build failure