### PR TITLE
Electron grouping discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add additional grouping discriminator property to events [#2544](https://github.com/bugsnag/bugsnag-js/pull/2544)
 - (react-native) Handle additional grouping discriminator [#2557](https://github.com/bugsnag/bugsnag-js/pull/2557)
+- (electron) Handle additional grouping discriminator [#2561](https://github.com/bugsnag/bugsnag-js/pull/2561)
 
 ### Changed
 

--- a/packages/plugin-electron-client-state-manager/client-state-manager.js
+++ b/packages/plugin-electron-client-state-manager/client-state-manager.js
@@ -22,6 +22,13 @@ module.exports = {
       return ret
     }
 
+    const origSetGroupingDiscriminator = client.setGroupingDiscriminator
+    client.setGroupingDiscriminator = (...args) => {
+      const ret = origSetGroupingDiscriminator.call(client, ...args)
+      emitter.emit('GroupingDiscriminatorUpdate', client.getGroupingDiscriminator())
+      return ret
+    }
+
     const origAddMetadata = client.addMetadata
     client.addMetadata = (...args) => {
       const ret = origAddMetadata.call(client, ...args)

--- a/packages/plugin-electron-client-state-manager/client-state-manager.js
+++ b/packages/plugin-electron-client-state-manager/client-state-manager.js
@@ -80,12 +80,15 @@ module.exports = {
     }
 
     // handle a bulk update of initial values from a new renderer
-    const bulkUpdate = ({ user, context, metadata, features }) => {
+    const bulkUpdate = ({ user, context, metadata, features, groupingDiscriminator }) => {
       if (user) {
         client.setUser(user.id, user.email, user.name)
       }
       if (context) {
         client.setContext(context)
+      }
+      if (groupingDiscriminator) {
+        client.setGroupingDiscriminator(groupingDiscriminator)
       }
       if (metadata) {
         for (const section in metadata) {

--- a/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
+++ b/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
@@ -253,7 +253,7 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     emitter.on('UserUpdate', userCb)
     emitter.on('FeatureFlagUpdate', featuresCb)
     emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
-    
+
     // update just metadata
     bulkUpdate({
       metadata: {
@@ -268,7 +268,7 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     expect(groupingDiscriminatorCb).not.toHaveBeenCalledWith()
   })
 
-    it('should support bulk updates (only grouping discriminator)', () => {
+  it('should support bulk updates (only grouping discriminator)', () => {
     const client = new Client({ apiKey: '123' }, {}, [stateManager], Notifier)
     const { emitter, bulkUpdate } = client.getPlugin('clientStateManager')
 

--- a/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
+++ b/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
@@ -147,11 +147,13 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     const featuresCb = jest.fn()
     const contextCb = jest.fn()
     const userCb = jest.fn()
+    const groupingDiscriminatorCb = jest.fn()
 
     emitter.on('FeatureFlagUpdate', featuresCb)
     emitter.on('MetadataReplace', metadataCb)
     emitter.on('ContextUpdate', contextCb)
     emitter.on('UserUpdate', userCb)
+    emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
 
     // update everything
     bulkUpdate({
@@ -165,7 +167,8 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
       features: [
         { name: 'flag name 1', variant: 'variant name 1' },
         { name: 'flag name 2', variant: 'variant name 2' }
-      ]
+      ],
+      groupingDiscriminator: 'discriminator'
     })
 
     expect(featuresCb).toHaveBeenCalledWith([
@@ -176,6 +179,7 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     expect(metadataCb).toHaveBeenCalledWith({ section: { key: 'value' } })
     expect(contextCb).toHaveBeenCalledWith('ctx')
     expect(userCb).toHaveBeenCalledWith({ id: '123', name: 'Jim', email: 'jim@jim.com' })
+    expect(groupingDiscriminatorCb).toHaveBeenCalledWith('discriminator')
   })
 
   it('should support bulk updates (only context)', () => {
@@ -185,10 +189,14 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     const metadataCb = jest.fn()
     const contextCb = jest.fn()
     const userCb = jest.fn()
+    const featuresCb = jest.fn()
+    const groupingDiscriminatorCb = jest.fn()
 
     emitter.on('MetadataReplace', metadataCb)
     emitter.on('ContextUpdate', contextCb)
     emitter.on('UserUpdate', userCb)
+    emitter.on('FeatureFlagUpdate', featuresCb)
+    emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
 
     // update just context
     bulkUpdate({
@@ -198,6 +206,8 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     expect(metadataCb).not.toHaveBeenCalled()
     expect(contextCb).toHaveBeenCalledWith('ctx')
     expect(userCb).not.toHaveBeenCalled()
+    expect(featuresCb).not.toHaveBeenCalled()
+    expect(groupingDiscriminatorCb).not.toHaveBeenCalled()
   })
 
   it('should support bulk updates (only user)', () => {
@@ -207,10 +217,14 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     const metadataCb = jest.fn()
     const contextCb = jest.fn()
     const userCb = jest.fn()
+    const featuresCb = jest.fn()
+    const groupingDiscriminatorCb = jest.fn()
 
     emitter.on('MetadataReplace', metadataCb)
     emitter.on('ContextUpdate', contextCb)
     emitter.on('UserUpdate', userCb)
+    emitter.on('FeatureFlagUpdate', featuresCb)
+    emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
 
     // update just user
     bulkUpdate({
@@ -220,6 +234,8 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     expect(metadataCb).not.toHaveBeenCalled()
     expect(contextCb).not.toHaveBeenCalledWith()
     expect(userCb).toHaveBeenCalledWith({ id: '123', name: 'Jim', email: 'jim@jim.com' })
+    expect(featuresCb).not.toHaveBeenCalledWith()
+    expect(groupingDiscriminatorCb).not.toHaveBeenCalledWith()
   })
 
   it('should support bulk updates (only metadata)', () => {
@@ -229,11 +245,15 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     const metadataCb = jest.fn()
     const contextCb = jest.fn()
     const userCb = jest.fn()
+    const featuresCb = jest.fn()
+    const groupingDiscriminatorCb = jest.fn()
 
     emitter.on('MetadataReplace', metadataCb)
     emitter.on('ContextUpdate', contextCb)
     emitter.on('UserUpdate', userCb)
-
+    emitter.on('FeatureFlagUpdate', featuresCb)
+    emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
+    
     // update just metadata
     bulkUpdate({
       metadata: {
@@ -244,5 +264,35 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     expect(metadataCb).toHaveBeenCalledWith({ section: { key: 'value' } })
     expect(contextCb).not.toHaveBeenCalled()
     expect(userCb).not.toHaveBeenCalled()
+    expect(featuresCb).not.toHaveBeenCalledWith()
+    expect(groupingDiscriminatorCb).not.toHaveBeenCalledWith()
+  })
+
+    it('should support bulk updates (only grouping discriminator)', () => {
+    const client = new Client({ apiKey: '123' }, {}, [stateManager], Notifier)
+    const { emitter, bulkUpdate } = client.getPlugin('clientStateManager')
+
+    const metadataCb = jest.fn()
+    const featuresCb = jest.fn()
+    const contextCb = jest.fn()
+    const groupingDiscriminatorCb = jest.fn()
+    const userCb = jest.fn()
+
+    emitter.on('MetadataReplace', metadataCb)
+    emitter.on('ContextUpdate', contextCb)
+    emitter.on('UserUpdate', userCb)
+    emitter.on('FeatureFlagUpdate', featuresCb)
+    emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
+
+    // update just context
+    bulkUpdate({
+      groupingDiscriminator: 'discriminator'
+    })
+
+    expect(metadataCb).not.toHaveBeenCalled()
+    expect(contextCb).not.toHaveBeenCalled()
+    expect(userCb).not.toHaveBeenCalled()
+    expect(featuresCb).not.toHaveBeenCalled()
+    expect(groupingDiscriminatorCb).toHaveBeenCalledWith('discriminator')
   })
 })

--- a/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
+++ b/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
@@ -284,7 +284,7 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     emitter.on('FeatureFlagUpdate', featuresCb)
     emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminatorCb)
 
-    // update just context
+    // update just grouping discriminator
     bulkUpdate({
       groupingDiscriminator: 'discriminator'
     })

--- a/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
+++ b/packages/plugin-electron-client-state-manager/test/client-state-manager.test.ts
@@ -29,6 +29,16 @@ describe('@bugsnag/plugin-electron-client-state-manager', () => {
     client.setContext('ctx')
   })
 
+  it('should emit events when grouping discriminator changes', done => {
+    const client = new Client({ apiKey: '123' }, {}, [stateManager], Notifier)
+    const { emitter } = client.getPlugin('clientStateManager')
+    emitter.on('GroupingDiscriminatorUpdate', (groupingDiscriminator: string) => {
+      expect(groupingDiscriminator).toBe('discriminator')
+      done()
+    })
+    client.setGroupingDiscriminator('discriminator')
+  })
+
   interface MetadataUpdatePayload {
     section: string
     values?: Record<string, unknown>

--- a/packages/plugin-electron-client-state-persistence/client-state-persistence.js
+++ b/packages/plugin-electron-client-state-persistence/client-state-persistence.js
@@ -36,6 +36,14 @@ module.exports = {
         }
       })
 
+      clientStateManager.emitter.on('GroupingDiscriminatorUpdate', groupingDiscriminator => {
+        try {
+          NativeClient.updateGroupingDiscriminator(groupingDiscriminator)
+        } catch (e) {
+          client._logger.error(e)
+        }
+      })
+
       clientStateManager.emitter.on('MetadataUpdate', ({ section, values }) => {
         try {
           NativeClient.updateMetadata(section, values)

--- a/packages/plugin-electron-client-state-persistence/src/api.c
+++ b/packages/plugin-electron-client-state-persistence/src/api.c
@@ -233,6 +233,35 @@ static napi_value UpdateContext(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value UpdateGroupingDiscriminator(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_status status = napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+  assert(status == napi_ok);
+
+  if (argc < 1) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments, expected 1");
+    return NULL;
+  }
+
+  napi_valuetype valuetype0;
+  status = napi_typeof(env, args[0], &valuetype0);
+  assert(status == napi_ok);
+
+  if (valuetype0 == napi_string) {
+    char *grouping_discriminator = read_string_value(env, args[0], false);
+    throw_error_from_status(env, becsp_set_grouping_discriminator(grouping_discriminator));
+    free(grouping_discriminator);
+  } else if (valuetype0 == napi_null) {
+    becsp_set_grouping_discriminator(NULL);
+  } else {
+    napi_throw_type_error(env, NULL,
+                          "Wrong argument type, expected string or null");
+  }
+
+  return NULL;
+}
+
 static napi_value UpdateUser(napi_env env, napi_callback_info info) {
   size_t argc = 3;
   napi_value args[3];
@@ -472,6 +501,10 @@ napi_value Init(napi_env env, napi_value exports) {
   assert(status == napi_ok);
 
   desc = DECLARE_NAPI_METHOD("updateContext", UpdateContext);
+  status = napi_define_properties(env, exports, 1, &desc);
+  assert(status == napi_ok);
+
+  desc = DECLARE_NAPI_METHOD("updateGroupingDiscriminator", UpdateGroupingDiscriminator);
   status = napi_define_properties(env, exports, 1, &desc);
   assert(status == napi_ok);
 

--- a/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.c
+++ b/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.c
@@ -43,6 +43,7 @@ static const char *const key_app = "app";
 static const char *const key_breadcrumbs = "breadcrumbs";
 static const char *const key_context = "context";
 static const char *const key_device = "device";
+static const char *const key_grouping_discriminator = "groupingDiscriminator";
 static const char *const key_metadata = "metadata";
 static const char *const key_feature_flags = "featureFlags";
 static const char *const key_session = "session";
@@ -213,6 +214,24 @@ BECSP_STATUS becsp_set_context(const char *context) {
     json_object_set_string(obj, key_context, context);
   } else {
     json_object_remove(obj, key_context);
+  }
+
+  serialize_data();
+  context_unlock();
+  return BECSP_STATUS_SUCCESS;
+}
+
+BECSP_STATUS becsp_set_grouping_discriminator(const char *grouping_discriminator) {
+  if (!g_context.data) {
+    return BECSP_STATUS_NOT_INSTALLED;
+  }
+  context_lock();
+
+  JSON_Object *obj = json_value_get_object(g_context.data);
+  if (grouping_discriminator) {
+    json_object_set_string(obj, key_grouping_discriminator, grouping_discriminator);
+  } else {
+    json_object_remove(obj, key_grouping_discriminator);
   }
 
   serialize_data();

--- a/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.h
+++ b/packages/plugin-electron-client-state-persistence/src/bugsnag_electron_client_state_persistence.h
@@ -69,6 +69,13 @@ BECSP_STATUS becsp_add_breadcrumb(const char *val);
 BECSP_STATUS becsp_set_context(const char *context);
 
 /**
+ * Set the grouping discriminator
+ *
+ * @param grouping_discriminator the new grouping discriminator value or NULL to unset
+ */
+BECSP_STATUS becsp_set_grouping_discriminator(const char *grouping_discriminator);
+
+/**
  * Set event user
  *
  * @param val JSON-serialized user value

--- a/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
+++ b/packages/plugin-electron-deliver-minidumps/deliver-minidumps.js
@@ -94,6 +94,7 @@ const takeEventSnapshot = (client) => ({
   app: { ...client._app },
   breadcrumbs: client._breadcrumbs.slice(),
   context: client._context,
+  groupingDiscriminator: client._groupingDiscriminator,
   device: { ...client._device },
   metadata: { ...client._metadata },
   featureFlags: featureFlagDelegate.toEventApi(client._features),

--- a/packages/plugin-electron-deliver-minidumps/event-serialisation.js
+++ b/packages/plugin-electron-deliver-minidumps/event-serialisation.js
@@ -9,6 +9,7 @@ const supportedProperties = [
   'device',
   'featureFlags',
   'groupingHash',
+  'groupingDiscriminator',
   'metaData',
   'request',
   'session',
@@ -96,6 +97,10 @@ function deserialiseEvent (json, minidumpPath) {
 
   if (hasValueForProperty(json, 'context')) {
     event.context = json.context
+  }
+
+  if (hasValueForProperty(json, 'groupingDiscriminator')) {
+    event.groupingDiscriminator = json.groupingDiscriminator
   }
 
   if (hasValueForProperty(json, 'device')) {

--- a/packages/plugin-electron-ipc/bugsnag-ipc-main.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-main.js
@@ -103,6 +103,7 @@ module.exports = class BugsnagIpcMain {
         type: this.client._config.appType
       }
       event.context = event.context || this.client._context
+      event.groupingDiscriminator = event.groupingDiscriminator || this.client._groupingDiscriminator
       event._metadata = { ...event._metadata, ...this.client._metadata }
       featureFlagDelegate.merge(event._features, this.client._features, event._featuresIndex)
       event._user = { ...event._user, ...this.client._user }
@@ -115,8 +116,8 @@ module.exports = class BugsnagIpcMain {
         if (!shouldSend) return resolve({ shouldSend: false })
 
         // extract just the properties we want from the event
-        const { app, breadcrumbs, context, device, _metadata, _features, _user } = event
-        resolve({ app, breadcrumbs, context, device, metadata: _metadata, features: _features, user: _user })
+        const { app, breadcrumbs, context, device, _metadata, _features, _user, groupingDiscriminator } = event
+        resolve({ app, breadcrumbs, context, device, metadata: _metadata, features: _features, user: _user, groupingDiscriminator })
       })
     })
   }
@@ -159,6 +160,8 @@ module.exports = class BugsnagIpcMain {
       ['update', this.update.bind(this)],
       ['getContext', this.client.getContext.bind(this.client)],
       ['setContext', this.client.setContext.bind(this.client)],
+      ['getGroupingDiscriminator', this.client.getGroupingDiscriminator.bind(this.client)],
+      ['setGroupingDiscriminator', this.client.setGroupingDiscriminator.bind(this.client)],
       ['addMetadata', this.client.addMetadata.bind(this.client)],
       ['clearMetadata', this.client.clearMetadata.bind(this.client)],
       ['getMetadata', this.client.getMetadata.bind(this.client)],

--- a/packages/plugin-electron-ipc/bugsnag-ipc-renderer.js
+++ b/packages/plugin-electron-ipc/bugsnag-ipc-renderer.js
@@ -25,6 +25,14 @@ const BugsnagIpcRenderer = {
     return safeInvoke(false, 'setContext', context)
   },
 
+  getGroupingDiscriminator () {
+    return safeInvoke(true, 'getGroupingDiscriminator')
+  },
+
+  setGroupingDiscriminator (groupingDiscriminator) {
+    return safeInvoke(false, 'setGroupingDiscriminator', groupingDiscriminator)
+  },
+
   addMetadata (...args) {
     return safeInvoke(false, 'addMetadata', ...args)
   },

--- a/packages/plugin-electron-ipc/test/bugsnag-ipc-main.test.ts
+++ b/packages/plugin-electron-ipc/test/bugsnag-ipc-main.test.ts
@@ -52,6 +52,23 @@ describe('BugsnagIpcMain', () => {
       expect(event.returnValue).toEqual('today')
     })
 
+    it('works for updating grouping discriminator', () => {
+      const client = new Client({ apiKey: '123' }, {}, [mockClientStateManagerPlugin], Notifier)
+      client.setGroupingDiscriminator = jest.fn()
+      const bugsnagIpcMain = new BugsnagIpcMain(client)
+      bugsnagIpcMain.handle({}, 'setGroupingDiscriminator', JSON.stringify('grouping-discriminator'))
+      expect(client.setGroupingDiscriminator).toHaveBeenCalledWith('grouping-discriminator')
+    })
+
+    it('returns the current grouping discriminator', () => {
+      const client = new Client({ apiKey: '123' }, {}, [mockClientStateManagerPlugin], Notifier)
+      client.setGroupingDiscriminator('current-grouping-discriminator')
+      const bugsnagIpcMain = new BugsnagIpcMain(client)
+      const event = { returnValue: undefined }
+      bugsnagIpcMain.handleSync(event, 'getGroupingDiscriminator')
+      expect(event.returnValue).toEqual('current-grouping-discriminator')
+    })
+
     it('works for updating user', () => {
       const client = new Client({ apiKey: '123' }, {}, [mockClientStateManagerPlugin], Notifier)
       client.setUser = jest.fn()
@@ -272,6 +289,7 @@ describe('BugsnagIpcMain', () => {
 
       client.leaveBreadcrumb('hi')
       client.setContext('ctx')
+      client.setGroupingDiscriminator('grouping-discriminator')
       client.setUser('123', 'jim@jim.com', 'Jim')
       client.addFeatureFlags([
         { name: 'flag1' },
@@ -297,6 +315,7 @@ describe('BugsnagIpcMain', () => {
         },
         breadcrumbs: client._breadcrumbs,
         context: 'ctx',
+        groupingDiscriminator: 'grouping-discriminator',
         device: { id: '123' },
         metadata: {
           app: { testingMode: 'unit' },

--- a/packages/plugin-electron-ipc/test/bugsnag-ipc-renderer.test.ts
+++ b/packages/plugin-electron-ipc/test/bugsnag-ipc-renderer.test.ts
@@ -36,6 +36,16 @@ describe('BugsnagIpcRenderer', () => {
     expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(CHANNEL_RENDERER_TO_MAIN, 'setContext', JSON.stringify('ctx'))
   })
 
+  it('should call ipcRenderer correctly for getGroupingDiscriminator', () => {
+    BugsnagIpcRenderer.getGroupingDiscriminator()
+    expect(electron.ipcRenderer.sendSync).toHaveBeenCalledWith(CHANNEL_RENDERER_TO_MAIN_SYNC, 'getGroupingDiscriminator')
+  })
+
+  it('should call ipcRenderer correctly for setGroupingDiscriminator', async () => {
+    await BugsnagIpcRenderer.setGroupingDiscriminator('ctx')
+    expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith(CHANNEL_RENDERER_TO_MAIN, 'setGroupingDiscriminator', JSON.stringify('ctx'))
+  })
+
   it('should call ipcRenderer correctly for getUser', () => {
     BugsnagIpcRenderer.getUser()
     expect(electron.ipcRenderer.sendSync).toHaveBeenCalledWith(

--- a/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
+++ b/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
@@ -24,6 +24,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
     client.addFeatureFlags = safeExec(client, BugsnagIpcRenderer, 'addFeatureFlags')
     client.clearFeatureFlag = safeExec(client, BugsnagIpcRenderer, 'clearFeatureFlag')
     client.clearFeatureFlags = safeExec(client, BugsnagIpcRenderer, 'clearFeatureFlags')
+    client.setGroupingDiscriminator = safeExec(client, BugsnagIpcRenderer, 'setGroupingDiscriminator')
 
     client.startSession = () => {
       safeExec(client, BugsnagIpcRenderer, 'startSession')()
@@ -64,5 +65,6 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
     client.getContext = safeExec(client, BugsnagIpcRenderer, 'getContext')
     client.getUser = safeExec(client, BugsnagIpcRenderer, 'getUser')
     client.getMetadata = safeExec(client, BugsnagIpcRenderer, 'getMetadata')
+    client.getGroupingDiscriminator = safeExec(client, BugsnagIpcRenderer, 'getGroupingDiscriminator')
   }
 })

--- a/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
+++ b/packages/plugin-electron-renderer-client-state-updates/client-state-updates.js
@@ -42,8 +42,12 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
       const updates = { metadata: client._metadata, features: client._features }
       const user = client.getUser()
       const context = client.getContext()
+      const groupingDiscriminator = client.getGroupingDiscriminator()
       if (context && context.length > 0) {
         updates.context = context
+      }
+      if (groupingDiscriminator) {
+        updates.groupingDiscriminator = groupingDiscriminator
       }
       if (Object.keys(user).length > 0) {
         updates.user = user
@@ -58,6 +62,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
     client._featuresIndex = {}
     client._features = []
     client._context = undefined
+    client._groupingDiscriminator = undefined
     client._user = {}
 
     // use main process state once configured properties are synched

--- a/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
+++ b/packages/plugin-electron-renderer-client-state-updates/test/client-state-updates.test.ts
@@ -27,6 +27,24 @@ describe('clientStateUpdatesPlugin', () => {
       expect(client.getContext()).toBe('ctx')
     })
 
+    it('propagates grouping discriminator changes', () => {
+      const mockBugsnagIpcRenderer = {
+        setGroupingDiscriminator: jest.fn()
+      }
+      const client = new Client({ apiKey: '123' }, {}, [clientStateUpdatesPlugin(mockBugsnagIpcRenderer)], Notifier)
+
+      client.setGroupingDiscriminator('discriminator')
+      expect(mockBugsnagIpcRenderer.setGroupingDiscriminator).toHaveBeenCalledWith('discriminator')
+    })
+
+    it('forwards upstream changes to grouping discriminator', () => {
+      const mockBugsnagIpcRenderer = {
+        getGroupingDiscriminator: () => 'discriminator'
+      }
+      const client = new Client({ apiKey: '123' }, {}, [clientStateUpdatesPlugin(mockBugsnagIpcRenderer)], Notifier)
+      expect(client.getGroupingDiscriminator()).toBe('discriminator')
+    })
+
     it('propagates user changes', () => {
       const mockBugsnagIpcRenderer = {
         setUser: jest.fn()

--- a/packages/plugin-electron-renderer-event-data/renderer-event-data.js
+++ b/packages/plugin-electron-renderer-event-data/renderer-event-data.js
@@ -8,6 +8,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
         app,
         breadcrumbs,
         context,
+        groupingDiscriminator,
         device,
         metadata,
         features,
@@ -18,6 +19,7 @@ module.exports = (BugsnagIpcRenderer = window.__bugsnag_ipc__) => ({
       if (shouldSend === false) return false
 
       event.context = event.context || context || getDefaultContext()
+      event._groupingDiscriminator = event._groupingDiscriminator || groupingDiscriminator
       event.breadcrumbs = breadcrumbs
       event.app = { ...event.app, ...app, codeBundleId: client._config.codeBundleId }
       event.device = { ...event.device, ...device }

--- a/packages/plugin-electron-renderer-event-data/test/renderer-event-data.test.ts
+++ b/packages/plugin-electron-renderer-event-data/test/renderer-event-data.test.ts
@@ -13,7 +13,7 @@ describe('plugin: electron renderer event data', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  it('sets context, breadcrumbs, app, device, user, feature flags and metadata from the main process', async () => {
+  it('sets context, groupingDiscriminator, breadcrumbs, app, device, user, feature flags and metadata from the main process', async () => {
     const context = 'abc context xyz'
     const breadcrumbs = [new Breadcrumb('message', { metadata: true }, 'manual')]
     const app = { abc: 123 }
@@ -21,8 +21,9 @@ describe('plugin: electron renderer event data', () => {
     const user = { id: '10293847' }
     const features = [{ name: 'flag1', variant: 'variant1' }]
     const metadata = { meta: { data: true } }
+    const groupingDiscriminator = 'test-discriminator'
 
-    const { sendEvent } = makeClient({ context, breadcrumbs, app, device, user, features, metadata })
+    const { sendEvent } = makeClient({ context, breadcrumbs, app, device, user, features, metadata, groupingDiscriminator })
 
     const event = await sendEvent()
 
@@ -33,6 +34,7 @@ describe('plugin: electron renderer event data', () => {
     expect(event.getUser()).toStrictEqual(user)
     expect(event._features).toStrictEqual(features)
     expect(event.getMetadata('meta')).toStrictEqual(metadata.meta)
+    expect(event.getGroupingDiscriminator()).toStrictEqual(groupingDiscriminator)
   })
 
   it('prefers pre-existing context from the event', async () => {
@@ -43,6 +45,16 @@ describe('plugin: electron renderer event data', () => {
     const event = await sendEvent()
 
     expect(event.context).toBe('hello')
+  })
+
+  it('prefers pre-existing groupingDiscriminator from the event', async () => {
+    const { client, sendEvent } = makeClient({ groupingDiscriminator: 'goodbye' })
+
+    client.addOnError(event => { event.setGroupingDiscriminator('hello') }, true)
+
+    const event = await sendEvent()
+
+    expect(event.getGroupingDiscriminator()).toBe('hello')
   })
 
   it('prefers pre-existing user from the event', async () => {

--- a/test/electron/features/grouping-discriminator.feature
+++ b/test/electron/features/grouping-discriminator.feature
@@ -2,6 +2,24 @@ Feature: Additional grouping discriminator
     Grouping discriminator field is included in electron events
     and can be passed between renderer and main processes.
 
+    Scenario: Main process grouping discriminator is sent with main errors
+        Given I launch an app with configuration:
+            | bugsnag | default |
+        When I click "main-process-set-grouping-discriminator"
+        And I click "main-notify"
+        Then the total requests received by the server matches:
+            | events | 1 |
+        And the event "groupingDiscriminator" equals "main-process-discriminator"
+
+    Scenario: Renderer process grouping discriminator is sent with renderer errors
+        Given I launch an app with configuration:
+            | bugsnag | default |
+        When I click "renderer-set-grouping-discriminator"
+        And I click "renderer-notify"
+        Then the total requests received by the server matches:
+            | events | 1 |
+        And the event "groupingDiscriminator" equals "renderer-process-discriminator"
+
     Scenario: Main process grouping discriminator persists across renderer errors
         Given I launch an app with configuration:
             | bugsnag | default |

--- a/test/electron/features/grouping-discriminator.feature
+++ b/test/electron/features/grouping-discriminator.feature
@@ -1,0 +1,21 @@
+Feature: Additional grouping discriminator
+    Grouping discriminator field is included in electron events
+    and can be passed between renderer and main processes.
+
+    Scenario: Main process grouping discriminator persists across renderer errors
+        Given I launch an app with configuration:
+            | bugsnag | default |
+        When I click "main-process-set-grouping-discriminator"
+        And I click "renderer-notify"
+        Then the total requests received by the server matches:
+            | events | 1 |
+        And the event "groupingDiscriminator" equals "main-process-discriminator"
+
+    Scenario: Renderer process grouping discriminator persists across main errors
+        Given I launch an app with configuration:
+            | bugsnag | default |
+        When I click "renderer-set-grouping-discriminator"
+        And I click "main-notify"
+        Then the total requests received by the server matches:
+            | events | 1 |
+        And the event "groupingDiscriminator" equals "renderer-process-discriminator"

--- a/test/electron/features/support/steps/request-steps.js
+++ b/test/electron/features/support/steps/request-steps.js
@@ -252,3 +252,11 @@ Then('the event has no feature flags', async () => {
   expect(payloads[0].events).toHaveLength(1)
   expect(payloads[0].events[0]).toHaveProperty('featureFlags', [])
 })
+
+Then('the event {string} equals {string}', async (field, expected) => {
+  const payloads = readPayloads(global.server.uploadsForType('event'))
+
+  expect(payloads).toHaveLength(1)
+  expect(payloads[0].events).toHaveLength(1)
+  expect(payloads[0].events[0]).toHaveProperty(field, expected)
+})

--- a/test/electron/fixtures/app/src/index.html
+++ b/test/electron/fixtures/app/src/index.html
@@ -69,5 +69,9 @@
         <li><a href="#" id="main-process-request-get-failure" onclick="RunnerAPI.mainProcessGetRequest(true)">Make a failed GET request</a></li>
         <li><a href="#" id="main-process-request-error" onclick="RunnerAPI.mainProcessRequestError()">Trigger a network request error</a></li>
     </ul>
+    <ul>
+        <li><a href="#" id="main-process-set-grouping-discriminator">Set grouping discriminator in main process</a></li>
+        <li><a href="#" id="renderer-set-grouping-discriminator">Set grouping discriminator in renderer</a></li>
+    </ul>
 </body>
 </html>

--- a/test/electron/fixtures/app/src/main.js
+++ b/test/electron/fixtures/app/src/main.js
@@ -148,3 +148,7 @@ ipcMain.on('main-process-get-request', (_event, fail) => {
 ipcMain.on('main-process-request-error', () => {
   networkRequestError()
 })
+
+ipcMain.on('main-process-set-grouping-discriminator', (_event, discriminator) => {
+  Bugsnag.setGroupingDiscriminator(discriminator)
+})

--- a/test/electron/fixtures/app/src/preload.js
+++ b/test/electron/fixtures/app/src/preload.js
@@ -48,5 +48,8 @@ contextBridge.exposeInMainWorld('RunnerAPI', {
   mainProcessRequestError: () => {
     ipcRenderer.send('main-process-request-error')
   },
+  mainProcessSetGroupingDiscriminator: (discriminator) => {
+    ipcRenderer.send('main-process-set-grouping-discriminator', discriminator)
+  },
   preloadStart: Date.now()
 })

--- a/test/electron/fixtures/app/src/renderer.js
+++ b/test/electron/fixtures/app/src/renderer.js
@@ -95,3 +95,11 @@ document.getElementById('renderer-clear-context').onclick = () => {
 document.getElementById('renderer-clear-metadata').onclick = () => {
   Bugsnag.clearMetadata('renderer')
 }
+
+document.getElementById('main-process-set-grouping-discriminator').onclick = () => {
+  window.RunnerAPI.mainProcessSetGroupingDiscriminator('main-process-discriminator')
+}
+
+document.getElementById('renderer-set-grouping-discriminator').onclick = () => {
+  Bugsnag.setGroupingDiscriminator('renderer-process-discriminator')
+}


### PR DESCRIPTION
## Goal

Adds support for grouping discriminator in Electron applications to enable additional event grouping capabilities across main and renderer processes.

- Implements setGroupingDiscriminator and getGroupingDiscriminator methods for both main and renderer processes
- Adds IPC communication to synchronize grouping discriminator values between processes
- Extends native client state persistence to store grouping discriminator data