### PR TITLE
Don't inject environment variables into build artifact

### DIFF
--- a/test/electron/fixtures/app/src/main.js
+++ b/test/electron/fixtures/app/src/main.js
@@ -11,7 +11,15 @@ const configFile = process.env.BUGSNAG_CONFIG || 'default'
 // eslint-disable-next-line no-undef
 const bugsnagConfig = __non_webpack_require__(`./${configFile}`)
 
-// eslint-disable-next-line no-undef
+const baseBugsnagConfig = {
+  apiKey: process.env.BUGSNAG_API_KEY,
+  endpoints: {
+    notify: process.env.BUGSNAG_ENDPOINT_NOTIFY,
+    sessions: process.env.BUGSNAG_ENDPOINT_SESSIONS,
+    minidumps: process.env.BUGSNAG_ENDPOINT_MINIDUMPS
+  }
+}
+
 const config = { ...baseBugsnagConfig, ...bugsnagConfig() }
 
 Bugsnag.start(config)

--- a/test/electron/fixtures/app/webpack.main.config.js
+++ b/test/electron/fixtures/app/webpack.main.config.js
@@ -16,16 +16,14 @@ module.exports = {
   plugins: [
     new webpack.ProgressPlugin(),
     new webpack.DefinePlugin({
-      baseBugsnagConfig: JSON.stringify({
-        apiKey: process.env.BUGSNAG_API_KEY,
-        endpoints: {
-          notify: process.env.BUGSNAG_ENDPOINT_NOTIFY,
-          sessions: process.env.BUGSNAG_ENDPOINT_SESSIONS,
-          minidumps: process.env.BUGSNAG_ENDPOINT_MINIDUMPS
-        }
-      }),
       preloadRelativeDir: JSON.stringify(join('..', 'renderer')),
       htmlRelativePath: JSON.stringify(join('..', 'renderer', 'main_window', 'index.html'))
+    }),
+    new webpack.EnvironmentPlugin({
+      BUGSNAG_API_KEY: process.env.BUGSNAG_API_KEY,
+      BUGSNAG_ENDPOINT_NOTIFY: process.env.BUGSNAG_ENDPOINT_NOTIFY,
+      BUGSNAG_ENDPOINT_SESSIONS: process.env.BUGSNAG_ENDPOINT_SESSIONS,
+      BUGSNAG_ENDPOINT_MINIDUMPS: process.env.BUGSNAG_ENDPOINT_MINIDUMPS
     })
   ],
   module: {


### PR DESCRIPTION
## Goal

Resolve security issue #132 caused by injecting environment variables such as api key into the webpack bundle, and instead read them at runtime.