### PR TITLE
Remove TODOs that we won't do

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -78,14 +78,13 @@ steps:
 
       #
       # BrowserStack https tests
-      # 
+      #
       - label: ":browserstack: {{matrix}} tests"
         matrix:
           - edge_17
           - safari_10
           - ios_15
           - android_8
-          # TODO: Move these to BitBar
           - chrome_43
           - chrome_72
           - firefox_78
@@ -146,38 +145,6 @@ steps:
         concurrency: 25
         concurrency_group: "bitbar"
         concurrency_method: eager
-
-# Skipped pending PLAT-10590
-#      - label: ":bitbar: {{matrix}} Browser tests (EU hub)"
-#        matrix:
-#          - chrome_43
-#          - chrome_72
-#          - firefox_78
-#        depends_on: "browser-maze-runner-bb"
-#        timeout_in_minutes: 30
-#        plugins:
-#          docker-compose#v4.12.0:
-#            pull: browser-maze-runner-bb
-#            run: browser-maze-runner-bb
-#            service-ports: true
-#            use-aliases: true
-#            command:
-#              - "--farm=bb"
-#              - "--browser={{matrix}}"
-#              - "--no-tunnel"
-#              - "--aws-public-ip"
-#              - "--selenium-server=https://eu-desktop-hub.bitbar.com/wd/hub"
-#          artifacts#v1.5.0:
-#            upload:
-#              - "./test/browser/maze_output/failed/**/*"
-#          test-collector#v1.10.2:
-#            files: "reports/TEST-*.xml"
-#            format: "junit"
-#            branch: "^main|next$$"
-#            api-token-env-name: "BROWSER_BUILDKITE_ANALYTICS_TOKEN"
-#        concurrency: 25
-#        concurrency_group: "bitbar"
-#        concurrency_method: eager
 
       - label: ":bitbar: ie_11 Browser tests"
         depends_on: "browser-maze-runner-bb"


### PR DESCRIPTION
## Goal

Removed TODOs that it turns out we won't be doing.  

## Design

We investigated moving these jobs to BB and found that the Ruby Appium client does not work with those browser versions and so we agreed with BitBar to turn off the VMs provided (they came with a non-trivial cost)..

## Testing

Covered by a barebones CI run and peer review only.