### PR TITLE
Migrate Electron Tests to macos 15

### DIFF
--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -5,7 +5,7 @@ steps:
     - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
       timeout_in_minutes: 40
       agents:
-        queue: macos-node-18
+        queue: macos-15
       env:
         NODE_VERSION: "{{matrix.node_version}}"
         ELECTRON_VERSION: "{{matrix.electron_version}}"

--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -21,7 +21,7 @@ steps:
             - "^28.0.0"
             - "^30.0.0"
           node_version:
-            - "18"
+            - "22"
       commands:
         - echo "Running on Node `node -v`"
         - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save

--- a/package-lock.json
+++ b/package-lock.json
@@ -4461,15 +4461,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
-    "node_modules/@jest/console/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/@jest/console/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4716,15 +4707,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/@jest/core/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
     },
     "node_modules/@jest/core/node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -5190,15 +5172,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@jest/environment/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@jest/environment/node_modules/ansi-styles": {
@@ -5870,15 +5843,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
-    "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/@jest/fake-timers/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -6359,15 +6323,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@jest/reporters/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6584,15 +6539,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@jest/test-result/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/@jest/test-result/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6723,15 +6669,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/@jest/test-sequencer/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
     },
     "node_modules/@jest/test-sequencer/node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -7233,15 +7170,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@jest/transform/node_modules/ansi-styles": {
@@ -11015,18 +10943,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-tools/node_modules/shell-quote": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-      "integrity": "sha512-V0iQEZ/uoem3NmD91rD8XiuozJnq9/ZJnbHVXHnWqP1ucAhS3yJ7sLIIzEi57wFFcK3oi3kFUC46uSyWr35mxg==",
-      "dev": true,
-      "dependencies": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
-    },
     "node_modules/@react-native-community/cli-tools/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12029,15 +11945,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/jest/node_modules/ansi-regex": {
@@ -14311,12 +14218,6 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "node_modules/array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha512-VW0FpCIhjZdarWjIz8Vpva7U95fl2Jn+b+mmFFMLn8PIVscOQcAgEznwUzTEuUHuqZqIxwzRlcaN/urTFFQoiw==",
-      "dev": true
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -14354,21 +14255,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.1.tgz",
-      "integrity": "sha512-sxHIeJTGEsRC8/hYkZzdJNNPZ41EXHVys7pqMw1iwE/Kx8/hto0UbDuGQsSJ0ujPovj9qUZl6EOY/EiZ2g3d9Q==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha512-8jR+StqaC636u7h3ye1co3lQRefgVVUQUhuAmRbDqIMeR2yuXzRvkCNQiQ5J/wbREmoBLNtp13dhaaVpZQDRUw==",
-      "dev": true
     },
     "node_modules/array-slice": {
       "version": "0.2.3",
@@ -20243,6 +20129,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -20252,6 +20139,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -21653,15 +21541,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/expect/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
     },
     "node_modules/expect/node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -25445,16 +25324,6 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
-    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -25769,15 +25638,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-changed-files/node_modules/ansi-styles": {
@@ -27401,15 +27261,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/jest-diff/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/jest-diff/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -27561,15 +27412,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/jest-each/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-each/node_modules/ansi-regex": {
@@ -28858,15 +28700,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/jest-matcher-utils/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/jest-matcher-utils/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -29040,15 +28873,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-message-util/node_modules/source-map": {
@@ -29250,15 +29074,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/jest-resolve-dependencies/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-resolve-dependencies/node_modules/ansi-styles": {
@@ -31824,15 +31639,6 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/jest-watcher/node_modules/ansi-styles": {
@@ -35412,15 +35218,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/metro-config/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/metro-config/node_modules/ansi-regex": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -35551,15 +35348,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/metro-core/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/metro-core/node_modules/anymatch": {
@@ -36136,15 +35924,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/metro/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/metro/node_modules/ansi-regex": {
@@ -37575,10 +37354,11 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -40422,15 +40202,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/react-native/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/react-native/node_modules/ansi-regex": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -41963,10 +41734,11 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -58175,7 +57947,7 @@
         "performance-now": "^2.1.0",
         "qs": "6.13.1",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "^5.0.0",
+        "tough-cookie": "5.1.1",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -58210,7 +57982,7 @@
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
-            "json-schema": "0.4.0",
+            "json-schema": "^0.4.0",
             "verror": "1.10.0"
           }
         },
@@ -58969,7 +58741,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -58987,15 +58759,6 @@
           "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
           "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
           "dev": true
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -59176,7 +58939,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -59194,15 +58957,6 @@
           "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
           "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
           "dev": true
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -59370,7 +59124,7 @@
             "@jest/test-result": "^26.6.2",
             "@jest/transform": "^26.6.2",
             "@jest/types": "^26.6.2",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0",
             "cjs-module-lexer": "^0.6.0",
             "collect-v8-coverage": "^1.0.0",
@@ -59561,7 +59315,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -59572,15 +59326,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -59683,7 +59428,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^17.0.8",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -60100,7 +59845,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -60118,15 +59863,6 @@
           "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
           "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
           "dev": true
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -60489,7 +60225,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -60500,15 +60236,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -60665,7 +60392,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -60676,15 +60403,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -60771,7 +60489,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -60789,15 +60507,6 @@
           "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
           "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
           "dev": true
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -60972,7 +60681,7 @@
             "@jest/test-result": "^26.6.2",
             "@jest/transform": "^26.6.2",
             "@jest/types": "^26.6.2",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0",
             "cjs-module-lexer": "^0.6.0",
             "collect-v8-coverage": "^1.0.0",
@@ -61183,7 +60892,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -61194,15 +60903,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -61484,7 +61184,7 @@
         "make-dir": "4.0.0",
         "minimatch": "3.0.5",
         "multimatch": "5.0.0",
-        "node-fetch": "2.6.7",
+        "node-fetch": "^2.6.7",
         "npm-package-arg": "11.0.2",
         "npm-packlist": "8.0.2",
         "npm-registry-fetch": "^17.1.0",
@@ -63944,9 +63644,9 @@
         "chalk": "^3.0.0",
         "lodash": "^4.17.15",
         "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "open": "^6.2.0",
-        "shell-quote": "1.6.1"
+        "shell-quote": "^1.7.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -63988,18 +63688,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "shell-quote": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-          "integrity": "sha512-V0iQEZ/uoem3NmD91rD8XiuozJnq9/ZJnbHVXHnWqP1ucAhS3yJ7sLIIzEi57wFFcK3oi3kFUC46uSyWr35mxg==",
-          "dev": true,
-          "requires": {
-            "array-filter": "~0.0.0",
-            "array-map": "~0.0.0",
-            "array-reduce": "~0.0.0",
-            "jsonify": "~0.0.0"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -64281,7 +63969,7 @@
         "@babel/types": "^7.20.7",
         "@types/babel__generator": "*",
         "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
+        "@types/babel__traverse": "7.17.1"
       }
     },
     "@types/babel__generator": {
@@ -64388,7 +64076,7 @@
       "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "4.17.28",
         "@types/node": "*"
       }
     },
@@ -64449,7 +64137,7 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "4.17.28",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
@@ -64572,7 +64260,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -64583,15 +64271,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -66305,12 +65984,6 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha512-VW0FpCIhjZdarWjIz8Vpva7U95fl2Jn+b+mmFFMLn8PIVscOQcAgEznwUzTEuUHuqZqIxwzRlcaN/urTFFQoiw==",
-      "dev": true
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -66342,18 +66015,6 @@
         "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       }
-    },
-    "array-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.1.tgz",
-      "integrity": "sha512-sxHIeJTGEsRC8/hYkZzdJNNPZ41EXHVys7pqMw1iwE/Kx8/hto0UbDuGQsSJ0ujPovj9qUZl6EOY/EiZ2g3d9Q==",
-      "dev": true
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha512-8jR+StqaC636u7h3ye1co3lQRefgVVUQUhuAmRbDqIMeR2yuXzRvkCNQiQ5J/wbREmoBLNtp13dhaaVpZQDRUw==",
-      "dev": true
     },
     "array-slice": {
       "version": "0.2.3",
@@ -67089,7 +66750,7 @@
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
         "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
+        "@types/babel__traverse": "7.17.1"
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -68184,7 +67845,7 @@
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
+        "braces": "^3.0.3",
         "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
@@ -69329,7 +68990,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^17.0.8",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -70854,6 +70515,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -70863,6 +70525,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -71937,7 +71600,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -71955,15 +71618,6 @@
           "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
           "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
           "dev": true
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -74760,20 +74414,8 @@
       "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
       "dev": true,
       "requires": {
-        "node-fetch": "^1.0.1",
+        "node-fetch": "^2.6.7",
         "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
       }
     },
     "isstream": {
@@ -74997,7 +74639,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -75008,15 +74650,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -75321,7 +74954,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^17.0.8",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -76152,7 +75785,7 @@
             "@babel/template": "^7.3.3",
             "@babel/types": "^7.3.3",
             "@types/babel__core": "^7.0.0",
-            "@types/babel__traverse": "^7.0.6"
+            "@types/babel__traverse": "7.17.1"
           }
         },
         "babel-preset-jest": {
@@ -76268,7 +75901,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -76279,15 +75912,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -76396,7 +76020,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -76407,15 +76031,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -77397,7 +77012,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -77408,15 +77023,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-regex": {
@@ -77551,16 +77157,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
+            "@types/yargs": "17.0.10"
           }
         },
         "source-map": {
@@ -77874,7 +77471,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -77885,15 +77482,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -78104,7 +77692,7 @@
           "requires": {
             "@babel/template": "^7.3.3",
             "@babel/types": "^7.3.3",
-            "@types/babel__traverse": "^7.0.6"
+            "@types/babel__traverse": "7.17.1"
           }
         },
         "babel-preset-current-node-syntax": {
@@ -78737,7 +78325,7 @@
           "requires": {
             "@babel/template": "^7.3.3",
             "@babel/types": "^7.3.3",
-            "@types/babel__traverse": "^7.0.6"
+            "@types/babel__traverse": "7.17.1"
           }
         },
         "babel-preset-current-node-syntax": {
@@ -79716,7 +79304,7 @@
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "17.0.10",
             "chalk": "^4.0.0"
           }
         },
@@ -79727,15 +79315,6 @@
           "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-          "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
           }
         },
         "ansi-styles": {
@@ -80081,7 +79660,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
+        "json-schema": "^0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -80206,7 +79785,7 @@
       "dev": true,
       "requires": {
         "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "shell-quote": "^1.7.3"
       }
     },
     "lerna": {
@@ -82228,7 +81807,7 @@
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
         "absolute-path": "^0.0.0",
-        "async": "^2.4.0",
+        "async": "^3.2.2",
         "babel-preset-fbjs": "^3.3.0",
         "buffer-crc32": "^0.2.13",
         "chalk": "^2.4.1",
@@ -82262,7 +81841,7 @@
         "metro-symbolicate": "0.59.0",
         "mime-types": "2.1.11",
         "mkdirp": "^0.5.1",
-        "node-fetch": "^2.2.0",
+        "node-fetch": "^2.6.7",
         "nullthrows": "^1.1.1",
         "resolve": "^1.5.0",
         "rimraf": "^2.5.4",
@@ -82337,16 +81916,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
+            "@types/yargs": "17.0.10"
           }
         },
         "ansi-regex": {
@@ -82366,8 +81936,7 @@
           }
         },
         "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
           "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
@@ -82875,16 +82444,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
+            "@types/yargs": "17.0.10"
           }
         },
         "ansi-regex": {
@@ -82991,16 +82551,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
+            "@types/yargs": "17.0.10"
           }
         },
         "anymatch": {
@@ -84132,9 +83683,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -86125,7 +85676,7 @@
       "integrity": "sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==",
       "dev": true,
       "requires": {
-        "shell-quote": "^1.6.1",
+        "shell-quote": "^1.7.3",
         "ws": "^7"
       }
     },
@@ -86184,16 +85735,7 @@
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^13.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "13.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
+            "@types/yargs": "17.0.10"
           }
         },
         "ansi-regex": {
@@ -87383,9 +86925,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "dev": true
     },
     "shellwords": {
@@ -90150,7 +89692,7 @@
           "dev": true,
           "requires": {
             "@types/body-parser": "*",
-            "@types/express-serve-static-core": "^4.17.33",
+            "@types/express-serve-static-core": "4.17.28",
             "@types/qs": "*",
             "@types/serve-static": "*"
           }


### PR DESCRIPTION
## Goal

Move the electron tests over to the macOS CI machines. Had to bump the package-lock.json to fix issues with `npm ci`

## Testing

Covered by CI