### PR TITLE
chore: add React Native plugin bugs metadata

### DIFF
--- a/packages/plugin-react-native-client-sync/package.json
+++ b/packages/plugin-react-native-client-sync/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
+  "bugs": {
+    "url": "https://github.com/bugsnag/bugsnag-js/issues"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-react-native-event-sync/package.json
+++ b/packages/plugin-react-native-event-sync/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
+  "bugs": {
+    "url": "https://github.com/bugsnag/bugsnag-js/issues"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git@github.com:bugsnag/bugsnag-js.git"
   },
+  "bugs": {
+    "url": "https://github.com/bugsnag/bugsnag-js/issues"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Goal

Add missing npm `bugs.url` metadata for three React Native plugin packages:

- `@bugsnag/plugin-react-native-hermes`
- `@bugsnag/plugin-react-native-client-sync`
- `@bugsnag/plugin-react-native-event-sync`

This points npm users to the public Bugsnag JS issue tracker. The change is metadata-only and does not affect runtime code, dependencies, package files, or build behavior.

## Testing

```sh
node - <<'NODE'
for (const dir of ['plugin-react-native-hermes','plugin-react-native-client-sync','plugin-react-native-event-sync']) {
  const p = require(`./packages/${dir}/package.json`)
  if (!p.name.startsWith('@bugsnag/plugin-react-native-') || p.bugs?.url !== 'https://github.com/bugsnag/bugsnag-js/issues') process.exit(1)
  console.log(`${p.name} metadata OK`)
}
NODE
for d in packages/plugin-react-native-hermes packages/plugin-react-native-client-sync packages/plugin-react-native-event-sync; do (cd $d && npm pack --dry-run --ignore-scripts --json >/tmp/$(basename $d)-pack.json); done
git diff --check
```
