### PR TITLE
(plugin-server-session): delay initialization until first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+(plugin-server-session) Delay session tracker initialization until first use [#2642](https://github.com/bugsnag/bugsnag-js/pull/2642)
+
 ### Dependencies
 
 Update bugsnag-cocoa to [6.34.1](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/6.34.1) [#2606](https://github.com/bugsnag/bugsnag-js/pull/2606)

--- a/packages/plugin-server-session/session.js
+++ b/packages/plugin-server-session/session.js
@@ -5,11 +5,17 @@ const runSyncCallbacks = require('@bugsnag/core/lib/sync-callback-runner')
 
 module.exports = {
   load: (client) => {
-    const sessionTracker = new SessionTracker(client._config.sessionSummaryInterval)
-    sessionTracker.on('summary', sendSessionSummary(client))
-    sessionTracker.start()
+    let sessionTracker = null
+
     client._sessionDelegate = {
       startSession: (client, session) => {
+        // Lazy initialization: only create and start the tracker on first use
+        if (!sessionTracker) {
+          sessionTracker = new SessionTracker(client._config.sessionSummaryInterval)
+          sessionTracker.on('summary', sendSessionSummary(client))
+          sessionTracker.start()
+        }
+
         client._session = session
         client._pausedSession = null
         sessionTracker.track(client._session)


### PR DESCRIPTION
## Goal

Serverless node plugins such as AWS Lambda (and the incoming Cloudflare Workers plugin) use `plugin-browser-session` and not `plugin-server-session`, but because `plugin-server-session` is bundled with the node notifier as an internal plugin, it's session tracking is still initialized on `start`, before any of the external plugins are loaded.

This causes problems in some environments like Cloudflare Workers, and results in unnecessary work and leaked timers, since the session delegate is replaced when those plugins are loaded.

## Design

This PR fixes the issue by delaying the session tracker initialization until `startSession` is actually called - this preserves the existing behaviour for 'regular' node environments while allowing the serverless plugins to load `plugin-browser-session` before any initialization happens. 

## Testing

Covered by existing tests