### PR TITLE
Upgrade Appium Version from 1.22 to 2.19.

### DIFF
--- a/.buildkite/basic/react-native-android-full-pipeline.yml
+++ b/.buildkite/basic/react-native-android-full-pipeline.yml
@@ -157,7 +157,7 @@ steps:
               - --app=/app/features/fixtures/generated/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
-              - --appium-version=1.22
+              - --appium-version=2.19
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip
@@ -206,7 +206,7 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix.reactnative}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
-              - --appium-version=1.22
+              - --appium-version=2.19
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip
@@ -260,7 +260,7 @@ steps:
               - --app=/app/features/fixtures/generated/react-native-navigation/old-arch/{{matrix}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
-              - --appium-version=1.22
+              - --appium-version=2.19
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip
@@ -302,7 +302,7 @@ steps:
               - --app=/app/features/fixtures/generated/react-native-navigation/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
-              - --appium-version=1.22
+              - --appium-version=2.19
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip

--- a/.buildkite/basic/react-native-android-pipeline.yml
+++ b/.buildkite/basic/react-native-android-pipeline.yml
@@ -47,7 +47,7 @@ steps:
               - --app=/app/features/fixtures/generated/new-arch/{{matrix}}/reactnative.apk
               - --farm=bb
               - --device=ANDROID_12
-              - --appium-version=1.22
+              - --appium-version=2.19
               - --fail-fast
               - --no-tunnel
               - --aws-public-ip

--- a/test/react-native/features/support/maze.all.cfg
+++ b/test/react-native/features/support/maze.all.cfg
@@ -1,1 +1,4 @@
 --a11y-locator
+--fail-fast
+--app-package=com.reactnative
+--app-activity=com.reactnative.MainActivity

--- a/test/react-native/features/support/maze.all.cfg
+++ b/test/react-native/features/support/maze.all.cfg
@@ -1,4 +1,3 @@
 --a11y-locator
---fail-fast
 --app-package=com.reactnative
 --app-activity=com.reactnative.MainActivity


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Bumped --appium-version from 1.22 to 2.19 in the React Native Android Buildkite pipelines.

## Design

<!-- Why was this approach used? -->
Earlier pipeline was using appium version 1.22 so we have changed appium version 2.19 commonly.

## Changeset

<!-- What changed? -->

Changed Pipeline.yml files to update version of appium from 1.22 to 2.19
Changed in maze config file : Added app package and app activity.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Yes, We have tested manual and automated maze runner test cases BB.