### PR TITLE
install all packages from repo for node fixtures

### DIFF
--- a/test/node/features/fixtures/cause/Dockerfile
+++ b/test/node/features/fixtures/cause/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/connect/Dockerfile
+++ b/test/node/features/fixtures/connect/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-express*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/contextualize/Dockerfile
+++ b/test/node/features/fixtures/contextualize/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/express/Dockerfile
+++ b/test/node/features/fixtures/express/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-express*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/handled/Dockerfile
+++ b/test/node/features/fixtures/handled/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/hono/Dockerfile
+++ b/test/node/features/fixtures/hono/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-hono*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/koa-1x/Dockerfile
+++ b/test/node/features/fixtures/koa-1x/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-koa*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/koa/Dockerfile
+++ b/test/node/features/fixtures/koa/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-koa*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/project_root/Dockerfile
+++ b/test/node/features/fixtures/project_root/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/proxy/Dockerfile
+++ b/test/node/features/fixtures/proxy/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/restify/Dockerfile
+++ b/test/node/features/fixtures/restify/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz bugsnag-plugin-restify*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/sessions/Dockerfile
+++ b/test/node/features/fixtures/sessions/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/surrounding_code/Dockerfile
+++ b/test/node/features/fixtures/surrounding_code/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/unhandled/Dockerfile
+++ b/test/node/features/fixtures/unhandled/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz

--- a/test/node/features/fixtures/webpack/Dockerfile
+++ b/test/node/features/fixtures/webpack/Dockerfile
@@ -8,5 +8,5 @@ RUN npm install
 
 COPY . ./
 
-RUN npm install --no-package-lock --no-save bugsnag-node*.tgz
+RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 RUN npm run build


### PR DESCRIPTION
## Goal

Ensure latest changes from repo are always tested

## Design

Update the Dockerfiles in the node fixtures to install _all_ bugsnag packages - this takes an extra 30 seconds during the build script, but ensures that no packages are installed from npm, and is future proofed for adding new packages.