### PR TITLE
use npm ci to prevent package-lock update

### DIFF
--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -12,7 +12,7 @@ ADD min_packages.tar .
 COPY bin ./bin
 COPY packages ./packages
 
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 RUN npm pack --verbose packages/js/


### PR DESCRIPTION
## Goal

Improve OpenSSF Score for pinned-dependencies