### PR TITLE
docs: change to correct anchor for reporting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Etc. See [packages](/packages) for a full list of contents.
 1. [Create a Bugsnag account](https://www.bugsnag.com)
 2. Complete the instructions in the [integration guide](https://docs.bugsnag.com/platforms/javascript/)
 3. Report handled exceptions using
-   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/#reporting-handled-exceptions)
+   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/#reporting-handled-errors)
 4. Customize your integration using the
    [configuration options](https://docs.bugsnag.com/platforms/javascript/configuration-options/)
 


### PR DESCRIPTION
## Goal

the current url leads to a non-existant anchor on https://docs.bugsnag.com/platforms/javascript/

## Changeset

see commit

## Testing

i clicked the new link whilst previewing the changes and https://docs.bugsnag.com/platforms/javascript/ scrolled to _Reporting handled errors_