### PR TITLE
Fix react-native-navigation tests

### DIFF
--- a/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/lib/ScenarioLauncher.js
@@ -24,8 +24,6 @@ async function runScenario (scenarioName, apiKey, notifyEndpoint, sessionEndpoin
   console.error('[Bugsnag ScenarioLauncher] clearing persistent data')
   NativeInterface.clearPersistentData()
 
-  console.error(`[Bugsnag ScenarioLauncher] with config: ${JSON.stringify(nativeConfig)} (native) and ${JSON.stringify(jsConfig)} (js)`)
-
   // start the native client
   console.error('[Bugsnag ScenarioLauncher] starting native Bugsnag')
   await NativeInterface.startBugsnag(nativeConfig)


### PR DESCRIPTION
## Goal

Fixes the react-native-navigation e2e tests by removing a problematic log statement

## Design

The test fixture was crashing trying to log out the stringified scenario config due to the react-native-navigation plugin object, so we've removed that log statement as it's not really necessary.

## Testing

Covered by CI