### PR TITLE
React Native 0.82 and 0.81 tests

### DIFF
--- a/.buildkite/basic/react-native-android-full-pipeline.yml
+++ b/.buildkite/basic/react-native-android-full-pipeline.yml
@@ -12,10 +12,10 @@ steps:
         key: "build-react-native-android-fixture-old-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: macos-node-18
+          queue: macos-15
         env:
           JAVA_VERSION: "{{matrix.java}}"
-          NODE_VERSION: "18"
+          NODE_VERSION: "{{matrix.node}}"
           RN_VERSION: "{{matrix.reactnative}}"
           RCT_NEW_ARCH_ENABLED: "0"
           BUILD_ANDROID: "true"
@@ -31,16 +31,21 @@ steps:
               - "0.74"
               - "0.76"
               - "0.78"
-              - "0.79"
+              - "0.80"
+              - "0.81"
             java:
               - "17"
+            node:
+              - "22"
           adjustments:
             - with:
                 reactnative: "0.68"
                 java: "11"
+                node: "18"
             - with:
                 reactnative: "0.69"
                 java: "11"
+                node: "18"
         retry:
           automatic:
             - exit_status: "*"
@@ -50,10 +55,10 @@ steps:
         key: "build-react-native-android-fixture-new-arch-full"
         timeout_in_minutes: 15
         agents:
-          queue: macos-node-18
+          queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
@@ -71,7 +76,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       - label: ':android: Build react-native-navigation {{matrix}} test fixture APK (Old Arch)'
         skip: true # Skipped pending PLAT-15027
@@ -169,7 +175,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       # current latest version (v7.40.1) of react-native-navigation's autolinking tool doesn't support RN 0.73+,
       # causing a build failure - see https://github.com/wix/react-native-navigation/issues/7821
@@ -215,7 +222,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       - label: ":bitbar: :android: react-native-navigation {{matrix}} Android 12 (Old Arch) end-to-end tests"
         skip: true # Skipped pending PLAT-15027

--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -5,37 +5,13 @@ steps:
 
   - group: "React Native (Android) Tests"
     steps:
-      - label: ':android: Build RN {{matrix}} test fixture APK (Old Arch)'
-        key: "build-react-native-android-fixture-old-arch"
-        timeout_in_minutes: 15
-        agents:
-          queue: macos-node-18
-        env:
-          JAVA_VERSION: "17"
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
-          BUILD_ANDROID: "true"
-        artifact_paths:
-          - "test/react-native/features/fixtures/generated/old-arch/**/reactnative.apk"
-        commands:
-          - "bundle install"
-          - "node scripts/generate-react-native-fixture.js"
-        matrix:
-          - "0.80"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
-
-      - label: ':android: Build RN {{matrix}} test fixture APK (New Arch)'
+      - label: ':android: Build RN {{matrix}} test fixture APK'
         key: "build-react-native-android-fixture-new-arch"
         timeout_in_minutes: 15
         agents:
-          queue: macos-node-18
+          queue: macos-15
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
@@ -49,51 +25,12 @@ steps:
             - exit_status: "*"
               limit: 1
         matrix:
-          - "0.80"
+          - "0.82"
 
       #
       # End-to-end tests
       #
-      - label: ":bitbar: :android: RN {{matrix}} Android 12 (Old Arch) end-to-end tests"
-        depends_on: "build-react-native-android-fixture-old-arch"
-        timeout_in_minutes: 30
-        plugins:
-          artifacts#v1.9.0:
-            download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
-            upload: ./test/react-native/maze_output/**/*
-          docker-compose#v4.12.0:
-            pull: react-native-maze-runner
-            run: react-native-maze-runner
-            service-ports: true
-            command:
-              - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
-              - --farm=bb
-              - --device=ANDROID_12
-              - --appium-version=1.22
-              - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
-          test-collector#v1.10.2:
-            files: "reports/TEST-*.xml"
-            format: "junit"
-            branch: "^main|next$$"
-            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
-        retry:
-          manual:
-            permit_on_passed: true
-          automatic:
-            - exit_status: 103  # Appium session failed
-              limit: 2
-        env:
-          RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
-        concurrency: 25
-        concurrency_group: "bitbar"
-        concurrency_method: eager
-        matrix:
-          - "0.80"
-
-      - label: ":bitbar: :android: RN {{matrix}} Android 12 (New Arch) end-to-end tests"
+      - label: ":bitbar: :android: RN {{matrix}} Android 12 end-to-end tests"
         depends_on: "build-react-native-android-fixture-new-arch"
         timeout_in_minutes: 30
         plugins:
@@ -130,5 +67,5 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.82"
 

--- a/.buildkite/basic/react-native-cli-pipeline.yml
+++ b/.buildkite/basic/react-native-cli-pipeline.yml
@@ -13,21 +13,21 @@ steps:
           queue: "macos-15-isolated"
         env:
           JAVA_VERSION: "17"
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
+          RCT_NEW_ARCH_ENABLED: "1"
           BUILD_ANDROID: "true"
           INIT_RN_CLI: "true"
         artifact_paths:
-          - "test/react-native-cli/features/fixtures/generated/old-arch/**/reactnative.apk"
+          - "test/react-native-cli/features/fixtures/generated/new-arch/**/reactnative.apk"
         commands:
           - "cd test/react-native-cli"
           - "bundle install"
           - "bundle exec maze-runner features/build-app-tests/build-android-app.feature"
         matrix:
+          - "0.82"
+          - "0.81"
           - "0.80"
-          - "0.79"
-          - "0.78"
         retry:
           automatic:
             - exit_status: "*"
@@ -40,23 +40,23 @@ steps:
         agents:
           queue: "macos-15-isolated"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
+          RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
           INIT_RN_CLI: "true"
           EXPORT_ARCHIVE: "0"
         artifact_paths:
-          - "test/react-native-cli/features/fixtures/generated/old-arch/**/output/reactnative.ipa"
+          - "test/react-native-cli/features/fixtures/generated/new-arch/**/output/reactnative.ipa"
         commands:
           - "cd test/react-native-cli"
           - "bundle install"
           - "bundle exec maze-runner features/build-app-tests/build-ios-app.feature"
         matrix:
+          - "0.82"
+          - "0.81"
           - "0.80"
-          - "0.79"
-          - "0.78"
         retry:
           automatic:
             - exit_status: "*"
@@ -70,13 +70,13 @@ steps:
         timeout_in_minutes: 30
         plugins:
           artifacts#v1.9.0:
-            download: "test/react-native-cli/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk"
+            download: "test/react-native-cli/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
             command:
-              - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
+              - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk
               - --farm=bs
               - --device=ANDROID_12
               - features/run-app-tests
@@ -92,9 +92,9 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
         matrix:
+          - "0.82"
+          - "0.81"
           - "0.80"
-          - "0.79"
-          - "0.78"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
@@ -105,13 +105,13 @@ steps:
         timeout_in_minutes: 30
         plugins:
           artifacts#v1.9.0:
-            download: "test/react-native-cli/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
+            download: "test/react-native-cli/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa"
             upload: ./test/react-native-cli/maze_output/**/*
           docker-compose#v4.12.0:
             pull: react-native-cli-maze-runner
             run: react-native-cli-maze-runner
             command:
-              - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
+              - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bs
               - --device=IOS_16
               - features/run-app-tests
@@ -127,9 +127,9 @@ steps:
         concurrency_group: "browserstack-app"
         concurrency_method: eager
         matrix:
+          - "0.82"
+          - "0.81"
           - "0.80"
-          - "0.79"
-          - "0.78"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed

--- a/.buildkite/basic/react-native-ios-full-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-full-pipeline.yml
@@ -9,14 +9,14 @@ steps:
       #
       # Test fixtures
       #
-      - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
+      - label: ':mac: Build RN {{matrix.reactnative}} test fixture ipa (Old Arch)'
         key: "build-react-native-ios-fixture-old-arch-full"
         timeout_in_minutes: 30
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
+          NODE_VERSION: "{{matrix.node}}"
+          RN_VERSION: "{{matrix.reactnative}}"
           RCT_NEW_ARCH_ENABLED: "0"
           BUILD_IOS: "true"
           XCODE_VERSION: "16.2.0"
@@ -26,13 +26,23 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          - "0.68"
-          - "0.69"
-          - "0.72"
-          - "0.74"
-          - "0.76"
-          - "0.78"
-          - "0.79"
+          setup:
+            reactnative:
+              - "0.72"
+              - "0.74"
+              - "0.76"
+              - "0.78"
+              - "0.80"
+              - "0.81"
+            node:
+              - "22"
+          adjustments:
+            - with:
+                reactnative: "0.68"
+                node: "18"
+            - with:
+                reactnative: "0.69"
+                node: "18"
         retry:
           automatic:
             - exit_status: "*"
@@ -44,7 +54,7 @@ steps:
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
+          NODE_VERSION: "22"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"
@@ -59,7 +69,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
         retry:
           automatic:
             - exit_status: "*"
@@ -161,7 +172,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch-full"
@@ -203,7 +215,8 @@ steps:
           - "0.74"
           - "0.76"
           - "0.78"
-          - "0.79"
+          - "0.80"
+          - "0.81"
 
       # current latest version (v7.40.1) of react-native-navigation's autolinking tool doesn't currently support RN 0.73+,
       # causing a build failure - see https://github.com/wix/react-native-navigation/issues/7821

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -9,36 +9,12 @@ steps:
       #
       # Test fixtures
       #
-      - label: ':mac: Build RN {{matrix}} test fixture ipa (Old Arch)'
-        key: "build-react-native-ios-fixture-old-arch"
-        timeout_in_minutes: 20
-        agents:
-          queue: "macos-15"
-        env:
-          NODE_VERSION: "18"
-          RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
-          BUILD_IOS: "true"
-          XCODE_VERSION: "16.2.0"
-        artifact_paths:
-          - "test/react-native/features/fixtures/generated/old-arch/**/output/reactnative.ipa"
-        commands:
-          - "bundle install"
-          - "node scripts/generate-react-native-fixture.js"
-        matrix:
-          - "0.80"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
-
-      - label: ':mac: Build RN {{matrix}} test fixture ipa (New Arch)'
+      - label: ':mac: Build RN {{matrix}} test fixture ipa'
         key: "build-react-native-ios-fixture-new-arch"
         timeout_in_minutes: 20
         agents:
           queue: "macos-15"
         env:
-          NODE_VERSION: "18"
           RN_VERSION: "{{matrix}}"
           RCT_NEW_ARCH_ENABLED: "1"
           BUILD_IOS: "true"
@@ -49,7 +25,7 @@ steps:
           - "bundle install"
           - "node scripts/generate-react-native-fixture.js"
         matrix:
-          - "0.80"
+          - "0.82"
         retry:
           automatic:
             - exit_status: "*"
@@ -57,45 +33,7 @@ steps:
       #
       # End-to-end tests
       #
-      - label: ":bitbar: :mac: RN {{matrix}} iOS (Old Arch) end-to-end tests"
-        depends_on: "build-react-native-ios-fixture-old-arch"
-        timeout_in_minutes: 30
-        plugins:
-          artifacts#v1.9.0:
-            download: "test/react-native/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa"
-            upload: ./test/react-native/maze_output/**/*
-          docker-compose#v4.12.0:
-            pull: react-native-maze-runner
-            run: react-native-maze-runner
-            service-ports: true
-            command:
-              - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
-              - --farm=bb
-              - --device=IOS_15
-              - --fail-fast
-              - --no-tunnel
-              - --aws-public-ip
-          test-collector#v1.10.2:
-            files: "reports/TEST-*.xml"
-            format: "junit"
-            branch: "^main|next$$"
-            api-token-env-name: "REACT_NATIVE_BUILDKITE_ANALYTICS_TOKEN"
-        retry:
-          manual:
-            permit_on_passed: true
-          automatic:
-            - exit_status: 103  # Appium session failed
-              limit: 2
-        env:
-          RN_VERSION: "{{matrix}}"
-          RCT_NEW_ARCH_ENABLED: "0"
-        concurrency: 25
-        concurrency_group: "bitbar"
-        concurrency_method: eager
-        matrix:
-          - "0.80"
-
-      - label: ":bitbar: :mac: RN {{matrix}} iOS (New Arch) end-to-end tests"
+      - label: ":bitbar: :mac: RN {{matrix}} iOS end-to-end tests"
         depends_on: "build-react-native-ios-fixture-new-arch"
         timeout_in_minutes: 30
         plugins:
@@ -131,5 +69,5 @@ steps:
         concurrency_group: "bitbar"
         concurrency_method: eager
         matrix:
-          - "0.80"
+          - "0.82"
 

--- a/scripts/generate-react-native-fixture.js
+++ b/scripts/generate-react-native-fixture.js
@@ -57,10 +57,10 @@ let reactNativeSafeAreaContextVersion = '4.14.0'
 
 // RN 0.77 requires react-native-screens 4.6.0, which in turn requires react navigation v7
 if (parseFloat(reactNativeVersion) >= 0.77) {
-  reactNavigationVersion = '7.1.14'
-  reactNavigationNativeStackVersion = '7.3.21'
-  reactNativeScreensVersion = '4.11.1'
-  reactNativeSafeAreaContextVersion = '5.5.1'
+  reactNavigationVersion = '7.1.18'
+  reactNavigationNativeStackVersion = '7.3.28'
+  reactNativeScreensVersion = '4.17.1'
+  reactNativeSafeAreaContextVersion = '5.6.1'
 } else if (parseFloat(reactNativeVersion) <= 0.69) {
   reactNativeScreensVersion = '3.14.0'
   reactNativeSafeAreaContextVersion = '4.3.4'

--- a/scripts/react-native/android-utils.js
+++ b/scripts/react-native/android-utils.js
@@ -6,7 +6,16 @@ module.exports = {
     // set android:usesCleartextTraffic="true" in AndroidManifest.xml
     const androidManifestPath = `${fixtureDir}/android/app/src/main/AndroidManifest.xml`
     let androidManifestContents = fs.readFileSync(androidManifestPath, 'utf8')
-    androidManifestContents = androidManifestContents.replace('<application', '<application android:usesCleartextTraffic="true"')
+
+    // RN 0.82+ uses a manifest placeholder that's autoconfigured by the RN gradle plugin
+    // eslint-disable-next-line no-template-curly-in-string
+    if (androidManifestContents.includes('${usesCleartextTraffic}')) {
+      // eslint-disable-next-line no-template-curly-in-string
+      androidManifestContents = androidManifestContents.replace('${usesCleartextTraffic}', 'true')
+    } else {
+      androidManifestContents = androidManifestContents.replace('<application', '<application android:usesCleartextTraffic="true"')
+    }
+
     fs.writeFileSync(androidManifestPath, androidManifestContents)
 
     // enable/disable the new architecture in gradle.properties


### PR DESCRIPTION
## Goal

Add React Native 0.82 and 0.81 tests to CI pipeline.

0.82 is the first version of React Native that is new architecture only, so this also removes old architecture tests from the basic pipelines.

As per the testing strategy, 0.79 tests have also been dropped.

## Testing

Covered by CI