### PR TITLE
Reset server request lists on navigation failure

### DIFF
--- a/test/browser/features/support/env.rb
+++ b/test/browser/features/support/env.rb
@@ -51,6 +51,7 @@ end
 BeforeAll do
   Maze.config.receive_no_requests_wait = 15
   Maze.config.enforce_bugsnag_integrity = false
+  Maze.config.reset_on_navigation_failure = true
   $browser = Browser.new(Maze.config.browser)
 end
 


### PR DESCRIPTION
## Goal

Avoid a test flake caused by the page being loaded twice after a driver restart, sending a 2nd and unexpected error.

## Testing

The config option's effect was tested with the change to Maze Runner, here the fact that the browser tests on CI run should be sufficient to show that it's not broken anything.