### PR TITLE
Move Electron tests to Isolated queue

### DIFF
--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -5,7 +5,7 @@ steps:
     - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
       timeout_in_minutes: 40
       agents:
-        queue: macos-15-4
+        queue: macos-15-isolated
       env:
         NODE_VERSION: "{{matrix.node_version}}"
         ELECTRON_VERSION: "{{matrix.electron_version}}"
@@ -21,7 +21,7 @@ steps:
             - "^28.0.0"
             - "^30.0.0"
           node_version:
-            - "22"
+            - "18"
       commands:
         - echo "Running on Node `node -v`"
         - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save

--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -5,7 +5,7 @@ steps:
     - label: "Electron {{matrix.electron_version}} tests - macOS - Node {{matrix.node_version}}"
       timeout_in_minutes: 40
       agents:
-        queue: macos-node-18
+        queue: macos-15-4
       env:
         NODE_VERSION: "{{matrix.node_version}}"
         ELECTRON_VERSION: "{{matrix.electron_version}}"
@@ -21,7 +21,7 @@ steps:
             - "^28.0.0"
             - "^30.0.0"
           node_version:
-            - "18"
+            - "22"
       commands:
         - echo "Running on Node `node -v`"
         - npm install electron@${ELECTRON_VERSION} --no-audit --progress=false --no-save


### PR DESCRIPTION
## Goal
Move the Electron tests to the isolated queue to improve the stability of tests due to it needing control of the screen

## Testing

Covered by CI