### PR TITLE
Run e2e tests with Ruby 4

### DIFF
--- a/dockerfiles/Dockerfile.browser
+++ b/dockerfiles/Dockerfile.browser
@@ -55,7 +55,7 @@ RUN find . -name package.json -type f -mindepth 2 -maxdepth 3 ! -path "./node_mo
 RUN rm -fr **/*/node_modules/
 
 # The maze-runner browser tests (W3C protocol)
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v10.10.1-cli AS browser-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v10-cli AS browser-maze-runner
 
 COPY --from=browser-feature-builder /app/test/browser /app/test/browser/
 WORKDIR /app/test/browser

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -22,7 +22,7 @@ RUN npm pack --verbose packages/plugin-restify/
 RUN npm pack --verbose packages/plugin-hono/
 
 # The maze-runner node tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v10.10.1-cli AS node-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v10-cli AS node-maze-runner
 WORKDIR /app/
 COPY packages/node/ .
 COPY test/node/features test/node/features

--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -5,7 +5,9 @@ require 'net/http'
 # @step_input reqbody [String] urlencoded data to send.
 # @step_input url [String] The URL to post data to.
 When("I POST the data {string} to the URL {string}") do |reqbody, url|
-  Net::HTTP.post(URI(url), reqbody)
+  Net::HTTP.post(URI(url),
+                 reqbody,
+                 'Content-Type' => 'application/x-www-form-urlencoded')
 end
 
 When('I open the URL {string} tolerating any error') do |url|


### PR DESCRIPTION
## Goal

Fixes an issue when running the e2e tests with Ruby 4.

## Design

Under Ruby 3, the `Net::HTTP.post` method would set the `Content-Type` for us, but now we need to set it explicitly to avoid an empty body being received by the test fixture.

## Testing

Covered by CI.