### PR TITLE
Reinstate code coverage check

### DIFF
--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -25,8 +25,10 @@ jobs:
           mkdir .diff
           npm ci
           npm run build
+          npm run test:coverage
           cat packages/browser/dist/bugsnag.min.js | wc -c > .diff/size-before-minified
           cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .diff/size-before-gzipped
+          cp coverage/coverage-summary.json .diff/coverage-before.json
 
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,8 +41,10 @@ jobs:
         run: |
           npm ci
           npm run build
+          npm run test:coverage
           cat packages/browser/dist/bugsnag.min.js | wc -c > .diff/size-after-minified
           cat packages/browser/dist/bugsnag.min.js | gzip | wc -c > .diff/size-after-gzipped
+          cp coverage/coverage-summary.json .diff/coverage-after.json
 
       - name: Run danger
         uses: danger/danger-js@67ed2c1f42fd2fc198cc3c14b43c8f83351f4fe9 # 13.0.5

--- a/.github/workflows/pr-diff.yml
+++ b/.github/workflows/pr-diff.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Record before stats
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_DISABLE_SANDBOX: 1
         run: |
           mkdir .diff
           npm ci
@@ -38,6 +39,7 @@ jobs:
       - name: Record after stats
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_DISABLE_SANDBOX: 1
         run: |
           npm ci
           npm run build

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,15 +1,18 @@
 /* global markdown */
 
 const { readFileSync } = require('fs')
+const coverageDiff = require('coverage-diff')
 
 const before = {
   minified: parseInt(readFileSync(`${__dirname}/.diff/size-before-minified`, 'utf8').trim()),
-  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-before-gzipped`, 'utf8').trim())
+  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-before-gzipped`, 'utf8').trim()),
+  coverage: JSON.parse(readFileSync(`${__dirname}/.diff/coverage-before.json`, 'utf8'))
 }
 
 const after = {
   minified: parseInt(readFileSync(`${__dirname}/.diff/size-after-minified`, 'utf8').trim()),
-  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-after-gzipped`, 'utf8').trim())
+  gzipped: parseInt(readFileSync(`${__dirname}/.diff/size-after-gzipped`, 'utf8').trim()),
+  coverage: JSON.parse(readFileSync(`${__dirname}/.diff/coverage-after.json`, 'utf8'))
 }
 
 const formatKbs = (n) => `${(n / 1000).toFixed(2)} kB`
@@ -33,5 +36,5 @@ markdown(`
 
 ### code coverage diff
 
-<_temporarily disabled_>
+${coverageDiff.diff(before.coverage, after.coverage).results}
 `)

--- a/jest.config.js
+++ b/jest.config.js
@@ -53,7 +53,8 @@ module.exports = {
       'plugin-browser-session',
       'plugin-network-instrumentation'
     ], {
-      testEnvironment: '<rootDir>/jest/FixJSDOMEnvironment.js'
+      testEnvironment: '<rootDir>/jest/FixJSDOMEnvironment.js',
+      modulePathIgnorePatterns: ['.verdaccio', 'dist', 'examples', 'fixtures']
     }),
     project('react native', [
       'react-native',

--- a/packages/node/test/notifier.test.ts
+++ b/packages/node/test/notifier.test.ts
@@ -12,6 +12,15 @@ describe('node notifier', () => {
     Bugsnag._client = null
   })
 
+  afterEach(() => {
+    // Clean up process listeners to prevent MaxListenersExceeded warning
+    // The unhandledRejection and uncaughtException plugins register listeners
+    // but don't have destroy methods called automatically
+    process.removeAllListeners('unhandledRejection')
+    process.removeAllListeners('uncaughtException')
+    jest.clearAllMocks()
+  })
+
   describe('isStarted()', () => {
     it('returns false when the notifier has not been initialised', () => {
       expect(Bugsnag.isStarted()).toBe(false)

--- a/packages/plugin-electron-ipc/preload.js
+++ b/packages/plugin-electron-ipc/preload.js
@@ -1,26 +1,28 @@
+(function () {
 // preloads run in devtools panes too, but we don't want to run there
-if (document.location.protocol === 'devtools:') return
+  if (document.location.protocol === 'devtools:') return
 
-const { ipcRenderer, contextBridge } = require('electron')
-const BugsnagIpcRenderer = require('./bugsnag-ipc-renderer')
-const { CHANNEL_CONFIG } = require('./lib/constants')
+  const { ipcRenderer, contextBridge } = require('electron')
+  const BugsnagIpcRenderer = require('./bugsnag-ipc-renderer')
+  const { CHANNEL_CONFIG } = require('./lib/constants')
 
-// one sync call is required on startup to get the main process config
-const config = ipcRenderer.sendSync(CHANNEL_CONFIG)
-if (!config) throw new Error('Bugsnag was not started in the main process before browser windows were created')
+  // one sync call is required on startup to get the main process config
+  const config = ipcRenderer.sendSync(CHANNEL_CONFIG)
+  if (!config) throw new Error('Bugsnag was not started in the main process before browser windows were created')
 
-// attach config to the exposed interface
-BugsnagIpcRenderer.config = JSON.parse(config)
+  // attach config to the exposed interface
+  BugsnagIpcRenderer.config = JSON.parse(config)
 
-// attach process info to the exposed interface
-const { isMainFrame, sandboxed, type } = process
-BugsnagIpcRenderer.process = { isMainFrame, sandboxed, type }
+  // attach process info to the exposed interface
+  const { isMainFrame, sandboxed, type } = process
+  BugsnagIpcRenderer.process = { isMainFrame, sandboxed, type }
 
-// expose Bugsnag as a global object for the browser
-try {
+  // expose Bugsnag as a global object for the browser
+  try {
   // assume contextIsolation=true
-  contextBridge.exposeInMainWorld('__bugsnag_ipc__', BugsnagIpcRenderer)
-} catch (e) {}
+    contextBridge.exposeInMainWorld('__bugsnag_ipc__', BugsnagIpcRenderer)
+  } catch (e) {}
 
-// expose for other preload scripts to use, this also covers contextIsolation=false
-window.__bugsnag_ipc__ = BugsnagIpcRenderer
+  // expose for other preload scripts to use, this also covers contextIsolation=false
+  window.__bugsnag_ipc__ = BugsnagIpcRenderer
+})()


### PR DESCRIPTION
This PR reinstates code coverage checks by reverting bugsnag/bugsnag-js#1882

Additionally, this PR resolves a number of memory leaks and warnings from the jest test runner, removing ~30s from the time taken to run unit tests and calculate coverage.
