### PR TITLE
fix deprication warning issue for parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (delivery-node) Replace deprecated `url.parse()` with `URL` constructor [#2730](https://github.com/bugsnag/bugsnag-js/pull/2730)
+
 ## [8.9.0] - 2026-04-08
 
 ### Fixed

--- a/packages/delivery-node/request.js
+++ b/packages/delivery-node/request.js
@@ -1,7 +1,6 @@
 const http = require('http')
 const https = require('https')
-// eslint-disable-next-line node/no-deprecated-api
-const { parse } = require('url')
+
 
 module.exports = ({ url, headers, body, agent }, cb) => {
   let didError = false
@@ -11,14 +10,14 @@ module.exports = ({ url, headers, body, agent }, cb) => {
     cb(err)
   }
 
-  const parsedUrl = parse(url)
+  const parsedUrl = new URL(url)
   const secure = parsedUrl.protocol === 'https:'
   const transport = secure ? https : http
   const req = transport.request({
     method: 'POST',
     hostname: parsedUrl.hostname,
     port: parsedUrl.port,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname + parsedUrl.search,
     headers,
     agent
   })

--- a/packages/delivery-node/request.js
+++ b/packages/delivery-node/request.js
@@ -1,7 +1,6 @@
 const http = require('http')
 const https = require('https')
 
-
 module.exports = ({ url, headers, body, agent }, cb) => {
   let didError = false
   const onError = (err) => {


### PR DESCRIPTION
## Goal

Fix deprecation warning for parse(url);

## Changeset

update with new URL(url) inside request.js

## Testing

did unit testing