### PR TITLE
Move React Native CLI tests off of the Node 18 queue due to its xcode requirement 

### DIFF
--- a/.buildkite/full/react-native-cli-pipeline.full.yml
+++ b/.buildkite/full/react-native-cli-pipeline.full.yml
@@ -9,7 +9,7 @@ steps:
         key: "build-react-native-cli-android-fixture"
         timeout_in_minutes: 15
         agents:
-          queue: macos-node-18
+          queue: macos-14
         env:
           JAVA_VERSION: "17"
           NODE_VERSION: "18"


### PR DESCRIPTION
## Goal

Move the React Native CLI Android tests off of the Node 18 queue as it requires a certain version o Xcode (React Native dep)

## Testing

Covered by CI