### PR TITLE
Ensure we're using the latest versions of iOS for testing

### DIFF
--- a/.buildkite/basic/react-native-ios-full-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-full-pipeline.yml
@@ -153,7 +153,6 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
-              - --appium-version=2.5.0
               - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
@@ -200,7 +199,6 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix.reactnative}}/output/reactnative.ipa
               - --farm=bb
-              - --appium-version=2.5.0
               - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
@@ -255,7 +253,6 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/react-native-navigation/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
-              - --appium-version=2.5.0
               - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
@@ -298,7 +295,6 @@ steps:
       #       command:
       #         - --app=/app/features/fixtures/generated/react-native-navigation/new-arch/{{matrix}}/output/reactnative.ipa
       #         - --farm=bb
-      #         - --appium-version=2.5.0
       #         - --device=IOS_17|IOS_18|IOS_26
       #         - --fail-fast
       #         - --no-tunnel

--- a/.buildkite/basic/react-native-ios-full-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-full-pipeline.yml
@@ -153,7 +153,8 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
-              - --device=IOS_15
+              - --appium-version=2.5.0
+              - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip
@@ -199,7 +200,8 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix.reactnative}}/output/reactnative.ipa
               - --farm=bb
-              - --device=IOS_15
+              - --appium-version=2.5.0
+              - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip
@@ -253,7 +255,8 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/react-native-navigation/old-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
-              - --device=IOS_15
+              - --appium-version=2.5.0
+              - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip
@@ -295,7 +298,8 @@ steps:
       #       command:
       #         - --app=/app/features/fixtures/generated/react-native-navigation/new-arch/{{matrix}}/output/reactnative.ipa
       #         - --farm=bb
-      #         - --device=IOS_15
+      #         - --appium-version=2.5.0
+      #         - --device=IOS_17|IOS_18|IOS_26
       #         - --fail-fast
       #         - --no-tunnel
       #         - --aws-public-ip

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -48,7 +48,6 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
-              - --appium-version=2.5.0
               - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel

--- a/.buildkite/basic/react-native-ios-pipeline.yml
+++ b/.buildkite/basic/react-native-ios-pipeline.yml
@@ -48,7 +48,8 @@ steps:
             command:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/output/reactnative.ipa
               - --farm=bb
-              - --device=IOS_15
+              - --appium-version=2.5.0
+              - --device=IOS_17|IOS_18|IOS_26
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip

--- a/test/react-native/features/native-stack.feature
+++ b/test/react-native/features/native-stack.feature
@@ -129,22 +129,23 @@ Scenario: Handled native promise rejection with native stacktrace
 
   # the javascript part follows
   # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
-  And the event "exceptions.0.stacktrace.20.columnNumber" equals the version-dependent string:
+  # We're check the method: asyncGeneratorStep
+  And the event "exceptions.0.stacktrace.21.columnNumber" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @not_null               |
   | new  | default | @skip                   |
   | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.20.file" equals the version-dependent string:
+  And the event "exceptions.0.stacktrace.21.file" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @not_null               |
   | new  | default | @skip                   |
   | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.20.lineNumber" equals the version-dependent string:
+  And the event "exceptions.0.stacktrace.21.lineNumber" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @not_null               |
   | new  | default | @skip                   |
   | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.20.type" equals the version-dependent string:
+  And the event "exceptions.0.stacktrace.21.type" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @null                   |
   | new  | default | @skip                   |
@@ -173,22 +174,23 @@ Scenario: Unhandled native promise rejection with native stacktrace
 
   # the javascript part follows
   # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
-  And the event "exceptions.0.stacktrace.20.columnNumber" equals the version-dependent string:
+  # We're check the method: asyncGeneratorStep
+  And the event "exceptions.0.stacktrace.21.columnNumber" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @not_null               |
   | new  | default | @skip                   |
   | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.20.file" equals the version-dependent string:
+  And the event "exceptions.0.stacktrace.21.file" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @not_null               |
   | new  | default | @skip                   |
   | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.20.lineNumber" equals the version-dependent string:
+  And the event "exceptions.0.stacktrace.21.lineNumber" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @not_null               |
   | new  | default | @skip                   |
   | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.20.type" equals the version-dependent string:
+  And the event "exceptions.0.stacktrace.21.type" equals the version-dependent string:
   | arch | version | value                   |
   | new  | 0.72    | @null                   |
   | new  | default | @skip                   |

--- a/test/react-native/features/steps/react-native-steps.rb
+++ b/test/react-native/features/steps/react-native-steps.rb
@@ -63,16 +63,11 @@ end
 
 When('I relaunch the app after a crash') do
   state = wait_for_app_state :not_running
-  # TODO: Really we should be using terminate_app/activate_app with the newer Appium client,
-  #       but for some reason they seem to make some scenarios flaky (presumably due to the
-  #       nature of how/when they close the app).
   manager = Maze::Api::Appium::AppManager.new
   if state != :not_running
-    manager.close
-    # manager.terminate
+    manager.terminate
   end
-  manager.launch
-  # manager.activate
+  manager.activate
 end
 
 When('I clear any error dialogue') do


### PR DESCRIPTION
## Goal

- Update the iOS versions we're using for tests
- Move to `activate_app` and `terminate_app`

Bump the stacktrace we're looking for `Handled native promise rejection with native stacktrace` and `Unhandled native promise rejection with native stacktrace`.

Looking at the stack traces, we appear to have an additional:

```
{
  "method"=>"<redacted>",
  "type"=>"cocoa",
  "machoVMAddress"=>"0x19011a000",
  "machoFile"=>"libdispatch.dylib",
  "symbolAddress"=>"0x1a2b64394",
  "machoUUID"=>"81D355DF-266A-3010-BAB8-113B76A206C1",
  "machoLoadAddress"=>"0x1a2b4e000",
  "frameAddress"=>"0x1a2b64528"
},
```

Before the `_pthread_wqthread` stacktrace.

## Testing

Covered by CI