### PR TITLE
build: re-enable danger.js PR comments

### DIFF
--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -1,6 +1,7 @@
 name: "PR diff bot"
 on: [pull_request]
-permissions: read-all
+permissions:
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
## Goal

Reinstates the GitHub Action permission required for danger.js to write to size diff to the PR.