### PR TITLE
Pin @angular-devkit/build-angular to 19.2.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3855,9 +3855,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -46690,7 +46690,7 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^19.0.5",
+        "@angular-devkit/build-angular": "19.2.14",
         "@angular/cli": "^19.0.5",
         "@angular/common": "^19.0.0",
         "@angular/compiler-cli": "^19.0.0",
@@ -52835,6 +52835,7 @@
     "packages/plugin-electron-app": {
       "name": "@bugsnag/plugin-electron-app",
       "version": "8.4.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0"
@@ -52876,6 +52877,7 @@
     "packages/plugin-electron-client-state-persistence": {
       "name": "@bugsnag/plugin-electron-client-state-persistence",
       "version": "8.4.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0"
@@ -55608,7 +55610,7 @@
     "@bugsnag/plugin-angular": {
       "version": "file:packages/plugin-angular",
       "requires": {
-        "@angular-devkit/build-angular": "^19.0.5",
+        "@angular-devkit/build-angular": "19.2.14",
         "@angular/cli": "^19.0.5",
         "@angular/common": "^19.0.0",
         "@angular/compiler-cli": "^19.0.0",
@@ -60698,9 +60700,9 @@
       "dev": true
     },
     "@inquirer/figures": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "dev": true
     },
     "@isaacs/cliui": {

--- a/packages/plugin-angular/package.json
+++ b/packages/plugin-angular/package.json
@@ -25,7 +25,7 @@
     "@bugsnag/js": "^8.0.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^19.0.5",
+    "@angular-devkit/build-angular": "19.2.14",
     "@angular/cli": "^19.0.5",
     "@angular/common": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",


### PR DESCRIPTION
## Goal

pin the version of `@angular-devkit/build-angular` to prevent the version of @inquirer/figures changing so frequently

## Testing

covered by existing ci