### PR TITLE
await next in hono error handler middleware

### DIFF
--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -38,3 +38,11 @@ jobs:
         cd test/aws-lambda
         bundle install
         bundle exec maze-runner
+
+    - name: Upload test artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: aws-lambda-test-results
+        path: test/aws-lambda/maze_output/
+        if-no-files-found: ignore

--- a/.github/workflows/aws-lambda.yml
+++ b/.github/workflows/aws-lambda.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Upload test artifacts
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: aws-lambda-test-results
         path: test/aws-lambda/maze_output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (plugin-hono) Fix issue where error handler middleware did not `await next()` [#2735](https://github.com/bugsnag/bugsnag-js/pull/2735)
+
 ## [8.9.0] - 2026-04-08
 
 ### Fixed

--- a/packages/plugin-hono/src/hono.js
+++ b/packages/plugin-hono/src/hono.js
@@ -37,15 +37,12 @@ module.exports = {
     })
 
     const errorHandler = createMiddleware(async (c, next) => {
-      let rethrow = false
-
       try {
         // Catch non-errors thrown in routes without causing the route to hang by awaiting the next() call inside a try/catch block.
         // The error is then attached to the context and processed in the same way as errors thrown in routes.
         await next()
       } catch (err) {
         c.error = err
-        rethrow = true
       }
 
       if (!c.error) return
@@ -65,8 +62,6 @@ module.exports = {
           client._notify(event)
         }
       }
-
-      if (rethrow) throw c.error
     })
 
     return { requestHandler, errorHandler }

--- a/packages/plugin-hono/src/hono.js
+++ b/packages/plugin-hono/src/hono.js
@@ -37,7 +37,7 @@ module.exports = {
     })
 
     const errorHandler = createMiddleware(async (c, next) => {
-      next()
+      await next()
 
       if (!c.error || !client._config.autoDetectErrors) return
 

--- a/packages/plugin-hono/src/hono.js
+++ b/packages/plugin-hono/src/hono.js
@@ -37,7 +37,13 @@ module.exports = {
     })
 
     const errorHandler = createMiddleware(async (c, next) => {
-      await next()
+      try {
+        // Catch non-errors thrown in routes without causing the route to hang by awaiting the next() call inside a try/catch block.
+        // The error is then attached to the context and processed in the same way as errors thrown in routes.
+        await next()
+      } catch (err) {
+        c.error = err
+      }
 
       if (!c.error || !client._config.autoDetectErrors) return
 

--- a/packages/plugin-hono/src/hono.js
+++ b/packages/plugin-hono/src/hono.js
@@ -37,12 +37,15 @@ module.exports = {
     })
 
     const errorHandler = createMiddleware(async (c, next) => {
+      let rethrow = false
+
       try {
         // Catch non-errors thrown in routes without causing the route to hang by awaiting the next() call inside a try/catch block.
         // The error is then attached to the context and processed in the same way as errors thrown in routes.
         await next()
       } catch (err) {
         c.error = err
+        rethrow = true
       }
 
       if (!c.error) return
@@ -62,6 +65,8 @@ module.exports = {
           client._notify(event)
         }
       }
+
+      if (rethrow) throw c.error
     })
 
     return { requestHandler, errorHandler }

--- a/packages/plugin-hono/src/hono.js
+++ b/packages/plugin-hono/src/hono.js
@@ -40,8 +40,8 @@ module.exports = {
       let rethrow = false
 
       try {
-        // Catch non-errors thrown in routes without causing the route to hang by awaiting the next() call inside a try/catch block.
-        // The error is then attached to the context and processed in the same way as errors thrown in routes.
+        // Catch all thrown values from routes by awaiting next() inside a try/catch block.
+        // This also ensures non-Error throws are attached to the context and processed without causing the route to hang.
         await next()
       } catch (err) {
         c.error = err

--- a/packages/plugin-hono/src/hono.js
+++ b/packages/plugin-hono/src/hono.js
@@ -37,29 +37,36 @@ module.exports = {
     })
 
     const errorHandler = createMiddleware(async (c, next) => {
+      let rethrow = false
+
       try {
         // Catch non-errors thrown in routes without causing the route to hang by awaiting the next() call inside a try/catch block.
         // The error is then attached to the context and processed in the same way as errors thrown in routes.
         await next()
       } catch (err) {
         c.error = err
+        rethrow = true
       }
 
-      if (!c.error || !client._config.autoDetectErrors) return
+      if (!c.error) return
 
-      const event = client.Event.create(c.error, false, handledState, 'hono middleware', 1)
+      if (client._config.autoDetectErrors) {
+        const event = client.Event.create(c.error, false, handledState, 'hono middleware', 1)
 
-      if (c.bugsnag) {
-        c.bugsnag._notify(event)
-      } else {
-        client._logger.warn(
-          'c.bugsnag is not defined. Make sure the @bugsnag/plugin-hono requestHandler middleware is added first.'
-        )
-        const { metadata, request } = await getRequestAndMetadataFromReq(c)
-        event.request = { ...event.request, ...request }
-        event.addMetadata('request', metadata)
-        client._notify(event)
+        if (c.bugsnag) {
+          c.bugsnag._notify(event)
+        } else {
+          client._logger.warn(
+            'c.bugsnag is not defined. Make sure the @bugsnag/plugin-hono requestHandler middleware is added first.'
+          )
+          const { metadata, request } = await getRequestAndMetadataFromReq(c)
+          event.request = { ...event.request, ...request }
+          event.addMetadata('request', metadata)
+          client._notify(event)
+        }
       }
+
+      if (rethrow) throw c.error
     })
 
     return { requestHandler, errorHandler }

--- a/test/aws-lambda/features/promise-rejection.feature
+++ b/test/aws-lambda/features/promise-rejection.feature
@@ -117,9 +117,7 @@ Scenario Outline: thrown non-error exceptions are reported when using hono
     Given I setup the environment
     When I invoke the "HonoFunction" lambda in "features/fixtures/hono-app" with the "events/throw-non-error.json" event
     Then the lambda response "errorMessage" equals "1"
-    And the lambda response "errorType" equals "Runtime.UnhandledPromiseRejection"
-    And the lambda response "trace" is an array with 4 elements
-    And the lambda response "trace.0" equals "Runtime.UnhandledPromiseRejection: 1"
+    And the lambda response "errorType" equals "number"
     And the lambda response "body" is null
     And the lambda response "statusCode" is null
     And the SAM exit code equals 0
@@ -127,9 +125,9 @@ Scenario Outline: thrown non-error exceptions are reported when using hono
     Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
     And the event "unhandled" is true
     And the event "severity" equals "error"
-    And the event "severityReason.type" equals "unhandledPromiseRejection"
+    And the event "severityReason.type" equals "unhandledErrorMiddleware"
     And the exception "errorClass" equals "InvalidError"
-    And the exception "message" matches "unhandledRejection handler received a non-error\."
+    And the exception "message" matches "unhandledErrorMiddleware handler received a non-error\."
     And the exception "type" equals "nodejs"
     And the event "metaData.AWS Lambda context.functionName" equals "HonoFunction"
     And the event "metaData.AWS Lambda context.awsRequestId" is not null

--- a/test/aws-lambda/features/promise-rejection.feature
+++ b/test/aws-lambda/features/promise-rejection.feature
@@ -111,30 +111,3 @@ Scenario: promise rejections are reported when using hono
     Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
     And the session "id" is not null
     And the session "startedAt" is a timestamp
-
-@hono-app
-Scenario Outline: thrown non-error exceptions are reported when using hono
-    Given I setup the environment
-    When I invoke the "HonoFunction" lambda in "features/fixtures/hono-app" with the "events/throw-non-error.json" event
-    Then the lambda response "errorMessage" equals "1"
-    And the lambda response "errorType" equals "number"
-    And the lambda response "body" is null
-    And the lambda response "statusCode" is null
-    And the SAM exit code equals 0
-    When I wait to receive an error
-    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
-    And the event "unhandled" is true
-    And the event "severity" equals "error"
-    And the event "severityReason.type" equals "unhandledErrorMiddleware"
-    And the exception "errorClass" equals "InvalidError"
-    And the exception "message" matches "unhandledErrorMiddleware handler received a non-error\."
-    And the exception "type" equals "nodejs"
-    And the event "metaData.AWS Lambda context.functionName" equals "HonoFunction"
-    And the event "metaData.AWS Lambda context.awsRequestId" is not null
-    And the event "device.runtimeVersions.node" matches "^18\.\d+\.\d+$"
-    When I wait to receive a session
-    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
-    And the session "id" is not null
-    And the session "startedAt" is a timestamp
-    And the event "session.events.handled" equals 0
-    And the event "session.events.unhandled" equals 1

--- a/test/aws-lambda/features/unhandled.feature
+++ b/test/aws-lambda/features/unhandled.feature
@@ -132,7 +132,7 @@ Scenario: unhandled asynchronous exceptions are reported when using serverless-e
     And the event "session.events.unhandled" equals 1
 
 @hono-app
-Scenario Outline: unhandled exceptions are reported when using hono
+Scenario: unhandled exceptions are reported when using hono
     Given I setup the environment
     When I invoke the "HonoFunction" lambda in "features/fixtures/hono-app" with the "events/unhandled.json" event
     And the SAM exit code equals 0
@@ -156,7 +156,7 @@ Scenario Outline: unhandled exceptions are reported when using hono
     And the event "session.events.unhandled" equals 1
 
 @hono-app
-Scenario Outline: unhandled asynchronous exceptions are reported when using hono
+Scenario: unhandled asynchronous exceptions are reported when using hono
     Given I setup the environment
     When I invoke the "HonoFunction" lambda in "features/fixtures/hono-app" with the "events/unhandled-async.json" event
     And the SAM exit code equals 0
@@ -180,7 +180,7 @@ Scenario Outline: unhandled asynchronous exceptions are reported when using hono
     And the event "session.events.unhandled" equals 1
 
 @hono-app
-Scenario Outline: thrown non-error exceptions are reported when using hono
+Scenario: thrown non-error exceptions are reported when using hono
     Given I setup the environment
     When I invoke the "HonoFunction" lambda in "features/fixtures/hono-app" with the "events/throw-non-error.json" event
     Then the lambda response "errorMessage" equals "1"

--- a/test/aws-lambda/features/unhandled.feature
+++ b/test/aws-lambda/features/unhandled.feature
@@ -179,3 +179,44 @@ Scenario Outline: unhandled asynchronous exceptions are reported when using hono
     And the event "session.events.handled" equals 0
     And the event "session.events.unhandled" equals 1
 
+@hono-app
+Scenario Outline: thrown non-error exceptions are reported when using hono
+    Given I setup the environment
+    When I invoke the "HonoFunction" lambda in "features/fixtures/hono-app" with the "events/throw-non-error.json" event
+    Then the lambda response "errorMessage" equals "1"
+    And the lambda response "errorType" equals "number"
+    And the lambda response "body" is null
+    And the lambda response "statusCode" is null
+    And the SAM exit code equals 0
+    When I wait to receive 2 errors
+
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "unhandledException"
+    And the exception "errorClass" equals "Error"
+    And the exception "message" equals "1"
+    And the exception "type" equals "nodejs"
+    And the event "metaData.AWS Lambda context.functionName" equals "HonoFunction"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    And the event "device.runtimeVersions.node" matches "^18\.\d+\.\d+$"
+
+    # Error thrown by hono
+    And I discard the oldest error
+    Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "unhandledErrorMiddleware"
+    And the exception "errorClass" equals "InvalidError"
+    And the exception "message" matches "hono middleware received a non-error\."
+    And the exception "type" equals "nodejs"
+    And the event "metaData.AWS Lambda context.functionName" equals "HonoFunction"
+    And the event "metaData.AWS Lambda context.awsRequestId" is not null
+    And the event "device.runtimeVersions.node" matches "^18\.\d+\.\d+$"
+
+    When I wait to receive a session
+    Then the session is valid for the session reporting API version "1" for the "Bugsnag Node" notifier
+    And the session "id" is not null
+    And the session "startedAt" is a timestamp
+    And the event "session.events.handled" equals 0
+    And the event "session.events.unhandled" equals 1

--- a/test/node/features/express.feature
+++ b/test/node/features/express.feature
@@ -163,7 +163,7 @@ Scenario: an unhandled promise rejection in an async callback (without request c
   And the exception "message" equals "unhandled rejection in async callback"
 
 Scenario: adding body to request metadata
-  When I POST the data "data=in_request_body" to the URL "http://express/bodytest"
+  When I POST the data "data=in_request_body" to the URL "http://express/bodytest" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -215,7 +215,7 @@ Scenario: Context-aware console breadcrumbs
   And the event "request.clientIp" is not null
 
 Scenario: context loss
-  When I POST the data "some=body_data" to the URL "http://express/context-loss"
+  When I POST the data "some=body_data" to the URL "http://express/context-loss" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the exception "errorClass" equals "Error"

--- a/test/node/features/express_disabled.feature
+++ b/test/node/features/express_disabled.feature
@@ -50,5 +50,5 @@ Scenario: a handled error passed to req.bugsnag.notify()
   And the event "request.clientIp" is not null
 
 Scenario: adding body to request metadata
-  When I POST the data "data=in_request_body" to the URL "http://express-disabled/bodytest"
+  When I POST the data "data=in_request_body" to the URL "http://express-disabled/bodytest" with the content type "application/x-www-form-urlencoded"
   And I should receive no errors

--- a/test/node/features/feature_flags.feature
+++ b/test/node/features/feature_flags.feature
@@ -9,7 +9,7 @@ Background:
 Scenario: adding feature flags for an unhandled error
   Given I start the service "express"
   And I wait for the host "express" to open port "80"
-  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://express/features/unhandled"
+  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://express/features/unhandled" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -29,7 +29,7 @@ Scenario: adding feature flags for an unhandled error
      | d             | 4       |
   # ensure each request can have its own set of feature flags
   When I discard the oldest error
-  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/unhandled"
+  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/unhandled" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   And the event contains the following feature flags:
      | featureFlag   | variant |
@@ -42,7 +42,7 @@ Scenario: adding feature flags for an unhandled error
 Scenario: adding feature flags for a handled error
   Given I start the service "express"
   And I wait for the host "express" to open port "80"
-  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://express/features/handled"
+  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://express/features/handled" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is false
@@ -62,7 +62,7 @@ Scenario: adding feature flags for a handled error
      | d             | 4       |
   # ensure each request can have its own set of feature flags
   When I discard the oldest error
-  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/handled"
+  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/handled" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   And the event contains the following feature flags:
      | featureFlag   | variant |
@@ -75,7 +75,7 @@ Scenario: adding feature flags for a handled error
 Scenario: clearing all feature flags doesn't affect subsequent requests
   Given I start the service "express"
   And I wait for the host "express" to open port "80"
-  When I POST the data "a=1&b=2&c=3&d=4&clearAllFeatureFlags" to the URL "http://express/features/unhandled"
+  When I POST the data "a=1&b=2&c=3&d=4&clearAllFeatureFlags" to the URL "http://express/features/unhandled" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
@@ -87,7 +87,7 @@ Scenario: clearing all feature flags doesn't affect subsequent requests
   And the event "request.httpMethod" equals "POST"
   And the event has no feature flags
   When I discard the oldest error
-  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/unhandled"
+  And I POST the data "x=9&y=8&z=7" to the URL "http://express/features/unhandled" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   And the event contains the following feature flags:
      | featureFlag   | variant |

--- a/test/node/features/fixtures/hono/Dockerfile
+++ b/test/node/features/fixtures/hono/Dockerfile
@@ -10,7 +10,5 @@ COPY . ./
 
 RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
-EXPOSE 80
-
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/hono/Dockerfile
+++ b/test/node/features/fixtures/hono/Dockerfile
@@ -10,5 +10,7 @@ COPY . ./
 
 RUN npm install --no-package-lock --no-save bugsnag-*.tgz
 
+EXPOSE 80
+
 ENV NODE_ENV production
 CMD node scenarios/app

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -23,7 +23,7 @@ app.get('/', (c) => {
 })
 
 app.get('/handled', async (c, next) => {
-    Bugsnag.notify(new Error('handled'));
+    c.bugsnag.notify(new Error('handled'));
     await next();
 });
 
@@ -56,7 +56,7 @@ app.get('/throw-non-error', async (c, next) => {
 // Causes a 'Context is not finalized' Error if the error handler middleware does not `await next()`
 app.post('/post-body', async (c) => {
   await c.req.raw.json();
-  Bugsnag.notify(new Error('error in post body route'));
+  c.bugsnag.notify(new Error('error in post body route'));
   return c.json({ a: 'test' });
 });
 

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -16,7 +16,6 @@ const app = new Hono();
 const middleware = Bugsnag.getPlugin('hono')
 
 app.use(middleware.requestHandler)
-
 app.use(middleware.errorHandler)
 
 app.get('/', (c) => {
@@ -52,14 +51,15 @@ app.get('/throw-non-error', async (c, next) => {
     throw 1 
 })
 
-app.get('/post-body', () => {
-    app.fetch('http://localhost/post', {
+app.get('/post-body', async (c) => {
+    const response = await app.fetch('http://127.0.0.1/post', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },
         body: JSON.stringify({ a: 1, b: 2 })
     })
+    return response;
 })
 
 app.post('/post', async (c) => {
@@ -71,3 +71,12 @@ serve({
     fetch: app.fetch,
     port: 80
 });
+
+// Keep the process alive
+process.on('SIGTERM', () => {
+    process.exit(0)
+})
+
+process.on('SIGINT', () => {
+    process.exit(0)
+})

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -48,8 +48,7 @@ app.get('/rejection-async', (c) => {
     }, 100)
 })
 
-// This route does not work with local testing, not sure why it's running here
-app.get('/throw-non-error', async (c, next) => {
+app.get('/throw-non-error', async (c) => {
     throw 1 
 })
 
@@ -64,12 +63,3 @@ serve({
     fetch: app.fetch,
     port: 80
 });
-
-// Keep the process alive
-process.on('SIGTERM', () => {
-    process.exit(0)
-})
-
-process.on('SIGINT', () => {
-    process.exit(0)
-})

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -56,7 +56,7 @@ app.get('/throw-non-error', async (c, next) => {
 // Causes a 'Context is not finalized' Error if the error handler middleware does not `await next()`
 app.post('/post-body', async (c) => {
   await c.req.raw.json();
-  Bugsnag.notify(new Error('error in post body route'))
+  Bugsnag.notify(new Error('error in post body route'));
   return c.json({ a: 'test' });
 });
 

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -51,21 +51,9 @@ app.get('/throw-non-error', async (c, next) => {
     throw 1 
 })
 
-app.get('/post-body', async (c) => {
-    const response = await app.fetch('http://127.0.0.1/post', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ a: 1, b: 2 })
-    })
-    return response;
+app.get('/health', (c) => {
+    return c.json({ status: 'ok' })
 })
-
-app.post('/post', async (c) => {
-    await c.req.raw.json();
-    return c.json({});
-});
 
 serve({
     fetch: app.fetch,

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -31,6 +31,7 @@ app.get('/sync', (c) => {
     throw new Error('sync')
 })
 
+// Causes the app to crash
 app.get('/async', (c) => {
     setTimeout(function () {
         throw new Error('async')
@@ -47,13 +48,17 @@ app.get('/rejection-async', (c) => {
     }, 100)
 })
 
+// This route does not work with local testing, not sure why it's running here
 app.get('/throw-non-error', async (c, next) => {
     throw 1 
 })
 
-app.get('/health', (c) => {
-    return c.json({ status: 'ok' })
-})
+// Causes a 'Context is not finalized' Error if the error handler middleware does not `await next()`
+app.post('/post-body', async (c) => {
+  await c.req.raw.json();
+  Bugsnag.notify(new Error('error in post body route'))
+  return c.json({ a: 'test' });
+});
 
 serve({
     fetch: app.fetch,

--- a/test/node/features/fixtures/hono/scenarios/app.js
+++ b/test/node/features/fixtures/hono/scenarios/app.js
@@ -52,6 +52,21 @@ app.get('/throw-non-error', async (c, next) => {
     throw 1 
 })
 
+app.get('/post-body', () => {
+    app.fetch('http://localhost/post', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ a: 1, b: 2 })
+    })
+})
+
+app.post('/post', async (c) => {
+    await c.req.raw.json();
+    return c.json({});
+});
+
 serve({
     fetch: app.fetch,
     port: 80

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -91,9 +91,9 @@ Scenario: throwing non-Error error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
-  And the event "severityReason.type" equals "unhandledPromiseRejection"
+  And the event "severityReason.type" equals "unhandledErrorMiddleware"
   And the exception "errorClass" equals "InvalidError"
-  And the exception "message" matches "unhandledRejection handler received a non-error\."
+  And the exception "message" matches "hono middleware received a non-error. See \"hono middleware\" tab for more detail."
   And the exception "type" equals "nodejs"
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -97,6 +97,6 @@ Scenario: throwing non-Error error
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"
 
-Scenario: post request with JSON body
-  When I open the URL "http://hono/post"
-  Then I should receive no errors
+# Scenario: post request with JSON body
+#   When I open the URL "http://hono/post"
+#   Then I should receive no errors

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -97,6 +97,6 @@ Scenario: throwing non-Error error
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"
 
-# Scenario: post request with JSON body
-#   When I open the URL "http://hono/post"
-#   Then I should receive no errors
+Scenario: post request with JSON body
+  When I open the URL "http://hono/post"
+  Then I should receive no errors

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -20,7 +20,6 @@ Scenario: A handled error
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/handled"
   And the event "request.httpMethod" equals "GET"
-  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: a synchronous thrown error in a route
   Then I open the URL "http://hono/sync?a=1&b=2c" tolerating any error
@@ -40,8 +39,8 @@ Scenario: a synchronous thrown error in a route
   And the event "metaData.request.path" equals "/sync"
   And the event "metaData.request.query.a" equals "1"
   And the event "metaData.request.query.b" equals "2c"
-  Then I open the URL "http://hono/health" and get a 200 response
 
+# This route will cause the app to crash
 Scenario: an asynchronous thrown error in a route
   Then I open the URL "http://hono/async" tolerating any error
   And I wait to receive an error
@@ -57,7 +56,6 @@ Scenario: an asynchronous thrown error in a route
   And the event "request.url" equals "http://hono/async"
   And the event "request.httpMethod" equals "GET"
   And the event "severityReason.attributes.framework" equals "Hono"
-  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: a synchronous promise rejection in a route
   Then I open the URL "http://hono/rejection-sync"
@@ -72,7 +70,6 @@ Scenario: a synchronous promise rejection in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/rejection-sync"
   And the event "request.httpMethod" equals "GET"
-  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: an asynchronous promise rejection in a route
   Then I open the URL "http://hono/rejection-async"
@@ -87,7 +84,6 @@ Scenario: an asynchronous promise rejection in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/rejection-async"
   And the event "request.httpMethod" equals "GET"
-  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: throwing non-Error error
   Then I open the URL "http://hono/throw-non-error"
@@ -101,4 +97,16 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"
-  Then I open the URL "http://hono/health" and get a 200 response
+
+Scenario: error handler awaits next()
+  When I POST the data "{}" to the URL "http://hono/post-body"
+  Then I wait to receive an error
+  Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the exception "errorClass" equals "Error"
+  And the exception "message" matches "error in post body route\."
+  And the exception "type" equals "nodejs"
+  And the "file" of stack frame 0 equals "scenarios/app.js"
+  And the event "request.url" equals "http://hono/post-body"
+  And the event "request.httpMethod" equals "POST"

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -99,7 +99,7 @@ Scenario: throwing non-Error error
   And the event "request.httpMethod" equals "GET"
 
 Scenario: error handler awaits next()
-  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://hono/post-body"
+  When I POST the JSON data "{\"a\":1,\"b\":2}" to the URL "http://hono/post-body"
   Then I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is false

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -99,13 +99,13 @@ Scenario: throwing non-Error error
   And the event "request.httpMethod" equals "GET"
 
 Scenario: error handler awaits next()
-  When I POST the JSON data "{\"a\":1,\"b\":2}" to the URL "http://hono/post-body"
+  When I POST the data "{\"a\":1,\"b\":2}" to the URL "http://hono/post-body" with the content type "application/json"
   Then I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the exception "errorClass" equals "Error"
-  And the exception "message" matches "error in post body route\."
+  And the exception "message" matches "error in post body route"
   And the exception "type" equals "nodejs"
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/post-body"

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -20,6 +20,7 @@ Scenario: A handled error
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/handled"
   And the event "request.httpMethod" equals "GET"
+  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: a synchronous thrown error in a route
   Then I open the URL "http://hono/sync?a=1&b=2c" tolerating any error
@@ -39,6 +40,7 @@ Scenario: a synchronous thrown error in a route
   And the event "metaData.request.path" equals "/sync"
   And the event "metaData.request.query.a" equals "1"
   And the event "metaData.request.query.b" equals "2c"
+  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: an asynchronous thrown error in a route
   Then I open the URL "http://hono/async" tolerating any error
@@ -55,6 +57,7 @@ Scenario: an asynchronous thrown error in a route
   And the event "request.url" equals "http://hono/async"
   And the event "request.httpMethod" equals "GET"
   And the event "severityReason.attributes.framework" equals "Hono"
+  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: a synchronous promise rejection in a route
   Then I open the URL "http://hono/rejection-sync"
@@ -69,6 +72,7 @@ Scenario: a synchronous promise rejection in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/rejection-sync"
   And the event "request.httpMethod" equals "GET"
+  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: an asynchronous promise rejection in a route
   Then I open the URL "http://hono/rejection-async"
@@ -83,6 +87,7 @@ Scenario: an asynchronous promise rejection in a route
   And the "file" of stack frame 0 equals "scenarios/app.js"
   And the event "request.url" equals "http://hono/rejection-async"
   And the event "request.httpMethod" equals "GET"
+  Then I open the URL "http://hono/health" and get a 200 response
 
 Scenario: throwing non-Error error
   Then I open the URL "http://hono/throw-non-error"
@@ -96,7 +101,4 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"
-
-Scenario: post request with JSON body
-  When I open the URL "http://hono/post"
-  Then I should receive no errors
+  Then I open the URL "http://hono/health" and get a 200 response

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -93,7 +93,7 @@ Scenario: throwing non-Error error
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledErrorMiddleware"
   And the exception "errorClass" equals "InvalidError"
-  And the exception "message" matches "hono middleware received a non-error. See \"hono middleware\" tab for more detail."
+  And the exception "message" matches "hono middleware received a non-error\."
   And the exception "type" equals "nodejs"
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -96,3 +96,7 @@ Scenario: throwing non-Error error
   And the exception "type" equals "nodejs"
   And the event "request.url" equals "http://hono/throw-non-error"
   And the event "request.httpMethod" equals "GET"
+
+Scenario: post request with JSON body
+  When I open the URL "http://hono/post"
+  Then I should receive no errors

--- a/test/node/features/hono.feature
+++ b/test/node/features/hono.feature
@@ -99,7 +99,7 @@ Scenario: throwing non-Error error
   And the event "request.httpMethod" equals "GET"
 
 Scenario: error handler awaits next()
-  When I POST the data "{}" to the URL "http://hono/post-body"
+  When I POST the data "a=1&b=2&c=3&d=4" to the URL "http://hono/post-body"
   Then I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is false

--- a/test/node/features/koa.feature
+++ b/test/node/features/koa.feature
@@ -114,7 +114,7 @@ Scenario: A handled error with ctx.bugsnag.notify()
   And the event "metaData.error_handler.after" is null
 
 Scenario: adding body to request metadata
-  When I POST the data "data=in_request_body" to the URL "http://koa/bodytest"
+  When I POST the data "data=in_request_body" to the URL "http://koa/bodytest" with the content type "application/x-www-form-urlencoded"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4" for the "Bugsnag Node" notifier
   And the event "unhandled" is true

--- a/test/node/features/koa_disabled.feature
+++ b/test/node/features/koa_disabled.feature
@@ -46,5 +46,5 @@ Scenario: A handled error with ctx.bugsnag.notify()
   And the event "request.clientIp" is not null
 
 Scenario: adding body to request metadata
-  When I POST the data "data=in_request_body" to the URL "http://koa-disabled/bodytest"
+  When I POST the data "data=in_request_body" to the URL "http://koa-disabled/bodytest" with the content type "application/x-www-form-urlencoded"
   And I should receive no errors

--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -4,24 +4,11 @@ require 'net/http'
 #
 # @step_input reqbody [String] urlencoded data to send.
 # @step_input url [String] The URL to post data to.
-When("I POST the data {string} to the URL {string}") do |reqbody, url|
+# @step_input content_type [String] The content type of the data being sent.
+When("I POST the data {string} to the URL {string} with content type {string}") do |reqbody, url, content_type|
   Net::HTTP.post(URI(url),
                  reqbody,
-                 'Content-Type' => 'application/x-www-form-urlencoded')
-end
-
-# Attempts to POST a string of JSON data to a server.
-#
-# @step_input reqbody [String] JSON data to send.
-# @step_input url [String] The URL to post data to.
-When("I POST the JSON data {string} to the URL {string}") do |reqbody, url|
-  response = Net::HTTP.post(URI(url),
-                            reqbody,
-                            'Content-Type' => 'application/json')
-  
-  unless response.is_a?(Net::HTTPSuccess)
-    raise "POST request failed with response code #{response.code}. Response body:\n\n#{response.body}"
-  end
+                 'Content-Type' => content_type)
 end
 
 When('I open the URL {string} tolerating any error') do |url|

--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -5,7 +5,7 @@ require 'net/http'
 # @step_input reqbody [String] urlencoded data to send.
 # @step_input url [String] The URL to post data to.
 # @step_input content_type [String] The content type of the data being sent.
-When("I POST the data {string} to the URL {string} with content type {string}") do |reqbody, url, content_type|
+When("I POST the data {string} to the URL {string} with the content type {string}") do |reqbody, url, content_type|
   Net::HTTP.post(URI(url),
                  reqbody,
                  'Content-Type' => content_type)

--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -10,6 +10,20 @@ When("I POST the data {string} to the URL {string}") do |reqbody, url|
                  'Content-Type' => 'application/x-www-form-urlencoded')
 end
 
+# Attempts to POST a string of JSON data to a server.
+#
+# @step_input reqbody [String] JSON data to send.
+# @step_input url [String] The URL to post data to.
+When("I POST the JSON data {string} to the URL {string}") do |reqbody, url|
+  response = Net::HTTP.post(URI(url),
+                            reqbody,
+                            'Content-Type' => 'application/json')
+  
+  unless response.is_a?(Net::HTTPSuccess)
+    raise "POST request failed with response code #{response.code}. Response body:\n\n#{response.body}"
+  end
+end
+
 When('I open the URL {string} tolerating any error') do |url|
   begin
     URI(url).open(&:read)

--- a/test/node/features/steps/server_fixture_request_steps.rb
+++ b/test/node/features/steps/server_fixture_request_steps.rb
@@ -1,8 +1,8 @@
 require 'net/http'
 
-# Attempts to POST a string of urlencoded data to a server.
+# Attempts to POST a string of request body data to a server.
 #
-# @step_input reqbody [String] urlencoded data to send.
+# @step_input reqbody [String] body data to send.
 # @step_input url [String] The URL to post data to.
 # @step_input content_type [String] The content type of the data being sent.
 When("I POST the data {string} to the URL {string} with the content type {string}") do |reqbody, url, content_type|


### PR DESCRIPTION
## Goal

Updates the Hono plugin’s error-handling middleware to properly await next() and adds/adjusts integration tests and fixtures to cover async behavior, non-Error throws, and request-body parsing.

## Changeset

- Update `@bugsnag/plugin-hono` error handler to await next() and handle thrown non-Error values.

## Testing

- Extend Node maze-runner steps/features to allow POSTing with an explicit Content-Type (including JSON).
- Adjust AWS Lambda Hono feature coverage and upload maze output artifacts on workflow failure.