### PR TITLE
Skip ios 11 tests

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -52,7 +52,7 @@ steps:
       #
       - label: ":browserstack: {{matrix}} non-https tests"
         matrix:
-          - ios_11
+          # - ios_11 - Skipped pending PLAT-14437
           - safari_16
         depends_on: "browser-maze-runner-bs"
         timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

Skip failing tests caused by browserstack availability