### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/plugin-react-native-hermes/package.json
+++ b/packages/plugin-react-native-hermes/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@bugsnag/plugin-react-native-hermes",
   "version": "8.9.0",
+  "bugs": {
+    "url": "https://github.com/bugsnag/bugsnag-js/issues"
+  },
   "main": "hermes.js",
   "description": "@bugsnag/react-native plugin to support Hermes",
   "homepage": "https://www.bugsnag.com/",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/plugin-react-native-hermes/package.json`.

Fixes npm tooling unable to resolve package metadata.