### PR TITLE
Update Electron test matrix

### DIFF
--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -18,7 +18,6 @@ steps:
             - "^38.0.0" # Latest Version
             - "^37.0.0" # EOL 2026-Jan-13
             - "^36.0.0" # EOL 2025-Oct-28
-            - "^34.0.0" # EOL 2025-Jun-24
           node_version:
             - "22"
       commands:

--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -15,9 +15,10 @@ steps:
       matrix:
         setup:
           electron_version:
-            - "^37.0.0" # Latest Version
+            - "^38.0.0" # Latest Version
+            - "^37.0.0" # EOL 2026-Jan-13
             - "^36.0.0" # EOL 2025-Oct-28
-            - "^35.0.0" # EOL 2025-Sep-02
+            - "^34.0.0" # EOL 2025-Jun-24
           node_version:
             - "22"
       commands:

--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -17,6 +17,7 @@ steps:
           electron_version:
             - "^37.0.0" # Latest Version
             - "^36.0.0" # EOL 2025-Oct-28
+            - "^35.0.0" # EOL 2025-Sep-02
           node_version:
             - "22"
       commands:

--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -15,11 +15,8 @@ steps:
       matrix:
         setup:
           electron_version:
-            - "^20.0.0"
-            - "^24.0.0"
-            - "^26.0.0"
-            - "^28.0.0"
-            - "^30.0.0"
+            - "^37.0.0" # Latest Version
+            - "^36.0.0" # EOL 2025-Oct-28
           node_version:
             - "22"
       commands:

--- a/.buildkite/basic/electron-pipeline.yml
+++ b/.buildkite/basic/electron-pipeline.yml
@@ -15,9 +15,14 @@ steps:
       matrix:
         setup:
           electron_version:
-            - "^38.0.0" # Latest Version
-            - "^37.0.0" # EOL 2026-Jan-13
-            - "^36.0.0" # EOL 2025-Oct-28
+            - "^41.0.0" # Latest Version
+            - "^40.0.0" # EOL 30-06-2026
+            - "^39.0.0" # EOL 05-05-2026
+            - "^38.0.0" # EOL 10-03-2026
+            - "^36.0.0" # EOL 28-10-2025
+            - "^34.0.0" # EOL 24-06-2025
+            - "^32.0.0" # EOL 04-03-2025
+            - "^30.0.0" # EOL 15-10-2024
           node_version:
             - "22"
       commands:


### PR DESCRIPTION
## Goal

Electron's [official support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines) is the latest 3 stable releases. This PR updates the Electron pipeline to test the latest 3 versions, and previous even versions until v30 which was end of life on 15th October 2024.