### PR TITLE
Convert @bugsnag/core/lib/callback-runner to TypeScript

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,6 @@
     "./lib/es-utils/keys": "./src/lib/es-utils/keys.js",
     "./lib/derecursify": "./src/lib/derecursify.js",
     "./lib/metadata-delegate": "./src/lib/metadata-delegate.js",
-    "./lib/callback-runner": "./src/lib/callback-runner.js",
     "./lib/node-fallback-stack": "./src/lib/node-fallback-stack.js",
     "./lib/sync-callback-runner": "./src/lib/sync-callback-runner.js",
     "./lib/path-normalizer": "./src/lib/path-normalizer.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,5 +7,6 @@ export { default as cloneClient } from './lib/clone-client'
 export { default as jsonPayload } from './lib/json-payload'
 export { default as intRange } from './lib/validators/int-range'
 export { default as isError } from './lib/iserror'
+export { default as runCallbacks } from "./lib/callback-runner";
 
 export * from './common'

--- a/packages/core/src/lib/callback-runner.d.ts
+++ b/packages/core/src/lib/callback-runner.d.ts
@@ -1,8 +1,0 @@
-import { NodeCallbackType } from './async-every'
-
-export default function callbackRunner<T>(
-  callbacks: any,
-  event: T,
-  onCallbackError: (err: Error) => void,
-  cb: NodeCallbackType<boolean>
-): void

--- a/packages/plugin-electron-ipc/bugsnag-ipc-main.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-main.js
@@ -1,5 +1,4 @@
-const { Breadcrumb, Event } = require('@bugsnag/core')
-const runCallbacks = require('@bugsnag/core/lib/callback-runner')
+const { Breadcrumb, Event, runCallbacks } = require('@bugsnag/core')
 const featureFlagDelegate = require('@bugsnag/core/lib/feature-flag-delegate')
 
 module.exports = class BugsnagIpcMain {


### PR DESCRIPTION
## Goal

Convert @bugsnag/core/lib/callback-runner to TypeScript

## Testing

Covered by existing end to end and unit tests