### PR TITLE
Manually parse urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+(plugin-network-instrumentation) Manually parse URLs to improve React Native compatibility [#2674](https://github.com/bugsnag/bugsnag-js/pull/2674)
 Update bugsnag-android to [v6.22.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.22.0) [#2656](https://github.com/bugsnag/bugsnag-js/pull/2656)
 
 ### Fixed

--- a/packages/node/test/notifier.test.ts
+++ b/packages/node/test/notifier.test.ts
@@ -4,6 +4,7 @@ describe('node notifier', () => {
   beforeAll(() => {
     jest.spyOn(console, 'debug').mockImplementation(() => {})
     jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'log').mockImplementation(() => {})
   })
 
   beforeEach(() => {

--- a/packages/plugin-aws-lambda/test/serverless-express.test.js
+++ b/packages/plugin-aws-lambda/test/serverless-express.test.js
@@ -14,6 +14,10 @@ let sentEvents
 let sentSessions
 
 describe('serverless express', function () {
+  beforeAll(() => {
+    jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
   beforeEach(function () {
     sentEvents = []
     sentSessions = []

--- a/packages/plugin-network-instrumentation/lib/extract-domain.js
+++ b/packages/plugin-network-instrumentation/lib/extract-domain.js
@@ -12,12 +12,22 @@ module.exports = function (url) {
 
     const urlWithoutProtocol = url.replace(/^https?:\/\//i, '')
 
-    const firstSlashIndex = urlWithoutProtocol.indexOf('/')
-    if (firstSlashIndex !== -1) {
-      return urlWithoutProtocol.substring(0, firstSlashIndex)
+    // Find the earliest occurrence of '/', '?', or '#' to determine the domain boundary
+    const slashIndex = urlWithoutProtocol.indexOf('/')
+    const queryIndex = urlWithoutProtocol.indexOf('?')
+    const hashIndex = urlWithoutProtocol.indexOf('#')
+    let endIndex = urlWithoutProtocol.length
+    if (slashIndex !== -1 && slashIndex < endIndex) {
+      endIndex = slashIndex
+    }
+    if (queryIndex !== -1 && queryIndex < endIndex) {
+      endIndex = queryIndex
+    }
+    if (hashIndex !== -1 && hashIndex < endIndex) {
+      endIndex = hashIndex
     }
 
-    return urlWithoutProtocol
+    return urlWithoutProtocol.substring(0, endIndex)
   } catch (e) {
     return 'unknown'
   }

--- a/packages/plugin-network-instrumentation/lib/extract-domain.js
+++ b/packages/plugin-network-instrumentation/lib/extract-domain.js
@@ -5,8 +5,19 @@
    */
 module.exports = function (url) {
   try {
-    const urlObj = new URL(url)
-    return urlObj.host
+    const isAbsolute = /^https?:\/\//i.test(url)
+    if (!isAbsolute) {
+      return 'unknown'
+    }
+
+    const urlWithoutProtocol = url.replace(/^https?:\/\//i, '')
+
+    const firstSlashIndex = urlWithoutProtocol.indexOf('/')
+    if (firstSlashIndex !== -1) {
+      return urlWithoutProtocol.substring(0, firstSlashIndex)
+    }
+
+    return urlWithoutProtocol
   } catch (e) {
     return 'unknown'
   }

--- a/packages/plugin-network-instrumentation/lib/parse-query-params.js
+++ b/packages/plugin-network-instrumentation/lib/parse-query-params.js
@@ -5,12 +5,24 @@
    */
 module.exports = function (url) {
   try {
-    const urlObj = new URL(url)
-    const params = {}
-    urlObj.searchParams.forEach((value, key) => {
-      params[key] = value
+    const queryStart = url.indexOf('?')
+    const hashStart = url.indexOf('#')
+
+    let queryString = ''
+    if (queryStart !== -1) {
+      const queryEnd = hashStart !== -1 && hashStart > queryStart ? hashStart : url.length
+      queryString = url.substring(queryStart + 1, queryEnd)
+    }
+
+    // convert query string to object without using UrlSearchParams
+    const queryStringObject = {}
+    const pairs = queryString.split('&').filter(pair => pair.length > 0)
+    pairs.forEach(pair => {
+      const [key, value] = pair.split('=')
+      queryStringObject[decodeURIComponent(key)] = decodeURIComponent(value || '')
     })
-    return params
+
+    return queryStringObject
   } catch (e) {
     return {}
   }

--- a/packages/plugin-network-instrumentation/lib/redact-query-parameters.js
+++ b/packages/plugin-network-instrumentation/lib/redact-query-parameters.js
@@ -16,25 +16,40 @@ module.exports = function (url, redactedKeys) {
 
   // Parse the URL - use a base only for relative URLs
   const urlObj = new URL(url, base)
-  const params = urlObj.search ? new URLSearchParams(urlObj.search) : new URLSearchParams()
+
+  // Extract query string manually from the original URL
+  const queryStart = url.indexOf('?')
+  const hashStart = url.indexOf('#')
+
+  let queryString = ''
+  if (queryStart !== -1) {
+    const queryEnd = hashStart !== -1 && hashStart > queryStart ? hashStart : url.length
+    queryString = url.substring(queryStart + 1, queryEnd)
+  }
 
   // Convert URLSearchParams to object without using Object.fromEntries()
+  const params = new URLSearchParams(queryString)
   const paramsObject = {}
   params.forEach((value, key) => {
     paramsObject[key] = value
   })
 
   const redactedParams = redactValues(paramsObject, redactedKeys)
-  if (urlObj.search) {
-    urlObj.search = new URLSearchParams(redactedParams).toString()
+  const redactedQueryString = new URLSearchParams(redactedParams).toString()
+
+  // Build the result URL manually
+  let result = urlObj.pathname
+  if (redactedQueryString) {
+    result += '?' + redactedQueryString
+  }
+  if (urlObj.hash) {
+    result += urlObj.hash
   }
 
   // Return appropriate format based on original URL type
   if (isAbsolute) {
-    return decodeURI(urlObj.toString())
+    return decodeURI(urlObj.origin + result)
   }
 
-  // For relative URLs, return only the path + search + hash components
-  const relativePart = urlObj.pathname + (urlObj.search || '') + urlObj.hash
-  return decodeURI(relativePart)
+  return decodeURI(result)
 }

--- a/packages/plugin-network-instrumentation/lib/redact-query-parameters.js
+++ b/packages/plugin-network-instrumentation/lib/redact-query-parameters.js
@@ -1,55 +1,23 @@
+const parseQueryParams = require('./parse-query-params')
 const redactValues = require('./redact-values')
 
-function isAbsoluteURL (url) {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(url)
-    return true
-  } catch (e) {
-    return false
-  }
-}
-
 module.exports = function (url, redactedKeys) {
-  const isAbsolute = isAbsoluteURL(url)
-  const base = isAbsolute ? undefined : 'http://localhost'
+  const paramsObject = parseQueryParams(url)
+  const redactedParams = redactValues(paramsObject, redactedKeys)
+  const redactedQueryString = Object.entries(redactedParams).map(([key, value]) => `${key}=${value}`).join('&')
 
-  // Parse the URL - use a base only for relative URLs
-  const urlObj = new URL(url, base)
-
-  // Extract query string manually from the original URL
   const queryStart = url.indexOf('?')
   const hashStart = url.indexOf('#')
-
-  let queryString = ''
-  if (queryStart !== -1) {
-    const queryEnd = hashStart !== -1 && hashStart > queryStart ? hashStart : url.length
-    queryString = url.substring(queryStart + 1, queryEnd)
-  }
-
-  // Convert URLSearchParams to object without using Object.fromEntries()
-  const params = new URLSearchParams(queryString)
-  const paramsObject = {}
-  params.forEach((value, key) => {
-    paramsObject[key] = value
-  })
-
-  const redactedParams = redactValues(paramsObject, redactedKeys)
-  const redactedQueryString = new URLSearchParams(redactedParams).toString()
+  const hash = hashStart !== -1 ? url.substring(hashStart) : ''
+  let result = queryStart !== -1 ? url.substring(0, queryStart) : url
 
   // Build the result URL manually
-  let result = urlObj.pathname
-  if (redactedQueryString) {
+  if (redactedQueryString && redactedQueryString.length > 0) {
     result += '?' + redactedQueryString
   }
-  if (urlObj.hash) {
-    result += urlObj.hash
+  if (hash) {
+    result += hash
   }
 
-  // Return appropriate format based on original URL type
-  if (isAbsolute) {
-    return decodeURI(urlObj.origin + result)
-  }
-
-  return decodeURI(result)
+  return result
 }

--- a/packages/plugin-network-instrumentation/lib/redact-query-parameters.js
+++ b/packages/plugin-network-instrumentation/lib/redact-query-parameters.js
@@ -16,7 +16,7 @@ module.exports = function (url, redactedKeys) {
 
   // Parse the URL - use a base only for relative URLs
   const urlObj = new URL(url, base)
-  const params = new URLSearchParams(urlObj.search)
+  const params = urlObj.search ? new URLSearchParams(urlObj.search) : new URLSearchParams()
 
   // Convert URLSearchParams to object without using Object.fromEntries()
   const paramsObject = {}
@@ -25,7 +25,9 @@ module.exports = function (url, redactedKeys) {
   })
 
   const redactedParams = redactValues(paramsObject, redactedKeys)
-  urlObj.search = new URLSearchParams(redactedParams).toString()
+  if (urlObj.search) {
+    urlObj.search = new URLSearchParams(redactedParams).toString()
+  }
 
   // Return appropriate format based on original URL type
   if (isAbsolute) {
@@ -33,6 +35,6 @@ module.exports = function (url, redactedKeys) {
   }
 
   // For relative URLs, return only the path + search + hash components
-  const relativePart = urlObj.pathname + urlObj.search + urlObj.hash
+  const relativePart = urlObj.pathname + (urlObj.search || '') + urlObj.hash
   return decodeURI(relativePart)
 }

--- a/test/browser/features/http_errors.feature
+++ b/test/browser/features/http_errors.feature
@@ -16,7 +16,7 @@ Feature: HTTP Errors
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
     And the event "severity" equals "error"
-    And the event "unhandled" is true
+    And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
     And the error payload field "events.0.context" equals the stored value "expected.context"
 
@@ -46,7 +46,7 @@ Feature: HTTP Errors
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
     And the event "severity" equals "error"
-    And the event "unhandled" is true
+    And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
     And the error payload field "events.0.context" equals the stored value "expected.context"
 
@@ -78,7 +78,7 @@ Feature: HTTP Errors
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
     And the event "severity" equals "error"
-    And the event "unhandled" is true
+    And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
     And the error payload field "events.0.context" equals the stored value "expected.context"
 
@@ -109,7 +109,7 @@ Feature: HTTP Errors
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
     And the event "severity" equals "error"
-    And the event "unhandled" is true
+    And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
     And the error payload field "events.0.context" equals the stored value "expected.context"
 

--- a/test/react-native/features/fixtures/expected_http_errors/401.json
+++ b/test/react-native/features/fixtures/expected_http_errors/401.json
@@ -1,6 +1,6 @@
 [
   {
-    "message": "^401: .*\/reflect\/[?]status=401$",
+    "message": "^401: .*\/reflect[?]status=401$",
     "errorClass": "HTTPError",
     "type": "reactnativejs",
     "stacktrace": "IGNORE"

--- a/test/react-native/features/fixtures/expected_http_errors/500.json
+++ b/test/react-native/features/fixtures/expected_http_errors/500.json
@@ -1,6 +1,6 @@
 [
   {
-    "message": "^500: .*\/reflect\/[?]status=500$",
+    "message": "^500: .*\/reflect[?]status=500$",
     "errorClass": "HTTPError",
     "type": "reactnativejs",
     "stacktrace": "IGNORE"

--- a/test/react-native/features/fixtures/scenario-launcher/scenarios/core/NetworkRequestScenario.js
+++ b/test/react-native/features/fixtures/scenario-launcher/scenarios/core/NetworkRequestScenario.js
@@ -18,9 +18,7 @@ export class NetworkRequestScenario extends Scenario {
   }
 
   run () {
-    const url = new URL(this.reflectEndpoint)
-    url.searchParams.append('status', this.statusCode)
-    fetch(url).catch((err) => {
+    fetch(`${this.reflectEndpoint}?status=${this.statusCode}`).catch((err) => {
       Bugsnag.notify(err)
     })
   }


### PR DESCRIPTION
## Goal

Removes the dependency on `URL` and `URLSearchParams` APIs from React Native test fixtures and network instrumentation code, replacing them with manual string parsing to avoid requiring polyfills in React Native environments.

## Changeset

- Implemented custom query parameter parsing and `URL` manipulation functions to avoid `URLSearchParams` dependency
- Updated test expectations to reflect the simplified URL format (removed trailing slash before query parameter)
- Nullify some console logging during unit tests
- Update invalid `unhandled` assertions in browser http error tests
