### PR TITLE
fix(plugin-window-onerror): catch errors when calling previous handler

### DIFF
--- a/packages/plugin-window-onerror/onerror.js
+++ b/packages/plugin-window-onerror/onerror.js
@@ -60,7 +60,7 @@ module.exports = (win = window, component = 'window onerror') => ({
         client._notify(event)
       }
 
-      if (typeof prevOnError === 'function') prevOnError.apply(this, arguments)
+      try { prevOnError.apply(this, arguments) } catch (e) {}
     }
 
     const prevOnError = win.onerror


### PR DESCRIPTION
## Goal

Updates the `window.onerror` plugin to guard against errors thrown when calling the previous onerror handler.

## Changeset

Wraps the function call in a try/catch instead of just checking if it's a function

## Testing

Added a new unit test