### PR TITLE
Fix `undefined is not a function` for `String.prototype.startsWith`

### DIFF
--- a/packages/core/client.js
+++ b/packages/core/client.js
@@ -169,7 +169,7 @@ class Client {
       // warn about an apikey that is not of the expected format
       if (!/^[0-9a-f]{32}$/i.test(config.apiKey)) errors.apiKey = 'should be a string of 32 hexadecimal characters'
 
-      if (opts.endpoints === undefined && config.apiKey.startsWith(HUB_PREFIX)) {
+      if (opts.endpoints === undefined && config.apiKey.indexOf(HUB_PREFIX) === 0) {
         config.endpoints = {
           notify: HUB_NOTIFY,
           sessions: HUB_SESSION


### PR DESCRIPTION
## Goal

On older browsers the latest bugsnag browser client fails with `undefined is not a function`

## Design

`.indexOf(...) === 0` is equivalent to `.startsWith()`, but has much better browser support.

## Changeset

- (browser) Fix `undefined is not a function`

## Testing

Verified manually on some old browser versions.