### PR TITLE
Automate main -> next sync

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -1,0 +1,26 @@
+name: Sync main to next
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync main to next
+        uses: bugsnag/github-action-branch-sync@v1
+        with:
+          source-branch: main
+          target-branch: next
+          labels: automation
+          reviewers: ${{ secrets.AUTOMATION_REVIEWERS }}
+          team-reviewers: ${{ secrets.AUTOMATION_TEAM_REVIEWERS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

Add GitHub action to sync changes from the main branch into next

The `AUTOMATION_TEAM_REVIEWERS` secret has also been added to the repository with the team @bugsnag/platforms-javascript-developers

This workflow will raise a PR whenever the `main` branch is updated, but will not recreate any additional PRs until after that one has been merged. allowing for updates to documentation, pushing additional tags, etc.