### PR TITLE
Only use Buildkite plugins once per step

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -18,7 +18,6 @@ steps:
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
               cache-from:
                 - browser-maze-runner-bb:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-          - docker-compose#v4.12.0:
               push:
                 - browser-maze-runner-bb:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
         retry:
@@ -39,7 +38,6 @@ steps:
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
               cache-from:
                 - browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
-          - docker-compose#v4.12.0:
               push:
                 - browser-maze-runner-bs:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-browser-${BRANCH_NAME}
         retry:

--- a/.buildkite/basic/node-pipeline.yml
+++ b/.buildkite/basic/node-pipeline.yml
@@ -19,7 +19,6 @@ steps:
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
               cache-from:
                 - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
-          - docker-compose#v4.12.0:
               push:
                 - node-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-node-${BRANCH_NAME}
         retry:

--- a/.buildkite/basic/react-native-android-full-pipeline.yml
+++ b/.buildkite/basic/react-native-android-full-pipeline.yml
@@ -16,7 +16,6 @@ steps:
               build: android-builder-base-java-11
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
               cache-from:  android-builder-base-java-11:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:android-builder-base-java-11
-          - docker-compose#v4.12.0:
               push: android-builder-base-java-11:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:android-builder-base-java-11
         retry:
           automatic:
@@ -32,7 +31,6 @@ steps:
               build: react-native-android-builder-java-11-node-16
               image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
               cache-from:  react-native-android-builder-java-11-node-16:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
-          - docker-compose#v4.12.0:
               push: react-native-android-builder-java-11-node-16:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-${BRANCH_NAME}
         retry:
           automatic:
@@ -44,7 +42,7 @@ steps:
       #
       - label: ":android: Build RN 0.68 Hermes apk"
         key: "rn-0-68-hermes-apk"
-        depends_on: 
+        depends_on:
           - "android-builder-image-java-11-node-16"
           - "publish-js"
         timeout_in_minutes: 20
@@ -63,7 +61,7 @@ steps:
 
       - label: ":android: Build RN 0.69 apk"
         key: "rn-0-69-apk"
-        depends_on: 
+        depends_on:
           - "android-builder-image-java-11-node-16"
           - "publish-js"
         timeout_in_minutes: 20

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,6 @@ steps:
           cache-from:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base
-      - docker-compose#v4.12.0:
           push:
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base-${BRANCH_NAME}
             - ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:ci-base


### PR DESCRIPTION
## Goal

Only use Buildkite plugins once per step, removing a warning that later steps will be ignored in a future version of the agent.

## Testing

Covered by CI, with the changed sub-pipelines triggered.