### PR TITLE
test: :test_tube: temporarily disable failing ios_11 non-https tests

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -52,7 +52,7 @@ steps:
       #
       - label: ":browserstack: {{matrix}} non-https tests"
         matrix:
-          - ios_11
+          # - ios_11
           - safari_16
         depends_on: "browser-maze-runner-bs"
         timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->