### PR TITLE
fix(plugin-cloudflare-workers): use request scoped client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-(plugin-cloudflare-workers): Add initial support for Cloudflare Workers [#2643](https://github.com/bugsnag/bugsnag-js/pull/2643)
+(plugin-cloudflare-workers): Add initial support for Cloudflare Workers [#2643](https://github.com/bugsnag/bugsnag-js/pull/2643) [#2644](https://github.com/bugsnag/bugsnag-js/pull/2644)
 
 ### Fixed
 

--- a/packages/plugin-cloudflare-workers/src/index.js
+++ b/packages/plugin-cloudflare-workers/src/index.js
@@ -1,5 +1,6 @@
 const bugsnagInFlight = require('@bugsnag/in-flight')
 const BugsnagPluginBrowserSession = require('@bugsnag/plugin-browser-session')
+const clone = require('@bugsnag/core/lib/clone-client')
 
 const SERVER_PLUGIN_NAMES = ['express', 'koa', 'restify', 'hono']
 const isServerPluginLoaded = client => SERVER_PLUGIN_NAMES.some(name => client.getPlugin(name))
@@ -42,13 +43,6 @@ const BugsnagPluginCloudflareWorkers = {
     bugsnagInFlight.trackInFlight(client)
     client._loadPlugin(BugsnagPluginBrowserSession)
 
-    // Reset the app duration between invocations, if the plugin is loaded
-    const appDurationPlugin = client.getPlugin('appDuration')
-
-    if (appDurationPlugin) {
-      appDurationPlugin.reset()
-    }
-
     return {
       createHandler ({ flushTimeoutMs = 2000 } = {}) {
         return wrapHandler.bind(null, client, flushTimeoutMs)
@@ -59,54 +53,65 @@ const BugsnagPluginCloudflareWorkers = {
 
 function wrapHandler (client, flushTimeoutMs, handler) {
   return async function (request, env, ctx) {
-    // Add request metadata via onError callback so server plugins can override
-    // Only add metadata if no server plugin is loaded
+    // Reset the app duration between invocations, if the plugin is loaded
+    const appDurationPlugin = client.getPlugin('appDuration')
+
+    if (appDurationPlugin) {
+      appDurationPlugin.reset()
+    }
+
+    // clone the client to be scoped to this request.
+    const requestClient = clone(client)
+
+    // only start a session and add request metadata if no server plugin is loaded,
+    // as those plugins will handle this themselves
     if (!isServerPluginLoaded(client)) {
-      client.addOnError((event) => {
+      if (requestClient._config.autoTrackSessions) {
+        requestClient.startSession()
+      }
+
+      requestClient.addOnError((event) => {
         const { metadata, request: requestData } = getRequestAndMetadataFromReq(request)
         event.request = { ...event.request, ...requestData }
         event.addMetadata('request', metadata)
       }, true)
     }
 
-    // Track sessions if autoTrackSessions is enabled and no server plugin is loaded
-    if (client._config.autoTrackSessions && !isServerPluginLoaded(client)) {
-      client.startSession()
-    }
+    return client._clientContext.run(requestClient, async () => {
+      try {
+        return await handler(request, env, ctx)
+      } catch (err) {
+        if (requestClient._config.autoDetectErrors && requestClient._config.enabledErrorTypes.unhandledExceptions) {
+          const handledState = {
+            severity: 'error',
+            unhandled: true,
+            severityReason: { type: 'unhandledException' }
+          }
 
-    try {
-      return await handler(request, env, ctx)
-    } catch (err) {
-      if (client._config.autoDetectErrors && client._config.enabledErrorTypes.unhandledExceptions) {
-        const handledState = {
-          severity: 'error',
-          unhandled: true,
-          severityReason: { type: 'unhandledException' }
+          const event = requestClient.Event.create(err, true, handledState, 'cloudflare workers plugin', 1)
+
+          requestClient._notify(event)
         }
 
-        const event = client.Event.create(err, true, handledState, 'cloudflare workers plugin', 1)
-
-        client._notify(event)
-      }
-
-      throw err
-    } finally {
-      // Use ctx.waitUntil to ensure flush completes even after response is returned
-      // This is critical for Cloudflare Workers as they can terminate immediately
-      if (ctx && typeof ctx.waitUntil === 'function') {
-        ctx.waitUntil(
-          bugsnagInFlight.flush(flushTimeoutMs).catch(err => {
-            client._logger.error(`Delivery may be unsuccessful: ${err.message}`)
-          })
-        )
-      } else {
-        try {
-          await bugsnagInFlight.flush(flushTimeoutMs)
-        } catch (err) {
-          client._logger.error(`Delivery may be unsuccessful: ${err.message}`)
+        throw err
+      } finally {
+        // use ctx.waitUntil to ensure flush completes even after response is returned
+        // this is critical for Cloudflare Workers as they can terminate immediately
+        if (ctx && typeof ctx.waitUntil === 'function') {
+          ctx.waitUntil(
+            bugsnagInFlight.flush(flushTimeoutMs).catch(err => {
+              requestClient._logger.error(`Delivery may be unsuccessful: ${err.message}`)
+            })
+          )
+        } else {
+          try {
+            await bugsnagInFlight.flush(flushTimeoutMs)
+          } catch (err) {
+            requestClient._logger.error(`Delivery may be unsuccessful: ${err.message}`)
+          }
         }
       }
-    }
+    })
   }
 }
 

--- a/packages/plugin-cloudflare-workers/test/index.test.ts
+++ b/packages/plugin-cloudflare-workers/test/index.test.ts
@@ -23,8 +23,8 @@ const createMockExecutionContext = (): MockExecutionContext => {
   } as unknown as MockExecutionContext
 }
 
-const createClient = (events: EventDeliveryPayload[], sessions: SessionDeliveryPayload[], config = {}) => {
-  const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginCloudflareWorkers], ...config })
+const createClient = (events: EventDeliveryPayload[], sessions: SessionDeliveryPayload[], config = {}, additionalPlugins: any[] = []) => {
+  const client = new Client({ apiKey: 'AN_API_KEY', plugins: [BugsnagPluginCloudflareWorkers, ...additionalPlugins], ...config })
 
   // @ts-ignore the following property is not defined on the public Event interface
   client.Event.__type = 'nodejs'
@@ -38,6 +38,12 @@ const createClient = (events: EventDeliveryPayload[], sessions: SessionDeliveryP
       sessions.push(payload)
       cb()
     }
+  }
+
+  // Mock _clientContext.run to execute the callback immediately
+  // This simulates AsyncLocalStorage behavior for testing
+  client._clientContext = {
+    run: jest.fn((requestClient, callback) => callback())
   }
 
   return client
@@ -97,6 +103,13 @@ describe('plugin: cloudflare workers', () => {
     // Wait for promises registered with ctx.waitUntil to complete
     await ctx._waitForAllPromises()
 
+    // Verify _clientContext.run was called with a cloned client
+    expect(client._clientContext.run).toHaveBeenCalledTimes(1)
+    expect(client._clientContext.run).toHaveBeenCalledWith(
+      expect.any(Client),
+      expect.any(Function)
+    )
+
     expect(events).toHaveLength(1)
 
     const event = events[0].events[0]
@@ -137,6 +150,11 @@ describe('plugin: cloudflare workers', () => {
       sendSession (payload, cb = () => {}) {
         setTimeout(cb, 250)
       }
+    }
+
+    // Mock _clientContext.run to execute the callback immediately
+    client._clientContext = {
+      run: jest.fn((requestClient, callback) => callback())
     }
 
     const timeoutError = new Error('flush timed out after 20ms')
@@ -200,6 +218,13 @@ describe('plugin: cloudflare workers', () => {
     const response = await exportedHandler.fetch?.(request, env, ctx)
     expect(await response?.text()).toBe('Hello World! test value')
 
+    // Verify _clientContext.run was called
+    expect(client._clientContext.run).toHaveBeenCalledTimes(1)
+    expect(client._clientContext.run).toHaveBeenCalledWith(
+      expect.any(Client),
+      expect.any(Function)
+    )
+
     expect(events).toHaveLength(0)
     expect(sessions).toHaveLength(1)
   })
@@ -234,6 +259,9 @@ describe('plugin: cloudflare workers', () => {
 
     // Wait for promises registered with ctx.waitUntil to complete
     await ctx._waitForAllPromises()
+
+    // Verify _clientContext.run was called
+    expect(client._clientContext.run).toHaveBeenCalledTimes(1)
 
     expect(events).toHaveLength(1)
 
@@ -312,5 +340,164 @@ describe('plugin: cloudflare workers', () => {
 
     expect(events).toHaveLength(0)
     expect(sessions).toHaveLength(1)
+  })
+
+  it('clones the client for each request to avoid callback accumulation', async () => {
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    const client = createClient(events, sessions)
+
+    const plugin = client.getPlugin('cloudflareWorkers')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+
+    const exportedHandler: ExportedHandler<Env> = {
+      fetch: bugsnagHandler(async (request, env, ctx) => {
+        throw new Error('Test error')
+      })
+    }
+
+    const request1 = new Request('https://example.com/request1?param1=value1', {
+      method: 'GET',
+      headers: {
+        'X-Custom-Header': 'request1'
+      }
+    }) as unknown as CloudflareRequest<unknown, IncomingRequestCfProperties<unknown>>
+    const request2 = new Request('https://example.com/request2?param2=value2', {
+      method: 'POST',
+      headers: {
+        'X-Custom-Header': 'request2'
+      }
+    }) as unknown as CloudflareRequest<unknown, IncomingRequestCfProperties<unknown>>
+    const env = {}
+    const ctx1 = createMockExecutionContext()
+    const ctx2 = createMockExecutionContext()
+
+    // Make two requests (both will throw errors)
+    await expect(exportedHandler.fetch?.(request1, env, ctx1)).rejects.toThrow('Test error')
+    await expect(exportedHandler.fetch?.(request2, env, ctx2)).rejects.toThrow('Test error')
+
+    // Wait for promises registered with ctx.waitUntil to complete
+    await ctx1._waitForAllPromises()
+    await ctx2._waitForAllPromises()
+
+    // Verify _clientContext.run was called twice with different cloned clients
+    expect(client._clientContext.run).toHaveBeenCalledTimes(2)
+
+    const firstCallClient = (client._clientContext.run as jest.Mock).mock.calls[0][0]
+    const secondCallClient = (client._clientContext.run as jest.Mock).mock.calls[1][0]
+
+    // Both should be Client instances but different instances
+    expect(firstCallClient).toBeInstanceOf(Client)
+    expect(secondCallClient).toBeInstanceOf(Client)
+    expect(firstCallClient).not.toBe(secondCallClient)
+    expect(firstCallClient).not.toBe(client)
+    expect(secondCallClient).not.toBe(client)
+
+    // Both requests should have started sessions
+    expect(sessions).toHaveLength(2)
+
+    // Verify two events were sent
+    expect(events).toHaveLength(2)
+
+    // Verify first event has correct request metadata
+    const event1 = events[0].events[0]
+    expect(event1.request).toMatchObject({
+      url: 'https://example.com/request1?param1=value1',
+      httpMethod: 'GET',
+      headers: expect.objectContaining({
+        'x-custom-header': 'request1'
+      })
+    })
+    // @ts-ignore
+    expect(event1._metadata?.request).toMatchObject({
+      url: 'https://example.com/request1?param1=value1',
+      path: '/request1',
+      httpMethod: 'GET',
+      query: {
+        param1: 'value1'
+      },
+      headers: expect.objectContaining({
+        'x-custom-header': 'request1'
+      })
+    })
+
+    // Verify second event has correct request metadata
+    const event2 = events[1].events[0]
+    expect(event2.request).toMatchObject({
+      url: 'https://example.com/request2?param2=value2',
+      httpMethod: 'POST',
+      headers: expect.objectContaining({
+        'x-custom-header': 'request2'
+      })
+    })
+    // @ts-ignore
+    expect(event2._metadata?.request).toMatchObject({
+      url: 'https://example.com/request2?param2=value2',
+      path: '/request2',
+      httpMethod: 'POST',
+      query: {
+        param2: 'value2'
+      },
+      headers: expect.objectContaining({
+        'x-custom-header': 'request2'
+      })
+    })
+  })
+
+  it('resets app duration plugin between requests', async () => {
+    const events: EventDeliveryPayload[] = []
+    const sessions: SessionDeliveryPayload[] = []
+
+    // Mock the app duration plugin
+    const mockReset = jest.fn()
+    const mockAppDurationPlugin = {
+      name: 'appDuration',
+      load: () => ({
+        reset: mockReset
+      })
+    }
+
+    const client = createClient(events, sessions, {}, [mockAppDurationPlugin])
+
+    const plugin = client.getPlugin('cloudflareWorkers')
+
+    if (!plugin) {
+      throw new Error('Plugin was not loaded!')
+    }
+
+    const bugsnagHandler = plugin.createHandler()
+
+    const exportedHandler: ExportedHandler<Env> = {
+      fetch: bugsnagHandler(async (request, env, ctx) => {
+        return new Response('OK') as unknown as CloudflareResponse
+      })
+    }
+
+    const request1 = new Request('https://example.com/request1') as unknown as CloudflareRequest<unknown, IncomingRequestCfProperties<unknown>>
+    const request2 = new Request('https://example.com/request2') as unknown as CloudflareRequest<unknown, IncomingRequestCfProperties<unknown>>
+    const request3 = new Request('https://example.com/request3') as unknown as CloudflareRequest<unknown, IncomingRequestCfProperties<unknown>>
+    const env = {}
+    const ctx1 = createMockExecutionContext()
+    const ctx2 = createMockExecutionContext()
+    const ctx3 = createMockExecutionContext()
+
+    // Make three requests
+    await exportedHandler.fetch?.(request1, env, ctx1)
+    await exportedHandler.fetch?.(request2, env, ctx2)
+    await exportedHandler.fetch?.(request3, env, ctx3)
+
+    // Wait for all promises to complete
+    await ctx1._waitForAllPromises()
+    await ctx2._waitForAllPromises()
+    await ctx3._waitForAllPromises()
+
+    // Verify reset was called for each request
+    expect(mockReset).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
## Goal

Updates the Cloudflare Workers plugin to use a request-scoped client and AsyncLocalStorage context to avoid state leaking between invocations

## Design

The plugin now clones the client for each request and runs the handler within the AsyncLocalStorage context, similar to other server framework plugins.

## Testing

Updated the unit tests to check that the client is cloned as expected and that the app duration is reset for each invocation.