### PR TITLE
fix(react-native): update Turbo Module check for 0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This release adds support for React Native 0.77 to `@bugsnag/react-native`
 
 - (plugin-angular) Added a null check so BugsnagErrorHandler fails silently when misconfigured [#2295](https://github.com/bugsnag/bugsnag-js/pull/2295)
 - (react-native) Fix no such module error when importing Bugsnag from Swift [#2335](https://github.com/bugsnag/bugsnag-js/pull/2335)
+- (react-native) Fix turbo module check in React Native 0.77 [#2341](https://github.com/bugsnag/bugsnag-js/pull/2341)
 
 ## [8.2.0] - 2025-01-27
 

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -12,7 +12,7 @@ module.exports = (client, NativeClient) => ({
       }
     }
 
-    const isTurboModuleEnabled = global.__turboModuleProxy != null
+    const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null
 
     const eventPayload = {
       errors: event.errors,

--- a/packages/plugin-react-native-event-sync/event-sync.js
+++ b/packages/plugin-react-native-event-sync/event-sync.js
@@ -1,6 +1,6 @@
 module.exports = (NativeClient) => ({
   load: (client) => {
-    const isTurboModuleEnabled = global.__turboModuleProxy != null
+    const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null
 
     if (isTurboModuleEnabled) {
       client.addOnError(event => {

--- a/packages/react-native/src/native.js
+++ b/packages/react-native/src/native.js
@@ -1,6 +1,6 @@
 const reactNative = require('react-native')
 
-const isTurboModuleEnabled = () => global.__turboModuleProxy != null
+const isTurboModuleEnabled = () => global.RN$Bridgeless || global.__turboModuleProxy != null
 
 export const NativeClient = isTurboModuleEnabled()
   ? reactNative.TurboModuleRegistry.get('BugsnagReactNative')

--- a/test/react-native/features/fixtures/scenario-launcher/src/lib/native.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/lib/native.js
@@ -1,6 +1,6 @@
 const reactNative = require('react-native')
 
-const isTurboModuleEnabled = () => global.__turboModuleProxy != null
+const isTurboModuleEnabled = () => global.RN$Bridgeless || global.__turboModuleProxy != null
 
 export const NativeInterface = isTurboModuleEnabled()
   ? reactNative.TurboModuleRegistry.get('BugsnagTestInterface')


### PR DESCRIPTION
## Goal

Fixes the logic that detects whether turbo modules are enabled - previously this relied on the presence of `global.__turboModuleProxy` but this is no longer set in RN 0.77 bridgeless mode (the default), causing the check to fail.

## Design

Update logic to check for the presence of `global.RN$Bridgeless` - if this is set then the app is running in bridgeless mode and turbo modules are enabled.

## Testing

Covered by CI