### PR TITLE
Add additional grouping discriminator to React Native

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "conventionalCommits.scopes": [
-        "core"
+        "core",
+        "react-native"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "conventionalCommits.scopes": [
-        "core",
-        "react-native"
-    ]
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add additional grouping discriminator property to events [#2544](https://github.com/bugsnag/bugsnag-js/pull/2544)
+- (react-native) Handle additional grouping discriminator [#2557](https://github.com/bugsnag/bugsnag-js/pull/2557)
 
 ### Changed
 

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -27,6 +27,7 @@ module.exports = (client, NativeClient) => ({
       user: event._user,
       metadata: derecursify(event._metadata),
       groupingHash: event.groupingHash,
+      groupingDiscriminator: event._groupingDiscriminator,
       apiKey: event.apiKey,
       featureFlags: event.toJSON().featureFlags,
       nativeStack: nativeStack,

--- a/packages/delivery-react-native/test/delivery.test.ts
+++ b/packages/delivery-react-native/test/delivery.test.ts
@@ -27,6 +27,7 @@ type NativeClientEvent = Pick<EventWithInternals,
   user: EventWithInternals['_user']
   metadata: EventWithInternals['_metadata']
   correlation: EventWithInternals['_correlation']
+  groupingDiscriminator: EventWithInternals['_groupingDiscriminator']
   nativeStack: NativeStackIOS | NativeStackAndroid
 }
 

--- a/packages/plugin-react-native-client-sync/client-sync.js
+++ b/packages/plugin-react-native-client-sync/client-sync.js
@@ -25,6 +25,13 @@ module.exports = (NativeClient) => ({
       return ret
     }
 
+    const origSetGroupingDiscriminator = client.setGroupingDiscriminator
+    client.setGroupingDiscriminator = function () {
+      const ret = origSetGroupingDiscriminator.apply(this, arguments)
+      NativeClient.updateGroupingDiscriminator(this._groupingDiscriminator)
+      return ret
+    }
+
     const origAddMetadata = client.addMetadata
     client.addMetadata = function (section, key, value) {
       const ret = origAddMetadata.apply(this, arguments)
@@ -98,6 +105,9 @@ module.exports = (NativeClient) => ({
           break
         case 'ContextUpdate':
           origSetContext.call(client, event.data)
+          break
+        case 'GroupingDiscriminatorUpdate':
+          origSetGroupingDiscriminator.call(client, event.data)
           break
         case 'AddFeatureFlag':
           origAddFeatureFlag.call(client, event.data.name, event.data.variant)

--- a/packages/plugin-react-native-client-sync/test/client-sync.test.ts
+++ b/packages/plugin-react-native-client-sync/test/client-sync.test.ts
@@ -36,6 +36,21 @@ describe('plugin: react native client sync', () => {
       c.setContext('1234')
     })
 
+    it('updates grouping discriminator', done => {
+      const c = new Client({
+        apiKey: 'api_key',
+        plugins: [
+          plugin({
+            updateGroupingDiscriminator: (update: any) => {
+              expect(update).toBe('test-discriminator')
+              done()
+            }
+          })
+        ]
+      })
+      c.setGroupingDiscriminator('test-discriminator')
+    })
+
     it('updates metadata', done => {
       const c = new Client({
         apiKey: 'api_key',
@@ -188,6 +203,19 @@ describe('plugin: react native client sync', () => {
 
       setTimeout(() => {
         expect(c.getContext()).toBe('new context')
+      }, 1)
+    })
+
+    it('silently updates grouping discriminator when an update is received', () => {
+      MockAddListener.mockImplementation((event: any, listener: (payload: any) => void) => {
+        setTimeout(() => listener({ type: 'GroupingDiscriminatorUpdate', data: 'new-discriminator' }), 0)
+      })
+      const c = new Client({ apiKey: 'api_key', plugins: [plugin()] })
+      expect(MockAddListener).toHaveBeenCalledWith('bugsnag::sync', expect.any(Function))
+      expect(c.getGroupingDiscriminator()).toBe(undefined)
+
+      setTimeout(() => {
+        expect(c.getGroupingDiscriminator()).toBe('new-discriminator')
       }, 1)
     })
 

--- a/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNativeImpl.java
+++ b/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNativeImpl.java
@@ -23,6 +23,7 @@ class BugsnagReactNativeImpl {
   static final String MODULE_NAME = "BugsnagReactNative";
 
   private static final String UPDATE_CONTEXT = "ContextUpdate";
+  private static final String UPDATE_GROUPING_DISCRIMINATOR = "GroupingDiscriminatorUpdate";
   private static final String UPDATE_USER = "UserUpdate";
   private static final String UPDATE_METADATA = "MetadataUpdate";
   private static final String ADD_FEATURE_FLAG = "AddFeatureFlag";
@@ -85,6 +86,7 @@ class BugsnagReactNativeImpl {
 
     switch (event.getType()) {
       case UPDATE_CONTEXT:
+      case UPDATE_GROUPING_DISCRIMINATOR:
         map.putString(DATA_KEY, (String) event.getData());
         break;
       case UPDATE_USER:
@@ -158,6 +160,14 @@ class BugsnagReactNativeImpl {
       plugin.updateContext(context);
     } catch (Throwable exc) {
       logFailure("updateContext", exc);
+    }
+  }
+
+  void updateGroupingDiscriminator(@Nullable String groupingDiscriminator) {
+    try {
+      plugin.updateGroupingDiscriminator(groupingDiscriminator);
+    } catch (Throwable exc) {
+      logFailure("updateGroupingDiscriminator", exc);
     }
   }
 

--- a/packages/react-native/android/src/newarch/java/com/bugsnag/android/NativeBugsnagImpl.java
+++ b/packages/react-native/android/src/newarch/java/com/bugsnag/android/NativeBugsnagImpl.java
@@ -72,6 +72,11 @@ public class NativeBugsnagImpl extends NativeBugsnagSpec {
   }
 
   @Override
+  public void updateGroupingDiscriminator(@Nullable String groupingDiscriminator) {
+    impl.updateGroupingDiscriminator(groupingDiscriminator);
+  }
+
+  @Override
   public void addMetadata(String section, ReadableMap metadata) {
     impl.addMetadata(section, metadata);
   }

--- a/packages/react-native/android/src/oldarch/java/com/bugsnag/android/BugsnagReactNative.java
+++ b/packages/react-native/android/src/oldarch/java/com/bugsnag/android/BugsnagReactNative.java
@@ -78,6 +78,11 @@ public class BugsnagReactNative extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  void updateGroupingDiscriminator(@Nullable String groupingDiscriminator) {
+    impl.updateGroupingDiscriminator(groupingDiscriminator);
+  }
+
+  @ReactMethod
   void addMetadata(@NonNull String section, @Nullable ReadableMap data) {
     impl.addMetadata(section, data);
   }

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -30,6 +30,7 @@
                                                     session:nil /* set by -[BugsnagClient notifyInternal:block:] */];
     event.context = payload[@"context"];
     event.groupingHash = payload[@"groupingHash"];
+    event.groupingDiscriminator = payload[@"groupingDiscriminator"];
 
     [event setCorrelationTraceId:correlation[@"traceId"] spanId:correlation[@"spanId"]];
 

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.mm
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNative.mm
@@ -73,6 +73,11 @@ BSG_EXPORT_METHOD(updateContext:(NSString *)context) {
     BSG_EXPORT_RETURN
 }
 
+BSG_EXPORT_METHOD(updateGroupingDiscriminator:(NSString *)groupingDiscriminator) {
+    [Bugsnag setGroupingDiscriminator:groupingDiscriminator];
+    BSG_EXPORT_RETURN
+}
+
 BSG_EXPORT_METHOD(updateCodeBundleId:(NSString *)codeBundleId) {
     Bugsnag.client.codeBundleId = codeBundleId; 
     BSG_EXPORT_RETURN

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativeEmitter.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagReactNativeEmitter.m
@@ -77,6 +77,15 @@ RCT_EXPORT_MODULE();
                 };
             }
             break;
+
+        case BSGClientObserverUpdateGroupingDiscriminator:
+            if ([value isKindOfClass:[NSString class]] || !value) {
+                return @{
+                    @"type": @"GroupingDiscriminatorUpdate",
+                    @"data": value ?: [NSNull null]
+                };
+            }
+            break;
     }
 
     return nil;

--- a/packages/react-native/src/NativeBugsnag.ts
+++ b/packages/react-native/src/NativeBugsnag.ts
@@ -42,6 +42,8 @@ export interface Spec extends TurboModule {
   clearFeatureFlag(name: string): void
 
   clearFeatureFlags(): void
+
+  updateGroupingDiscriminator(groupingDiscriminator: string | undefined | null): void
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/test/scenarios/GroupingDiscriminatorNativeScenario.kt
+++ b/test/react-native/features/fixtures/scenario-launcher/android/src/main/java/com/bugsnag/reactnative/test/scenarios/GroupingDiscriminatorNativeScenario.kt
@@ -1,0 +1,25 @@
+package com.reactnative.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.facebook.react.bridge.Promise
+
+class GroupingDiscriminatorNativeScenario(context: Context): Scenario(context) {
+
+    override fun run(promise: Promise) {
+        val exception = RuntimeException("GroupingDiscriminatorScenarioNative")
+        Bugsnag.notify(exception)
+        Thread.sleep(500)
+        Bugsnag.setGroupingDiscriminator("grouping-discriminator-from-native")
+        // JS layer will be automatically notified via the BugsnagReactNativeEmitter
+        // when setGroupingDiscriminator is called, which triggers the client observer
+    }
+
+    override fun runSync(): Boolean {
+        val exception = RuntimeException("GroupingDiscriminatorScenarioNative")
+        Bugsnag.notify(exception)
+        Thread.sleep(500)
+        Bugsnag.setGroupingDiscriminator("grouping-discriminator-from-native")
+        return true
+    }
+}

--- a/test/react-native/features/fixtures/scenario-launcher/ios/BugsnagTestInterface.xcodeproj/project.pbxproj
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/BugsnagTestInterface.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		DA2260AC2E58AD79008384E6 /* BugsnagTestInterface.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA2260AB2E58AD79008384E6 /* BugsnagTestInterface.mm */; };
 		DA2260D42E58AD99008384E6 /* ContextNativeCustomScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2260B42E58AD99008384E6 /* ContextNativeCustomScenario.m */; };
+		DA2260D42E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2260B42E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.m */; };
 		DA2260D52E58AD99008384E6 /* MetadataNativeUnhandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2260C02E58AD99008384E6 /* MetadataNativeUnhandledScenario.m */; };
 		DA2260D62E58AD99008384E6 /* UserNativeClientScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2260D32E58AD99008384E6 /* UserNativeClientScenario.m */; };
 		DA2260D72E58AD99008384E6 /* StartSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2260CF2E58AD99008384E6 /* StartSessionScenario.m */; };
@@ -54,6 +55,8 @@
 		DA2260B22E58AD99008384E6 /* BreadcrumbsNativeManualScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BreadcrumbsNativeManualScenario.m; path = Scenarios/BreadcrumbsNativeManualScenario.m; sourceTree = "<group>"; };
 		DA2260B32E58AD99008384E6 /* ContextNativeCustomScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ContextNativeCustomScenario.h; path = Scenarios/ContextNativeCustomScenario.h; sourceTree = "<group>"; };
 		DA2260B42E58AD99008384E6 /* ContextNativeCustomScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ContextNativeCustomScenario.m; path = Scenarios/ContextNativeCustomScenario.m; sourceTree = "<group>"; };
+		DA2260B32E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = GroupingDiscriminatorNativeScenario.h; path = Scenarios/GroupingDiscriminatorNativeScenario.h; sourceTree = "<group>"; };
+		DA2260B42E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = GroupingDiscriminatorNativeScenario.m; path = Scenarios/GroupingDiscriminatorNativeScenario.m; sourceTree = "<group>"; };
 		DA2260B52E58AD99008384E6 /* DeviceNativeHandledScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DeviceNativeHandledScenario.h; path = Scenarios/DeviceNativeHandledScenario.h; sourceTree = "<group>"; };
 		DA2260B62E58AD99008384E6 /* DeviceNativeHandledScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = DeviceNativeHandledScenario.m; path = Scenarios/DeviceNativeHandledScenario.m; sourceTree = "<group>"; };
 		DA2260B72E58AD99008384E6 /* DeviceNativeUnhandledScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DeviceNativeUnhandledScenario.h; path = Scenarios/DeviceNativeUnhandledScenario.h; sourceTree = "<group>"; };
@@ -109,6 +112,8 @@
 				DA2260B22E58AD99008384E6 /* BreadcrumbsNativeManualScenario.m */,
 				DA2260B32E58AD99008384E6 /* ContextNativeCustomScenario.h */,
 				DA2260B42E58AD99008384E6 /* ContextNativeCustomScenario.m */,
+				DA2260B32E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.h */,
+				DA2260B42E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.m */,
 				DA2260B52E58AD99008384E6 /* DeviceNativeHandledScenario.h */,
 				DA2260B62E58AD99008384E6 /* DeviceNativeHandledScenario.m */,
 				DA2260B72E58AD99008384E6 /* DeviceNativeUnhandledScenario.h */,
@@ -215,6 +220,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA2260D42E58AD99008384E6 /* ContextNativeCustomScenario.m in Sources */,
+				DA2260D42E58AD99008384E6 /* GroupingDiscriminatorNativeScenario.m in Sources */,
 				DA2260D52E58AD99008384E6 /* MetadataNativeUnhandledScenario.m in Sources */,
 				DA2260D62E58AD99008384E6 /* UserNativeClientScenario.m in Sources */,
 				DA2260D72E58AD99008384E6 /* StartSessionScenario.m in Sources */,

--- a/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorNativeScenario.h
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorNativeScenario.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+@interface GroupingDiscriminatorNativeScenario : Scenario
+
+@end

--- a/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorNativeScenario.m
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorNativeScenario.m
@@ -1,0 +1,15 @@
+#import "GroupingDiscriminatorNativeScenario.h"
+
+@implementation GroupingDiscriminatorNativeScenario
+
+- (void)run: (RCTPromiseResolveBlock)resolve
+     reject:(RCTPromiseRejectBlock)reject {
+  NSException *exception = [[NSException alloc] initWithName:@"NSException" reason:@"GroupingDiscriminatorScenarioNative" userInfo:nil];
+  [Bugsnag notify:exception];
+  [NSThread sleepForTimeInterval:0.5];
+  [Bugsnag setGroupingDiscriminator:@"grouping-discriminator-from-native"];
+  // JS layer will be automatically notified via the BugsnagReactNativeEmitter
+  // when setGroupingDiscriminator is called, which triggers BSGClientObserverUpdateGroupingDiscriminator
+}
+
+@end

--- a/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorScenario.h
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorScenario.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+@interface GroupingDiscriminatorScenario : Scenario
+
+@end

--- a/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorScenario.m
+++ b/test/react-native/features/fixtures/scenario-launcher/ios/Scenarios/GroupingDiscriminatorScenario.m
@@ -1,0 +1,11 @@
+#import "GroupingDiscriminatorScenario.h"
+
+@implementation GroupingDiscriminatorScenario
+
+- (void)run: (RCTPromiseResolveBlock)resolve
+     reject:(RCTPromiseRejectBlock)reject {
+  // This scenario is driven from the JS side
+  // The native part doesn't need to do anything specific
+}
+
+@end

--- a/test/react-native/features/fixtures/scenario-launcher/src/scenarios/GroupingDiscriminatorNativeScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/scenarios/GroupingDiscriminatorNativeScenario.js
@@ -1,0 +1,18 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+import { NativeInterface } from '../lib/native'
+
+export class GroupingDiscriminatorNativeScenario extends Scenario {
+  run () {
+    // Set initial grouping discriminator in JavaScript
+    Bugsnag.setGroupingDiscriminator('grouping-discriminator-from-js')
+
+    // Trigger the native scenario which will set the grouping discriminator
+    setTimeout(async () => {
+      await NativeInterface.runScenario('GroupingDiscriminatorNativeScenario')
+      setTimeout(() => {
+        Bugsnag.notify(new Error('GroupingDiscriminatorScenarioJS'))
+      }, 100)
+    }, 100)
+  }
+}

--- a/test/react-native/features/fixtures/scenario-launcher/src/scenarios/GroupingDiscriminatorScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/scenarios/GroupingDiscriminatorScenario.js
@@ -1,0 +1,32 @@
+import Scenario from './Scenario'
+import Bugsnag from '@bugsnag/react-native'
+
+export class GroupingDiscriminatorScenario extends Scenario {
+  run () {
+    // 1. Notify with error that has no discriminator
+    Bugsnag.notify(new Error('no-discriminator'))
+
+    // 2. Notify with error that should use client discriminator
+    Bugsnag.setGroupingDiscriminator('client-discriminator')
+    Bugsnag.notify(new Error('client-discriminator'))
+
+    // 3. Notify with error and set event discriminator
+    Bugsnag.notify(new Error('event-discriminator'), event => {
+      event.setGroupingDiscriminator('event-discriminator')
+    })
+
+    // 4. Notify with error and explicitly set event discriminator to null
+    Bugsnag.notify(new Error('null-discriminator'), event => {
+      event.setGroupingDiscriminator(null)
+    })
+
+    // 5. Notify with error and explicitly set event discriminator to undefined
+    Bugsnag.notify(new Error('undefined-discriminator'), event => {
+      event.setGroupingDiscriminator(undefined)
+    })
+
+    // 6. Clear client grouping discriminator and notify
+    Bugsnag.setGroupingDiscriminator(undefined)
+    Bugsnag.notify(new Error('no-discriminator-2'))
+  }
+}

--- a/test/react-native/features/fixtures/scenario-launcher/src/scenarios/index.js
+++ b/test/react-native/features/fixtures/scenario-launcher/src/scenarios/index.js
@@ -81,3 +81,7 @@ export { ReactNavigationBreadcrumbsDisabledScenario } from './ReactNavigationBre
 // react-native-navigation.feature
 export { ReactNativeNavigationBreadcrumbsEnabledScenario } from './ReactNativeNavigationBreadcrumbsEnabledScenario'
 export { ReactNativeNavigationBreadcrumbsDisabledScenario } from './ReactNativeNavigationBreadcrumbsDisabledScenario'
+
+// grouping-discriminator.feature
+export { GroupingDiscriminatorScenario } from './GroupingDiscriminatorScenario'
+export { GroupingDiscriminatorNativeScenario } from './GroupingDiscriminatorNativeScenario'

--- a/test/react-native/features/grouping-discriminator.feature
+++ b/test/react-native/features/grouping-discriminator.feature
@@ -1,0 +1,23 @@
+@grouping_discriminator
+Feature: Grouping discriminator functionality
+
+Scenario: multiple notify() calls with different grouping discriminators
+  When I run "GroupingDiscriminatorScenario"
+  And I wait to receive 6 errors
+  Then the following sets are present in the current error payloads:
+    | events.0.exceptions.0.message | events.0.groupingDiscriminator |
+    | no-discriminator              | nil                            |
+    | client-discriminator          | client-discriminator           |
+    | event-discriminator           | event-discriminator            |
+    | null-discriminator            | nil                            |
+    | undefined-discriminator       | nil                            |
+    | no-discriminator-2            | nil                            |
+
+Scenario: Grouping discriminator set in JavaScript is reflected in native
+  When I run "GroupingDiscriminatorNativeScenario"
+  And I wait to receive 2 errors
+  Then the following sets are present in the current error payloads:
+    | events.0.exceptions.0.message       | events.0.groupingDiscriminator      |
+    | GroupingDiscriminatorScenarioNative | grouping-discriminator-from-js      |
+    | GroupingDiscriminatorScenarioJS     | grouping-discriminator-from-native  |
+    

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -129,6 +129,10 @@ Then('the following sets are present in the current {word} payloads:') do |reque
     payload_hash
   end
   expected_values.each do |expected_data|
+    # if value is 'nil' then the field should not be present in the payload
+    expected_data.each do |field_path, expected_value|
+      expected_data[field_path] = nil if expected_value == 'nil'
+    end
     Maze.check.true(payload_values.include?(expected_data),
                     "#{expected_data} was not found in any of the current payloads")
   end


### PR DESCRIPTION
## Goal

This PR adds additional grouping discriminator functionality to React Native by implementing support for grouping discriminators in the React Native SDK. The feature allows setting and updating grouping discriminators both from JavaScript and native code, with synchronization between the JS and native layers.

- Implements JavaScript API for setting grouping discriminators with client-sync functionality
- Adds native iOS and Android implementations for updating grouping discriminators
- Creates comprehensive test scenarios covering various grouping discriminator use cases