### PR TITLE
Ensure AWS Lambda tests run overnight

### DIFF
--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -5,6 +5,8 @@ permissions: read-all
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   test:


### PR DESCRIPTION
## Goal

Add cron job to GitHub action to ensure AWS Lambda tests run overnight