### PR TITLE
Add delay between layer starts in test scenario launcher

### DIFF
--- a/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
@@ -24,9 +24,16 @@ async function runScenario (scenarioName, apiKey, notifyEndpoint, sessionEndpoin
   console.error('[Bugsnag ScenarioLauncher] clearing persistent data')
   NativeInterface.clearPersistentData()
 
+  console.error(`[Bugsnag ScenarioLauncher] with config: ${JSON.stringify(nativeConfig)} (native) and ${JSON.stringify(jsConfig)} (js)`)
+
   // start the native client
   console.error('[Bugsnag ScenarioLauncher] starting native Bugsnag')
   await NativeInterface.startBugsnag(nativeConfig)
+
+  // The calls between starting the native client and starting the js client
+  // Are typically longer than we see here, so we add a delay to ensure the
+  // native client is fully initialised before the js client is started
+  await new Promise(resolve => setTimeout(resolve, 50))
 
   // start the js client
   console.error('[Bugsnag ScenarioLauncher] starting js Bugsnag')


### PR DESCRIPTION
## Goal

Resolve flakes in test fixtures caused by starting the native and js bugsnag instances at the same time, which is not indicative of real world behaviour

## Testing

Ran flakey test 15 times in a row with no issues encountered