### PR TITLE
Remove devices no longer available on browserstack

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -50,7 +50,6 @@ steps:
       #
       - label: ":browserstack: {{matrix}} non-https tests"
         matrix:
-          - ios_11
           - safari_16
         depends_on: "browser-maze-runner-bs"
         timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

Skip iOS 11 non-http browser tests due to browserstack device availability