### PR TITLE
Pin React Native CLI version

### DIFF
--- a/scripts/generate-react-native-cli-fixture.js
+++ b/scripts/generate-react-native-cli-fixture.js
@@ -55,7 +55,7 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   }
 
   // create the test fixture
-  const RNInitArgs = ['@react-native-community/cli@latest', 'init', 'reactnative', '--directory', fixtureDir, '--version', reactNativeVersion, '--pm', 'npm', '--skip-install']
+  const RNInitArgs = ['@react-native-community/cli@16.0.2', 'init', 'reactnative', '--directory', fixtureDir, '--version', reactNativeVersion, '--pm', 'npm', '--skip-install']
   execFileSync('npx', RNInitArgs, { stdio: 'inherit' })
 
   replaceGeneratedFixtureFiles()

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -85,7 +85,7 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
   }
 
   // create the test fixture
-  const RNInitArgs = ['@react-native-community/cli@latest', 'init', 'reactnative', '--directory', fixtureDir, '--version', reactNativeVersion, '--pm', 'npm', '--skip-install']
+  const RNInitArgs = ['@react-native-community/cli@16.0.2', 'init', 'reactnative', '--directory', fixtureDir, '--version', reactNativeVersion, '--pm', 'npm', '--skip-install']
   execFileSync('npx', RNInitArgs, { stdio: 'inherit' })
 
   replaceGeneratedFixtureFiles()


### PR DESCRIPTION
## Goal

Pinning the version of the React Native CLI to 16.0.2 to side step an issue with 17.0.0 that is causing failing CI buids.

## Testing

Covered by CI & tested locally