### PR TITLE
Update handled errors link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Etc. See [packages](/packages) for a full list of contents.
 1. [Create a Bugsnag account](https://www.bugsnag.com)
 2. Complete the instructions in the [integration guide](https://docs.bugsnag.com/platforms/javascript/)
 3. Report handled exceptions using
-   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/#reporting-handled-exceptions)
+   [`Bugsnag.notify()`](https://docs.bugsnag.com/platforms/javascript/#reporting-handled-errors)
 4. Customize your integration using the
    [configuration options](https://docs.bugsnag.com/platforms/javascript/configuration-options/)
 


### PR DESCRIPTION
Link was https://docs.bugsnag.com/platforms/javascript/#reporting-handled-exceptions which is incorrect and just takes you to the root of the page. This has now been corrected to https://docs.bugsnag.com/platforms/javascript/#reporting-handled-errors.

Reported in https://github.com/bugsnag/bugsnag-js/pull/2560