### PR TITLE
Replace "the test should run in this browser" steps with Cucumber tags

### DIFF
--- a/test/browser/features/auto_detect_errors.feature
+++ b/test/browser/features/auto_detect_errors.feature
@@ -1,30 +1,30 @@
 @auto_detect_errors
 Feature: Switching off automatic reporting
 
-Scenario: setting autoDetectErrors option to false
-  When I navigate to the test URL "/auto_detect_errors/script/autodetect_false.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the event "unhandled" is false
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "manual notify does work"
-  And the exception "type" equals "browserjs"
+  Scenario: setting autoDetectErrors option to false
+    When I navigate to the test URL "/auto_detect_errors/script/autodetect_false.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "manual notify does work"
+    And the exception "type" equals "browserjs"
 
-Scenario: setting enabledErrorTypes.unhandledExceptions option to false
-  When I navigate to the test URL "/auto_detect_errors/script/unhandled_exceptions_false.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the event "unhandled" is false
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "manual notify does work"
-  And the exception "type" equals "browserjs"
+  Scenario: setting enabledErrorTypes.unhandledExceptions option to false
+    When I navigate to the test URL "/auto_detect_errors/script/unhandled_exceptions_false.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "manual notify does work"
+    And the exception "type" equals "browserjs"
 
-@requires_promise
-Scenario: setting enabledErrorTypes.unhandledRejections option to false
-  When I navigate to the test URL "/auto_detect_errors/script/unhandled_rejections_false.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the event "unhandled" is false
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "manual notify does work"
-  And the exception "type" equals "browserjs"
+  @requires_promise
+  Scenario: setting enabledErrorTypes.unhandledRejections option to false
+    When I navigate to the test URL "/auto_detect_errors/script/unhandled_rejections_false.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "manual notify does work"
+    And the exception "type" equals "browserjs"

--- a/test/browser/features/auto_detect_errors.feature
+++ b/test/browser/features/auto_detect_errors.feature
@@ -19,9 +19,9 @@ Scenario: setting enabledErrorTypes.unhandledExceptions option to false
   And the exception "message" equals "manual notify does work"
   And the exception "type" equals "browserjs"
 
+@requires_promise
 Scenario: setting enabledErrorTypes.unhandledRejections option to false
   When I navigate to the test URL "/auto_detect_errors/script/unhandled_rejections_false.html"
-  And the test should run in this browser
   Then I wait to receive an error
   And the error is a valid browser payload for the error reporting API
   And the event "unhandled" is false

--- a/test/browser/features/cause.feature
+++ b/test/browser/features/cause.feature
@@ -1,32 +1,32 @@
 @skip_ie_8 @skip_ie_9 @skip_ie_10 @skip_ie_11 @skip_firefox_30 @skip_safari_6
 Feature: Error.cause
 
-Scenario: Error thrown with an assigned Error cause property  
-  When I navigate to the test URL "/cause/script/property.html"
-  And the test should run in this browser
-  And I wait to receive an error
-  Then the error is a valid browser payload for the error reporting API
-  And the error payload field "events.0.exceptions" is an array with 2 elements
-  And the error payload field "events.0.exceptions.0.errorClass" equals "Error"
-  And the error payload field "events.0.exceptions.0.message" equals "I am the error"
-  And the error payload field "events.0.exceptions.0.type" equals "browserjs"
-  And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
-  And the error payload field "events.0.exceptions.1.errorClass" equals "Error"
-  And the error payload field "events.0.exceptions.1.message" equals "I am the cause"
-  And the error payload field "events.0.exceptions.1.type" equals "browserjs"
-  And the error payload field "events.0.exceptions.1.stacktrace" is a non-empty array
+  @requires_error_cause
+  Scenario: Error thrown with an assigned Error cause property
+    When I navigate to the test URL "/cause/script/property.html"
+    And I wait to receive an error
+    Then the error is a valid browser payload for the error reporting API
+    And the error payload field "events.0.exceptions" is an array with 2 elements
+    And the error payload field "events.0.exceptions.0.errorClass" equals "Error"
+    And the error payload field "events.0.exceptions.0.message" equals "I am the error"
+    And the error payload field "events.0.exceptions.0.type" equals "browserjs"
+    And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+    And the error payload field "events.0.exceptions.1.errorClass" equals "Error"
+    And the error payload field "events.0.exceptions.1.message" equals "I am the cause"
+    And the error payload field "events.0.exceptions.1.type" equals "browserjs"
+    And the error payload field "events.0.exceptions.1.stacktrace" is a non-empty array
 
-Scenario: Error thrown with an Error cause in the constructor  
-  When I navigate to the test URL "/cause/script/constructor.html"
-  And the test should run in this browser
-  And I wait to receive an error
-  Then the error is a valid browser payload for the error reporting API
-  And the error payload field "events.0.exceptions" is an array with 2 elements
-  And the error payload field "events.0.exceptions.0.errorClass" equals "Error"
-  And the error payload field "events.0.exceptions.0.message" equals "I am the error"
-  And the error payload field "events.0.exceptions.0.type" equals "browserjs"
-  And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
-  And the error payload field "events.0.exceptions.1.errorClass" equals "Error"
-  And the error payload field "events.0.exceptions.1.message" equals "I am the cause"
-  And the error payload field "events.0.exceptions.1.type" equals "browserjs"
-  And the error payload field "events.0.exceptions.1.stacktrace" is a non-empty array
+  @requires_error_cause
+  Scenario: Error thrown with an Error cause in the constructor
+    When I navigate to the test URL "/cause/script/constructor.html"
+    And I wait to receive an error
+    Then the error is a valid browser payload for the error reporting API
+    And the error payload field "events.0.exceptions" is an array with 2 elements
+    And the error payload field "events.0.exceptions.0.errorClass" equals "Error"
+    And the error payload field "events.0.exceptions.0.message" equals "I am the error"
+    And the error payload field "events.0.exceptions.0.type" equals "browserjs"
+    And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+    And the error payload field "events.0.exceptions.1.errorClass" equals "Error"
+    And the error payload field "events.0.exceptions.1.message" equals "I am the cause"
+    And the error payload field "events.0.exceptions.1.type" equals "browserjs"
+    And the error payload field "events.0.exceptions.1.stacktrace" is a non-empty array

--- a/test/browser/features/fixtures/auto_detect_errors/script/unhandled_rejections_false.html
+++ b/test/browser/features/fixtures/auto_detect_errors/script/unhandled_rejections_false.html
@@ -15,13 +15,6 @@
     </script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = (typeof Promise !== 'undefined' && 'onunhandledrejection' in window)
-        ? 'YES'
-        : 'NO'
-    </script>
     <script>
       Promise.reject(new Error('auto detect errors does not work'))
     </script>

--- a/test/browser/features/fixtures/cause/script/constructor.html
+++ b/test/browser/features/fixtures/cause/script/constructor.html
@@ -17,17 +17,6 @@
 </head>
 
 <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-        function shouldRun() {
-            var err = new Error('error', { cause: new Error('cause') })
-            return !!err.cause
-        }
-        var el = document.getElementById('bugsnag-test-should-run')
-        el.textContent = el.innerText = shouldRun()
-            ? 'YES'
-            : 'NO'
-    </script>
     <script>
         var originalCause = new Error('I am the cause')
         throw new Error('I am the error', { cause: originalCause })

--- a/test/browser/features/fixtures/cause/script/property.html
+++ b/test/browser/features/fixtures/cause/script/property.html
@@ -17,18 +17,6 @@
 </head>
 
 <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-        function shouldRun() {
-            var err = new Error('error')
-            err.cause = new Error('cause')
-            return !!err.cause
-        }
-        var el = document.getElementById('bugsnag-test-should-run')
-        el.textContent = el.innerText = shouldRun()
-            ? 'YES'
-            : 'NO'
-    </script>
     <script>
         var error = new Error("I am the error")
         error.cause = new Error("I am the cause")

--- a/test/browser/features/fixtures/handled/browserify/promise_catch.html
+++ b/test/browser/features/fixtures/handled/browserify/promise_catch.html
@@ -5,12 +5,5 @@
     <script src="dist/promise_catch.js"></script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Promise !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/rollup/promise_catch.html
+++ b/test/browser/features/fixtures/handled/rollup/promise_catch.html
@@ -5,12 +5,5 @@
     <script src="dist/promise_catch.js"></script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Promise !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/script/promise_catch.html
+++ b/test/browser/features/fixtures/handled/script/promise_catch.html
@@ -14,13 +14,6 @@
     </script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Promise !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
     <script>
       go()
         .then(function () {})

--- a/test/browser/features/fixtures/handled/typescript/promise_catch.html
+++ b/test/browser/features/fixtures/handled/typescript/promise_catch.html
@@ -5,13 +5,6 @@
     <script src="/docs/node_modules/@bugsnag/browser/dist/bugsnag.min.js"></script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Promise !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
     <script src="dist/promise_catch.js"></script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/webpack3/promise_catch.html
+++ b/test/browser/features/fixtures/handled/webpack3/promise_catch.html
@@ -5,12 +5,5 @@
     <script src="dist/promise_catch.js"></script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Promise !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/handled/webpack4/promise_catch.html
+++ b/test/browser/features/fixtures/handled/webpack4/promise_catch.html
@@ -5,12 +5,5 @@
     <script src="dist/promise_catch.js"></script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Promise !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/navigation/script/navigation.html
+++ b/test/browser/features/fixtures/navigation/script/navigation.html
@@ -14,13 +14,6 @@
     </script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof history.pushState === 'function'
-        ? 'YES'
-        : 'NO'
-    </script>
     <script>
       window.history.pushState({}, '', '/234235')
       throw new Error('history')

--- a/test/browser/features/fixtures/network_breadcrumbs/script/fetch_failure.html
+++ b/test/browser/features/fixtures/network_breadcrumbs/script/fetch_failure.html
@@ -17,16 +17,9 @@
       fetch("i_dont_exist.html").then(function () {
         Bugsnag.notify(new Error("This error should have network breadcrumbs attached"))
       })
-    
+
     </script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = 'fetch' in window
-        ? 'YES'
-        : 'NO'
-    </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/network_breadcrumbs/script/fetch_success.html
+++ b/test/browser/features/fixtures/network_breadcrumbs/script/fetch_success.html
@@ -17,16 +17,9 @@
       fetch("fetch_success.html").then(function () {
         Bugsnag.notify(new Error("This error should have network breadcrumbs attached"))
       })
-    
+
     </script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = 'fetch' in window
-        ? 'YES'
-        : 'NO'
-    </script>
   </body>
 </html>

--- a/test/browser/features/fixtures/network_breadcrumbs/script/xhr_failure.html
+++ b/test/browser/features/fixtures/network_breadcrumbs/script/xhr_failure.html
@@ -29,13 +29,6 @@
 </head>
 
 <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-        var el = document.getElementById('bugsnag-test-should-run')
-        el.textContent = el.innerText = 'XMLHttpRequest' in window && 'WeakMap' in window
-            ? 'YES'
-            : 'NO'
-    </script>
 </body>
 
 </html>

--- a/test/browser/features/fixtures/network_breadcrumbs/script/xhr_success.html
+++ b/test/browser/features/fixtures/network_breadcrumbs/script/xhr_success.html
@@ -28,13 +28,6 @@
 </head>
 
 <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-        var el = document.getElementById('bugsnag-test-should-run')
-        el.textContent = el.innerText = 'XMLHttpRequest' in window && 'WeakMap' in window
-            ? 'YES'
-            : 'NO'
-    </script>
 </body>
 
 </html>

--- a/test/browser/features/fixtures/plugin_angular/angular_12/src/index.html
+++ b/test/browser/features/fixtures/plugin_angular/angular_12/src/index.html
@@ -8,15 +8,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <pre id="bugsnag-test-should-run">PENDING</pre>
-  <script>
-    var el = document.getElementById('bugsnag-test-should-run')
-    el.textContent = el.innerText = (
-      typeof Set !== 'undefined' &&
-      typeof Promise !== 'undefined' &&
-      typeof Array.from === 'function'
-    ) ? 'YES' : 'NO'
-  </script>
   <app-root></app-root>
 </body>
 </html>

--- a/test/browser/features/fixtures/plugin_angular/angular_17/src/index.html
+++ b/test/browser/features/fixtures/plugin_angular/angular_17/src/index.html
@@ -8,15 +8,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <pre id="bugsnag-test-should-run">PENDING</pre>
-  <script>
-    var el = document.getElementById('bugsnag-test-should-run')
-    el.textContent = el.innerText = (
-      typeof Set !== 'undefined' &&
-      typeof Promise !== 'undefined' &&
-      typeof Array.from === 'function'
-    ) ? 'YES' : 'NO'
-  </script>
   <app-root></app-root>
 </body>
 </html>

--- a/test/browser/features/fixtures/plugin_react/webpack4/index.html
+++ b/test/browser/features/fixtures/plugin_react/webpack4/index.html
@@ -4,14 +4,7 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
     <div id="root"></div>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = typeof Set !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
     <script src="dist/app.js"></script>
   </body>
 </html>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue2/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue2/index.html
@@ -4,26 +4,10 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
     <div id="app">
       <p>{{ message }}</p>
       <span>{{ errr() }}</span>
     </div>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      var isLetSupported = false
-      var hasSafari10Bug = true
-      try {
-        eval('let a = "foo"')
-        isLetSupported = true
-        // See https://bugs.webkit.org/show_bug.cgi?id=171041
-        eval('let e = e => { console.log(e); for (let e of [1, 2, 3]) console.log(e) }')
-        hasSafari10Bug = false
-      } catch (e) {}
-      el.textContent = el.innerText = isLetSupported && !hasSafari10Bug && typeof Proxy !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
     <script src="dist/bundle.js"></script>
   </body>
 </html>

--- a/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
+++ b/test/browser/features/fixtures/plugin_vue/typescript_vue3/index.html
@@ -4,25 +4,10 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
     <div id="app">
       <p>{{ message }}</p>
       <span>{{ errr() }}</span>
     </div>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      var isClassSupported = false
-      var isObjectSpreadSupported = false
-      try {
-        eval('class Foo extends Object {}')
-        isClassSupported = true
-        eval('const a = {}; const b = { ...a }')
-        isObjectSpreadSupported = true
-      } catch (e) {}
-      el.textContent = el.innerText = isClassSupported && isObjectSpreadSupported && typeof Proxy !== 'undefined'
-        ? 'YES'
-        : 'NO'
-    </script>
     <script src="dist/bundle.js"></script>
   </body>
 </html>

--- a/test/browser/features/fixtures/unhandled/script/promise_rejection.html
+++ b/test/browser/features/fixtures/unhandled/script/promise_rejection.html
@@ -14,13 +14,6 @@
     </script>
   </head>
   <body>
-    <pre id="bugsnag-test-should-run">PENDING</pre>
-    <script>
-      var el = document.getElementById('bugsnag-test-should-run')
-      el.textContent = el.innerText = (typeof Promise !== 'undefined' && 'onunhandledrejection' in window)
-        ? 'YES'
-        : 'NO'
-    </script>
     <script>
       Promise.reject(new Error('broken promises'))
     </script>

--- a/test/browser/features/handled_errors.feature
+++ b/test/browser/features/handled_errors.feature
@@ -1,117 +1,117 @@
 @handled
 Feature: Reporting handled errors
 
-Scenario Outline: calling notify() with Error
-  When I navigate to the test URL "/handled/<type>/notify_new_error.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "bad things"
-  And the exception "type" equals "browserjs"
-  And the error payload field "events.0.app.type" equals "browser"
-  And event 0 is handled
+  Scenario Outline: calling notify() with Error
+    When I navigate to the test URL "/handled/<type>/notify_new_error.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "bad things"
+    And the exception "type" equals "browserjs"
+    And the error payload field "events.0.app.type" equals "browser"
+    And event 0 is handled
 
-  Examples:
-    | type       |
-    | script     |
-    | webpack3   |
-    | webpack4   |
-    | browserify |
-    | rollup     |
-    | typescript |
+    Examples:
+      | type       |
+      | script     |
+      | webpack3   |
+      | webpack4   |
+      | browserify |
+      | rollup     |
+      | typescript |
 
-Scenario Outline: calling notify() with Error within try/catch
-  When I navigate to the test URL "/handled/<type>/try_catch_notify.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception matches the "handled" values for the current browser
-  And the exception "type" equals "browserjs"
-  And event 0 is handled
+  Scenario Outline: calling notify() with Error within try/catch
+    When I navigate to the test URL "/handled/<type>/try_catch_notify.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception matches the "handled" values for the current browser
+    And the exception "type" equals "browserjs"
+    And event 0 is handled
 
-  Examples:
-    | type       |
-    | script     |
-    | webpack3   |
-    | webpack4   |
-    | browserify |
-    | rollup     |
-    | typescript |
+    Examples:
+      | type       |
+      | script     |
+      | webpack3   |
+      | webpack4   |
+      | browserify |
+      | rollup     |
+      | typescript |
 
-Scenario Outline: calling notify() with Error within Promise catch
-  When I navigate to the test URL "/handled/<type>/promise_catch.html"
-  And the test should run in this browser
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "bad things"
-  And the exception "type" equals "browserjs"
-  And event 0 is handled
+  @requires_promise
+  Scenario Outline: calling notify() with Error within Promise catch
+    When I navigate to the test URL "/handled/<type>/promise_catch.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "bad things"
+    And the exception "type" equals "browserjs"
+    And event 0 is handled
 
-  Examples:
-    | type       |
-    | script     |
-    | webpack3   |
-    | webpack4   |
-    | browserify |
-    | rollup     |
-    | typescript |
+    Examples:
+      | type       |
+      | script     |
+      | webpack3   |
+      | webpack4   |
+      | browserify |
+      | rollup     |
+      | typescript |
 
-Scenario: calling notify() with an object, getting a generated a stacktrace
-  When I navigate to the test URL "/handled/script/notify_object.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Errr"
-  And the exception "message" equals "make a stacktrace for me"
-  And the exception "type" equals "browserjs"
+  Scenario: calling notify() with an object, getting a generated a stacktrace
+    When I navigate to the test URL "/handled/script/notify_object.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Errr"
+    And the exception "message" equals "make a stacktrace for me"
+    And the exception "type" equals "browserjs"
 
-  # this ensures the first generated stackframe doesn't come from bugsnag's source
-  And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
-  And event 0 is handled
+    # this ensures the first generated stackframe doesn't come from bugsnag's source
+    And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+    And event 0 is handled
 
-Scenario: calling notify() with a string, getting a generated stacktrace
-  When I navigate to the test URL "/handled/script/notify_string.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "make a stacktrace for me"
-  And the exception "type" equals "browserjs"
+  Scenario: calling notify() with a string, getting a generated stacktrace
+    When I navigate to the test URL "/handled/script/notify_string.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "make a stacktrace for me"
+    And the exception "type" equals "browserjs"
 
-  # this ensures the first generated stackframe doesn't come from bugsnag's source
-  And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
-  And event 0 is handled
+    # this ensures the first generated stackframe doesn't come from bugsnag's source
+    And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+    And event 0 is handled
 
-Scenario: calling window.client.notify() with an object, getting a generated stacktrace
-  When I navigate to the test URL "/handled/script/client_notify_object.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "make a stacktrace for me"
-  And the exception "type" equals "browserjs"
+  Scenario: calling window.client.notify() with an object, getting a generated stacktrace
+    When I navigate to the test URL "/handled/script/client_notify_object.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "make a stacktrace for me"
+    And the exception "type" equals "browserjs"
 
-  # this ensure the stacktrace features all of the nested stackframes
-  And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
-  And the error payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
-  And the error payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
-  And event 0 is handled
+    # this ensure the stacktrace features all of the nested stackframes
+    And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
+    And event 0 is handled
 
-Scenario: calling window.client.notify() with a string, getting a generated stacktrace
-  When I navigate to the test URL "/handled/script/client_notify_string.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "make a stacktrace for me"
-  And the exception "type" equals "browserjs"
+  Scenario: calling window.client.notify() with a string, getting a generated stacktrace
+    When I navigate to the test URL "/handled/script/client_notify_string.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "make a stacktrace for me"
+    And the exception "type" equals "browserjs"
 
-  # this ensure the stacktrace features all of the nested stackframes
-  And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
-  And the error payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
-  And the error payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
-  And event 0 is handled
+    # this ensure the stacktrace features all of the nested stackframes
+    And the error payload field "events.0.exceptions.0.stacktrace.0.method" equals "a"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.method" equals "b"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.method" equals "c"
+    And event 0 is handled
 
-Scenario: overridden handled state in a callback
-  When I navigate to the test URL "/handled/script/callback_override.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "message" ends with "hello"
-  # The severity is "error" because only the handled-ness has been changed
-  And event 0 is handled with the severity "error"
+  Scenario: overridden handled state in a callback
+    When I navigate to the test URL "/handled/script/callback_override.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "message" ends with "hello"
+    # The severity is "error" because only the handled-ness has been changed
+    And event 0 is handled with the severity "error"

--- a/test/browser/features/inline_script.feature
+++ b/test/browser/features/inline_script.feature
@@ -20,9 +20,9 @@ Feature: Inline script detection
     And event 0 is handled
     And the event "metaData.script" is null
 
+  @requires_history_management
   Scenario: inline script detected after location change
     When I navigate to the test URL "/navigation/script/navigation.html"
-    And the test should run in this browser
     Then I wait to receive an error
     And the error is a valid browser payload for the error reporting API
     And the event "metaData.script.content" matches "throw new Error\('history'\)"

--- a/test/browser/features/network_breadcrumbs.feature
+++ b/test/browser/features/network_breadcrumbs.feature
@@ -3,30 +3,32 @@ Feature: Network breadcrumbs
 
   Bugsnag error reports should include breadcrumbs for network requests, including those made using fetch, and xml http requests.
 
+  @requires_fetch
   Scenario: A fetch request succeeds
     When I navigate to the test URL "/network_breadcrumbs/script/fetch_success.html"
-    And the test should run in this browser
     And I wait to receive an error
     Then the error is a valid browser payload for the error reporting API
     And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/network_breadcrumbs/json/fetch_success.json"
 
+  @requires_fetch
   Scenario: A fetch request fails
     When I navigate to the test URL "/network_breadcrumbs/script/fetch_failure.html"
-    And the test should run in this browser
     And I wait to receive an error
     Then the error is a valid browser payload for the error reporting API
     And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/network_breadcrumbs/json/fetch_failure.json"
 
+  @requires_weak_map
+  @requires_xml_http_request
   Scenario: An xmlHttpRequest succeeds
     When I navigate to the test URL "/network_breadcrumbs/script/xhr_success.html"
-    And the test should run in this browser
     And I wait to receive an error
     Then the error is a valid browser payload for the error reporting API
     And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/network_breadcrumbs/json/xhr_success.json"
 
+  @requires_weak_map
+  @requires_xml_http_request
   Scenario: An xmlHttpRequest fails
     When I navigate to the test URL "/network_breadcrumbs/script/xhr_failure.html"
-    And the test should run in this browser
     And I wait to receive an error
     Then the error is a valid browser payload for the error reporting API
     And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/network_breadcrumbs/json/xhr_failure.json"

--- a/test/browser/features/plugin_angular.feature
+++ b/test/browser/features/plugin_angular.feature
@@ -4,13 +4,15 @@
 @skip_safari_10 @skip_before_ios_12
 Feature: Angular support
 
-Scenario Outline: basic error handler usage
-  When I navigate to the test URL "/plugin_angular/angular_<version>/dist/index.html"
-  And the test should run in this browser
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the error payload field "events.0.device.runtimeVersions.angular" is not null
-  Examples:
-    | version |
-    | 12      |
-    | 17      |
+  @requires_promise
+  @requires_set
+  @requires_array_from
+  Scenario Outline: basic error handler usage
+    When I navigate to the test URL "/plugin_angular/angular_<version>/dist/index.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the error payload field "events.0.device.runtimeVersions.angular" is not null
+    Examples:
+      | version |
+      | 12      |
+      | 17      |

--- a/test/browser/features/plugin_react.feature
+++ b/test/browser/features/plugin_react.feature
@@ -1,11 +1,11 @@
 @plugin_react
 Feature: React support
 
-Scenario: basic error boundary usage
-  When I navigate to the test URL "/plugin_react/webpack4/index.html"
-  And the test should run in this browser
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "borked"
-  And the event "metaData.react.componentStack" is not null
+  @requires_set
+  Scenario: basic error boundary usage
+    When I navigate to the test URL "/plugin_react/webpack4/index.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "borked"
+    And the event "metaData.react.componentStack" is not null

--- a/test/browser/features/plugin_vue.feature
+++ b/test/browser/features/plugin_vue.feature
@@ -11,9 +11,11 @@ Feature: Vue support
     And the exception "message" equals "borked"
     And the event "metaData.vue.errorInfo" is not null
 
+  @requires_let
+  @requires_proxy
+  @skip_safari_10
   Scenario: vue3 + typescript usage
     When I navigate to the test URL "/plugin_vue/typescript_vue3/index.html"
-    And the test should run in this browser
     Then I wait to receive an error
     And the error is a valid browser payload for the error reporting API
     And the exception "errorClass" equals "Error"
@@ -21,9 +23,11 @@ Feature: Vue support
     And the event "metaData.vue.errorInfo" equals "render function"
     And the event "metaData.vue.component" equals "App"
 
+  @requires_let
+  @requires_proxy
+  @skip_safari_10
   Scenario: vue2 + typescript usage
     When I navigate to the test URL "/plugin_vue/typescript_vue2/index.html"
-    And the test should run in this browser
     Then I wait to receive an error
     And the error is a valid browser payload for the error reporting API
     And the exception "errorClass" equals "Error"

--- a/test/browser/features/steps/browser_steps.rb
+++ b/test/browser/features/steps/browser_steps.rb
@@ -20,18 +20,6 @@ When('the exception matches the {string} values for the current browser') do |fi
   end
 end
 
-When('the test should run in this browser') do
-  wait = Selenium::WebDriver::Wait.new(timeout: 10)
-  wait.until {
-    Maze.driver.find_element(id: 'bugsnag-test-should-run') &&
-        Maze.driver.find_element(id: 'bugsnag-test-should-run').text != 'PENDING'
-  }
-  if Maze.driver.find_element(id: 'bugsnag-test-should-run').text == 'NO'
-    Maze::Server.reset!
-    skip_this_scenario
-  end
-end
-
 When('I let the test page run for up to {int} seconds') do |n|
   wait = Selenium::WebDriver::Wait.new(timeout: n)
   wait.until {

--- a/test/browser/features/support/browser.rb
+++ b/test/browser/features/support/browser.rb
@@ -1,0 +1,232 @@
+require 'yaml'
+
+# Provides information on browser support for features needed in the e2e tests.
+# Source: caniuse.com
+class Browser
+  def initialize(browser_spec)
+    # e.g. "chrome_61", "edge_latest", "chrome"
+    @name, version = browser_spec.split("_")
+
+    # Assume Android runs the latest Chrome and iOS/Safari versions match.
+    if @name == "android"
+      @name = "chrome"
+      @version = Integer::MAX
+    end
+    @name = "safari" if @name == "ios"
+
+    # Assume we're running the latest version if there is no version present.
+    @version = if version.nil? || version == "latest"
+                 Integer::Max
+               else
+                 Integer(version)
+               end
+  end
+
+  # https://caniuse.com/wf-array-from
+  def supports_array_from?
+    case @name
+    when "chrome"
+      @version >= 45
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 38
+    when "safari"
+      @version >= 10
+    when "ie"
+      false # Determined manually using a test page
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/mdn-javascript_builtins_error_cause
+  def supports_error_cause?
+    case @name
+    when "chrome"
+      @version >= 93
+    when "edge"
+      @version >= 93
+    when "firefox"
+      @version >= 91
+    when "safari"
+      @version >= 15
+    when "ie"
+      false
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/fetch
+  def supports_fetch?
+    case @name
+    when "chrome"
+      @version >= 42
+    when "edge"
+      @version >= 14
+    when "firefox"
+      @version >= 39
+    when "safari"
+      @version >= 10  # 10.1
+    when "ie"
+      false
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/mdn-api_history
+  def supports_history_management?
+    case @name
+    when "chrome"
+      @version >= 4
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 2
+    when "safari"
+      @version >= 3 # 3.1
+    when "ie"
+      @version >= 10
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  def supports_let?
+    case @name
+    when "chrome"
+      @version >= 49
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 44
+    when "safari"
+      @version >= 11
+    when "ie"
+      @version >= 11 # Partial - let variables are not bound separately to each iteration of for loops
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/promises
+  def supports_promise?
+    case @name
+    when "chrome"
+      @version >= 33
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 29
+    when "safari"
+      @version >= 7 # 7.1
+    when "ie"
+      false
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/proxy
+  def supports_proxy?
+    case @name
+    when "chrome"
+      @version >= 49
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 18
+    when "safari"
+      @version >= 10
+    when "ie"
+      false
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/mdn-javascript_builtins_set
+  def supports_set?
+    case @name
+    when "chrome"
+      @version >= 38
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 13
+    when "safari"
+      @version >= 8
+    when "ie"
+      @version >= 11
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/mdn-api_window_unhandledrejection_event
+  def supports_unhandled_rejection?
+    case @name
+    when "chrome"
+      @version >= 49
+    when "edge"
+      @version >= 79
+    when "firefox"
+      @version >= 69
+    when "safari"
+      @version >= 11
+    when "ie"
+      false
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/weakmap
+  def supports_weak_map?
+    case @name
+    when "chrome"
+      @version >= 51
+    when "edge"
+      @version >= 15
+    when "firefox"
+      @version >= 54
+    when "safari"
+      @version >= 10
+    when "ie"
+      @version >= 11 # Partial - Notable partial support in IE11 includes (at least some) support for const, let, block-level function declaration, typed arrays, Map, Set and WeakMap.
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+
+  # https://caniuse.com/wf-xhr
+  def supports_xml_http_request?
+    case @name
+    when "chrome"
+      @version >= 4
+    when "edge"
+      @version >= 12
+    when "firefox"
+      @version >= 2
+    when "safari"
+      @version >= 3 # 3.1
+    when "ie"
+      @version >= 11 # Determined manually using a test page
+    else
+      # Assume support for unknown browsers
+      true
+    end
+  end
+end

--- a/test/browser/features/support/browser.rb
+++ b/test/browser/features/support/browser.rb
@@ -13,15 +13,16 @@ class Browser
     if @name == "android"
       @name = "chrome"
       @version = Float::INFINITY
-    end
-    @name = "safari" if @name == "ios"
+    else
+      @name = "safari" if @name == "ios"
 
-    # Assume we're running the latest version if there is no version present.
-    @version = if version.nil? || version == "latest"
-                 Float::INFINITY
-               else
-                 Integer(version)
-               end
+      # Assume we're running the latest version if there is no version present.
+      @version = if version.nil? || version == "latest"
+                   Float::INFINITY
+                 else
+                   Integer(version)
+                 end
+    end
   end
 
   # https://caniuse.com/wf-array-from

--- a/test/browser/features/support/browser.rb
+++ b/test/browser/features/support/browser.rb
@@ -3,6 +3,8 @@ require 'yaml'
 # Provides information on browser support for features needed in the e2e tests.
 # Source: caniuse.com
 class Browser
+  attr_reader :name
+
   def initialize(browser_spec)
     # e.g. "chrome_61", "edge_latest", "chrome"
     @name, version = browser_spec.split("_")
@@ -10,13 +12,13 @@ class Browser
     # Assume Android runs the latest Chrome and iOS/Safari versions match.
     if @name == "android"
       @name = "chrome"
-      @version = Integer::MAX
+      @version = Float::INFINITY
     end
     @name = "safari" if @name == "ios"
 
     # Assume we're running the latest version if there is no version present.
     @version = if version.nil? || version == "latest"
-                 Integer::Max
+                 Float::INFINITY
                else
                  Integer(version)
                end

--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -47,9 +47,11 @@ ERRORS.keys.each do |browser|
     skip_this_scenario if Maze.config.browser == browser
   end
 end
+
 BeforeAll do
   Maze.config.receive_no_requests_wait = 15
   Maze.config.enforce_bugsnag_integrity = false
+  $browser = Browser.new(Maze.config.browser)
 end
 
 at_exit do

--- a/test/browser/features/support/requires.rb
+++ b/test/browser/features/support/requires.rb
@@ -1,0 +1,5 @@
+Before('@requires_promises') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support Promises") unless $browser.supports_promise?
+end
+
+

--- a/test/browser/features/support/requires.rb
+++ b/test/browser/features/support/requires.rb
@@ -1,5 +1,43 @@
-Before('@requires_promises') do |_scenario|
+Before('@requires_array_from') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support Array.from") unless $browser.supports_array_from?
+end
+
+Before('@requires_error_cause') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support error.cause") unless $browser.supports_error_cause?
+end
+
+Before('@requires_fetch') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support fetch()") unless $browser.supports_fetch?
+end
+
+Before('@requires_history_management') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support history management") unless $browser.supports_history_management?
+end
+
+Before('@requires_let') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support let") unless $browser.supports_let?
+end
+
+Before('@requires_promise') do |_scenario|
   skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support Promises") unless $browser.supports_promise?
 end
 
+Before('@requires_proxy') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support Proxy") unless $browser.supports_proxy?
+end
 
+Before('@requires_set') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support Set") unless $browser.supports_set?
+end
+
+Before('@requires_unhandled_rejection') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support onunhandledrejection") unless $browser.supports_unhandled_rejection?
+end
+
+Before('@requires_weak_map') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support WeakMap") unless $browser.supports_weak_map?
+end
+
+Before('@requires_xml_http_request') do |_scenario|
+  skip_this_scenario("Skipping scenario on #{$browser.name} as it does not support XMLHttpRequest") unless $browser.supports_xml_http_request?
+end

--- a/test/browser/features/unhandled_errors.feature
+++ b/test/browser/features/unhandled_errors.feature
@@ -1,64 +1,65 @@
 @unhandled
 Feature: Reporting unhandled errors
 
-Scenario: syntax errors
-  When I navigate to the test URL "/unhandled/script/syntax_error.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception matches the "unhandled_syntax" values for the current browser
-  And the error payload field "events.0.app.type" equals "browser"
-  And event 0 is unhandled
+  Scenario: syntax errors
+    When I navigate to the test URL "/unhandled/script/syntax_error.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception matches the "unhandled_syntax" values for the current browser
+    And the error payload field "events.0.app.type" equals "browser"
+    And event 0 is unhandled
 
-Scenario: thrown errors
-  When I navigate to the test URL "/unhandled/script/thrown.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception matches the "unhandled_thrown" values for the current browser
-  And event 0 is unhandled
+  Scenario: thrown errors
+    When I navigate to the test URL "/unhandled/script/thrown.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception matches the "unhandled_thrown" values for the current browser
+    And event 0 is unhandled
 
-Scenario: unhandled promise rejections
-  When I navigate to the test URL "/unhandled/script/promise_rejection.html"
-  And the test should run in this browser
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "broken promises"
-  And event 0 is unhandled
+  @requires_promise
+  @requires_unhandled_rejection
+  Scenario: unhandled promise rejections
+    When I navigate to the test URL "/unhandled/script/promise_rejection.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "broken promises"
+    And event 0 is unhandled
 
-Scenario: undefined function invocation
-  When I navigate to the test URL "/unhandled/script/undefined_function.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception matches the "unhandled_undefined_function" values for the current browser
-  And event 0 is unhandled
+  Scenario: undefined function invocation
+    When I navigate to the test URL "/unhandled/script/undefined_function.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception matches the "unhandled_undefined_function" values for the current browser
+    And event 0 is unhandled
 
-Scenario: decoding malformed URI component
-  When I navigate to the test URL "/unhandled/script/malformed_uri.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception matches the "unhandled_malformed_uri" values for the current browser
-  And event 0 is unhandled
+  Scenario: decoding malformed URI component
+    When I navigate to the test URL "/unhandled/script/malformed_uri.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception matches the "unhandled_malformed_uri" values for the current browser
+    And event 0 is unhandled
 
-Scenario: detecting unhandled promise rejections with bluebird
-  When I navigate to the test URL "/unhandled/script/bluebird.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "errorClass" equals "Error"
-  And the exception "message" equals "broken bluebird promises"
-  And event 0 is unhandled
+  Scenario: detecting unhandled promise rejections with bluebird
+    When I navigate to the test URL "/unhandled/script/bluebird.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "broken bluebird promises"
+    And event 0 is unhandled
 
-Scenario: parsing stacks correctly with "@" in filename
-  When I navigate to the test URL "/unhandled/script/at_filename.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "message" ends with "at in filename"
-  And the "file" of stack frame 0 ends with "unhandled/script/@dist/at_filename.js"
-  And event 0 is unhandled
+  Scenario: parsing stacks correctly with "@" in filename
+    When I navigate to the test URL "/unhandled/script/at_filename.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "message" ends with "at in filename"
+    And the "file" of stack frame 0 ends with "unhandled/script/@dist/at_filename.js"
+    And event 0 is unhandled
 
-Scenario: overridden handled state in a callback
-  When I navigate to the test URL "/unhandled/script/override_unhandled.html"
-  Then I wait to receive an error
-  And the error is a valid browser payload for the error reporting API
-  And the exception "message" equals "hello"
-  # The severity is "warning" because only the handled-ness has been changed
-  And event 0 is unhandled with the severity "warning"
+  Scenario: overridden handled state in a callback
+    When I navigate to the test URL "/unhandled/script/override_unhandled.html"
+    Then I wait to receive an error
+    And the error is a valid browser payload for the error reporting API
+    And the exception "message" equals "hello"
+    # The severity is "warning" because only the handled-ness has been changed
+    And event 0 is unhandled with the severity "warning"


### PR DESCRIPTION
## Goal

Avoid running scenarios at all if the browser does not support the features needed, reducing the time taken for the whole test run and number of automation flakes.

## Design

This change moves away from dynamically determining if a browser supports the JS features needed for the test, to a knowledge-base approach.  Information (from caniuse.com) on browser support for all the features needed has been captured in a new Browser` class - as we already do in bugsnag-js-performance.  New `@requires_....` tags use this information to skip scenarios completely when the browser does not support the features needed.  This speeds up the whole test run and reduces test flakes (before we're doing less automation).

## Changeset

- New `Browser` class, acting as the knowledge base for browser version support of various features.
- Several new "requires" tags added for the skipping of scenarios not supported by the current browser version.
- Remove `the test should run in this browser` Cucumber step.  
- Remove `bugsnag-test-should-run` element from all test fixtures. 

## Testing

Covered by CI with the browser sub-pipeline unblocked.