### PR TITLE
Skip failing tests

### DIFF
--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -72,7 +72,7 @@ const REACT_NAVIGATION_PEER_DEPENDENCIES = [
   `react-native-safe-area-context@${reactNativeSafeAreaContextVersion}`
 ]
 
-const reactNativeNavigationVersion = '7.41.0' // Issue with 7.42.0
+const reactNativeNavigationVersion = '7.45.0'
 const REACT_NATIVE_NAVIGATION_PEER_DEPENDENCIES = [
   `react-native-navigation@${reactNativeNavigationVersion}`
 ]

--- a/test/react-native/features/app.feature
+++ b/test/react-native/features/app.feature
@@ -23,6 +23,8 @@ Scenario: App data in Handled JS error
   | android | android |
   | ios     | iOS     |
 
+# Skipped pending PLAT-14039
+@skip_new_arch_ios
 Scenario: App data in Unhandled JS error
   When I run "AppJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "AppJsUnhandledScenario"

--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -27,6 +27,8 @@ Scenario: Device data in Handled JS error
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
 
+# Skipped pending PLAT-14039
+@skip_new_arch_ios
 Scenario: Device data in Unhandled JS error
   When I run "DeviceJsUnhandledScenario" and relaunch the crashed app
   And I configure Bugsnag for "DeviceJsUnhandledScenario"

--- a/test/react-native/features/feature_flags.feature
+++ b/test/react-native/features/feature_flags.feature
@@ -21,6 +21,8 @@ Scenario: Sends handled exception which includes feature flags added in the noti
   And event 0 does not contain the feature flag "should_not_be_reported_2"
   And event 0 does not contain the feature flag "should_not_be_reported_3"
 
+# Skipped pending PLAT-14039
+@skip_new_arch_ios
 Scenario: Sends unhandled exception which includes feature flags added in the notify callback
   When I run "FeatureFlagsScenario" with data "unhandled callback" and relaunch the crashed app
   And I configure Bugsnag for "FeatureFlagsScenario"

--- a/test/react-native/features/fixtures/app/dynamic/react-native-navigation/index.js
+++ b/test/react-native/features/fixtures/app/dynamic/react-native-navigation/index.js
@@ -7,7 +7,8 @@ console.reportErrorsAsExceptions = false
 
 export const AppScreen = () => {
   useEffect(() => {
-    launchScenario()
+    const clearPersistentData = false
+    launchScenario(() => {}, clearPersistentData)
   }, [])
 
   return (

--- a/test/react-native/features/fixtures/scenario-launcher/package.json
+++ b/test/react-native/features/fixtures/scenario-launcher/package.json
@@ -23,7 +23,7 @@
     "@bugsnag/plugin-react-navigation": "*",
     "@bugsnag/plugin-react-native-navigation": "*",
     "@react-navigation/native": "*",
-    "@react-navigation/native-stack": "7.2.1",
+    "@react-navigation/native-stack": "*",
     "react": "*",
     "react-native": "*",
     "react-native-file-access": "*"

--- a/test/react-native/features/fixtures/scenario-launcher/package.json
+++ b/test/react-native/features/fixtures/scenario-launcher/package.json
@@ -23,7 +23,7 @@
     "@bugsnag/plugin-react-navigation": "*",
     "@bugsnag/plugin-react-native-navigation": "*",
     "@react-navigation/native": "*",
-    "@react-navigation/native-stack": "*",
+    "@react-navigation/native-stack": "7.2.1",
     "react": "*",
     "react-native": "*",
     "react-native-file-access": "*"

--- a/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
@@ -3,7 +3,7 @@ import { getCurrentCommand } from './CommandRunner'
 import { NativeInterface } from './native'
 import Bugsnag from '@bugsnag/react-native'
 
-async function runScenario (scenarioName, apiKey, notifyEndpoint, sessionEndpoint, scenarioData, setScenario) {
+async function runScenario (scenarioName, apiKey, notifyEndpoint, sessionEndpoint, scenarioData, setScenario, clearPersistentData) {
   console.error(`[Bugsnag ScenarioLauncher] running scenario: ${scenarioName}`)
 
   const nativeConfig = {
@@ -21,8 +21,10 @@ async function runScenario (scenarioName, apiKey, notifyEndpoint, sessionEndpoin
   const scenario = new Scenarios[scenarioName](nativeConfig, jsConfig, scenarioData)
 
   // clear persistent data
-  console.error('[Bugsnag ScenarioLauncher] clearing persistent data')
-  NativeInterface.clearPersistentData()
+  if (clearPersistentData) {
+    console.error('[Bugsnag ScenarioLauncher] clearing persistent data')
+    NativeInterface.clearPersistentData()
+  }
 
   console.error(`[Bugsnag ScenarioLauncher] with config: ${JSON.stringify(nativeConfig)} (native) and ${JSON.stringify(jsConfig)} (js)`)
 
@@ -75,7 +77,7 @@ async function startBugsnag (scenarioName, apiKey, notifyEndpoint, sessionEndpoi
   Bugsnag.start(jsConfig)
 }
 
-export async function launchScenario (setScenario) {
+export async function launchScenario (setScenario, clearPersistentData = true) {
   const command = await getCurrentCommand()
 
   switch (command.action) {
@@ -86,7 +88,8 @@ export async function launchScenario (setScenario) {
         command.notify,
         command.sessions,
         command.scenario_data,
-        setScenario
+        setScenario,
+        clearPersistentData
       )
 
     case 'start-bugsnag':

--- a/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
@@ -26,8 +26,6 @@ async function runScenario (scenarioName, apiKey, notifyEndpoint, sessionEndpoin
     NativeInterface.clearPersistentData()
   }
 
-  console.error(`[Bugsnag ScenarioLauncher] with config: ${JSON.stringify(nativeConfig)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-
   // start the native client
   console.error('[Bugsnag ScenarioLauncher] starting native Bugsnag')
   await NativeInterface.startBugsnag(nativeConfig)

--- a/test/react-native/features/fixtures/scenario-launcher/src/scenarios/ReactNativeNavigationBreadcrumbsEnabledScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/scenarios/ReactNativeNavigationBreadcrumbsEnabledScenario.js
@@ -9,7 +9,7 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const HomeScreen = (props) => {
   useEffect(() => {
-    console.error('[BugsnagRNN] HomeScreen mounted')
+    console.error('[BugsnagRNN] HomeScreen mounted');
 
     (async () => {
       await delay(1000)
@@ -35,7 +35,7 @@ const HomeScreen = (props) => {
 
 const DetailsScreen = (props) => {
   useEffect(() => {
-    console.error('[BugsnagRNN] DetailsScreen mounted')
+    console.error('[BugsnagRNN] DetailsScreen mounted');
 
     (async () => {
       await delay(1000)
@@ -64,7 +64,7 @@ export class ReactNativeNavigationBreadcrumbsEnabledScenario extends Scenario {
 
   componentDidMount () {
     console.error('[BugsnagRNN] ReactNativeNavigationBreadcrumbsEnabledScenario mounted')
-  } 
+  }
 
   run () {
     Navigation.registerComponent('Home', () => HomeScreen)

--- a/test/react-native/features/fixtures/scenario-launcher/src/scenarios/ReactNativeNavigationBreadcrumbsEnabledScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/scenarios/ReactNativeNavigationBreadcrumbsEnabledScenario.js
@@ -9,14 +9,14 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const HomeScreen = (props) => {
   useEffect(() => {
-    console.log('HomeScreen mounted')
+    console.error('[BugsnagRNN] HomeScreen mounted')
 
     (async () => {
       await delay(1000)
-      console.log('HomeScreen notifying error')
+      console.error('[BugsnagRNN] HomeScreen notifying error')
       Bugsnag.notify(new Error('HomeNavigationError'))
       await delay(250)
-      console.log('HomeScreen navigating to Details')
+      console.error('[BugsnagRNN] HomeScreen navigating to Details')
 
       Navigation.push(props.componentId, {
         component: {
@@ -35,14 +35,14 @@ const HomeScreen = (props) => {
 
 const DetailsScreen = (props) => {
   useEffect(() => {
-    console.log('DetailsScreen mounted')
+    console.error('[BugsnagRNN] DetailsScreen mounted')
 
     (async () => {
       await delay(1000)
-      console.log('DetailsScreen notifying error')
+      console.error('[BugsnagRNN] DetailsScreen notifying error')
       Bugsnag.notify(new Error('DetailsNavigationError'))
       await delay(250)
-      console.log('DetailsScreen throwing error')
+      console.error('[BugsnagRNN] DetailsScreen throwing error')
       throw new Error('DetailsNavigationUnhandledError')
     })()
   }, [])
@@ -56,14 +56,14 @@ const DetailsScreen = (props) => {
 
 export class ReactNativeNavigationBreadcrumbsEnabledScenario extends Scenario {
   constructor (configuration, jsConfig) {
-    console.log('ReactNativeNavigationBreadcrumbsEnabledScenario constructor called')
+    console.error('[BugsnagRNN] ReactNativeNavigationBreadcrumbsEnabledScenario constructor called')
     super()
     jsConfig.plugins = [new BugsnagReactNativeNavigation(Navigation)]
-    console.log('ReactNativeNavigationBreadcrumbsEnabledScenario constructed')
+    console.error('[BugsnagRNN] ReactNativeNavigationBreadcrumbsEnabledScenario constructed')
   }
 
   componentDidMount () {
-    console.log('ReactNativeNavigationBreadcrumbsEnabledScenario mounted')
+    console.error('[BugsnagRNN] ReactNativeNavigationBreadcrumbsEnabledScenario mounted')
   } 
 
   run () {

--- a/test/react-native/features/fixtures/scenario-launcher/src/scenarios/ReactNativeNavigationBreadcrumbsEnabledScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/scenarios/ReactNativeNavigationBreadcrumbsEnabledScenario.js
@@ -9,10 +9,15 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const HomeScreen = (props) => {
   useEffect(() => {
+    console.log('HomeScreen mounted')
+
     (async () => {
       await delay(1000)
+      console.log('HomeScreen notifying error')
       Bugsnag.notify(new Error('HomeNavigationError'))
       await delay(250)
+      console.log('HomeScreen navigating to Details')
+
       Navigation.push(props.componentId, {
         component: {
           name: 'Details'
@@ -30,10 +35,14 @@ const HomeScreen = (props) => {
 
 const DetailsScreen = (props) => {
   useEffect(() => {
+    console.log('DetailsScreen mounted')
+
     (async () => {
       await delay(1000)
+      console.log('DetailsScreen notifying error')
       Bugsnag.notify(new Error('DetailsNavigationError'))
       await delay(250)
+      console.log('DetailsScreen throwing error')
       throw new Error('DetailsNavigationUnhandledError')
     })()
   }, [])
@@ -47,9 +56,15 @@ const DetailsScreen = (props) => {
 
 export class ReactNativeNavigationBreadcrumbsEnabledScenario extends Scenario {
   constructor (configuration, jsConfig) {
+    console.log('ReactNativeNavigationBreadcrumbsEnabledScenario constructor called')
     super()
     jsConfig.plugins = [new BugsnagReactNativeNavigation(Navigation)]
+    console.log('ReactNativeNavigationBreadcrumbsEnabledScenario constructed')
   }
+
+  componentDidMount () {
+    console.log('ReactNativeNavigationBreadcrumbsEnabledScenario mounted')
+  } 
 
   run () {
     Navigation.registerComponent('Home', () => HomeScreen)

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -171,7 +171,9 @@ Scenario: Handled JS error with native stacktrace
   | old  | default | @null                   |
 
 # Skipped on New Arch below 0.74 - see PLAT-12193
-@ios_only @skip_new_arch_below_074
+@ios_only @skip_new_arch_below_074 
+# Skipped pending PLAT-14039
+@skip_new_arch
 Scenario: Unhandled JS error with native stacktrace
   When I run "NativeStackUnhandledScenario"
   Then I wait to receive an error

--- a/test/react-native/features/override_unhandled.feature
+++ b/test/react-native/features/override_unhandled.feature
@@ -11,6 +11,7 @@ Scenario: Non-fatal error overridden to unhandled
     And the event "session.events.handled" equals 0
     And the event "session.events.unhandled" equals 1
 
+@skip_new_arch_ios
 Scenario: Fatal error overridden to handled
     When I run "UnhandledOverrideJsErrorScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledOverrideJsErrorScenario"

--- a/test/react-native/features/react-native-navigation.feature
+++ b/test/react-native/features/react-native-navigation.feature
@@ -3,9 +3,10 @@ Feature: Navigation plugin features
 
 Scenario: Navigating screens causes breadcrumbs and context to be updated
   When I run "ReactNativeNavigationBreadcrumbsEnabledScenario"
-  And I relaunch the app after a crash
+  And I wait to receive 2 errors
+  Then I relaunch the app after a crash
   And I configure Bugsnag for "ReactNativeNavigationBreadcrumbsEnabledScenario"
-  And I wait to receive 3 errors
+  And I wait to receive 1 error
 
   # Handled error on Home screen
   Then the exception "message" equals "HomeNavigationError"

--- a/test/react-native/features/support/env.rb
+++ b/test/react-native/features/support/env.rb
@@ -38,6 +38,10 @@ Before('@skip_new_arch') do |scenario|
   skip_this_scenario("Skipping scenario") if ENV['RCT_NEW_ARCH_ENABLED'].eql?('1')
 end
 
+Before('@skip_new_arch_ios') do |scenario|
+  skip_this_scenario("Skipping scenario") unless Maze::Helper.get_current_platform == 'ios' && !ENV['RCT_NEW_ARCH_ENABLED']
+end
+
 Before('@skip_old_arch') do |scenario|
   skip_this_scenario("Skipping scenario") unless ENV['RCT_NEW_ARCH_ENABLED'].eql?('1')
 end

--- a/test/react-native/features/unhandled-ios.feature
+++ b/test/react-native/features/unhandled-ios.feature
@@ -28,6 +28,8 @@ Scenario: Reporting an Unhandled promise rejection as handled
   And the event "unhandled" is false
   And the exception "message" equals "UnhandledJsPromiseRejectionAsHandledScenario"
 
+# Skipped pending PLAT-14039
+@skip_new_arch
 Scenario: Reporting an Unhandled Native error
   When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledNativeErrorScenario"
@@ -56,6 +58,8 @@ Scenario: Reporting an Unhandled Native error
   | new  | default | UnhandledNativeErrorScenario                                                                                              |
   | old  | default | UnhandledNativeErrorScenario                                                                                              |
 
+# Skipped pending PLAT-14039
+@skip_new_arch
 Scenario: Updating severity on an unhandled JS error
   When I run "UnhandledJsErrorSeverityScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsErrorSeverityScenario"

--- a/test/react-native/features/unhandled-ios.feature
+++ b/test/react-native/features/unhandled-ios.feature
@@ -1,6 +1,8 @@
 @ios_only
 Feature: Reporting unhandled errors
 
+# Skipped pending PLAT-14039
+@skip_new_arch
 Scenario: Reporting an Unhandled error
   When I run "UnhandledJsErrorScenario" and relaunch the crashed app
   And I configure Bugsnag for "UnhandledJsErrorScenario"


### PR DESCRIPTION
## Goal

Skip unhandled JS error tests on React Native iOS with new architecture pending changes to unhandled JS error discarding