### PR TITLE
Remove skips for browser versions no longer tested against

### DIFF
--- a/test/browser/features/cause.feature
+++ b/test/browser/features/cause.feature
@@ -1,4 +1,4 @@
-@skip_ie_8 @skip_ie_9 @skip_ie_10 @skip_ie_11 @skip_firefox_30 @skip_safari_6
+@skip_ie_11
 Feature: Error.cause
 
   @requires_error_cause

--- a/test/browser/features/delivery.feature
+++ b/test/browser/features/delivery.feature
@@ -1,6 +1,5 @@
 Feature: Delivery of errors
 
-  @skip_ie_10
   Scenario: Delivery is attempted oversized payloads
     When I set the HTTP status code for the next "POST" request to 400
     And I navigate to the test URL "/delivery/script/oversized.html"

--- a/test/browser/features/network_breadcrumbs.feature
+++ b/test/browser/features/network_breadcrumbs.feature
@@ -1,4 +1,4 @@
-@network_breadcrumbs @skip_ie_8 @skip_ie_9
+@network_breadcrumbs
 Feature: Network breadcrumbs
 
   Bugsnag error reports should include breadcrumbs for network requests, including those made using fetch, and xml http requests.

--- a/test/browser/features/plugin_angular.feature
+++ b/test/browser/features/plugin_angular.feature
@@ -1,7 +1,7 @@
 @plugin_angular
 
 # Skipped on older Safari versions not supported by Angular 10 - Angular renders the fixture component twice, causing duplicate events to be reported
-@skip_safari_10 @skip_before_ios_12
+@skip_safari_10
 Feature: Angular support
 
   @requires_promise

--- a/test/browser/features/plugin_vue.feature
+++ b/test/browser/features/plugin_vue.feature
@@ -1,8 +1,6 @@
 @plugin_vue
 Feature: Vue support
 
-  # Skipped on IE <=10, see https://github.com/vuejs/vue/issues/12837
-  @skip_ie_8 @skip_ie_9 @skip_ie_10
   Scenario: basic error handler usage
     When I navigate to the test URL "/plugin_vue/webpack4/index.html"
     Then I wait to receive an error

--- a/test/browser/features/web_worker.feature
+++ b/test/browser/features/web_worker.feature
@@ -1,8 +1,5 @@
-# browsers that do not support web workers
-@skip_ie_8 @skip_ie_9
-
-# browsers that currently throw errors in our test fixtures 
-@skip_ie_10 @skip_ie_11 @skip_chrome_43 @skip_edge_17 @skip_safari_10 @skip_before_ios_12
+# browsers that currently throw errors in our test fixtures
+@skip_ie_11 @skip_chrome_43 @skip_edge_17 @skip_safari_10
 
 Feature: worker notifier
 
@@ -17,7 +14,7 @@ Feature: worker notifier
   Scenario: config.autoDetectErrors defaults to false
     Given I navigate to the test URL "/web_worker/worker_auto_detect_errors/default"
     Then I should receive no errors
- 
+
   Scenario: setting config.autoDetectErrors option to true
     Given I navigate to the test URL "/web_worker/worker_auto_detect_errors/enabled"
     And I wait to receive an error
@@ -48,7 +45,7 @@ Feature: worker notifier
     Then the session is a valid browser payload for the session tracking API
 
   # Not supported on Safari https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy#browser_compatibility
-  @skip_safari_16 @skip_ios_12
+  @skip_safari_16
   Scenario: Integrity headers are set when setPayloadChecksums is true
     When I navigate to the test URL "/web_worker/integrity"
     And I wait to receive an error

--- a/test/node/features/koa-1x.feature
+++ b/test/node/features/koa-1x.feature
@@ -1,4 +1,3 @@
-@skip_before_node_8
 Feature: @bugsnag/plugin-koa (koa v1.x support)
 
 Background:

--- a/test/node/features/koa-1x_disabled.feature
+++ b/test/node/features/koa-1x_disabled.feature
@@ -1,4 +1,3 @@
-@skip_before_node_8
 Feature: @bugsnag/plugin-koa (koa v1.x support) autoDetectErrors=false
 
 Background:

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -1,4 +1,3 @@
-@skip_before_node_8
 Feature: @bugsnag/plugin-koa
 
 Background:

--- a/test/node/features/koa_disabled.feature
+++ b/test/node/features/koa_disabled.feature
@@ -1,4 +1,3 @@
-@skip_before_node_8
 Feature: @bugsnag/plugin-koa autoDetectErrors=false
 
 Background:

--- a/test/node/features/webpack.feature
+++ b/test/node/features/webpack.feature
@@ -1,4 +1,3 @@
-@skip_before_node_6
 @skip_node_18
 Feature: Webpack bundling support for node apps
 


### PR DESCRIPTION
## Goal

Reduce clutter in the test files by removing skips for browser versions no longer tested against.

## Testing

Covered CI with the node and browser pipelines released.