### PR TITLE
Update assertions on `freeDisk` on iOS

### DIFF
--- a/test/react-native/features/device-ios.feature
+++ b/test/react-native/features/device-ios.feature
@@ -21,8 +21,7 @@ Scenario: Device data in Handled JS error
   And the event "device.runtimeVersions.reactNativeJsEngine" matches "^jsc|hermes$"
   And the error payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
-  # Skipped - PLAT-11345
-  # And the error payload field "events.0.device.freeDisk" is greater than 0
+  And the error payload field "events.0.device.freeDisk" is null
   And the event "device.modelNumber" is not null
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
@@ -48,8 +47,7 @@ Scenario: Device data in Unhandled JS error
   And the event "device.runtimeVersions.reactNativeJsEngine" matches "^jsc|hermes$"
   And the error payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
-  # Skipped - PLAT-11345
-  # And the error payload field "events.0.device.freeDisk" is greater than 0
+  And the error payload field "events.0.device.freeDisk" is null
   And the event "device.modelNumber" is not null
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
@@ -74,8 +72,7 @@ Scenario: Device data in Handled native error
   And the event "device.runtimeVersions.reactNativeJsEngine" matches "^jsc|hermes$"
   And the error payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
-  # Skipped - PLAT-11345
-  # And the error payload field "events.0.device.freeDisk" is greater than 0
+  And the error payload field "events.0.device.freeDisk" is null
   And the event "device.modelNumber" is not null
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0
@@ -98,8 +95,7 @@ Scenario: Device data in Unhandled native error
   And the event "device.runtimeVersions.clangVersion" matches "^\d+\.\d+\.\d+.+$"
   And the error payload field "events.0.device.freeMemory" is greater than 0
   And the event "device.manufacturer" equals "Apple"
-  # Skipped - PLAT-11345
-  # And the error payload field "events.0.device.freeDisk" is greater than 0
+  And the error payload field "events.0.device.freeDisk" is null
   And the event "device.modelNumber" is not null
   And the event "device.model" matches "^iPhone|iPad(\d|[,\.])+$"
   And the error payload field "events.0.device.totalMemory" is greater than 0


### PR DESCRIPTION
## Goal

Add null check for `freeDisk` on iOS to existing tests - this value is no longer automatically set on iOS.

This could be manually set and asserted against in the scenario, i.e.:

```
[Bugsnag.instance.configuration.device setValue:@(1234567) forKey:@"freeDisk"];
```

but does not feel like a useful test.