### PR TITLE
Update react native unhandled js exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update bugsnag-android to [v6.12.1](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.12.1) [#2359](https://github.com/bugsnag/bugsnag-js/pull/2359)
 - Update bugsnag-cocoa to [v6.32.1](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.32.1) [#2355](https://github.com/bugsnag/bugsnag-js/pull/2355)
 
+### Fixed
+
+- (react-native) Fix double reported unhandled js errors when using new architecture [#2398](https://github.com/bugsnag/bugsnag-js/pull/2398)
+
 ## [8.3.0] - 2025-03-04
 
 This release adds support for React Native 0.77 and 0.78 to `@bugsnag/react-native`

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
@@ -39,8 +39,7 @@
     // so we need to use an onSendError block and discard based on the error message instead.
     #ifdef RCT_NEW_ARCH_ENABLED
     [client.configuration addOnSendErrorBlock:^BOOL (BugsnagEvent *event) {
-        return !([event.errors[0].errorMessage hasPrefix:@"Exception in HostFunction: Unhandled JS Exception"] 
-            || [event.errors[0].errorMessage hasPrefix:@"ExceptionsManager.reportException raised an exception: Unhandled JS Exception"]);
+        return ![event.errors[0].errorMessage containsString:@"Unhandled JS Exception:"];
     }];
     #endif
 }

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativePlugin.m
@@ -39,7 +39,8 @@
     // so we need to use an onSendError block and discard based on the error message instead.
     #ifdef RCT_NEW_ARCH_ENABLED
     [client.configuration addOnSendErrorBlock:^BOOL (BugsnagEvent *event) {
-        return ![event.errors[0].errorMessage hasPrefix:@"Exception in HostFunction: Unhandled JS Exception"];
+        return !([event.errors[0].errorMessage hasPrefix:@"Exception in HostFunction: Unhandled JS Exception"] 
+            || [event.errors[0].errorMessage hasPrefix:@"ExceptionsManager.reportException raised an exception: Unhandled JS Exception"]);
     }];
     #endif
 }

--- a/test/react-native/features/unhandled-ios.feature
+++ b/test/react-native/features/unhandled-ios.feature
@@ -32,9 +32,9 @@ Scenario: Reporting an Unhandled Native error
   Then I wait to receive an error
   And the event "exceptions.0.errorClass" equals the version-dependent string:
   | arch | version | value                   |
-  | new  | 0.78    | N8facebook3jsi7JSErrorE |
-  | new  | 0.77    | N8facebook3jsi7JSErrorE |
-  | new  | 0.76    | N8facebook3jsi7JSErrorE |
+  | new  | 0.78    | NSException             |
+  | new  | 0.77    | NSException             |
+  | new  | 0.76    | NSException             |
   | new  | 0.75    | N8facebook3jsi7JSErrorE |
   | new  | 0.74    | N8facebook3jsi7JSErrorE |
   | new  | 0.73    | N8facebook3jsi7JSErrorE |

--- a/test/react-native/features/unhandled-ios.feature
+++ b/test/react-native/features/unhandled-ios.feature
@@ -45,9 +45,9 @@ Scenario: Reporting an Unhandled Native error
   And the event "unhandled" is true
   And the event "exceptions.0.message" equals the version-dependent string:
   | arch | version | value                                                                                                                     |
-  | new  | 0.78    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
-  | new  | 0.77    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
-  | new  | 0.76    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
+  | new  | 0.78    | UnhandledNativeErrorScenario                                                                                              |
+  | new  | 0.77    | UnhandledNativeErrorScenario                                                                                              |
+  | new  | 0.76    | UnhandledNativeErrorScenario                                                                                              |
   | new  | 0.75    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.74    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |
   | new  | 0.73    | Exception in HostFunction: UnhandledNativeErrorScenario\n\nError: Exception in HostFunction: UnhandledNativeErrorScenario |


### PR DESCRIPTION
## Goal

Update react native exception handling to discard double reported errors caused by unhandled js errors

## Changeset

Update expected string in error discard code when using new architecture

## Testing

Existing ci tests