### PR TITLE
fix(plugin-network-instrumentation): omit stacktrace from HTTP Error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,41 +4,42 @@
 
 ### Changed
 
-(plugin-network-instrumentation) Manually parse URLs to improve React Native compatibility [#2674](https://github.com/bugsnag/bugsnag-js/pull/2674)
-Update bugsnag-android to [v6.22.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.22.0) [#2656](https://github.com/bugsnag/bugsnag-js/pull/2656)
-Update bugsnag-cocoa to [v6.35.0](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.35.0) [#2663](https://github.com/bugsnag/bugsnag-js/pull/2663)
+- (plugin-network-instrumentation) Manually parse URLs to improve React Native compatibility [#2674](https://github.com/bugsnag/bugsnag-js/pull/2674)
+- Update bugsnag-android to [v6.22.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.22.0) [#2656](https://github.com/bugsnag/bugsnag-js/pull/2656)
+- Update bugsnag-cocoa to [v6.35.0](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.35.0) [#2663](https://github.com/bugsnag/bugsnag-js/pull/2663)
 
 ### Fixed
 
-(plugin-network-instrumentation) Report HTTP Errors as handled [#2662](https://github.com/bugsnag/bugsnag-js/pull/2662)
-
+- (plugin-network-instrumentation) Report HTTP Errors as handled [#2662](https://github.com/bugsnag/bugsnag-js/pull/2662)
+- (plugin-network-instrumentation) Omit stacktraces from HTTP Error events [#2684](https://github.com/bugsnag/bugsnag-js/pull/2684)
+ 
 ### Dependencies
 
-Update bugsnag-android to [v6.23.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.23.0) [#2673](https://github.com/bugsnag/bugsnag-js/pull/2673)
+- Update bugsnag-android to [v6.23.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.23.0) [#2673](https://github.com/bugsnag/bugsnag-js/pull/2673)
 
 ## [8.8.1] - 2026-01-26
 
 ### Fixed
 
-(plugin-network-breadcrumbs, plugin-network-instrumentation) Ensure XMLHttpRequest response types are handled gracefully [#2660](https://github.com/bugsnag/bugsnag-js/pull/2660)
+- (plugin-network-breadcrumbs, plugin-network-instrumentation) Ensure XMLHttpRequest response types are handled gracefully [#2660](https://github.com/bugsnag/bugsnag-js/pull/2660)
 
 ## [8.8.0] - 2026-01-20
 
 This release adds support for notitfying failed network requests using the new `plugin-network-instrumentation` package
 ### Added
 
-(plugin-network-instrumentation) Add new plugin to notify failed network requests [#2647](https://github.com/bugsnag/bugsnag-js/pull/2647)
-(plugin-cloudflare-workers): Add initial support for Cloudflare Workers [#2643](https://github.com/bugsnag/bugsnag-js/pull/2643) [#2644](https://github.com/bugsnag/bugsnag-js/pull/2644)
-(plugin-contextualize) Return callback value from contextualize plugin [#2654](https://github.com/bugsnag/bugsnag-js/pull/2654)
+- (plugin-network-instrumentation) Add new plugin to notify failed network requests [#2647](https://github.com/bugsnag/bugsnag-js/pull/2647)
+- (plugin-cloudflare-workers): Add initial support for Cloudflare Workers [#2643](https://github.com/bugsnag/bugsnag-js/pull/2643) [#2644](https://github.com/bugsnag/bugsnag-js/pull/2644)
+- (plugin-contextualize) Return callback value from contextualize plugin [#2654](https://github.com/bugsnag/bugsnag-js/pull/2654)
 
 ### Fixed
 
-(plugin-server-session) Delay session tracker initialization until first use [#2642](https://github.com/bugsnag/bugsnag-js/pull/2642)
+- (plugin-server-session) Delay session tracker initialization until first use [#2642](https://github.com/bugsnag/bugsnag-js/pull/2642)
 
 ### Dependencies
 
-Update bugsnag-cocoa to [6.34.1](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/6.34.1) [#2606](https://github.com/bugsnag/bugsnag-js/pull/2606)
-Update bugsnag-android to [v6.20.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.20.0) [#2625](https://github.com/bugsnag/bugsnag-js/pull/2625)
+- Update bugsnag-cocoa to [6.34.1](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/6.34.1) [#2606](https://github.com/bugsnag/bugsnag-js/pull/2606)
+- Update bugsnag-android to [v6.20.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.20.0) [#2625](https://github.com/bugsnag/bugsnag-js/pull/2625)
 
 ## [8.7.0] - 2025-10-13
 

--- a/packages/plugin-network-instrumentation/network-instrumentation.js
+++ b/packages/plugin-network-instrumentation/network-instrumentation.js
@@ -148,6 +148,7 @@ module.exports = (config = {}, global = window) => {
             0
           )
 
+          event.errors[0].stacktrace = [] // Omit the stacktrace for HTTP errors
           event.request = requestObj
           event.response = responseObj
           event.context = `${method} ${domain}`

--- a/packages/plugin-network-instrumentation/test/network-instrumentation-xhr.test.ts
+++ b/packages/plugin-network-instrumentation/test/network-instrumentation-xhr.test.ts
@@ -133,6 +133,7 @@ describe('plugin-network-instrumentation', () => {
       // Verify error details
       expect(event.exceptions[0].errorClass).toBe('HTTPError')
       expect(event.exceptions[0].errorMessage).toBe('404: https://api.example.com/users/123')
+      expect(event.exceptions[0].stacktrace).toEqual([]) // Stacktrace should be empty for HTTP errors
       expect(event.context).toBe('POST api.example.com')
       expect(event.severity).toBe('error')
       expect(event.unhandled).toBe(false)

--- a/packages/plugin-network-instrumentation/test/network-instrumentation.test.ts
+++ b/packages/plugin-network-instrumentation/test/network-instrumentation.test.ts
@@ -85,6 +85,7 @@ describe('plugin-network-instrumentation', () => {
 
       expect(event.exceptions[0].errorClass).toBe('HTTPError')
       expect(event.exceptions[0].errorMessage).toBe('404: https://example.com/api/users')
+      expect(event.exceptions[0].stacktrace).toEqual([]) // Stacktrace should be empty for HTTP errors
       expect(event.context).toBe('GET example.com')
       expect(event.severity).toBe('error')
       expect(event.unhandled).toBe(false)

--- a/test/browser/features/http_errors.feature
+++ b/test/browser/features/http_errors.feature
@@ -15,6 +15,7 @@ Feature: HTTP Errors
 
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the event "severity" equals "error"
     And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
@@ -45,6 +46,7 @@ Feature: HTTP Errors
 
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the event "severity" equals "error"
     And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
@@ -77,6 +79,7 @@ Feature: HTTP Errors
 
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the event "severity" equals "error"
     And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"
@@ -108,6 +111,7 @@ Feature: HTTP Errors
 
     And the exception "errorClass" equals "HTTPError"
     And the error payload field "events.0.exceptions.0.message" equals the stored value "expected.exception.message"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the event "severity" equals "error"
     And the event "unhandled" is false
     And the event "severityReason.type" equals "httpError"


### PR DESCRIPTION
## Goal

As per the design, HTTP Error events should not include a stacktrace

## Design
`plugin-network-instrumentation` now creates an event with an empty stacktrace

## Testing

Added unit and e2e test assertions to check the event stacktrace is empty