### PR TITLE
Update Danger JS action to use Docker image

### DIFF
--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -43,6 +43,6 @@ jobs:
           cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .diff/size-after-gzipped
 
       - name: Run danger
-        uses: danger/danger-js@67ed2c1f42fd2fc198cc3c14b43c8f83351f4fe9 # 13.0.5
+        uses: docker://ghcr.io/danger/danger-js@sha256:66d5394557aef115c9b8086e9886fc24ee32d82ad222efb83778468538a91ef0 # 13.0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

CI speed improvement

https://github.com/bugsnag/bugsnag-js/actions/workflows/pr-diff.yml

## Design
- GHCR images (ghcr.io/danger/danger-js) are prebuilt and cached on GitHub-hosted runners
- Completely removed Dockerfile-based builds

## Changeset

use ghcr.io

## Testing

-