### PR TITLE
Only run full builds on next when FULL_SCHEDULED_BUILD is set

### DIFF
--- a/.buildkite/pipeline_trigger.js
+++ b/.buildkite/pipeline_trigger.js
@@ -8,6 +8,7 @@ const ignoredFiles = ["README.md", "LICENSE.txt", ".gitignore", "TESTING.md", "o
 const baseBranch = process.env.BUILDKITE_PULL_REQUEST_BASE_BRANCH;
 const currentBranch = process.env.BUILDKITE_BRANCH;
 const commitMessage = process.env.BUILDKITE_MESSAGE || "";
+const isFullBuild = process.env.FULL_SCHEDULED_BUILD === "1";
 
 if (baseBranch) {
   console.log(`Fetching latest changes from ${baseBranch}`);
@@ -21,7 +22,8 @@ packageManifest.forEach(({ paths, block, pipeline }) => {
   let upload = false;
 
   if (commitMessage.includes("[full ci]") ||
-    ["next", "main"].includes(currentBranch) ||
+    isFullBuild ||
+    ["main"].includes(currentBranch) ||
     ["main"].includes(baseBranch)) {
     console.log(`Upload pipeline file: ${pipeline}`);
     execSync(`buildkite-agent pipeline upload ${pipeline}`);

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ compile_commands.json
 .cache
 .clangd
 Gemfile.lock
+# IDE files
+.idea/
+*.iml


### PR DESCRIPTION
## Goal

Only run full builds on next when FULL_SCHEDULED_BUILD is set.

## Design

We run a full build every morning, so there's no need to run a full build on `next` after every PR merge during the day.

## Testing

Branched off of this and created a build manually with the variable set.  I'll also check that a full build doesn't occur after merging this.