### PR TITLE
Reinstate 0.78 old arch ios tests

### DIFF
--- a/.buildkite/basic/react-native-ios-full-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-full-pipeline.yml
@@ -66,8 +66,7 @@ steps:
           - "0.72"
           - "0.74"
           - "0.76"
-          # TODO: 0.77 moved to the basic pipeline (where 0.78 has been skipped) pending PLAT-14005
-          #- "0.77"
+          - "0.77"
         retry:
           automatic:
             - exit_status: "*"
@@ -254,8 +253,7 @@ steps:
           - "0.72"
           - "0.74"
           - "0.76"
-          # TODO: 0.77 moved to the basic pipeline (where 0.78 has been skipped) pending PLAT-14005
-          #- "0.77"
+          - "0.77"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -27,8 +27,7 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          # TODO: 0.78 moved back to 0.77 pending PLAT-14005
-          - "0.77"
+          - "0.78"
         retry:
           automatic:
             - exit_status: "*"
@@ -93,8 +92,7 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          # TODO: 0.78 moved back to 0.77 pending PLAT-14005
-          - "0.77"
+          - "0.78"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"


### PR DESCRIPTION
## Goal

Reinstate 0.78 old arch iOS tests for React Native. 

These began failing a couple of weeks ago, but now appear to be working again - it's not clear exactly why they started failing, but most likely this was a React Native bug that was fixed in 0.78.2 (released last week)

## Testing

Covered by CI