### PR TITLE
Replace deprecated devices android_9 for browserstack

### DIFF
--- a/.buildkite/basic/browser-pipeline.yml
+++ b/.buildkite/basic/browser-pipeline.yml
@@ -82,7 +82,7 @@ steps:
           - "edge_17"
           - "safari_10"
           - "ios_15"
-          - "android_9"
+          - "android_13"
           - "chrome_43"
           - "chrome_72"
           - "firefox_78"

--- a/test/react-native-cli/TESTING.md
+++ b/test/react-native-cli/TESTING.md
@@ -80,7 +80,7 @@ particular, these commands need the `BrowserStackLocal` binary (available
     ```shell script
     bundle exec maze-runner --app=./build/rn0_63.apk \
                             --farm=bs \
-                            --device=ANDROID_9_0 \
+                            --device=ANDROID_16 \
                             --bs-local=~/BrowserStackLocal \
                             features/run-app-tests
     ```

--- a/test/react-native/TESTING.md
+++ b/test/react-native/TESTING.md
@@ -96,7 +96,7 @@ particular, these commands need the `BrowserStackLocal` binary (available
     ```shell script
     bundle exec maze-runner --app=<PATH_TO_TEST_FIXTURE_APK> \
                             --farm=bs \
-                            --device=ANDROID_9_0 \
+                            --device=ANDROID_16 \
                             features/app.feature
     ```
 1. Or on iOS:


### PR DESCRIPTION
## Goal

Replace deprecated android_9 with android_13 in BrowserStack device mappings.
Update test command examples in TESTING.md to use the new Android device.

## Testing

Run the updated commands locally and verify BrowserStack Device Availability for android_13 and ANDROID_16