### PR TITLE
Report error cause with native stacktrace for Turbo Module exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@
 ### Changed
 
 - (plugin-network-instrumentation) Manually parse URLs to improve React Native compatibility [#2674](https://github.com/bugsnag/bugsnag-js/pull/2674)
-- Update bugsnag-android to [v6.22.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.22.0) [#2656](https://github.com/bugsnag/bugsnag-js/pull/2656)
-- Update bugsnag-cocoa to [v6.35.0](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.35.0) [#2663](https://github.com/bugsnag/bugsnag-js/pull/2663)
 
 ### Fixed
 
 - (plugin-network-instrumentation) Report HTTP Errors as handled [#2662](https://github.com/bugsnag/bugsnag-js/pull/2662)
 - (plugin-network-instrumentation) Omit stacktraces from HTTP Error events [#2684](https://github.com/bugsnag/bugsnag-js/pull/2684)
+- (react-native) Report error cause with native stacktrace for Turbo Module exceptions [#2686] (https://github.com/bugsnag/bugsnag-js/pull/2686)
  
 ### Dependencies
 
+- Update bugsnag-cocoa to [v6.35.0](https//github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.35.0) [#2663](https://github.com/bugsnag/bugsnag-js/pull/2663)
+- Update bugsnag-android to [v6.22.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.22.0) [#2656](https://github.com/bugsnag/bugsnag-js/pull/2656)
 - Update bugsnag-android to [v6.23.0](https//github.com/bugsnag/bugsnag-android/releases/tag/v6.23.0) [#2673](https://github.com/bugsnag/bugsnag-js/pull/2673)
 
 ## [8.8.1] - 2026-01-26
@@ -26,6 +27,7 @@
 ## [8.8.0] - 2026-01-20
 
 This release adds support for notitfying failed network requests using the new `plugin-network-instrumentation` package
+
 ### Added
 
 - (plugin-network-instrumentation) Add new plugin to notify failed network requests [#2647](https://github.com/bugsnag/bugsnag-js/pull/2647)

--- a/packages/delivery-react-native/delivery.js
+++ b/packages/delivery-react-native/delivery.js
@@ -3,12 +3,35 @@ const derecursify = require('@bugsnag/core/lib/derecursify')
 module.exports = (client, NativeClient) => ({
   sendEvent: (payload, cb = () => {}) => {
     const event = payload.events[0]
-    let nativeStack
+
     if (event.originalError) {
+      // extract native stacktrace from originalError if available
+      let nativeErrorMessage, nativeStack
       if (event.originalError.nativeStackIOS) {
+        // old arch ios
+        nativeErrorMessage = event.originalError.message
         nativeStack = event.originalError.nativeStackIOS
       } else if (event.originalError.nativeStackAndroid) {
+        // old arch android
+        nativeErrorMessage = event.originalError.message
         nativeStack = event.originalError.nativeStackAndroid
+      } else if (event.originalError.cause && event.originalError.cause.stackSymbols) {
+        // new arch ios
+        nativeErrorMessage = event.originalError.cause.message
+        nativeStack = event.originalError.cause.stackSymbols
+      } else if (event.originalError.cause && event.originalError.cause.stackElements) {
+        // new arch android
+        nativeErrorMessage = event.originalError.cause.message
+        nativeStack = event.originalError.cause.stackElements
+      }
+
+      if (nativeErrorMessage && nativeStack) {
+      // add the native stack to the corresponding error in the event payload
+        const nativeError = event.errors.find(err => err.errorMessage === nativeErrorMessage)
+
+        if (nativeError) {
+          nativeError.nativeStack = nativeStack
+        }
       }
     }
 
@@ -30,7 +53,6 @@ module.exports = (client, NativeClient) => ({
       groupingDiscriminator: event._groupingDiscriminator,
       apiKey: event.apiKey,
       featureFlags: event.toJSON().featureFlags,
-      nativeStack: nativeStack,
       correlation: event._correlation
     }
 

--- a/packages/delivery-react-native/test/delivery.test.ts
+++ b/packages/delivery-react-native/test/delivery.test.ts
@@ -31,9 +31,17 @@ type NativeClientEvent = Pick<EventWithInternals,
   nativeStack: NativeStackIOS | NativeStackAndroid
 }
 
+interface ReactNativeErrorCause {
+  name: string
+  message: string
+  stackSymbols?: NativeStackIOS
+  stackElements?: NativeStackAndroid
+}
+
 class ReactNativeError extends Error {
   nativeStackAndroid?: NativeStackAndroid
   nativeStackIOS?: NativeStackIOS
+  cause?: ReactNativeErrorCause
 }
 
 describe('delivery: react native', () => {
@@ -111,7 +119,8 @@ describe('delivery: react native', () => {
     ]
     c.notify(error, (e) => {}, (err, event) => {
       expect(err).not.toBeTruthy()
-      expect(sent[0].nativeStack).toEqual(error.nativeStackIOS)
+      // @ts-expect-error nativeStack is added by the delivery module
+      expect(sent[0].errors[0].nativeStack).toEqual(error.nativeStackIOS)
       done()
     })
   })
@@ -137,7 +146,96 @@ describe('delivery: react native', () => {
     ]
     c.notify(error, (e) => {}, (err, event) => {
       expect(err).not.toBeTruthy()
-      expect(sent[0].nativeStack).toBe(error.nativeStackAndroid)
+      // @ts-expect-error nativeStack is added by the delivery module
+      expect(sent[0].errors[0].nativeStack).toBe(error.nativeStackAndroid)
+      done()
+    })
+  })
+
+  it('extracts iOS native error cause', done => {
+    const sent: NativeClientEvent[] = []
+    const NativeClient = {
+      dispatchAsync: (event: NativeClientEvent) => {
+        sent.push(event)
+        return new Promise((resolve) => resolve(true))
+      }
+    }
+    const c = new Client({ apiKey: 'api_key' })
+    c._setDelivery(client => delivery(client, NativeClient))
+    const error = new ReactNativeError('oh no')
+    const stackSymbols = [
+      '0   ReactNativeTest                     0x000000010fda7f1b RCTJSErrorFromCodeMessageAndNSError + 79',
+      '1   ReactNativeTest                     0x000000010fd76897 __41-[RCTModuleMethod processMethodSignature]_block_invoke_2.103 + 97',
+      '2   ReactNativeTest                     0x000000010fccd9c3 -[BenCrash asyncReject:rejecter:] + 106',
+      '3   CoreFoundation                      0x00007fff23e44dec __invoking___ + 140',
+      '4   CoreFoundation                      0x00007fff23e41fd1 -[NSInvocation invoke] + 321',
+      '5   CoreFoundation                      0x00007fff23e422a4 -[NSInvocation invokeWithTarget:] + 68',
+      '6   ReactNativeTest                     0x000000010fd76eae -[RCTModuleMethod invokeWithBridge:module:arguments:] + 578',
+      '7   ReactNativeTest                     0x000000010fd79138 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 246'
+    ]
+
+    error.cause = {
+      name: 'NativeiOSException',
+      message: 'Native iOS error occurred',
+      stackSymbols
+    }
+
+    c.notify(error, (e) => {}, (err, event) => {
+      expect(err).not.toBeTruthy()
+      expect(sent[0].errors[0].errorMessage).toEqual(error.message)
+      // @ts-expect-error nativeStack is added by the delivery module
+      expect(sent[0].errors[0].nativeStack).toBeUndefined()
+
+      expect(sent[0].errors[1].errorMessage).toBeDefined()
+      expect(sent[0].errors[1].errorMessage).toEqual(error.cause?.message)
+      expect(sent[0].errors[1].errorClass).toBeDefined()
+      expect(sent[0].errors[1].errorClass).toEqual(error.cause?.name)
+
+      // @ts-expect-error nativeStack is added by the delivery module
+      expect(sent[0].errors[1].nativeStack).toEqual(error.cause.stackSymbols)
+      done()
+    })
+  })
+
+  it('extracts Android native error cause', done => {
+    const sent: NativeClientEvent[] = []
+    const NativeClient = {
+      dispatchAsync: (event: NativeClientEvent) => {
+        sent.push(event)
+        return new Promise((resolve) => resolve(true))
+      }
+    }
+    const c = new Client({ apiKey: 'api_key' })
+    c._setDelivery(client => delivery(client, NativeClient))
+    const error = new ReactNativeError('oh no')
+    const stackElements = [
+      {
+        class: 'com.testing.Blah',
+        lineNumber: 101,
+        file: 'app/com.testing.Blah.java',
+        methodName: 'crash()'
+      }
+    ]
+
+    error.cause = {
+      name: 'NativeAndroidException',
+      message: 'Native Android error occurred',
+      stackElements
+    }
+
+    c.notify(error, (e) => {}, (err, event) => {
+      expect(err).not.toBeTruthy()
+      expect(sent[0].errors[0].errorMessage).toEqual(error.message)
+      // @ts-expect-error nativeStack is added by the delivery module
+      expect(sent[0].errors[0].nativeStack).toBeUndefined()
+
+      expect(sent[0].errors[1].errorMessage).toBeDefined()
+      expect(sent[0].errors[1].errorMessage).toEqual(error.cause?.message)
+      expect(sent[0].errors[1].errorClass).toBeDefined()
+      expect(sent[0].errors[1].errorClass).toEqual(error.cause?.name)
+
+      // @ts-expect-error nativeStack is added by the delivery module
+      expect(sent[0].errors[1].nativeStack).toEqual(error.cause.stackElements)
       done()
     })
   })

--- a/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
+++ b/packages/react-native/ios/BugsnagReactNative/BugsnagEventDeserializer.m
@@ -9,6 +9,7 @@
 #import "BugsnagEventDeserializer.h"
 
 #import "BugsnagInternals.h"
+#import <Bugsnag/BugsnagStacktrace.h>
 
 @implementation BugsnagEventDeserializer
 
@@ -25,7 +26,7 @@
                                                        user:[[BugsnagUser alloc] initWithDictionary:user]
                                                    metadata:metadata
                                                 breadcrumbs:[self deserializeBreadcrumbs:payload[@"breadcrumbs"]]
-                                                     errors:@[[BugsnagError new]]
+                                                     errors:[self deserializeErrors:payload[@"errors"]]
                                                     threads:[self deserializeThreads:payload[@"threads"]]
                                                     session:nil /* set by -[BugsnagClient notifyInternal:block:] */];
     event.context = payload[@"context"];
@@ -49,13 +50,17 @@
         }
     }
 
-    NSDictionary *error = payload[@"errors"][0];
+    return event;
+}
 
-    if (error != nil) {
-        event.errors[0].errorClass = error[@"errorClass"];
-        event.errors[0].errorMessage = error[@"errorMessage"];
+- (NSArray<BugsnagError *> *)deserializeErrors:(NSArray *)errors {
+    NSMutableArray *array = [NSMutableArray new];
+    for (NSDictionary *error in errors) {
+        BugsnagError *errorObj = [BugsnagError new];
+        errorObj.errorClass = error[@"errorClass"];
+        errorObj.errorMessage = error[@"errorMessage"];
         NSArray<NSDictionary *> *stacktrace = error[@"stacktrace"];
-        NSArray<NSString *> *nativeStack = payload[@"nativeStack"];
+        NSArray<NSString *> *nativeStack = error[@"nativeStack"];
         if (nativeStack) {
             NSMutableArray<NSDictionary *> *mixedStack = [NSMutableArray array];
             for (BugsnagStackframe *frame in [BugsnagStackframe stackframesWithCallStackSymbols:nativeStack]) {
@@ -66,10 +71,13 @@
             [mixedStack addObjectsFromArray:stacktrace];
             stacktrace = mixedStack;
         }
-        [event attachCustomStacktrace:stacktrace withType:@"reactnativejs"];
+
+        errorObj.stacktrace = [BugsnagStacktrace stacktraceFromJson:stacktrace].trace;
+        errorObj.type = BSGErrorTypeReactNativeJs;
+        [array addObject:errorObj];
     }
 
-    return event;
+    return array;
 }
 
 - (NSArray *)deserializeBreadcrumbs:(NSArray *)crumbs {

--- a/test/react-native/features/native-stack-android.feature
+++ b/test/react-native/features/native-stack-android.feature
@@ -1,7 +1,8 @@
+@android_only
 Feature: Native stacktrace is parsed for promise rejections
 
 # Skipped on New Arch below 0.74 - see PLAT-12193
-@android_only @skip_new_arch_below_074
+@skip_new_arch_below_074
 Scenario: Handled native promise rejection with native stacktrace
   When I run "NativePromiseRejectionHandledScenario"
   Then I wait to receive an error
@@ -11,7 +12,6 @@ Scenario: Handled native promise rejection with native stacktrace
   # On 0.75+ the Error name is set to the native exception class
   And the event "exceptions.0.errorClass" equals the version-dependent string:
     | arch | version | value                      |
-    | new  | 0.72    | Error                      |
     | new  | 0.74    | Error                      |
     | new  | default | java.lang.RuntimeException |
     | old  | 0.68    | Error                      |
@@ -41,14 +41,14 @@ Scenario: Handled native promise rejection with native stacktrace
     | runScenario |
 
   # the javascript part follows
-  # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
+  # On New Arch there is no JS stacktrace - see PLAT-12193
   And the stacktrace contains "file" equal to the version-dependent string:
   | arch | version | value                   |
   | new  | default | @skip                   |
   | old  | default | index.android.bundle    |
 
 # Skipped on New Arch below 0.74 - see PLAT-12193
-@android_only @skip_new_arch_below_074
+@skip_new_arch_below_074
 Scenario: Unhandled native promise rejection with native stacktrace
   When I run "NativePromiseRejectionUnhandledScenario"
   Then I wait to receive an error
@@ -57,7 +57,6 @@ Scenario: Unhandled native promise rejection with native stacktrace
   # On 0.75+ the Error name is set to the native exception class
   And the event "exceptions.0.errorClass" equals the version-dependent string:
     | arch | version | value                      |
-    | new  | 0.72    | Error                      |
     | new  | 0.74    | Error                      |
     | new  | default | java.lang.RuntimeException |
     | old  | 0.68    | Error                      |
@@ -94,7 +93,7 @@ Scenario: Unhandled native promise rejection with native stacktrace
     | runScenario |
 
   # the javascript part follows
-  # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
+  # On New Arch there is no JS stacktrace - see PLAT-12193
   And the stacktrace contains "file" equal to the version-dependent string:
   | arch | version | value                   |
   | new  | default | @skip                   |
@@ -105,93 +104,47 @@ Scenario: Unhandled native promise rejection with native stacktrace
 #   And the error payload field "events.0.exceptions.1.stacktrace.1.lineNumber" equals 1
 #   And the error payload field "events.0.exceptions.1.stacktrace.2.lineNumber" equals 2
 
-# Skipped on New Arch below 0.74 - see PLAT-12193
-@ios_only @skip_new_arch_below_074
-Scenario: Handled native promise rejection with native stacktrace
-  When I run "NativePromiseRejectionHandledScenario"
-  Then I wait to receive an error
-  And the event "unhandled" is false
-  And the error payload field "events.0.exceptions" is an array with 1 elements
-  And the event "exceptions.0.errorClass" equals "Error"
-  And the event "exceptions.0.message" equals "NativePromiseRejectionHandledScenario"
-  And the event "exceptions.0.type" equals "reactnativejs"
-  And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
-
-  # the native part of the stack comes first
-  And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoVMAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.method" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "cocoa"
-
-  # the javascript part follows
-  # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
-  # We're check the method: asyncGeneratorStep
-  And the event "exceptions.0.stacktrace.21.columnNumber" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @not_null               |
-  | new  | default | @skip                   |
-  | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.21.file" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @not_null               |
-  | new  | default | @skip                   |
-  | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.21.lineNumber" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @not_null               |
-  | new  | default | @skip                   |
-  | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.21.type" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @null                   |
-  | new  | default | @skip                   |
-  | old  | default | @null                   |
-
-# Skipped on New Arch below 0.74 - see PLAT-12193
-@ios_only @skip_new_arch_below_074
-Scenario: Unhandled native promise rejection with native stacktrace
-  When I run "NativePromiseRejectionUnhandledScenario"
+@skip_old_arch @skip_new_arch_below_074
+Scenario: Unhandled exception in synchronous turbo module method with native stacktrace
+  When I run "UnhandledNativeErrorSyncScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledNativeErrorSyncScenario"
   Then I wait to receive an error
   And the event "unhandled" is true
+
+  # First exception is the JS Error with JS stacktrace
   And the event "exceptions.0.errorClass" equals "Error"
-  And the event "exceptions.0.message" equals "NativePromiseRejectionUnhandledScenario"
+  And the event "exceptions.0.message" equals "Exception in HostFunction: UnhandledNativeErrorScenario"
   And the event "exceptions.0.type" equals "reactnativejs"
-  And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+  And the event "exceptions.0.stacktrace.0.method" equals "runScenarioSync"
+  And the event "exceptions.0.stacktrace.0.file" equals "(native)"
+  And the event "exceptions.0.stacktrace.1.method" equals "run"
+  And the event "exceptions.0.stacktrace.1.file" equals "index.android.bundle"
 
-  # the native part of the stack comes first
-  And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.machoVMAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.method" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" is not null
-  And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "cocoa"
+  # Second exception (cause) is the native exception with native stacktrace
+  And the event "exceptions.1.errorClass" equals "java.lang.RuntimeException"
+  And the event "exceptions.1.message" equals "UnhandledNativeErrorScenario"
+  And the event "exceptions.1.type" equals "reactnativejs"
+  And the event "exceptions.1.stacktrace.0.method" equals "com.reactnative.scenarios.Scenario.generateException"
+  And the event "exceptions.1.stacktrace.0.file" equals "Scenario.kt"
+  And the event "exceptions.1.stacktrace.0.type" equals "android"
 
-  # the javascript part follows
-  # On 0.74+ New Arch there is no JS stacktrace - see PLAT-12193
-  # We're check the method: asyncGeneratorStep
-  And the event "exceptions.0.stacktrace.21.columnNumber" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @not_null               |
-  | new  | default | @skip                   |
-  | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.21.file" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @not_null               |
-  | new  | default | @skip                   |
-  | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.21.lineNumber" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @not_null               |
-  | new  | default | @skip                   |
-  | old  | default | @not_null               |
-  And the event "exceptions.0.stacktrace.21.type" equals the version-dependent string:
-  | arch | version | value                   |
-  | new  | 0.72    | @null                   |
-  | new  | default | @skip                   |
-  | old  | default | @null                   |
+@skip_old_arch @skip_new_arch_below_074
+Scenario: Unhandled exception in asynchronous turbo module method with native stacktrace
+  When I run "UnhandledNativeErrorScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledNativeErrorScenario"
+  Then I wait to receive an error
+  And the event "unhandled" is true
+
+  # First exception is the JS Error, however there is no JS stacktrace
+  And the event "exceptions.0.errorClass" equals "Error"
+  And the event "exceptions.0.message" equals "Exception in HostFunction: UnhandledNativeErrorScenario"
+  And the event "exceptions.0.type" equals "reactnativejs"
+  And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
+
+  # Second exception (cause) is the native exception with native stacktrace
+  And the event "exceptions.1.errorClass" equals "java.lang.RuntimeException"
+  And the event "exceptions.1.message" equals "UnhandledNativeErrorScenario"
+  And the event "exceptions.1.type" equals "reactnativejs"
+  And the event "exceptions.1.stacktrace.0.method" equals "com.reactnative.scenarios.Scenario.generateException"
+  And the event "exceptions.1.stacktrace.0.file" equals "Scenario.kt"
+  And the event "exceptions.1.stacktrace.0.type" equals "android"

--- a/test/react-native/features/native-stack-ios.feature
+++ b/test/react-native/features/native-stack-ios.feature
@@ -1,0 +1,116 @@
+@ios_only
+Feature: Native stacktrace is parsed for promise rejections
+
+# Skipped on New Arch below 0.74 - see PLAT-12193
+@skip_new_arch_below_074
+Scenario: Handled native promise rejection with native stacktrace
+  When I run "NativePromiseRejectionHandledScenario"
+  Then I wait to receive an error
+  And the event "unhandled" is false
+  And the error payload field "events.0.exceptions" is an array with 1 elements
+  And the event "exceptions.0.errorClass" equals "Error"
+  And the event "exceptions.0.message" equals "NativePromiseRejectionHandledScenario"
+  And the event "exceptions.0.type" equals "reactnativejs"
+  And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+
+  # the native part of the stack comes first
+  And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoVMAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.method" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "cocoa"
+
+  # the javascript part follows
+  # On New Arch there is no JS stacktrace - see PLAT-12193
+  # We're check the method: asyncGeneratorStep
+  And the event "exceptions.0.stacktrace.21.columnNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.21.file" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.21.lineNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.21.type" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @null                   |
+
+# Skipped on New Arch below 0.74 - see PLAT-12193
+@skip_new_arch_below_074
+Scenario: Unhandled native promise rejection with native stacktrace
+  When I run "NativePromiseRejectionUnhandledScenario"
+  Then I wait to receive an error
+  And the event "unhandled" is true
+  And the event "exceptions.0.errorClass" equals "Error"
+  And the event "exceptions.0.message" equals "NativePromiseRejectionUnhandledScenario"
+  And the event "exceptions.0.type" equals "reactnativejs"
+  And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+
+  # the native part of the stack comes first
+  And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" equals "reactnative"
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.machoVMAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.method" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" is not null
+  And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "cocoa"
+
+  # the javascript part follows
+  # On New Arch there is no JS stacktrace - see PLAT-12193
+  # We're check the method: asyncGeneratorStep
+  And the event "exceptions.0.stacktrace.21.columnNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.21.file" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.21.lineNumber" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @not_null               |
+  And the event "exceptions.0.stacktrace.21.type" equals the version-dependent string:
+  | arch | version | value                   |
+  | new  | default | @skip                   |
+  | old  | default | @null                   |
+
+@skip_old_arch @skip_new_arch_below_074
+Scenario: Unhandled synchronous turbo module exception with native stacktrace
+  When I run "UnhandledNativeErrorSyncScenario" and relaunch the crashed app
+  And I configure Bugsnag for "UnhandledNativeErrorSyncScenario"
+  Then I wait to receive an error
+  And the event "unhandled" is true
+
+  # First exception is the JS Error with JS stacktrace
+  And the event "exceptions.0.errorClass" equals "Error"
+  And the event "exceptions.0.message" equals the version-dependent string:
+  | arch | version | value                                                                                  |
+  | new  | 0.74    | Exception in HostFunction: UnhandledNativeErrorScenario                                |
+  | new  | default | BugsnagTestInterface.runScenarioSync raised an exception: UnhandledNativeErrorScenario |
+
+  And the event "exceptions.0.type" equals "reactnativejs"
+  And the event "exceptions.0.stacktrace.0.method" equals "runScenarioSync"
+  And the event "exceptions.0.stacktrace.0.file" equals "(native)"
+  And the event "exceptions.0.stacktrace.1.method" equals "run"
+  And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex "main\.jsbundle$"
+
+  # Second exception (cause) is the native exception with native stacktrace
+  And the event "exceptions.1.errorClass" equals "NSException"
+  And the event "exceptions.1.message" equals "UnhandledNativeErrorScenario"
+  And the event "exceptions.1.type" equals "reactnativejs"
+  And each element in error payload field "events.0.exceptions.1.stacktrace" has "frameAddress"
+  And each element in error payload field "events.0.exceptions.1.stacktrace" has "machoFile"
+  And each element in error payload field "events.0.exceptions.1.stacktrace" has "machoLoadAddress"
+  And each element in error payload field "events.0.exceptions.1.stacktrace" has "machoUUID"
+  And each element in error payload field "events.0.exceptions.1.stacktrace" has "machoVMAddress"
+  And each element in error payload field "events.0.exceptions.1.stacktrace" has "symbolAddress"


### PR DESCRIPTION
## Goal

In The New Architecture, when an unhandled exception occurs in a Turbo Module method, React Native throws a JS error with a `cause` property containing the native exception class, error message and stacktrace.

Although the JS SDK supports error causes, these native causes are not parsed correctly in events as they don't contain valid JS stacktraces (the cause stack is reported as `stackElements` on Android and `stackSymbols`/`stackReturnAddresses` on iOS) - so we end up reporting events with an empty stacktrace in the 'Caused by' error.

This PR fixes the error reporting for these cases, so that native 'Caused by' errors are reported correctly with a full native stacktrace while maintaining backwards compatibility with native stack handling for Old Architecture.

(Note: on iOS, exceptions in async Turbo Module methods result in a native crash that is detected by the Cocoa SDK, so this does not apply in those cases)

## Changeset

- Updated the native stack handling in `delivery-react-native` to extract the `nativeStack` property for native error causes.

- Updated `BugsnagEventDeserializer.m` in the iOS native module to correctly handle events containing multiple errors (the equivalent changes for Android were released in v6.22.0 of `bugsnag-plugin-react-native`)

## Testing

Added new unit test and e2e test cases