### PR TITLE
[PLAT-13740] Add Node 18 queue to steps that support it

### DIFF
--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -6,7 +6,7 @@ steps:
   - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
     timeout_in_minutes: 40
     agents:
-      queue: macos-14
+      queue: macos-node-18
     env:
       NODE_VERSION: "{{matrix.node_version}}"
       ELECTRON_VERSION: "{{matrix.electron_version}}"

--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -9,7 +9,7 @@ steps:
         key: "build-react-native-android-fixture-old-arch"
         timeout_in_minutes: 15
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
@@ -32,7 +32,7 @@ steps:
         key: "build-react-native-android-fixture-new-arch"
         timeout_in_minutes: 15
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"

--- a/.buildkite/full/react-native-android-pipeline.full.yml
+++ b/.buildkite/full/react-native-android-pipeline.full.yml
@@ -66,7 +66,7 @@ steps:
         key: "build-react-native-android-fixture-old-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
@@ -92,7 +92,7 @@ steps:
         key: "build-react-native-android-fixture-new-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
@@ -119,7 +119,7 @@ steps:
         key: "build-react-native-navigation-android-fixture-old-arch"
         timeout_in_minutes: 30
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"
@@ -144,7 +144,7 @@ steps:
         key: "build-react-native-navigation-android-fixture-new-arch"
         timeout_in_minutes: 30
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"

--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -9,7 +9,7 @@ steps:
         key: "build-react-native-cli-android-fixture"
         timeout_in_minutes: 15
         agents:
-          queue: macos-14
+          queue: macos-node-18
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
   - label: ":copyright: License Audit"
     timeout_in_minutes: 20
     agents:
-      queue: macos-14
+      queue: "macos"
     command: scripts/license_finder.sh
 
   #
@@ -25,7 +25,7 @@ steps:
     key: "publish-js"
     timeout_in_minutes: 10
     agents:
-      queue: "macos-14"
+      queue: "macos-node-18"
     env:
       NODE_VERSION: "18"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
   - label: ":copyright: License Audit"
     timeout_in_minutes: 20
     agents:
-      queue: "macos"
+      queue: "macos-node-18"
     command: scripts/license_finder.sh
 
   #


### PR DESCRIPTION
## Goal

To help with load on the queue, I've setup a new queue for node 18 steps that do not require a specific macos version. This should reduce the wait time on CI runs as well as free up some of the macos 14 machines for other builds

## Testing

Covered by CI