### PR TITLE
build(bumpsnag): reduce GHA permissions to job level

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,8 +1,5 @@
 name: update-dependencies
-permissions:
-  contents: write
-  pull-requests: write
-  repository-projects: read
+permissions: read-all
 
 on:
   repository_dispatch:
@@ -21,6 +18,9 @@ on:
 jobs:
   update-dependencies:
     runs-on: macos-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       SUBMODULE: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_submodule || inputs.target_submodule }}
       VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_version || inputs.target_version }}


### PR DESCRIPTION
## Goal

As per [best-practices](https://github.com/ossf/scorecard/blob/49c0eed3a423f00c872b5c3c9f1bbca9e8aae799/docs/checks.md#token-permissions), moving the dependency updater permissions to be job-level rather than global. 