### PR TITLE
Http errors suggestions and fixes

### DIFF
--- a/packages/plugin-http-errors/README.md
+++ b/packages/plugin-http-errors/README.md
@@ -14,29 +14,20 @@ yarn add @bugsnag/plugin-http-errors
 
 ```js
 import Bugsnag from '@bugsnag/js'
-import createHttpErrorPlugin from '@bugsnag/plugin-http-errors'
-
-const plugin = createHttpErrorPlugin({
-  httpErrorCodes: [401, { min: 404, max: 499 }], // handle individual error codes or ranges of error codes 
-  maxRequestSize: 5_000, // don't capture requests over 5kb
-  onHttpError: ({ request, response }) => {
-    // Only handle 5xx errors
-    if (response.statusCode < 500 || response.statusCode > 599) return false
-
-    // Exclude specific domains
-    if (request.url.indexOf('redacted.domain.com') === 0) return false
-
-    // Update properties on the reported request and response
-    request.url = '[REDACTED]'
-    response.statusCode = 418
-
-    return true // return value will determine whether the error is reported
-  }
-})
+import BugsnagPluginHttpErrors from '@bugsnag/plugin-http-errors'
 
 Bugsnag.start({
-  apiKey: 'YOUR_API_KEY',
-  plugins: [plugin]
+  apiKey: 'YOUR_API_KEY_HERE',
+  plugins: [BugsnagPluginHttpErrors({
+    httpErrorCodes = [400, 401, { min: 450: max 499 }], // Status codes to report as errors
+    maxRequestSize = 20_000,                            // Truncate the request and response body over this size (in kb) 
+    onHttpError: ({ request, response }) => {
+      request.headers['x-custom-header'] = 'value'      // Modify any request values before sending
+      response.body = 'custom body'                     // Modify any response values before sending
+
+      return false                                      // Don't report this request an as error
+    }
+  })]
 })
 ```
 

--- a/packages/plugin-http-errors/lib/redact-query-parameters.js
+++ b/packages/plugin-http-errors/lib/redact-query-parameters.js
@@ -2,9 +2,10 @@ const redactValues = require('./redact-values')
 
 function isAbsoluteURL (url) {
   try {
-    URL.parse ? URL.parse(url) : new URL(url)
+    // eslint-disable-next-line no-new
+    new URL(url)
     return true
-  } catch {
+  } catch (e) {
     return false
   }
 }

--- a/packages/plugin-http-errors/lib/redact-query-parameters.js
+++ b/packages/plugin-http-errors/lib/redact-query-parameters.js
@@ -1,8 +1,20 @@
 const redactValues = require('./redact-values')
-const defaultBaseURL = 'http://invalid-base.com'
+
+function isAbsoluteURL (url) {
+  try {
+    URL.parse ? URL.parse(url) : new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}
 
 module.exports = function (url, redactedKeys) {
-  const urlObj = new URL(url, defaultBaseURL) // base needed for relative URLs
+  const isAbsolute = isAbsoluteURL(url)
+  const base = isAbsolute ? undefined : 'http://localhost'
+
+  // Parse the URL - use a base only for relative URLs
+  const urlObj = new URL(url, base)
   const params = new URLSearchParams(urlObj.search)
 
   // Convert URLSearchParams to object without using Object.fromEntries()
@@ -13,8 +25,13 @@ module.exports = function (url, redactedKeys) {
 
   const redactedParams = redactValues(paramsObject, redactedKeys)
   urlObj.search = new URLSearchParams(redactedParams).toString()
-  const urlString = decodeURI(urlObj.toString())
-  return urlString.startsWith(defaultBaseURL)
-    ? urlString.slice(defaultBaseURL.length)
-    : urlString
+
+  // Return appropriate format based on original URL type
+  if (isAbsolute) {
+    return decodeURI(urlObj.toString())
+  }
+
+  // For relative URLs, return only the path + search + hash components
+  const relativePart = urlObj.pathname + urlObj.search + urlObj.hash
+  return decodeURI(relativePart)
 }

--- a/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
+++ b/packages/plugin-network-breadcrumbs/test/network-breadcrumbs.test.ts
@@ -29,6 +29,10 @@ class XMLHttpRequest {
     this?._listeners[evt].push(listener)
   }
 
+  getAllResponseHeaders () {
+    return ''
+  }
+
   removeEventListener (evt: 'load'| 'error', listener: () => void) {
     for (let i = this?._listeners?.[evt]?.length ?? 0 - 1; i >= 0; i--) {
       if (listener.name === this?._listeners?.[evt]?.[i]?.name) delete this?._listeners[evt][i]

--- a/packages/request-tracker/lib/fetch-tracker.js
+++ b/packages/request-tracker/lib/fetch-tracker.js
@@ -58,7 +58,7 @@ function createFetchTracker (global, options = {}) {
         type: 'fetch',
         input: urlOrRequest,
         headers: requestHeaders,
-        body: options.body
+        body: options ? options.body : undefined
       }
 
       const { onRequestEnd } = tracker.start(context)

--- a/packages/request-tracker/lib/headers-to-object.js
+++ b/packages/request-tracker/lib/headers-to-object.js
@@ -8,8 +8,13 @@ module.exports = function (headers) {
 
   const obj = {}
   if (typeof headers.entries === 'function') {
-    for (const [key, value] of headers.entries()) {
+    var iterator = headers.entries()
+    var entry = iterator.next()
+    while (!entry.done) {
+      var key = entry.value[0]
+      var value = entry.value[1]
       obj[key] = value
+      entry = iterator.next()
     }
   } else if (headers.forEach) {
     headers.forEach((value, key) => {

--- a/packages/request-tracker/lib/xhr-tracker.js
+++ b/packages/request-tracker/lib/xhr-tracker.js
@@ -105,6 +105,7 @@ function createXhrTracker (global, options = {}) {
       tracker._restore = () => {
         global.XMLHttpRequest.prototype.open = originalOpen
         global.XMLHttpRequest.prototype.send = originalSend
+        global.XMLHttpRequest.prototype.setRequestHeader = originalSetRequestHeader
         delete global.__bugsnag_xhr_tracker__
       }
     }

--- a/test/browser/features/fixtures/handled/webpack3/webpack.config.js
+++ b/test/browser/features/fixtures/handled/webpack3/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     filename: '[name].js'
   },
   plugins: [
-    new es3ifyPlugin(),
-    new webpack.optimize.UglifyJsPlugin({ compress: false, mangle: false, ie8: true })
+    new es3ifyPlugin()
+    // UglifyJs plugin disabled due to ES6 compatibility issues
   ]
 }

--- a/test/browser/features/fixtures/handled/webpack4/webpack.config.js
+++ b/test/browser/features/fixtures/handled/webpack4/webpack.config.js
@@ -15,6 +15,6 @@ module.exports = {
   },
   plugins: [
     new es3ifyPlugin(),
-    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false, ie8: true } })
+    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false } })
   ]
 }

--- a/test/browser/features/fixtures/http_errors/webpack.config.js
+++ b/test/browser/features/fixtures/http_errors/webpack.config.js
@@ -32,6 +32,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false, ie8: true } })
+    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false } })
   ]
 }

--- a/test/browser/features/fixtures/plugin_react/webpack4/webpack.config.js
+++ b/test/browser/features/fixtures/plugin_react/webpack4/webpack.config.js
@@ -24,6 +24,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false, ie8: true } })
+    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false } })
   ]
 }

--- a/test/browser/features/fixtures/plugin_vue/webpack4/webpack.config.js
+++ b/test/browser/features/fixtures/plugin_vue/webpack4/webpack.config.js
@@ -22,6 +22,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false, ie8: true } })
+    new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { compress: false, mangle: false } })
   ]
 }

--- a/test/browser/features/http_errors.feature
+++ b/test/browser/features/http_errors.feature
@@ -30,7 +30,6 @@ Feature: HTTP Errors
 
     And the event "response.statusCode" equals 401
     And the event "response.headers.content-length" equals "37"
-    
     # Response body is not captured for fetch requests
     And the event "response.body" is null
     And the event "response.bodyLength" is null


### PR DESCRIPTION
## Goal

This PR applies suggestions and fixes related to HTTP error handling, primarily removing deprecated IE8 compatibility options from webpack configurations and improving URL handling for modern browsers.

- Removes `ie8: true` option from UglifyJsPlugin configurations across multiple webpack config files
- Improves URL parsing logic to handle both absolute and relative URLs without relying on a placeholder base URL
- Refactors iterator usage to be ES5-compatible by avoiding destructuring syntax