### PR TITLE
Do not use Maze.driver directly

### DIFF
--- a/.buildkite/basic/react-native-ios-full-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-full-pipeline.yml
@@ -254,7 +254,8 @@ steps:
           - "0.72"
           - "0.74"
           - "0.76"
-          - "0.77"
+          # TODO: 0.77 moved to the basic pipeline (where 0.78 has been skipped) pending PLAT-14005
+          #- "0.77"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"

--- a/.buildkite/basic/react-native-ios-full-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-full-pipeline.yml
@@ -66,7 +66,8 @@ steps:
           - "0.72"
           - "0.74"
           - "0.76"
-          - "0.77"
+          # TODO: 0.77 moved to the basic pipeline (where 0.78 has been skipped) pending PLAT-14005
+          #- "0.77"
         retry:
           automatic:
             - exit_status: "*"
@@ -216,7 +217,7 @@ steps:
         concurrency: 5
         concurrency_group: "browserstack-app"
         concurrency_method: eager
-      
+
       - label: ":bitbar: :mac: RN {{matrix}} iOS (Old Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-old-arch-full"
         timeout_in_minutes: 40

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -93,7 +93,8 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.78"
+          # TODO: 0.78 moved back to 0.77 pending PLAT-14005
+          - "0.77"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -27,7 +27,8 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          - "0.78"
+          # TODO: 0.78 moved back to 0.77 pending PLAT-14005
+          - "0.77"
         retry:
           automatic:
             - exit_status: "*"

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -10,7 +10,7 @@ end
 
 Before do
   # See https://www.browserstack.com/docs/app-automate/appium/troubleshooting/app-orientation-issues
-  Maze.driver.set_rotation(:portrait)
+  Maze::Api::Appium::DeviceManager.new.set_rotation(:portrait)
 end
 
 Before('@android_only') do |_scenario|


### PR DESCRIPTION
## Goal

Do not use Maze.driver directly, so that any Appium session failures are reported.

## Testing

Covered by CI - I unblocked the React Native tests as those using the code that's been updated.