### PR TITLE
 Convert @bugsnag/plugin-stackframe-path-normaliser to TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3968,9 +3968,9 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.0.tgz",
+      "integrity": "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -53730,9 +53730,9 @@
       "dev": true
     },
     "@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.0.tgz",
+      "integrity": "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==",
       "dev": true,
       "requires": {
         "@inquirer/figures": "^1.0.13",

--- a/packages/plugin-stackframe-path-normaliser/package.json
+++ b/packages/plugin-stackframe-path-normaliser/package.json
@@ -1,13 +1,24 @@
 {
   "name": "@bugsnag/plugin-stackframe-path-normaliser",
   "version": "8.4.0",
-  "main": "path-normaliser.js",
+  "main": "dist/path-normaliser.js",
+  "types": "dist/types/path-normaliser.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/path-normaliser.d.ts",
+      "default": "./dist/path-normaliser.js",
+      "import": "./dist/path-normaliser.mjs"
+    }
+  },
   "description": "@bugsnag/js plugin to normalise file paths in stackframes",
   "homepage": "https://www.bugsnag.com/",
   "repository": {
     "type": "git",
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -18,5 +29,11 @@
   },
   "devDependencies": {
     "@bugsnag/core": "^8.4.0"
+  },
+  "scripts": {
+    "build": "npm run build:npm",
+    "build:npm": "rollup --config rollup.config.npm.mjs",
+    "clean": "rm -rf dist/*",
+    "test:types": "tsc -p tsconfig.json"
   }
 }

--- a/packages/plugin-stackframe-path-normaliser/rollup.config.npm.mjs
+++ b/packages/plugin-stackframe-path-normaliser/rollup.config.npm.mjs
@@ -1,0 +1,6 @@
+import createRollupConfig from "../../.rollup/index.mjs"
+
+export default createRollupConfig({
+    input: "src/path-normaliser.ts",
+    external: [/node_modules/],
+})

--- a/packages/plugin-stackframe-path-normaliser/src/path-normaliser.ts
+++ b/packages/plugin-stackframe-path-normaliser/src/path-normaliser.ts
@@ -1,7 +1,9 @@
-module.exports = {
+import type { Plugin, Stackframe } from '@bugsnag/core'
+
+const plugin: Plugin = {
   load (client) {
     client.addOnError(event => {
-      const allFrames = event.errors.reduce((accum, er) => accum.concat(er.stacktrace), [])
+      const allFrames: Stackframe[] = event.errors.reduce((accum: Stackframe[], er) => accum.concat(er.stacktrace), [])
 
       allFrames.forEach(stackframe => {
         if (typeof stackframe.file !== 'string') {
@@ -13,3 +15,5 @@ module.exports = {
     })
   }
 }
+
+export default plugin

--- a/packages/plugin-stackframe-path-normaliser/test/path-normaliser.test.ts
+++ b/packages/plugin-stackframe-path-normaliser/test/path-normaliser.test.ts
@@ -1,4 +1,4 @@
-import plugin from '../'
+import plugin from '../src/path-normaliser'
 import { Client, Event } from '@bugsnag/core'
 
 describe('plugin: stackframe path normaliser', () => {

--- a/packages/plugin-stackframe-path-normaliser/tsconfig.json
+++ b/packages/plugin-stackframe-path-normaliser/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Goal

 Convert @bugsnag/plugin-stackframe-path-normaliser to TypeScript

## Design

Publish ES modules and convert Node packages to TypeScript

## Changeset

Refactor @bugsnag/plugin-stackframe-path-normaliser package

## Testing

Covered by existing end to end and unit tests