### PR TITLE
Move AWS lambda tests from MacOS/Buildkite to GHA

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,27 +37,6 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ":aws-lambda: AWS Lambda tests"
-    timeout_in_minutes: 35
-    agents:
-      queue: "macos-14"
-    env:
-      NODE_VERSION: "18"
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-    plugins:
-      test-collector#v1.10.2:
-        files: "test/aws-lambda/reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-        api-token-env-name: "JS_AWS_LAMBDA_BUILDKITE_ANALYTICS_TOKEN"
-    commands:
-      # force the NPM registry as the default on CI is artifactory, which can't
-      # currently install from our lockfile
-      - npm ci --registry https://registry.npmjs.org
-      - cd test/aws-lambda
-      - bundle install
-      - bundle exec maze-runner
-
   #
   # Core tests and checks
   #

--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -28,7 +28,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.1'
-        bundler-cache: true
 
     - name: Install Node
       uses: actions/setup-node@v4

--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -1,0 +1,42 @@
+name: AWS Lambda tests
+
+permissions: read-all
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: 18
+
+    steps:
+    - name: Install libcurl4-openssl-dev and net-tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
+        sudo apt-get install net-tools
+
+    - run: sam --version
+
+    - uses: actions/checkout@v2
+
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+
+    - name: Install Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: $NODE_VERSION
+
+    - name: Run tests
+      run: |
+        cd test/aws-lambda
+        bundle install
+        bundle exec maze-runner

--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -19,15 +19,15 @@ jobs:
 
     - run: sam --version
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Install Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
         ruby-version: '3.1'
 
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
       with:
         node-version: 18
 

--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -10,9 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    env:
-      NODE_VERSION: 18
-
     steps:
     - name: Install libcurl4-openssl-dev and net-tools
       run: |
@@ -32,7 +29,7 @@ jobs:
     - name: Install Node
       uses: actions/setup-node@v4
       with:
-        node-version: $NODE_VERSION
+        node-version: 18
 
     - name: Run tests
       run: |

--- a/test/aws-lambda/Gemfile
+++ b/test/aws-lambda/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', '~>9.0'
+# gem 'bugsnag-maze-runner', '~>9.0'
 
 # Use a branch of Maze Runner
-#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/use-maze-check'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'aws-lambda-response'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../../../maze-runner'

--- a/test/aws-lambda/Gemfile
+++ b/test/aws-lambda/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-# gem 'bugsnag-maze-runner', '~>9.0'
+gem 'bugsnag-maze-runner', '~>9.0'
 
 # Use a branch of Maze Runner
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'aws-lambda-response'
+# gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/use-maze-check'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../../../maze-runner'

--- a/test/aws-lambda/features/steps/aws-lambda-steps.rb
+++ b/test/aws-lambda/features/steps/aws-lambda-steps.rb
@@ -1,7 +1,7 @@
 Given('I setup the environment') do
   steps %Q{
     Given I store the api key in the environment variable "BUGSNAG_API_KEY"
-    And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://host.docker.internal:9339/notify"
-    And I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to "http://host.docker.internal:9339/sessions"
+    And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://localhost:9339/notify"
+    And I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to "http://localhost:9339/sessions"
   }
 end

--- a/test/aws-lambda/features/steps/aws-lambda-steps.rb
+++ b/test/aws-lambda/features/steps/aws-lambda-steps.rb
@@ -4,6 +4,7 @@ Given('I setup the environment') do
   else
     # Use the default for docker bridge host
     host_name = '172.17.0.1'
+  end
   steps %Q{
     Given I store the api key in the environment variable "BUGSNAG_API_KEY"
     And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://#{host_name}:9339/notify"

--- a/test/aws-lambda/features/steps/aws-lambda-steps.rb
+++ b/test/aws-lambda/features/steps/aws-lambda-steps.rb
@@ -1,7 +1,12 @@
 Given('I setup the environment') do
+  if ENV['NETWORK_NAME']
+    host_name = 'host.docker.internal'
+  else
+    # Use the default for docker bridge host
+    host_name = '172.17.0.1'
   steps %Q{
     Given I store the api key in the environment variable "BUGSNAG_API_KEY"
-    And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://localhost:9339/notify"
-    And I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to "http://localhost:9339/sessions"
+    And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to "http://#{host_name}:9339/notify"
+    And I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to "http://#{host_name}:9339/sessions"
   }
 end

--- a/test/aws-lambda/features/support/env.rb
+++ b/test/aws-lambda/features/support/env.rb
@@ -1,20 +1,4 @@
 BeforeAll do
-  `command -v sam`
-
-  if $? != 0
-    puts <<~ERROR
-    The AWS SAM CLI must be installed before running these tests!
-  
-    See the installation instructions:
-    https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html
-  
-    If you have already installed the SAM CLI, check that it's in your PATH:
-    $ command -v sam
-    ERROR
-
-    exit 127
-  end
-
   success = system(File.realpath("#{__dir__}/../scripts/build-fixtures"))
 
   unless success


### PR DESCRIPTION
## Goal

This allows us to remove docker as a requirement from our MacOS boxes, and have the lambda tests run more consistently.

Note - We should wait for a maze-runner release feat. https://github.com/bugsnag/maze-runner/pull/722 before this is merged, as that PR fixes an issue with lambda tests seemingly flaking.