### PR TITLE
Ensure correct heading name is used for changelog entry

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -53,15 +53,15 @@ jobs:
       - name: Commit and push changes
         run: BUMPSNAG_TARGET_HEADING="[Unreleased]" bundle exec bumpsnag commit-update $SUBMODULE $VERSION
 
-      # - name: List current branch name
-      #   id: current-branch
-      #   run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+      - name: List current branch name
+        id: current-branch
+        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
 
-      # - name: Create pull request
-      #   if: ${{ steps.current-branch.outputs.branch != 'next'}}
-      #   run: >
-      #    gh pr create -B next
-      #    -H bumpsnag-$SUBMODULE-$VERSION
-      #    --title "Update $SUBMODULE to version $VERSION"
-      #    --body 'Created by bumpsnag'
-      #    --reviewer $REVIEWER
+      - name: Create pull request
+        if: ${{ steps.current-branch.outputs.branch != 'next'}}
+        run: >
+         gh pr create -B next
+         -H bumpsnag-$SUBMODULE-$VERSION
+         --title "Update $SUBMODULE to version $VERSION"
+         --body 'Created by bumpsnag'
+         --reviewer $REVIEWER

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -51,17 +51,17 @@ jobs:
         run: TARGET_SUBMODULE=$SUBMODULE TARGET_VERSION=$VERSION bundle exec scripts/update-dependencies.rb
 
       - name: Commit and push changes
-        run: bundle exec bumpsnag commit-update $SUBMODULE $VERSION
+        run: BUMPSNAG_TARGET_HEADING="[Unreleased]" bundle exec bumpsnag commit-update $SUBMODULE $VERSION
 
-      - name: List current branch name
-        id: current-branch
-        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+      # - name: List current branch name
+      #   id: current-branch
+      #   run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Create pull request
-        if: ${{ steps.current-branch.outputs.branch != 'next'}}
-        run: >
-         gh pr create -B next
-         -H bumpsnag-$SUBMODULE-$VERSION
-         --title "Update $SUBMODULE to version $VERSION"
-         --body 'Created by bumpsnag'
-         --reviewer $REVIEWER
+      # - name: Create pull request
+      #   if: ${{ steps.current-branch.outputs.branch != 'next'}}
+      #   run: >
+      #    gh pr create -B next
+      #    -H bumpsnag-$SUBMODULE-$VERSION
+      #    --title "Update $SUBMODULE to version $VERSION"
+      #    --body 'Created by bumpsnag'
+      #    --reviewer $REVIEWER

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'xcodeproj', '< 1.26.0'
 
 # Only install bumpsnag if we're using Github actions
 unless ENV['GITHUB_ACTIONS'].nil?
-  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'unreleased-title'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'xcodeproj', '< 1.26.0'
 
 # Only install bumpsnag if we're using Github actions
 unless ENV['GITHUB_ACTIONS'].nil?
-  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'unreleased-title'
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
 end


### PR DESCRIPTION
## Goal

Instead of creating a new TBD heading when updating dependencies this PR, with a corresponding change in bumpsnag, will use `[Unreleased]` as a heading instead, either adding it or adding the changelog entry under it.