### PR TITLE
Enforced pre‑commit and CI rules to block .log files and detect secret patterns

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,5 +26,7 @@ jobs:
       # Run Gitleaks (NO LICENSE REQUIRED)
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         with:
           config-path: .gitleaks.toml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,7 @@ name: Security Enforcement
 on:
   pull_request:
   push:
-    branches: [ feature/pre-commit-test ]
+    branches: [ next, main ]
 
 jobs:
   security:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,30 @@
+name: Security Enforcement
+
+on:
+  pull_request:
+  push:
+    branches: [ feature/pre-commit-test ]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Block .log files anywhere in repo
+      - name: Block .log files
+        run: |
+          if git ls-files | grep -E "\.log$"; then
+            echo "❌ .log files detected. Remove them before merge."
+            exit 1
+          fi
+
+      # Run Gitleaks (NO LICENSE REQUIRED)
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,5 +28,6 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config-path: .gitleaks.toml

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Gemfile.lock
 .idea/
 *.iml
 zscaler-root-ca.crt*
+
+# Log files
+*.log
+logs/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "Gitleaks Config"
+
+[[rules]]
+id = "generic-api-key"
+description = "Generic API Key"
+regex = '''(?i)(api[_-]?key|apikey|secret|token)\s*[:=]\s*['"]?[A-Za-z0-9_-]{20,}['"]?'''
+
+[[rules]]
+id = "hardcoded-password"
+description = "Hardcoded password"
+regex = '''(?i)(password|passwd|pwd)\s*[:=]\s*['"][^'"\n]{4,}['"]'''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  # Basic hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+
+  # Block .log files
+  - repo: local
+    hooks:
+      - id: block-log-files
+        name: Block .log files
+        entry: bash -c 'if git diff --cached --name-only | grep -E "\.log$"; then echo "❌ .log files are not allowed"; exit 1; fi'
+        language: system
+        stages: [pre-commit]
+
+  # Secret detection
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Enforced pre‑commit and CI rules to block .log files and detect secret patterns.

Refer https://smartbear.atlassian.net/wiki/spaces/SEC/pages/6377472003/2026-04-17+-+Expose+BrowserStack+access+token+in+Maze-runner.log+file