### PR TITLE
Update usage of URL constructor in test steps

### DIFF
--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -10,7 +10,7 @@ end
 
 When('I open the URL {string} tolerating any error') do |url|
   begin
-    URI.open(url, &:read)
+    URI(url).open(&:read)
   rescue
     $logger.debug $!.inspect
   end


### PR DESCRIPTION
## Goal

Resolve code scanning issue:

> Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value